### PR TITLE
docs: define runtime harness dispatch pattern

### DIFF
--- a/.osc/plans/active/001-generic-osc-core-amendment-4.md
+++ b/.osc/plans/active/001-generic-osc-core-amendment-4.md
@@ -1,0 +1,36 @@
+# Amendment 4: 001-generic-osc-core
+
+## Parent
+
+001-generic-osc-core
+
+## Date
+
+2026-05-12
+
+## Learning
+
+Daniel's Command Center proved the missing private bridge: Hermes Kanban can remain operational truth while a bounded harness dispatcher launches OMX `$ralplan` and records run evidence. Open Scaffold should absorb this as a public pattern, but not by copying Daniel-specific Hermes Kanban, Codex auth, Discord, or `.omx/` Command Center machinery into core.
+
+The clarified layer split is:
+
+```text
+Open Scaffold core = portable task/run/evidence contract
+Coordinator/task bridge = operational state and launch decision
+Runtime harness = execution lane
+Operator surface = glass/question/approval transport
+GitHub = publication/review layer
+```
+
+## New direction
+
+Add public documentation for the runtime harness dispatch pattern. Open Scaffold core should continue generating `.osc/runs/<run_id>/run.json` with `spawning: false`, while documenting how coordinators/adapters consume that package to launch OMX/OMC/plain-agent/human lanes and promote evidence back.
+
+This slice should also include a Mermaid diagram showing the current system position: private Command Center bridge proven, Open Scaffold now productizing the public contract/docs, future adapter/binding work still separate.
+
+## Impact on acceptance criteria
+
+- Extends Amendment 3 AC16/AC18: generated run records are not only schema artifacts; docs must show how a coordinator/adapter consumes them for real harness dispatch without moving spawning into core.
+- Adds AC21: docs include a Mermaid process diagram locating the current phase between the proven Command Center bridge and future public runtime bindings.
+- Adds AC22: docs explicitly distinguish Open Scaffold's portable pattern from Daniel-specific Hermes Kanban/Command Center implementation.
+- Adds AC23: docs include an OMX `$ralplan` dispatch example that preserves core's non-spawning boundary and commit/push approval gate.

--- a/MISSION.md
+++ b/MISSION.md
@@ -31,3 +31,4 @@ One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line piv
 2026-05-11: Reframed Open Scaffold ontology and roadmap via `.osc/plans/active/001-generic-osc-core-amendment-1.md`.
 2026-05-11: Adopted external OMC/OMX/Hermes/clawhip boundary correction via `.osc/plans/active/001-generic-osc-core-amendment-2.md`.
 2026-05-11: Documented task/run/operator-surface model and added v1 run binding schema via `.osc/plans/active/001-generic-osc-core-amendment-3.md`.
+2026-05-12: Document runtime harness dispatch bridge pattern for Open Scaffold core — see `.osc/plans/active/001-generic-osc-core-amendment-4.md`.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ ROADMAP / idea
 | 🧰 **`osc` CLI** | Runtime-neutral command-line helper. Parses plans, reports status, and writes prompt/artifact bundles under `.osc/runs/` without spawning agents. Run binding options can record task/run/operator/harness metadata. | [→](package.json) |
 | 🔌 **Integrations and harnesses** | Open Scaffold supports orchestrators/agents and runtime harnesses without confusing their roles: Hermes/Claw/etc. can operate the scaffold; OMC and OMX are Claude Code/Codex workflow harnesses. | [→](docs/ADAPTERS.md) |
 | 🧾 **Task/run model** | `task_id` owns durable work, `run_id` owns one execution attempt, chat threads are operator-surface bindings, and ambiguous packages route to clarification before harness dispatch. | [→](docs/TASK_RUN_MODEL.md) |
+| 🚦 **Runtime dispatch pattern** | Coordinators consume `.osc/runs/<run_id>/run.json` and launch OMX/OMC/plain-agent/human lanes while core stays non-spawning. Includes the current Mermaid map. | [→](docs/RUNTIME_HARNESS_DISPATCH.md) |
 | 🐙 **GitHub PR loop** | Issues, branches, PR templates, CI, Codex review triggers, and human approvals become the publication/review layer for semi-autonomous work. | [→](docs/GITHUB_WORKFLOW.md) |
 | 🛩️ **Glass cockpit** | Discord/Slack/Telegram/GitHub comments can expose nudges, blockers, approvals, and build-in-public reports while the repo/task/GitHub chain stays canonical. | [→](docs/OPEN_SCAFFOLD_SYSTEM.md) |
 
@@ -173,6 +174,8 @@ npm run osc -- run .osc/plans/active/my-first-task.md \
 ```
 
 This writes `.osc/runs/<run_id>/run.json` with task/run bindings, executor choice, operator-surface binding, package-quality checks, prompts, and commit policy. If the package lacks goal, acceptance criteria, verification, or has blocking open questions, dispatch should route to clarification/deep-interview before implementation.
+
+For the public coordinator-to-harness pattern, including the current Mermaid map of where the system is now, see [docs/RUNTIME_HARNESS_DISPATCH.md](docs/RUNTIME_HARNESS_DISPATCH.md).
 
 ### 5. Open a traceable PR when code changes
 

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -90,7 +90,7 @@ Examples:
 - a local SQLite task queue
 - a custom orchestrator board
 
-Open Scaffold should define how roadmap items and plans link to these systems, but it should not assume one board is universal.
+Open Scaffold should define how roadmap items and plans link to these systems, but it should not assume one board is universal. The dispatch pattern is documented in [`docs/RUNTIME_HARNESS_DISPATCH.md`](RUNTIME_HARNESS_DISPATCH.md): core creates the package, coordinators/task bridges choose and launch the harness, and evidence returns to `.osc/runs`, GitHub, or release notes.
 
 A live task should dispatch work through a canonical run record instead of through a chat thread or runtime transcript directly. See [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md) for the v1 task/run/operator-surface schema.
 

--- a/docs/RUNTIME_HARNESS_DISPATCH.md
+++ b/docs/RUNTIME_HARNESS_DISPATCH.md
@@ -1,0 +1,171 @@
+# Runtime Harness Dispatch Pattern
+
+Open Scaffold core defines the portable contract for semi-autonomous work. It does **not** own the local control plane that launches agents. A coordinator or runtime-specific binding consumes `.osc/runs/<run_id>/run.json` and dispatches the selected harness.
+
+This page captures the pattern proven in Daniel's private Command Center with Hermes Kanban -> OMX `$ralplan`, then translates it into the public Open Scaffold model.
+
+## Executive rule
+
+```text
+Open Scaffold packages.
+A task bridge coordinates.
+A harness executes.
+An operator surface observes.
+GitHub publishes.
+Evidence proves.
+```
+
+## Where we are right now
+
+```mermaid
+flowchart TD
+    A["1. Product intent\nROADMAP / GitHub issue / Kanban card"] --> B["2. Open Scaffold contract\nplan/spec + task_id"]
+    B --> C["3. Run package\n.osc/runs/<run_id>/run.json"]
+    C --> D["4. Coordinator / task bridge\nHermes Kanban, GitHub bot, Linear/Jira bridge, custom script"]
+    D --> E["5. Runtime harness\nOMX $ralplan/$ralph, OMC /ralplan, plain agent, human"]
+    E --> F["6. Evidence + postflight\nlogs, outputs, verification, operator decision"]
+    F --> G["7. Publication\nbranch / PR / CI / Codex review / release note"]
+
+    D -. "status/questions only" .-> H["Glass cockpit\nDiscord / Slack / Telegram / GitHub comments"]
+    H -. "question_id -> run_id" .-> D
+
+    X["Daniel Command Center PR #4\nprivate bridge proved:\nKanban -> OMX -> run evidence"] --> Y["You are here in Open Scaffold\nproductizing the public contract/docs"]
+    Y --> C
+
+    classDef done fill:#DCFCE7,stroke:#16A34A,color:#052e16;
+    classDef current fill:#FEF3C7,stroke:#D97706,color:#451a03;
+    classDef future fill:#DBEAFE,stroke:#2563EB,color:#0f172a;
+    class X done;
+    class Y current;
+    class E,F,G future;
+```
+
+Current state:
+
+- The **private Command Center bridge** has been proven with Hermes Kanban dispatching a task into detached OMX `$ralplan` and preserving run evidence.
+- Open Scaffold already has the generic `task_id` / `run_id` / `operator_surface` schema.
+- This Open Scaffold slice documents the bridge as a public, runtime-neutral dispatch pattern.
+- The next adapter/product step is an OMX/OMC binding that consumes `.osc/runs/<run_id>/run.json` and performs real launch/postflight outside core.
+
+## Layer ownership
+
+| Layer | Owns | Examples | Must not own |
+|---|---|---|---|
+| Open Scaffold core | repo-native contract, run packet, evidence locations, task/run identity | `.osc/plans`, `.osc/runs`, `osc run`, docs, PR templates | live task lifecycle, runtime auth, agent spawning |
+| Task bridge / coordinator | operational state and dispatch decision | Hermes Kanban, GitHub Issues bot, Linear/Jira bridge, local queue | final evidence or runtime internals |
+| Runtime harness | actual planning/build/review loop while alive | OMX, OMC, Claude Code, Codex CLI, human lane | canonical task database or commit authority |
+| Operator surface | visibility, questions, approvals | Discord, Slack, Telegram, GitHub comments, CLI dashboard | source of truth |
+| GitHub/publication | versioned implementation and review | branch, PR, CI, Codex connector review, release | runtime session truth |
+
+## Canonical public flow
+
+```text
+ROADMAP item / issue / task
+  -> plan or spec in .osc/plans or .osc/specs
+  -> osc run ... --task-id ... --executor ... --harness-skill ...
+  -> .osc/runs/<run_id>/run.json
+  -> coordinator/adapter validates packageQuality.executable
+  -> selected harness executes in isolated session/worktree
+  -> artifacts/logs/outputs promoted back to .osc/runs and/or PR
+  -> postflight verifies against acceptance criteria
+  -> operator approval gates merge/release
+```
+
+## What Open Scaffold core should generate
+
+Open Scaffold core should generate or preserve enough information for a launcher to act without guessing:
+
+```json
+{
+  "taskId": "issue:42",
+  "runId": "20260512T090000Z-m5-runtime-harness-bindings",
+  "executor": {
+    "lane": "omx-codex",
+    "harnessSkill": "$ralplan",
+    "spawning": false
+  },
+  "runtime": {
+    "repoPath": "/absolute/path/to/repo",
+    "worktreePath": null,
+    "branch": "feat/runtime-harness-bindings"
+  },
+  "bindings": {
+    "operatorSurface": "discord",
+    "operatorThreadId": null,
+    "githubIssue": "42",
+    "githubPr": null
+  },
+  "packageQuality": {
+    "executable": true,
+    "blockers": [],
+    "requiredAction": null
+  },
+  "commitPolicy": "no commit/push unless explicitly approved by the operator"
+}
+```
+
+`spawning: false` is deliberate. Core writes the black-box recorder package; a coordinator or adapter launches the harness.
+
+## What the coordinator/adapter should do
+
+A coordinator or runtime-specific binding should:
+
+1. Read `.osc/runs/<run_id>/run.json`.
+2. Refuse dispatch unless `packageQuality.executable` is true.
+3. Validate executor lane and harness skill.
+4. Create an isolated runtime session or worktree when needed.
+5. Launch the selected harness with the generated prompt/artifact bundle.
+6. Attach runtime bindings back to the run record:
+   - tmux session
+   - process id
+   - worktree
+   - branch
+   - log paths
+   - operator thread/comment id
+7. Route blocking questions by `question_id -> run_id`, never by latest chat message.
+8. Promote final artifacts, status, logs, and verification evidence back into `.osc/runs`, GitHub PRs, or release notes.
+9. Leave commit/push/merge gated by the operator unless the package explicitly grants that authority.
+
+## OMX example
+
+A coordinator can turn this Open Scaffold command:
+
+```bash
+npm run osc -- run .osc/plans/active/001-runtime-harness-bindings.md \
+  --task-id issue:42 \
+  --executor omx-codex \
+  --harness-skill '$ralplan' \
+  --operator-surface discord \
+  --repo /path/to/repo
+```
+
+into a bounded OMX launch such as:
+
+```text
+$ralplan "Read .osc/runs/<run_id>/package.md. Plan only. Do not implement, commit, push, deploy, or publish. If blocked, emit BLOCKED with a question_id. If ready, emit READY_FOR_POSTFLIGHT and cite evidence paths."
+```
+
+The exact launch mechanics — tmux, Codex auth, update prompts, hooks, watchdogs, and runtime logs — belong in an OMX binding or coordinator, not Open Scaffold core.
+
+## Anti-patterns
+
+Avoid:
+
+- putting Hermes Kanban, Discord bot state, or Daniel-specific auth setup inside Open Scaffold core;
+- making Discord the task database;
+- letting OMX/OMC runtime state replace `.osc/runs` evidence;
+- dispatching a harness from vague prose without a run packet;
+- letting a chat reply answer a question without `question_id -> run_id` correlation;
+- treating `spawning: false` as a limitation instead of the core boundary.
+
+## Product implication
+
+Open Scaffold should productize the method, not Daniel's private cockpit. The public core should make every task/run/harness boundary clear enough that many coordinators can implement the launch layer:
+
+```text
+Open Scaffold core = WHAT/WHERE/PROOF
+Coordinator/adapter = WHEN/WHO/LAUNCH
+Harness = HOW TO EXECUTE
+Operator surface = HUMAN CONTROL GLASS
+GitHub = PUBLIC VERSIONED REVIEW
+```

--- a/docs/TASK_RUN_MODEL.md
+++ b/docs/TASK_RUN_MODEL.md
@@ -148,7 +148,7 @@ Runtime state is live/forensic until promoted into the run packet, evidence, doc
 }
 ```
 
-Generic Open Scaffold sets `spawning: false`: the core writes the package and bindings; a coordinator or runtime adapter performs actual dispatch.
+Generic Open Scaffold sets `spawning: false`: the core writes the package and bindings; a coordinator or runtime adapter performs actual dispatch. See [`docs/RUNTIME_HARNESS_DISPATCH.md`](RUNTIME_HARNESS_DISPATCH.md) for the public pattern that maps `.osc/runs/<run_id>/run.json` into OMX/OMC/plain-agent/human execution without moving private control-plane machinery into core.
 
 ## Lifecycle states
 


### PR DESCRIPTION
## Summary

- Adds `docs/RUNTIME_HARNESS_DISPATCH.md`, translating the proven private Command Center Kanban -> OMX bridge into Open Scaffold's public runtime-neutral pattern.
- Includes the requested Mermaid diagram showing where the system is now: Command Center bridge proven, Open Scaffold currently productizing the public contract/docs, future adapter/binding work still separate.
- Links the new dispatch doc from README, `docs/TASK_RUN_MODEL.md`, and `docs/OPEN_SCAFFOLD_SYSTEM.md`.
- Adds Amendment 4 and MISSION changelog entry to preserve the scope evolution.

## Boundary preserved

Open Scaffold core still does **not** spawn agents. It packages:

```text
.osc plan/spec -> .osc/runs/<run_id>/run.json -> coordinator/adapter consumes -> harness executes -> evidence returns
```

## Verification

- `npm test` → 2 files / 6 tests passed
- `npm run build` → passed
- `npm run osc -- verify` → passed
- `./verify.sh --standard` → 4 pass / 0 fail / 0 warn
- `git diff --check` → passed
- changed-file secret scan → no hits
