### PR TITLE
docs: define slice close evidence protocol

### DIFF
--- a/.osc/plans/active/002-slice-close-evidence-loop.md
+++ b/.osc/plans/active/002-slice-close-evidence-loop.md
@@ -1,0 +1,85 @@
+# Plan: slice-close-evidence-loop
+
+## Status
+
+active
+
+## Context
+
+PR #4 productized the runtime-harness dispatch boundary: Open Scaffold packages work, coordinators dispatch, harnesses execute, operator surfaces observe, and evidence proves. The next product gap is the closed-loop evidence protocol from ROADMAP Milestone 2: how a semi-autonomous slice is judged closed, how weak approvals are distinguished from strong product acceptance, and how corrections carry into the next slice without private chat or Command Center context.
+
+## Goal
+
+Define a runtime-neutral slice-close and evidence loop so any Open Scaffold repo can prove what happened in a task/run, record approval quality, and generate the next slice from durable evidence rather than vanished chat context.
+
+## Constraints / Out of scope
+
+- Do not spawn agents, run harnesses, or add any private reference-implementation machinery to Open Scaffold core.
+- Do not make a chat thread, runtime transcript, or private implementation run ledger canonical truth.
+- Do not require one task system; GitHub Issues, Hermes Kanban, Linear/Jira, local queues, and manual operation must all fit.
+- Keep the first slice documentation/schema-first; CLI helpers are allowed only if they write/validate repo-local artifacts without dispatching runtimes.
+
+## Files to touch
+
+- `ROADMAP.md` — mark Milestone 2 status and connect it to the task/run dispatch work from Milestone 4.
+- `docs/SLICE_CLOSE_PROTOCOL.md` — define slice states, evidence receipt format, approval-strength taxonomy, correction routing, and next-slice inheritance.
+- `docs/TASK_RUN_MODEL.md` — link run lifecycle states to slice close / postflight / evidence receipt concepts.
+- `docs/OPEN_SCAFFOLD_SYSTEM.md` — place slice close in the ontology without promoting a coordinator or cockpit to source of truth.
+- `README.md` — add a concise product-facing pointer to the closed-loop protocol.
+- `.osc/plans/active/001-generic-osc-core-amendment-5.md` or a follow-up active plan — only if execution reveals this changes the existing core plan scope; otherwise keep this as the standalone slice plan.
+- `src/` and `tests/` — optional, only for a minimal `osc` validation/report helper that remains non-spawning.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Audit existing README/docs/CLI run schema for current lifecycle/evidence language | None | A |
+| T2 | Draft `docs/SLICE_CLOSE_PROTOCOL.md` with slice states, evidence receipt schema, approval taxonomy, and correction routing | T1 | B |
+| T3 | Patch roadmap/system/task-run docs to point at the protocol and preserve layer boundaries | T2 | C |
+| T4 | Optional: add a minimal non-spawning `osc` helper or schema fixture for postflight/evidence validation | T2 | C |
+| T5 | Run verification, check for private reference-implementation leakage, and prepare PR body with Codex review status field | T3, T4 | D |
+
+### Parallel groups
+
+- **Group A**: T1 establishes current language and prevents duplicate concepts.
+- **Group B**: T2 is the core product design artifact.
+- **Group C**: T3 and optional T4 can proceed once the protocol shape is stable.
+- **Group D**: T5 validates public runtime-neutral boundaries and repo health.
+
+### Dependencies
+
+- T2 depends on T1 so the protocol extends, rather than rewrites, the current task/run model.
+- T3 and T4 depend on T2 because docs and optional helpers should cite a stable protocol.
+- T5 depends on all changed docs/code.
+
+### Delegation notes
+
+- Suitable for bounded docs-first execution by a plain agent, Claude Code, Codex, OMC, or OMX, but the Open Scaffold core output remains files/schema/checks only.
+- If a harness is used, generate a run packet with `spawning: false`; the coordinator/adapter owns actual launch and evidence promotion.
+
+## Acceptance criteria
+
+- [ ] `docs/SLICE_CLOSE_PROTOCOL.md` defines a clear public protocol for slice close, postflight, evidence receipt, approval strength, correction routing, and next-slice inheritance.
+- [ ] The protocol distinguishes strong product approval, weak-positive/procedural approval, rejection, and blocked/needs-human states.
+- [ ] The protocol maps outcomes to durable artifact destinations: plan amendment, evidence receipt, roadmap update, issue/task comment, PR/release note, or next-slice plan.
+- [ ] Public docs preserve Open Scaffold's boundary: core packages and validates; coordinators track/dispatch; harnesses execute; operator surfaces observe; GitHub publishes; evidence proves.
+- [ ] No text requires Hermes Kanban, a private Command Center-style reference implementation, Discord, OMC, OMX, Codex, or Claude as mandatory infrastructure.
+- [ ] If any CLI code is added, tests prove it writes/validates artifacts only and never spawns a runtime.
+- [ ] The PR body links roadmap item, plan, task/run identity if used, verification, Codex review status, and evidence paths.
+
+## Verification steps
+
+1. Run `npm test` if TypeScript or CLI files change; expected result: all tests pass.
+2. Run `npm run build` if TypeScript or CLI files change; expected result: build passes.
+3. Run `npm run osc -- verify`; expected result: Open Scaffold compliance passes.
+4. Run `./verify.sh --standard`; expected result: standard checks pass.
+5. Run `git diff --check`; expected result: no whitespace errors.
+6. Search changed files for private leakage terms/paths such as user-local absolute paths, private run IDs, tokens, and single-operator setup claims; expected result: no private machinery embedded in core docs.
+
+## Open questions
+
+- Should the first implementation include only docs/schema, or also a tiny `osc postflight` / `osc evidence` validator?
+- Should slice-close evidence live under `.osc/runs/<run_id>/postflight.md`, `.osc/runs/<run_id>/evidence.json`, `docs/evidence/`, or allow all three with clear ownership?
+- What minimum approval taxonomy is enough for v1 without overbuilding a workflow engine?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ open-scaffold has multiple layers. The **core system** is framework-agnostic rep
 - **Roadmap source of direction:** `ROADMAP.md` — product/system milestones and the self-dogfood chain from roadmap item to issue/task, plan, run packet, PR, and release note.
 - **System ontology:** `docs/OPEN_SCAFFOLD_SYSTEM.md` — boundary map for Open Scaffold core, orchestrators/agents, OMC/OMX runtime harnesses, task bridges, glass-cockpit surfaces, and GitHub.
 - **Task/run model:** `docs/TASK_RUN_MODEL.md` — `task_id` for durable work, `run_id` for one execution attempt, `question_id` for operator prompts, and chat/thread ids as optional bindings.
+- **Slice close protocol:** `docs/SLICE_CLOSE_PROTOCOL.md` — evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance.
 - **GitHub workflow:** `docs/GITHUB_WORKFLOW.md` — issue → task/run → branch/PR → CI/Codex review → human approval → merge traceability.
 - **Plans directory:** `.osc/plans/` — immutable plan files organized in stage subfolders (`active/`, `backlog/`, `done/`, `blocked/`), one per task/feature slice, conforming to the 7-section schema in `.osc/plans/handoff-template.md`. The folder IS the status — see `.osc/plans/WORKFLOW.md` for movement rules.
 - **Amendments:** new learnings become `<plan-slug>-amendment-<n>.md` in the same stage folder as the parent plan, scaffolded by `./amend.sh <plan-slug>`. Plans are never edited in place; amendment files and MISSION.md's changelog are never hand-written.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ open-scaffold has multiple layers. The **core system** is framework-agnostic rep
 - **`ROADMAP.md`** — product/system milestones and the self-dogfood chain from roadmap item to issue/task, plan, run packet, PR, and release note.
 - **`docs/OPEN_SCAFFOLD_SYSTEM.md`** — boundary map for Open Scaffold core, orchestrators/agents, OMC/OMX runtime harnesses, task bridges, glass-cockpit surfaces, and GitHub.
 - **`docs/TASK_RUN_MODEL.md`** — task/run/operator-surface identity model: `task_id`, `run_id`, `question_id`, runtime bindings, and chat/thread bindings.
+- **`docs/SLICE_CLOSE_PROTOCOL.md`** — evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance.
 - **`docs/GITHUB_WORKFLOW.md`** — GitHub issue, PR template, Codex connector review, CI, and merge/release traceability.
 - **`.osc/plans/`** — plan files organized in stage subfolders (`active/`, `backlog/`, `done/`, `blocked/`). The folder IS the status. Plans are **immutable** once committed. New learnings become amendment files named `<slug>-amendment-<n>.md` in the same stage folder as the parent. The handoff template in `.osc/plans/handoff-template.md` defines the exact 7-section schema every plan follows. See `.osc/plans/WORKFLOW.md` for movement rules between stage folders.
 - **`docs/decisions/`** — `README.md` is the public design-choices page (paired views, immutable plans, adapter-mediated orchestration). The full ADR records that back these decisions live internally in `.osc-dev/decisions/` and do not ship with the public template.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ ROADMAP / idea
 | 🧰 **`osc` CLI** | Runtime-neutral command-line helper. Parses plans, reports status, and writes prompt/artifact bundles under `.osc/runs/` without spawning agents. Run binding options can record task/run/operator/harness metadata. | [→](package.json) |
 | 🔌 **Integrations and harnesses** | Open Scaffold supports orchestrators/agents and runtime harnesses without confusing their roles: Hermes/Claw/etc. can operate the scaffold; OMC and OMX are Claude Code/Codex workflow harnesses. | [→](docs/ADAPTERS.md) |
 | 🧾 **Task/run model** | `task_id` owns durable work, `run_id` owns one execution attempt, chat threads are operator-surface bindings, and ambiguous packages route to clarification before harness dispatch. | [→](docs/TASK_RUN_MODEL.md) |
+| 🧪 **Slice close protocol** | Evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance keep "done" from becoming vibes. | [→](docs/SLICE_CLOSE_PROTOCOL.md) |
 | 🚦 **Runtime dispatch pattern** | Coordinators consume `.osc/runs/<run_id>/run.json` and launch OMX/OMC/plain-agent/human lanes while core stays non-spawning. Includes the current Mermaid map. | [→](docs/RUNTIME_HARNESS_DISPATCH.md) |
 | 🐙 **GitHub PR loop** | Issues, branches, PR templates, CI, Codex review triggers, and human approvals become the publication/review layer for semi-autonomous work. | [→](docs/GITHUB_WORKFLOW.md) |
 | 🛩️ **Glass cockpit** | Discord/Slack/Telegram/GitHub comments can expose nudges, blockers, approvals, and build-in-public reports while the repo/task/GitHub chain stays canonical. | [→](docs/OPEN_SCAFFOLD_SYSTEM.md) |
@@ -352,6 +353,8 @@ Not an FAQ. These are the questions that matter most. For the full list, see [do
 
 **Task / Run / Question** — `task_id` is durable work identity, `run_id` is one execution attempt, and `question_id` is one blocking clarification/approval inside a run. Chat thread/message ids are bindings, not canonical truth.
 
+**Slice Close** — The evidence-backed decision that a feature slice is approved, weak-approved, rejected, blocked, closed, or carried into a next slice. It records acceptance-gate status, verification evidence, known gaps, approval strength, and correction routing. See [`docs/SLICE_CLOSE_PROTOCOL.md`](docs/SLICE_CLOSE_PROTOCOL.md).
+
 **Plan Immutability** — Once a plan is committed to git, it is never edited. Changes layer on top as amendments. This is the single rule that prevents silent scope creep.
 
 **Scaffold** — The project-specific structure that organizes plans, decisions, amendments, and handovers in your repo. open-scaffold is a scaffold. OMC and OMX are runtimes.
@@ -374,6 +377,7 @@ open-scaffold has several cooperating layers:
 - **Runtime lanes** — OMC for Claude Code and OMX for Codex. They amplify execution through bound run IDs but do not own the source of truth.
 - **Event transport** — clawhip-style tools, webhooks, and gateways route session/status events into operator surfaces.
 - **GitHub review layer** — issues, branches, PRs, CI, Codex review, and human approvals gate publication.
+- **Slice close / evidence loop** — evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance prevent weak or missing proof from becoming durable product truth.
 - **Glass cockpits** — Discord/Slack/Telegram/GitHub comments/CLI dashboards expose status, blockers, approvals, and build-in-public streams.
 
 The scaffold is the load-bearing part. Agents and runtimes amplify it. Cockpits make it visible. You can strip the runtimes away and the methodology still holds.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,14 +77,16 @@ Acceptance criteria:
 
 ## Milestone 2 — Evolutionary closed-loop protocol
 
+Status: in progress via `.osc/plans/active/002-slice-close-evidence-loop.md` and `docs/SLICE_CLOSE_PROTOCOL.md`.
+
 Goal: productize the “slice → feedback → correction → approval → next slice” learning loop.
 
 Deliverables:
 
-- Define feedback-capture format.
-- Define slice close criteria.
+- Define feedback-capture format. First public shape: evidence receipt in `docs/SLICE_CLOSE_PROTOCOL.md`.
+- Define slice close criteria. First public shape: postflight checklist and approval taxonomy in `docs/SLICE_CLOSE_PROTOCOL.md`.
 - Define how corrections become amendments, evidence, roadmap changes, or next-slice inheritance.
-- Add validation checks for stale state, fake evidence, or weak approvals.
+- Add validation checks for stale state, fake evidence, or weak approvals. First public shape: manual checklist and anti-patterns; CLI validation remains a future implementation option.
 
 Acceptance criteria:
 

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -18,6 +18,7 @@ Open Scaffold core owns the portable project substrate:
 - `.osc/specs/` — durable specs and context packs.
 - `.osc/runs/` — generated run packets, prompt bundles, execution evidence.
 - `docs/` — decisions, workflow standards, examples, operator guidance.
+- `docs/SLICE_CLOSE_PROTOCOL.md` — evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance.
 - `verify.sh` / `osc verify` — methodology compliance checks.
 - `.github/` templates — issue and PR traceability for GitHub-centered workflows.
 
@@ -92,7 +93,7 @@ Examples:
 
 Open Scaffold should define how roadmap items and plans link to these systems, but it should not assume one board is universal. The dispatch pattern is documented in [`docs/RUNTIME_HARNESS_DISPATCH.md`](RUNTIME_HARNESS_DISPATCH.md): core creates the package, coordinators/task bridges choose and launch the harness, and evidence returns to `.osc/runs`, GitHub, or release notes.
 
-A live task should dispatch work through a canonical run record instead of through a chat thread or runtime transcript directly. See [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md) for the v1 task/run/operator-surface schema.
+A live task should dispatch work through a canonical run record instead of through a chat thread or runtime transcript directly. See [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md) for the v1 task/run/operator-surface schema. A task or run should close through the evidence-backed slice-close protocol in [`docs/SLICE_CLOSE_PROTOCOL.md`](SLICE_CLOSE_PROTOCOL.md), not merely because a runtime or chat message says "done".
 
 ```text
 task_id = durable product/work item
@@ -156,6 +157,7 @@ Use these statements in product docs and agent prompts:
 
 ```text
 Open Scaffold is the repo protocol, not the agent runtime.
+Slice close requires evidence, acceptance-gate status, and an explicit approval/rejection/block decision; chat alone is not closure.
 Hermes is a coordinator / stateful product-workflow surface that may use Kanban, nudges, package/task state, and operator interaction.
 Hermes Kanban/Nudge is a coordination/control layer, not a Codex or Claude Code runtime.
 Claude Code, Codex, Gemini, Claw/OpenClaw, and custom agents can operate Open Scaffold directly when bounded by the repo contract.
@@ -195,6 +197,7 @@ Open Scaffold roadmap/plan or external task card
   -> executor produces result artifact, diff, PR, status, or blocker
   -> coordinator updates task state, asks the operator, or nudges next step
   -> evidence and decisions are promoted back into Open Scaffold/GitHub
+  -> slice close records acceptance-gate status, approval strength, corrections, and next-slice inheritance
 ```
 
 Rules:

--- a/docs/SLICE_CLOSE_PROTOCOL.md
+++ b/docs/SLICE_CLOSE_PROTOCOL.md
@@ -1,0 +1,324 @@
+# Slice Close Protocol
+
+Open Scaffold does not treat "the agent says it is done" as done. A slice closes only when the repo can show what was attempted, what evidence exists, what acceptance criteria passed or failed, what the operator decided, and what the next slice inherits.
+
+This protocol productizes the closed loop:
+
+```text
+slice -> run -> evidence -> postflight -> approval decision -> correction routing -> next slice
+```
+
+## Executive rule
+
+```text
+A slice is not closed by chat.
+A slice is closed by evidence, acceptance-gate status, and an explicit decision.
+```
+
+Chat threads, runtime transcripts, terminal logs, and coordinator task comments can help humans operate the work. They are not enough by themselves. The durable close record must point back to Open Scaffold files, task/run identifiers, GitHub artifacts, or evidence paths.
+
+## Layer ownership
+
+| Layer | Owns | Does not own |
+|---|---|---|
+| Open Scaffold core | close protocol, evidence receipt shape, postflight fields, next-slice inheritance rules | live task board, agent spawning, runtime auth |
+| Task system / coordinator | live state such as ready/running/blocked/review/done | final proof by itself |
+| Runtime harness / agent | execution attempt while alive | canonical closure or approval |
+| Operator surface | questions, approvals, visible status | source of truth |
+| GitHub / release layer | branch, PR, review, CI, release note | runtime session truth |
+| Evidence | proof of outputs, checks, decisions, and gaps | vague vibes |
+
+## Identity chain
+
+A meaningful slice should be reconstructable from stable identifiers:
+
+```text
+roadmap_item
+  -> plan_or_spec
+  -> task_id
+  -> run_id(s)
+  -> evidence_receipt(s)
+  -> postflight_decision
+  -> next_action
+```
+
+Not every tiny task needs every link. But if a slice changes product direction, public docs, code, release notes, or a multi-agent workflow, it should have enough of this chain for the next human or agent to resume without chat memory.
+
+## Slice states
+
+Recommended slice states:
+
+```text
+planned
+  -> packaged
+  -> dispatched | manual_execution
+  -> running
+  -> evidence_ready
+  -> postflighted
+  -> approved | weak_approved | rejected | blocked
+  -> closed | next_slice_created
+```
+
+State meanings:
+
+- `planned` — a roadmap item, issue, plan, or spec exists.
+- `packaged` — a bounded run packet or manual execution contract exists.
+- `dispatched` — a coordinator launched or assigned execution.
+- `manual_execution` — a human or direct agent worked without runtime dispatch, still under the plan/spec.
+- `running` — work is active.
+- `evidence_ready` — outputs and verification evidence are available for review.
+- `postflighted` — someone or something compared evidence to acceptance criteria.
+- `approved` — strong approval; the result meets the product bar.
+- `weak_approved` — procedural or fatigue approval; acceptable to move on, but downstream slices should treat it as weak signal.
+- `rejected` — output does not meet the bar; correction required.
+- `blocked` — cannot close because a human, dependency, credential, access, or external input is missing.
+- `closed` — no follow-up required beyond routine archive/release bookkeeping.
+- `next_slice_created` — follow-up work has a durable plan/issue/task.
+
+## Evidence receipt
+
+An evidence receipt is a short durable record that lets reviewers audit the close decision without reading an entire transcript.
+
+Recommended location:
+
+```text
+.osc/runs/<run_id>/evidence.md
+.osc/runs/<run_id>/postflight.md
+```
+
+If a repo does not track generated `.osc/runs/`, use a stable tracked location such as:
+
+```text
+docs/evidence/<date>-<slice>.md
+```
+
+Minimum receipt shape:
+
+```yaml
+schema: open-scaffold.evidence.v1
+slice: docs-runtime-dispatch
+plan: .osc/plans/active/001-example.md
+task_id: issue:42
+run_id: 20260512T090000Z-docs-runtime-dispatch
+operator_surface: github-pr
+pr: 12
+commit_or_branch: feat/docs-runtime-dispatch
+acceptance_gate:
+  status: pass | partial | fail | blocked
+  criteria:
+    - id: AC1
+      status: pass
+      evidence: docs/RUNTIME_HARNESS_DISPATCH.md
+    - id: AC2
+      status: partial
+      evidence: "Manual review: wording still needs example"
+verification:
+  - command: ./verify.sh --standard
+    result: pass
+  - command: npm run osc -- verify
+    result: pass
+artifacts:
+  changed_files:
+    - docs/RUNTIME_HARNESS_DISPATCH.md
+    - docs/TASK_RUN_MODEL.md
+  outputs:
+    - docs/RUNTIME_HARNESS_DISPATCH.md#where-we-are-right-now
+known_gaps:
+  - "Runtime binding starter kit remains future work."
+approval:
+  status: approved | weak_approved | rejected | blocked
+  approver: human | maintainer | reviewer | automated-check
+  rationale: "Why this decision was made."
+next_action:
+  type: close | amend_plan | create_next_slice | update_roadmap | open_issue | retry_run | block
+  target: .osc/plans/backlog/002-next-slice.md
+```
+
+The schema is intentionally plain text/YAML-friendly. Tools can validate it later, but humans should be able to write and review it today.
+
+## Postflight checklist
+
+Before a slice is called closed, answer these in writing:
+
+1. **What was the slice goal?** Link the plan/spec/issue.
+2. **What changed?** Link changed files, artifacts, PR, or release note.
+3. **Which acceptance criteria passed?** Mark each `pass`, `partial`, `fail`, or `blocked`.
+4. **What verification ran?** Include exact commands, manual checks, screenshots, reviewer comments, or CI links.
+5. **What evidence proves it?** Link durable files, PR comments, CI logs, screenshots, generated outputs, or release notes.
+6. **What gaps remain?** Include known defects, weak evidence, skipped checks, or unresolved product taste questions.
+7. **What did the operator decide?** Use the approval taxonomy below.
+8. **What happens next?** Close, amend, create next slice, retry, block, or release.
+
+## Approval taxonomy
+
+Use a small, explicit vocabulary.
+
+### `approved`
+
+Strong product approval.
+
+Use when:
+
+- acceptance criteria pass;
+- evidence is durable and inspectable;
+- known gaps are acceptable or separately tracked;
+- the human/product owner or required review gate explicitly accepts the result.
+
+Downstream meaning: future slices may treat this output as stable baseline unless new evidence appears.
+
+### `weak_approved`
+
+Procedural, fatigue, or weak-positive approval.
+
+Use when:
+
+- the result is allowed to move forward, but confidence is limited;
+- approval came from "good enough for now", not strong taste/product validation;
+- verification passed mechanically but the product bar is uncertain;
+- review was shallow, time-boxed, or explicitly provisional.
+
+Downstream meaning: future slices must inherit the caution. Do not use weak approval as proof of product quality.
+
+### `rejected`
+
+The slice does not meet the bar.
+
+Use when:
+
+- acceptance criteria fail;
+- evidence is missing or fake;
+- the output drifts from the goal;
+- a reviewer/product owner says the result is not acceptable.
+
+Downstream meaning: create a correction plan, amend the existing plan if scope changed, or retry with a new run.
+
+### `blocked`
+
+The slice cannot be judged yet.
+
+Use when:
+
+- credentials, access, external input, stakeholder decision, environment, or human review is missing;
+- the evidence exists but cannot be validated yet;
+- a blocking question is open.
+
+Downstream meaning: record the blocker and owner. Do not call the slice closed.
+
+## Correction routing
+
+When postflight finds new information, route it deliberately:
+
+| Finding | Durable destination |
+|---|---|
+| Original goal changed | plan amendment via `./amend.sh <plan-slug>` |
+| Acceptance criteria changed | plan amendment |
+| Evidence exists for the current run | `.osc/runs/<run_id>/` or tracked evidence doc |
+| Product direction changed | `ROADMAP.md` update or roadmap amendment/PR |
+| Operational task status changed | task system / issue / coordinator comment |
+| Public code/docs changed | branch / PR / release note |
+| Follow-up work is needed | new plan in `.osc/plans/backlog/` or issue/task |
+| Runtime failed or was blocked | new run record or blocker note; do not rewrite the failed run |
+| Approval was weak | evidence receipt + next-slice caution |
+
+The rule: **promote the learning to the layer that will need it next**. Do not hide product corrections in chat. Do not turn every task comment into roadmap truth.
+
+## Next-slice inheritance
+
+A next slice should inherit only explicit durable facts:
+
+```yaml
+inherits_from:
+  previous_slice: docs-runtime-dispatch
+  previous_run: 20260512T090000Z-docs-runtime-dispatch
+  approval_status: weak_approved
+  carried_forward:
+    - "Runtime-specific binding examples still missing."
+    - "Need one complete PR-to-release dogfood example."
+  do_not_assume:
+    - "Weak approval means the UX language is product-grade."
+```
+
+If the previous slice was `weak_approved`, `rejected`, or `blocked`, the next slice must name the inherited caution or blocker. This prevents accidental laundering of weak evidence into strong product truth.
+
+## Close decision examples
+
+### Strong close
+
+```text
+Decision: approved
+Reason: all acceptance criteria passed, docs are linked from README and task/run model, verify.sh and osc verify passed, Codex review found no major issues.
+Next action: merge PR and add release note.
+```
+
+### Weak close
+
+```text
+Decision: weak_approved
+Reason: mechanical checks passed and the doc is usable, but no external user validated the terminology yet.
+Next action: create next slice for examples/user-facing quickstart; inherit terminology caution.
+```
+
+### Rejected
+
+```text
+Decision: rejected
+Reason: output explains runtime dispatch but accidentally makes Discord look canonical.
+Next action: amend plan with boundary correction and retry docs slice.
+```
+
+### Blocked
+
+```text
+Decision: blocked
+Reason: CI evidence cannot be inspected because the integration is unavailable.
+Next action: task owner wires CI access; do not close slice.
+```
+
+## Anti-patterns
+
+Avoid:
+
+- calling a slice closed because an agent said "done";
+- treating a runtime transcript as evidence without durable links;
+- merging weak approval into the next slice as if it were strong product validation;
+- rewriting a failed run instead of creating a retry;
+- burying corrections in chat or a private task board;
+- requiring one specific coordinator, chat surface, or runtime harness for closure;
+- treating `postflighted` as the same thing as `approved`.
+
+## Minimal manual template
+
+Copy this into a PR body, issue comment, or evidence file when no tooling exists yet:
+
+```markdown
+## Slice close
+
+- Plan/spec:
+- Task ID:
+- Run ID:
+- PR/branch:
+- Acceptance gate: pass | partial | fail | blocked
+- Verification:
+  - `command` -> result
+- Evidence:
+  - path/link
+- Known gaps:
+  - ...
+- Approval decision: approved | weak_approved | rejected | blocked
+- Rationale:
+- Correction routing:
+- Next-slice inheritance:
+```
+
+## Product implication
+
+Open Scaffold's job is not to make every run autonomous. Its job is to make semi-autonomous work auditable:
+
+```text
+Open Scaffold core = contract + evidence shape
+Coordinator = live state + dispatch choice
+Harness/agent = execution
+Operator surface = human visibility and decisions
+GitHub = public review and release
+Evidence receipt = proof and inheritance
+```

--- a/docs/TASK_RUN_MODEL.md
+++ b/docs/TASK_RUN_MODEL.md
@@ -40,7 +40,7 @@ One concrete execution attempt against a task or plan. In Open Scaffold core, a 
   prompts/
 ```
 
-A run can succeed, fail, block for a question, be cancelled, or be postflighted. A retry is a new run, not a rewrite of the old one.
+A run can succeed, fail, block for a question, be cancelled, or be postflighted. A retry is a new run, not a rewrite of the old one. Slice closure is a separate evidence-backed decision: a postflight can produce `approved`, `weak_approved`, `rejected`, or `blocked` outcomes as defined in [`docs/SLICE_CLOSE_PROTOCOL.md`](SLICE_CLOSE_PROTOCOL.md).
 
 ### `question_id`
 
@@ -166,6 +166,8 @@ created
 
 State transitions should be idempotent. A restarted coordinator may re-read the run store, repost current status, or re-bind a cockpit thread without duplicating terminal summaries, open questions, or completion reports.
 
+`postflighted` is not the same as `approved`. Postflight means the evidence was reviewed against acceptance criteria. The close decision may still be `approved`, `weak_approved`, `rejected`, or `blocked`; record that decision using the slice-close protocol.
+
 ## Executable package gate
 
 No harness should execute unbounded prose. A run package should contain:
@@ -206,6 +208,7 @@ Kanban/GitHub/CLI/chat creates or selects task_id
 - Runtime harness: execution while alive.
 - Operator surface: visibility/questions/approvals.
 - GitHub PR/release: versioned publication.
+- Evidence receipt / postflight: proof, approval strength, correction routing, and next-slice inheritance.
 - Evidence: proof of what happened.
 
 ## Anti-patterns


### PR DESCRIPTION
## Summary

- Adds `docs/SLICE_CLOSE_PROTOCOL.md`, a runtime-neutral protocol for evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance.
- Activates `.osc/plans/active/002-slice-close-evidence-loop.md` as the Milestone 2 product slice.
- Links the protocol from README, ROADMAP, `docs/TASK_RUN_MODEL.md`, `docs/OPEN_SCAFFOLD_SYSTEM.md`, and paired agent instruction views (`AGENTS.md` / `CLAUDE.md`).
- Keeps Open Scaffold core non-spawning and runtime-neutral: no private reference implementation machinery, no required Hermes/Kanban/Discord/OMC/OMX/Codex/Claude dependency.

## Product boundary

```text
Open Scaffold core = contract + evidence shape
Coordinator = live state + dispatch choice
Harness/agent = execution
Operator surface = human visibility and decisions
GitHub = public review and release
Evidence receipt = proof and inheritance
```

## Verification

- `./verify.sh --standard` → 4 pass / 0 fail / 0 warn
- `npm run osc -- verify` → passed
- `npm test` → 2 files / 6 tests passed
- `npm run build` → passed
- `git diff --cached --check` → passed before commit
- private leakage scan over changed files → no local path / Command Center path / obvious token hits

## Codex review

- Requested after PR open via `@codex review`.
