### PR TITLE
fix: address Codex verify feedback from PR #10

### DIFF
--- a/.osc/plans/active/011-codex-pr10-verify-feedback.md
+++ b/.osc/plans/active/011-codex-pr10-verify-feedback.md
@@ -1,0 +1,42 @@
+# Plan: codex-pr10-verify-feedback
+
+## Status
+
+active
+
+## Context
+
+Codex review on PR #10 arrived after merge and flagged two `verify.sh` bugs: GNU `stat -f %m` can return filesystem text instead of epoch mtime, and the immutability check failed to warn on the first post-create content edit. Daniel also corrected the process: wait at least two minutes for Codex before treating review as blocked/no-response.
+
+## Goal
+
+Patch PR #10 verification regressions and document the Codex wait-time process correction without changing Open Scaffold's runtime-neutral core boundary.
+
+## Constraints / Out of scope
+
+- Do not change release scope or retag unless explicitly needed.
+- Do not add GitHub-network-dependent validation to core in this hotfix.
+- Keep this as a small verification bugfix.
+
+## Files to touch
+
+- `verify.sh` — fix GNU/BSD stat fallback and immutability edit-count threshold.
+
+## Acceptance criteria
+
+- [ ] `verify.sh --strict` works on macOS/BSD and does not contain GNU-unsafe `stat -f %m` first ordering.
+- [ ] The plan immutability check warns on any post-create content-modifying commit while allowing pure renames/moves.
+- [ ] Standard verification, strict verification, CLI verification, tests, build, and whitespace checks pass.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected result: pass.
+2. Run `./verify.sh --strict`; expected result: pass with no warnings in current repo.
+3. Run `npm run osc -- verify`; expected result: pass.
+4. Run `npm test`; expected result: pass.
+5. Run `npm run build`; expected result: pass.
+6. Run `git diff --check`; expected result: pass.
+
+## Open questions
+
+- Should a future M7 validation slice add portable shell unit tests for `verify.sh` using fake `stat` implementations?

--- a/verify.sh
+++ b/verify.sh
@@ -200,8 +200,8 @@ if [ "$TIER" = "--strict" ]; then
         relpath=$(python3 -c "import os; print(os.path.relpath('$f', '$ROOT'))" 2>/dev/null || printf '%s' "$f" | sed "s|$ROOT/||")
         # Count commits that modified this file's content (renames/moves during close are allowed)
         commit_count=$(git -C "$ROOT" log --oneline --diff-filter=M --follow -- "$relpath" 2>/dev/null | wc -l | tr -d ' ')
-        if [ "$commit_count" -gt 1 ]; then
-          warn "Plan $basename was modified after initial commit ($commit_count commits)"
+        if [ "$commit_count" -gt 0 ]; then
+          warn "Plan $basename was modified after initial commit ($commit_count content-modifying commit(s))"
           IMMUTABLE_OK=false
         fi
       done
@@ -293,8 +293,11 @@ fi
     case "$basename" in
       README.md|WORKFLOW.md|handoff-template.md|*-amendment-*) continue ;;
     esac
-    # macOS/BSD stat first, GNU stat fallback
-    MTIME=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || printf '%s' "$NOW_EPOCH")
+    # GNU stat first, BSD/macOS stat fallback. GNU `stat -f %m` succeeds but returns filesystem text.
+    MTIME=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || printf '%s' "$NOW_EPOCH")
+    case "$MTIME" in
+      ''|*[!0-9]*) MTIME="$NOW_EPOCH" ;;
+    esac
     AGE_DAYS=$(( (NOW_EPOCH - MTIME) / 86400 ))
     if [ "$AGE_DAYS" -gt "$STALE_DAYS" ]; then
       warn "Active plan $basename has not changed for $AGE_DAYS days (threshold $STALE_DAYS)"


### PR DESCRIPTION
## Summary
- Fixes PR #10 Codex feedback on `verify.sh`.
- Uses GNU `stat -c %Y` before BSD `stat -f %m`, because GNU `stat -f %m` can succeed while returning filesystem text.
- Makes the immutability check warn on any content-modifying commit after creation while still allowing pure rename/move closes.
- Adds an active trace plan for this hotfix.

## Traceability
- Source review: PR #10 Codex comments
- Plan: `.osc/plans/active/011-codex-pr10-verify-feedback.md`

## Verification
- [x] `./verify.sh --standard`
- [x] `./verify.sh --strict`
- [x] `npm run osc -- verify`
- [x] `npm test`
- [x] `npm run build`
- [x] `git diff --check`

## Codex review
- Will trigger with `@codex review` and wait/poll at least 2 minutes before taking next action.
