### PR TITLE
fix: align Node engine range with toolchain support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20.19.0"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.17.10",


### PR DESCRIPTION
## Summary
- Tightens the root Node engine range so it no longer advertises unsupported Node 21/23 runtimes.
- Matches the effective Vitest/Vite engine intersection: Node 20.19+, Node 22.12+, or Node 24+.

## Verification
- [x] npm ci
- [x] npm run build
- [x] npm test
- [x] ./verify.sh --strict
- [x] npm audit
- [x] git diff --check

Codex feedback follow-up from #12.
