### PR TITLE
docs: add native runtime exploration to roadmap

### DIFF
--- a/.osc/plans/backlog/017-runtime-strategy-native-runtime-exploration.md
+++ b/.osc/plans/backlog/017-runtime-strategy-native-runtime-exploration.md
@@ -1,0 +1,84 @@
+# Plan: runtime-strategy-native-runtime-exploration
+
+## Status
+
+backlog
+
+## Context
+
+Open Scaffold currently presents itself as a runtime-neutral launch checklist, dispatch contract, and black-box recorder. That boundary is useful, but it may also dilute the product if users expect the system to initiate or supervise actual agent work. This plan captures the unresolved strategic question: should Open Scaffold stay non-spawning, add a thin opt-in spawner, or eventually grow a native runtime as a separate governed layer?
+
+## Goal
+
+Produce a decision-grade runtime strategy that says whether Open Scaffold should remain non-spawning, add thin adapter invocation, move spawning into adapter packages, or explore a native runtime product.
+
+## Constraints / Out of scope
+
+- Do not implement real autonomous runtime spawning in this discovery slice.
+- Do not add Claude/Codex/OpenCode/Hermes/OMC/OMX-specific dependencies to core during discovery.
+- Do not weaken the current safety boundary without an explicit decision record.
+- Do not treat a thin spawner and a native runtime as the same product choice.
+- Do not overfit the answer to Daniel's local Command Center setup; public Open Scaffold users must be considered.
+
+## Files to touch
+
+- `ROADMAP.md` — keep the runtime strategy question visible as a product milestone.
+- `MISSION.md` — clarify current non-spawning stance while acknowledging explicit long-term exploration.
+- `docs/SPAWNING_BOUNDARY.md` — likely new decision/discovery note for thin `osc spawn` versus native runtime.
+- `docs/RUNTIME_BINDING_CONTRACT.md` — update only if the discovery changes the contract language.
+- `docs/OPEN_SCAFFOLD_SYSTEM.md` — update only if the system ontology gains a runtime layer.
+- `docs/decisions/README.md` or a future ADR file — record the final decision and rationale.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Product vision analysis: what runtime ownership would add beyond launch checklist / dispatch contract / black-box recorder | None | A |
+| T2 | Technology and market scan: compare agent runtimes, coding-agent CLIs, workflow engines, CI runners, task orchestrators, and evidence/audit systems | None | A |
+| T3 | Architecture options: no-spawn, thin `osc spawn`, adapter packages, sibling runtime product, hosted coordinator, native runtime | T1, T2 | B |
+| T4 | Safety/governance model: credentials, env allowlists, workspace isolation, process supervision, commit authority, audit trail, failure states | T1, T2 | B |
+| T5 | Recommendation and decision record: choose what to build now, what to defer, and what not to do | T3, T4 | C |
+| T6 | Roadmap update: convert the chosen direction into concrete follow-up slices with acceptance criteria | T5 | D |
+
+### Parallel groups
+
+- **Group A**: product vision and external technology scan can run independently.
+- **Group B**: architecture and safety can run in parallel after the first analysis pass.
+- **Group C/D**: recommendation and roadmap updates must wait for evidence.
+
+### Dependencies
+
+- Do not write a final decision before T1–T4 have explicit evidence.
+- Do not prototype a real spawner before the safety model is written.
+
+### Delegation notes
+
+- This is suitable for multi-agent research: one product strategist, one runtime/architecture reviewer, one safety/governance reviewer, and one skeptical critic.
+- Ask reviewers to challenge whether native runtime ownership would strengthen or confuse Open Scaffold's identity.
+
+## Acceptance criteria
+
+- [ ] The discovery compares at least five relevant external systems or product categories, not just Open Scaffold internals.
+- [ ] The final recommendation distinguishes clearly between no-spawn, thin local adapter invocation, official adapter packages, and native runtime ownership.
+- [ ] Safety/governance requirements are explicit: credentials, env allowlists, workspace isolation, process lifecycle, audit logs, commit/push/merge authority, and failure states.
+- [ ] The recommendation states what Open Scaffold wants to be in one sentence.
+- [ ] If thin `osc spawn` is recommended, its first implementation slice is limited to fake/local adapters and dispatch receipts.
+- [ ] If native runtime exploration remains open, the roadmap captures it as an explicit research/product track, not accidental scope creep.
+- [ ] Public docs continue to state honestly what exists today versus what is future exploration.
+
+## Verification steps
+
+1. Run `./verify.sh --strict`; expected pass.
+2. Run `git diff --check`; expected clean.
+3. Review `MISSION.md`, `ROADMAP.md`, and any decision docs together; expected no contradiction between current non-spawning boundary and long-term runtime exploration.
+4. Ask a skeptical reviewer whether the recommendation over-expands Open Scaffold; expected critique is addressed or captured as an open question.
+
+## Open questions
+
+- Is Open Scaffold's strongest identity the repo-native protocol/black-box recorder, or does it need a runtime to become a product rather than methodology?
+- Should `osc spawn` be a core command, an official plugin/package, or only an example adapter pattern?
+- Would native runtime ownership compete with or complement Hermes, OMC, OMX, Claude Code, Codex, OpenCode, and GitHub Actions?
+- What minimum supervision features would make a native runtime meaningfully different from shelling out to existing CLIs?
+- Should an Open Scaffold Runtime be a sibling product that consumes `.osc` packets rather than part of core?

--- a/MISSION.md
+++ b/MISSION.md
@@ -9,13 +9,14 @@ Open Scaffold is a runtime-neutral, repo-native operating system for agent-orche
 - Define clear integration boundaries between orchestrators, runtime harnesses, operator surfaces, repository truth, and GitHub issue/PR workflows.
 - Productize the closed evolutionary loop: slice work, capture feedback, amend plans, verify against acceptance criteria, and feed learnings into the next slice.
 - Ship a Discord glass-cockpit pattern for private control rooms, team control rooms, and build-in-public workflows while keeping durable truth in the repo/GitHub/task system.
+- Investigate whether Open Scaffold should remain a runtime-neutral launch checklist/dispatch contract/black-box recorder, add a thin opt-in spawner, or eventually grow a native runtime as a separate explicitly-governed product layer.
 - Dogfood Open Scaffold on Open Scaffold itself: use the framework to grow the framework.
 
 ## Non-Goals
 
 Explicit things this project is NOT trying to do. Legitimate scope discipline starts here. When new information arrives that would change what belongs in this list, follow the amendment protocol in `.osc/plans/README.md` — do not silently edit the list.
 
-- Open Scaffold core does not own autonomous agent spawning or long-running execution loops.
+- Open Scaffold core does not own autonomous agent spawning or long-running execution loops today; any move toward thin spawning or a native runtime requires explicit roadmap investigation, architectural decision records, security analysis, and separate approval rather than accidental scope creep.
 - Open Scaffold core does not make Discord, Slack, Telegram, or any chat surface the source of truth.
 - Open Scaffold core does not require Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, OMC, OMX, or any other specific runtime.
 - Open Scaffold core does not treat OMC/OMX as equivalent to orchestrator agents: OMC is a Claude Code workflow harness; OMX is a Codex workflow/execution harness.
@@ -27,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-13: added native runtime / thin spawner exploration as an explicit long-term roadmap question rather than an accidental core scope change
 - 2026-05-12: closed 013-binding-example
 - 2026-05-12: closed 012-independent-review-hardening — independent review hardening shipped: quick/standard/strict tier behavior corrected, vitest upgraded to clear npm audit, OMC/OMX runtime state ignored, verification clean
 - 2026-05-12: closed 011-codex-pr10-verify-feedback — PR #11 merged; verification hotfix accepted, strict/standard/CLI/test/build checks passing before post-v0.3 review roadmap work

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -307,6 +307,42 @@ Deliverables:
 - Remove or generalize private/Daniel-specific context in public docs.
 - State honestly what exists today versus what is adapter/backlog work.
 
+### Milestone 16 — Runtime strategy and native-runtime exploration
+
+Status: backlog via `.osc/plans/backlog/017-runtime-strategy-native-runtime-exploration.md`.
+
+Goal: decide, with evidence, whether Open Scaffold should remain a runtime-neutral launch checklist/dispatch contract/black-box recorder, add a thin opt-in `osc spawn` adapter invoker, or eventually grow a native runtime as a distinct product layer.
+
+Current stance:
+
+- Open Scaffold core does **not** currently provide an autonomous agent runtime.
+- That boundary is intentional today, but not sacred forever.
+- A thin `osc spawn` command or native runtime must not be added by drift; it needs explicit investigation, architecture, security analysis, competitive review, and product-vision work.
+
+Discovery tracks:
+
+1. **Product vision** — what would a native runtime make possible that a launch checklist and adapter contract cannot?
+2. **Architecture** — whether runtime concerns belong in core, optional packages, adapter repos, or a sibling runtime product.
+3. **Technology scan** — compare relevant agent runtimes, coding-agent CLIs, task orchestrators, workflow engines, CI runners, and black-box/evidence systems.
+4. **Safety/governance** — credential boundaries, environment allowlists, process supervision, workspace isolation, commit/push/merge authority, audit trails, and failure states.
+5. **MVP options** — no-spawn, thin `osc spawn`, adapter package, local daemon, hosted coordinator, or full native runtime.
+6. **Adoption impact** — whether spawning makes Open Scaffold meaningfully easier to try, or whether it confuses the runtime-neutral promise.
+
+Candidate outcomes:
+
+- Keep core non-spawning and improve docs/examples only.
+- Add an explicit thin `osc spawn --adapter <name>` that invokes configured local commands and records dispatch receipts.
+- Move runtime launching into official adapter packages such as `open-scaffold-omx` / `open-scaffold-omc`.
+- Create a separate Open Scaffold Runtime product that consumes `.osc` packets without bloating core.
+- Decide that native runtime ownership is strategically wrong and document why.
+
+Acceptance direction:
+
+- No implementation before a written decision.
+- No hidden runtime/provider coupling in core.
+- Any prototype starts with a fake/local adapter and dispatch receipt, not real autonomous mutation.
+- The final decision must state what Open Scaffold wants to be in one sentence.
+
 ## Parking lot
 
 - MCP bridge for structured harness dispatch/status/artifact retrieval.


### PR DESCRIPTION
## Summary
- Adds native runtime / thin spawner exploration as an explicit long-term product question in `MISSION.md`.
- Adds Roadmap Milestone 16 for runtime strategy and native-runtime exploration.
- Adds backlog plan `.osc/plans/backlog/017-runtime-strategy-native-runtime-exploration.md` to structure the discovery work before any implementation.

## Why
Open Scaffold currently does not provide an agent runtime. That boundary is useful, but the roadmap should explicitly investigate whether the project should stay a runtime-neutral launch checklist/dispatch contract/black-box recorder, add a thin opt-in `osc spawn`, move spawning into adapter packages, or eventually grow a separate native runtime product.

This PR does not implement spawning. It prevents accidental scope creep by making the decision explicit.

## Test plan
- [x] `npm test`
- [x] `npm run build`
- [x] `./verify.sh --strict`
- [x] `git diff --check`

Codex review: pending / to be triggered with `@codex review`.