### PR TITLE
docs: update Open Scaffold repository owner

### DIFF
--- a/.osc/releases/2026-05-12-binding-example.md
+++ b/.osc/releases/2026-05-12-binding-example.md
@@ -10,7 +10,7 @@ The example validates the generated run packet, prints the handoff summary an ex
 
 - Roadmap milestone: `ROADMAP.md` → Milestone 12 — Minimal runtime binding example.
 - Plan: `.osc/plans/active/013-binding-example.md` before close; `.osc/plans/done/013-binding-example.md` after close.
-- Pull Request: PR #14 — https://github.com/jeanclaudevibedan/open-scaffold/pull/14.
+- Pull Request: PR #14 — https://github.com/graphanov/open-scaffold/pull/14.
 - RALPLAN run packet: `.osc/runs/20260512T211904Z-013-binding-example-run/run.json`.
 - ULTRAWORK run packet: `.osc/runs/20260512T213342Z-013-binding-example-run/run.json`.
 - Public docs:

--- a/.osc/releases/2026-05-12-self-dogfood-release-loop.md
+++ b/.osc/releases/2026-05-12-self-dogfood-release-loop.md
@@ -21,7 +21,7 @@ ROADMAP.md Milestone 6 — Self-dogfood release loop
 
 ## Work item
 
-- Issue: https://github.com/jeanclaudevibedan/open-scaffold/issues/8
+- Issue: https://github.com/graphanov/open-scaffold/issues/8
 - Task ID: `issue:8`
 - Plan: `.osc/plans/done/005-self-dogfood-release-loop.md`
 - Run ID: `20260512T135850Z-005-self-dogfood-release-loop-run`
@@ -30,7 +30,7 @@ ROADMAP.md Milestone 6 — Self-dogfood release loop
 - Harness skill: `none`
 - Operator surface: `github`
 - Branch: `docs/self-dogfood-release-loop`
-- PR: https://github.com/jeanclaudevibedan/open-scaffold/pull/9
+- PR: https://github.com/graphanov/open-scaffold/pull/9
 
 ## Run packet summary
 

--- a/.osc/releases/2026-05-12-v0.3.0-runtime-neutral-baseline.md
+++ b/.osc/releases/2026-05-12-v0.3.0-runtime-neutral-baseline.md
@@ -24,7 +24,7 @@ Date: 2026-05-12
 - Issue #8 / PR #9: Self-dogfood proof chain.
 - PR #10: v2 roadmap/stale-state/release baseline.
 - Tag: `v0.3.0`.
-- GitHub Release: https://github.com/jeanclaudevibedan/open-scaffold/releases/tag/v0.3.0
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.3.0
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 # Agent Instructions
 
-This project is [open-scaffold](https://github.com/jeanclaudevibedan/open-scaffold), a runtime-neutral repo-native operating system for agent-orchestrated development. It ships with a persistent project structure — mission, roadmap, immutable plans, amendment protocols, decisions, evidence, run packets, and session handover practices — so that any agent or orchestrator (Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, or similar) can operate in the repository from commit #1 without re-explanation.
+This project is [open-scaffold](https://github.com/graphanov/open-scaffold), a runtime-neutral repo-native operating system for agent-orchestrated development. It ships with a persistent project structure — mission, roadmap, immutable plans, amendment protocols, decisions, evidence, run packets, and session handover practices — so that any agent or orchestrator (Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, or similar) can operate in the repository from commit #1 without re-explanation.
 
 ## Layered architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 # Project Context
 
-This project is [open-scaffold](https://github.com/jeanclaudevibedan/open-scaffold), a runtime-neutral repo-native operating system for agent-orchestrated development. It ships with a persistent project structure — mission, roadmap, immutable plans, amendment protocols, decisions, evidence, run packets, and session handover practices — so that any agent or orchestrator can operate in this repository from commit #1 without re-explanation. Read this file first, then consult `MISSION.md` for what the project actually is.
+This project is [open-scaffold](https://github.com/graphanov/open-scaffold), a runtime-neutral repo-native operating system for agent-orchestrated development. It ships with a persistent project structure — mission, roadmap, immutable plans, amendment protocols, decisions, evidence, run packets, and session handover practices — so that any agent or orchestrator can operate in this repository from commit #1 without re-explanation. Read this file first, then consult `MISSION.md` for what the project actually is.
 
 ## Layered architecture
 

--- a/LLM_QUICKSTART.md
+++ b/LLM_QUICKSTART.md
@@ -1,6 +1,6 @@
 # LLM Quickstart — open-scaffold
 
-You are an LLM helping a human bootstrap a new project from the [open-scaffold](https://github.com/jeanclaudevibedan/open-scaffold) template. Walk the human through the steps below interactively — confirm each step with them before proceeding to the next.
+You are an LLM helping a human bootstrap a new project from the [open-scaffold](https://github.com/graphanov/open-scaffold) template. Walk the human through the steps below interactively — confirm each step with them before proceeding to the next.
 
 ## Capability check
 
@@ -18,14 +18,14 @@ State which mode you're in before step 1.
 Then run (replacing `<name>` with the project name you just collected — not the literal string `open-scaffold`):
 
 ```bash
-gh repo create <name> --template jeanclaudevibedan/open-scaffold --clone
+gh repo create <name> --template graphanov/open-scaffold --clone
 cd <name>
 ```
 
 Fallback if `gh` is unavailable:
 
 ```bash
-git clone https://github.com/jeanclaudevibedan/open-scaffold <name>
+git clone https://github.com/graphanov/open-scaffold <name>
 cd <name>
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **A repo-native operating system for agent-orchestrated development.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-black.svg)](LICENSE)
-[![Template](https://img.shields.io/badge/GitHub-Template-blue.svg)](https://github.com/jeanclaudevibedan/open-scaffold/generate)
+[![Template](https://img.shields.io/badge/GitHub-Template-blue.svg)](https://github.com/graphanov/open-scaffold/generate)
 [![Works with](https://img.shields.io/badge/Works%20with-Any%20agent-green.svg)](#-recommended-runtimes)
 [![Built with](https://img.shields.io/badge/Built%20with-itself-ff69b4.svg)](#-dogfooded)
 
@@ -105,7 +105,7 @@ Each phase maps to a concrete file or command. Full phase-to-tool cheat sheet li
 > Paste this one-liner into any LLM — coding agent (Claude Code, Cursor, Codex CLI) or chat LLM (ChatGPT, Claude.ai, Gemini web). The agent clones the template, opens [`LLM_QUICKSTART.md`](LLM_QUICKSTART.md) from inside the clone, detects its own capability, and walks you through bootstrap → verify → handoff.
 >
 > ```text
-> Clone https://github.com/jeanclaudevibedan/open-scaffold into a new project directory, then open LLM_QUICKSTART.md from inside the clone and walk me through it.
+> Clone https://github.com/graphanov/open-scaffold into a new project directory, then open LLM_QUICKSTART.md from inside the clone and walk me through it.
 > ```
 >
 > **Prefer to drive it yourself?** The manual steps below do the same thing by hand. ⬇️
@@ -115,7 +115,7 @@ Each phase maps to a concrete file or command. Full phase-to-tool cheat sheet li
 ### 1. Create your project from the template
 
 ```bash
-gh repo create <your-project> --template jeanclaudevibedan/open-scaffold --clone
+gh repo create <your-project> --template graphanov/open-scaffold --clone
 cd <your-project>
 ```
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -12,7 +12,7 @@ This page uses precise language:
 
 For the full taxonomy, see [`docs/OPEN_SCAFFOLD_SYSTEM.md`](OPEN_SCAFFOLD_SYSTEM.md).
 
-## Generic core: `jeanclaudevibedan/open-scaffold`
+## Generic core: `graphanov/open-scaffold`
 
 Namespace: `.osc/`
 CLI: `osc`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -64,7 +64,7 @@ Questions that didn't make the cut for the main README but are still worth answe
 
 ### Who built this?
 
-> [@jeanclaudevibedan](https://github.com/jeanclaudevibedan). Scoped, planned, implemented, reviewed, and shipped using the scaffold's own methodology.
+> [@graphanov](https://github.com/graphanov). Scoped, planned, implemented, reviewed, and shipped using the scaffold's own methodology.
 
 ### Is it production-ready, or a toy?
 


### PR DESCRIPTION
## Summary
- Updates canonical Open Scaffold repository references from `jeanclaudevibedan/open-scaffold` to `graphanov/open-scaffold` after the GitHub username/repo ownership transfer.
- Updates template-generation and clone commands in README/LLM quickstart.
- Updates root agent instruction links and public release/evidence references.
- Leaves adapter repository links unchanged because `open-scaffold-omc` and `open-scaffold-omx` still resolve under `jeanclaudevibedan`.

## Verification
- [x] `git diff --check`
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- [x] `npm test` — 4 files, 13 tests passed
- [x] `npm run build`
- [x] scanned for stale `jeanclaudevibedan/open-scaffold` core references; only adapter repo references remain under the old owner.

## Codex review
- [ ] `@codex review` triggered
