### PR TITLE
Add external review ingest backlog plans

### DIFF
--- a/.osc/plans/backlog/018-readme-compression.md
+++ b/.osc/plans/backlog/018-readme-compression.md
@@ -1,0 +1,43 @@
+# Plan: 018-readme-compression
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified "README compression to ≤6 KB" as a high-impact improvement. This draft is a review-ingest artifact only; move to `active/` only after the owner accepts the slice.
+
+## Goal
+
+Compress the README first-touch path to no more than 6 KiB while preserving links to deeper protocol docs.
+
+## Constraints / Out of scope
+
+- Do not edit `MISSION.md` in this slice.
+- Do not edit committed plans in `.osc/plans/done/`.
+- Do not change the product strategy beyond the owner-approved scope for this slice.
+- Keep private Daniel Command Center context out of public product docs.
+
+## Files to touch
+
+- `README.md` — compress first-touch content and link to deeper docs.
+- `docs/FAQ.md` or existing docs — receive displaced deep content if needed.
+
+## Acceptance criteria
+
+- [ ] `wc -c README.md` prints a value less than or equal to `6144`.
+- [ ] README includes a one-sentence statement of what Open Scaffold is.
+- [ ] README links to deeper docs for workflow/protocol details instead of deleting them silently.
+- [ ] `./verify.sh --standard` exits 0.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Re-run the command(s) named in the acceptance criteria; expected each mechanical threshold is met.
+4. Confirm `git status --short` contains no edits to `MISSION.md`, `.osc/plans/active/`, or `.osc/plans/done/` unless separately owner-approved.
+
+## Open questions
+
+- Which owner-approved differentiator sentence should the compressed README use?

--- a/.osc/plans/backlog/019-comparison-page.md
+++ b/.osc/plans/backlog/019-comparison-page.md
@@ -1,0 +1,43 @@
+# Plan: 019-comparison-page
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified "Comparison page for spec-kit / BMAD / Agent OS" as a high-impact improvement. This draft is a review-ingest artifact only; move to `active/` only after the owner accepts the slice.
+
+## Goal
+
+Add an honest comparison page that helps readers choose Open Scaffold or an alternative without overclaiming.
+
+## Constraints / Out of scope
+
+- Do not edit `MISSION.md` in this slice.
+- Do not edit committed plans in `.osc/plans/done/`.
+- Do not change the product strategy beyond the owner-approved scope for this slice.
+- Keep private Daniel Command Center context out of public product docs.
+
+## Files to touch
+
+- `docs/COMPARISON.md` — new comparison page.
+- `README.md` — link to comparison page only if owner approves README touch in the execution slice.
+
+## Acceptance criteria
+
+- [ ] `docs/COMPARISON.md` contains sections for spec-kit, BMAD, Agent OS, and Open Scaffold.
+- [ ] Each compared project has at least one "use this when" and one "do not use this when" bullet.
+- [ ] The page states at least one Open Scaffold differentiator as `[OWNER DECISION REQUIRED]` if not yet decided.
+- [ ] `./verify.sh --standard` exits 0.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Re-run the command(s) named in the acceptance criteria; expected each mechanical threshold is met.
+4. Confirm `git status --short` contains no edits to `MISSION.md`, `.osc/plans/active/`, or `.osc/plans/done/` unless separately owner-approved.
+
+## Open questions
+
+- What exact differentiator should be treated as owner-approved?

--- a/.osc/plans/backlog/020-reference-truth-audit.md
+++ b/.osc/plans/backlog/020-reference-truth-audit.md
@@ -1,0 +1,44 @@
+# Plan: 020-reference-truth-audit
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified "Truth-label public references to private/future tools" as a high-impact improvement. This draft is a review-ingest artifact only; move to `active/` only after the owner accepts the slice.
+
+## Goal
+
+Audit public docs for Hermes, Claw/OpenClaw, clawhip, OMC, OMX, and adapter references, then label each as linked, private, future, or removed.
+
+## Constraints / Out of scope
+
+- Do not edit `MISSION.md` in this slice.
+- Do not edit committed plans in `.osc/plans/done/`.
+- Do not change the product strategy beyond the owner-approved scope for this slice.
+- Keep private Daniel Command Center context out of public product docs.
+
+## Files to touch
+
+- `README.md` — likely first-touch reference cleanup.
+- `docs/*.md` — public docs with tool references.
+- `docs/decisions/README.md` — design rationale links if stale.
+
+## Acceptance criteria
+
+- [ ] A search for `Hermes|Claw|OpenClaw|clawhip|OMC|OMX` in public docs has no unqualified private/future references.
+- [ ] Every remaining private or unavailable tool reference is labeled as private, future, conceptual, or linked to a public repository.
+- [ ] No `.osc-dev/` private decision text is copied into public docs.
+- [ ] `./verify.sh --standard` exits 0.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Re-run the command(s) named in the acceptance criteria; expected each mechanical threshold is met.
+4. Confirm `git status --short` contains no edits to `MISSION.md`, `.osc/plans/active/`, or `.osc/plans/done/` unless separately owner-approved.
+
+## Open questions
+
+- Should private Hermes/Claw references be removed from first-touch docs or kept as dogfood examples with labels?

--- a/.osc/plans/backlog/021-identity-rename-audit.md
+++ b/.osc/plans/backlog/021-identity-rename-audit.md
@@ -1,0 +1,45 @@
+# Plan: 021-identity-rename-audit
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified "Resolve public identity drift" as a high-impact improvement. This draft is a review-ingest artifact only; move to `active/` only after the owner accepts the slice.
+
+## Goal
+
+Eliminate stale `jeanclaudevibedan` public references or mark intentional redirects so the canonical owner path is clear.
+
+## Constraints / Out of scope
+
+- Do not edit `MISSION.md` in this slice.
+- Do not edit committed plans in `.osc/plans/done/`.
+- Do not change the product strategy beyond the owner-approved scope for this slice.
+- Keep private Daniel Command Center context out of public product docs.
+
+## Files to touch
+
+- `README.md` — badges/links if stale.
+- `docs/FAQ.md` — stale owner links if present.
+- `docs/ROACH_PI_INSPIRATION.md` — stale owner links if present.
+- `docs/decisions/README.md` — current stale adapter links.
+
+## Acceptance criteria
+
+- [ ] `grep -R "jeanclaudevibedan" README.md docs AGENTS.md CLAUDE.md package.json .github` returns no stale public owner URLs, or only explicit redirect notes.
+- [ ] Canonical Open Scaffold repository references use `graphanov/open-scaffold`.
+- [ ] OMC/OMX adapter references either use canonical URLs or are labeled as historical/unmigrated.
+- [ ] `./verify.sh --standard` exits 0.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Re-run the command(s) named in the acceptance criteria; expected each mechanical threshold is met.
+4. Confirm `git status --short` contains no edits to `MISSION.md`, `.osc/plans/active/`, or `.osc/plans/done/` unless separately owner-approved.
+
+## Open questions
+
+- Are adapter repos being renamed under `graphanov`, or should docs retain old URLs as historical until the migration happens?

--- a/.osc/plans/backlog/022-sixty-second-demo.md
+++ b/.osc/plans/backlog/022-sixty-second-demo.md
@@ -1,0 +1,44 @@
+# Plan: 022-sixty-second-demo
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified "Add 60-second demo artifact" as a high-impact improvement. This draft is a review-ingest artifact only; move to `active/` only after the owner accepts the slice.
+
+## Goal
+
+Add a short demo path that shows what a user gets without reading the full methodology.
+
+## Constraints / Out of scope
+
+- Do not edit `MISSION.md` in this slice.
+- Do not edit committed plans in `.osc/plans/done/`.
+- Do not change the product strategy beyond the owner-approved scope for this slice.
+- Keep private Daniel Command Center context out of public product docs.
+
+## Files to touch
+
+- `README.md` — link/embed the demo.
+- `docs/QUICKSTART.md` or `docs/EXAMPLES.md` — demo script or screenshot strip.
+- `assets/` or docs image path — optional screenshot/asciinema asset.
+
+## Acceptance criteria
+
+- [ ] A demo artifact exists and is linked from README.
+- [ ] A fresh reader can see mission file, plan file, verification command, and resulting status/evidence within the demo.
+- [ ] The demo path can be completed in under 60 seconds when followed as a viewer, measured by script length or recording duration.
+- [ ] `./verify.sh --standard` exits 0.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Re-run the command(s) named in the acceptance criteria; expected each mechanical threshold is met.
+4. Confirm `git status --short` contains no edits to `MISSION.md`, `.osc/plans/active/`, or `.osc/plans/done/` unless separately owner-approved.
+
+## Open questions
+
+- Should the first demo be asciinema, screenshots, or a text-only scripted transcript?

--- a/.osc/plans/backlog/023-worked-downstream-example.md
+++ b/.osc/plans/backlog/023-worked-downstream-example.md
@@ -1,0 +1,44 @@
+# Plan: 023-worked-downstream-example
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified "Worked non-framework example" as a high-impact improvement. This draft is a review-ingest artifact only; move to `active/` only after the owner accepts the slice.
+
+## Goal
+
+Create one small, public-safe worked example that demonstrates Open Scaffold on non-framework work.
+
+## Constraints / Out of scope
+
+- Do not edit `MISSION.md` in this slice.
+- Do not edit committed plans in `.osc/plans/done/`.
+- Do not change the product strategy beyond the owner-approved scope for this slice.
+- Keep private Daniel Command Center context out of public product docs.
+
+## Files to touch
+
+- `docs/EXAMPLES.md` — example index/walkthrough.
+- `examples/` or external repo link — worked example artifacts.
+- `.osc/plans/backlog/014-downstream-example-project.md` — reference existing roadmap context, not edit.
+
+## Acceptance criteria
+
+- [ ] The example is not Open Scaffold improving Open Scaffold.
+- [ ] The example includes mission, plan, run/evidence or verification, and close/summary artifacts.
+- [ ] The example can be followed from a clean checkout without private Daniel Command Center dependencies.
+- [ ] `./verify.sh --standard` exits 0.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Re-run the command(s) named in the acceptance criteria; expected each mechanical threshold is met.
+4. Confirm `git status --short` contains no edits to `MISSION.md`, `.osc/plans/active/`, or `.osc/plans/done/` unless separately owner-approved.
+
+## Open questions
+
+- Should this start as an in-repo fixture, docs-only walkthrough, or separate public repo?

--- a/.osc/plans/backlog/024-roadmap-scope-discipline.md
+++ b/.osc/plans/backlog/024-roadmap-scope-discipline.md
@@ -1,0 +1,44 @@
+# Plan: 024-roadmap-scope-discipline
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified "Roadmap scope discipline draft" as a high-impact improvement. This draft is a review-ingest artifact only; move to `active/` only after the owner accepts the slice.
+
+## Goal
+
+Prepare owner-reviewed roadmap changes that defer compliance-grade OS/hashgraph exploration from the public near-term roadmap.
+
+## Constraints / Out of scope
+
+- Do not edit `MISSION.md` in this slice.
+- Do not edit committed plans in `.osc/plans/done/`.
+- Do not change the product strategy beyond the owner-approved scope for this slice.
+- Keep private Daniel Command Center context out of public product docs.
+
+## Files to touch
+
+- `ROADMAP.md` — target of a future owner-approved patch, not modified by this draft.
+- `.osc/research/2026-05-14-roadmap-amendment-draft.md` — proposed diff text.
+- `docs/FUTURE_IDEAS.md` or `.osc-dev/research/` — optional parking lot if owner wants preservation.
+
+## Acceptance criteria
+
+- [ ] Roadmap draft marks compliance-grade agentic OS/hashgraph exploration as deferred, not silently deleted.
+- [ ] Roadmap draft includes a concise rationale referencing external-review-ingest.
+- [ ] Roadmap draft caps publicly visible planned milestones to no more than five ahead.
+- [ ] `./verify.sh --standard` exits 0 before any future roadmap edit is proposed for merge.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Re-run the command(s) named in the acceptance criteria; expected each mechanical threshold is met.
+4. Confirm `git status --short` contains no edits to `MISSION.md`, `.osc/plans/active/`, or `.osc/plans/done/` unless separately owner-approved.
+
+## Open questions
+
+- Hard-delete the exploration from public roadmap, or preserve as private `.osc-dev` research / future ideas?

--- a/.osc/plans/backlog/025-minimum-viable-scaffold.md
+++ b/.osc/plans/backlog/025-minimum-viable-scaffold.md
@@ -1,0 +1,44 @@
+# Plan: 025-minimum-viable-scaffold
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified "Minimum viable scaffold definition" as a high-impact improvement. This draft is a review-ingest artifact only; move to `active/` only after the owner accepts the slice.
+
+## Goal
+
+Define which Open Scaffold files/concepts are core for first use and which are optional/deep-cut.
+
+## Constraints / Out of scope
+
+- Do not edit `MISSION.md` in this slice.
+- Do not edit committed plans in `.osc/plans/done/`.
+- Do not change the product strategy beyond the owner-approved scope for this slice.
+- Keep private Daniel Command Center context out of public product docs.
+
+## Files to touch
+
+- `docs/MINIMUM_VIABLE_SCAFFOLD.md` — new core vs optional guide.
+- `README.md` — optional link to the guide.
+- `docs/WORKFLOW.md` — optional alignment if owner approves.
+
+## Acceptance criteria
+
+- [ ] A core/optional table lists every root-level scaffold artifact and every `.osc/` required directory.
+- [ ] The guide identifies a smallest viable adoption path with no more than five required steps.
+- [ ] Optional protocols are explicitly labeled optional, advanced, or adapter-specific.
+- [ ] `./verify.sh --standard` exits 0.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Re-run the command(s) named in the acceptance criteria; expected each mechanical threshold is met.
+4. Confirm `git status --short` contains no edits to `MISSION.md`, `.osc/plans/active/`, or `.osc/plans/done/` unless separately owner-approved.
+
+## Open questions
+
+- Should the minimum viable path optimize for solo devs, small teams, or orchestrator-led teams?

--- a/.osc/plans/backlog/026-vocabulary-compression.md
+++ b/.osc/plans/backlog/026-vocabulary-compression.md
@@ -1,0 +1,50 @@
+# Plan: 026-vocabulary-compression
+
+## Status
+
+backlog
+
+## Context
+
+The 2026-05-14 external review identified vocabulary inflation as an adoption tax. After the owner filled ADR 0001, lightweight external adoption for solo developers and small teams is the explicit direction, so a vocabulary compression pass is now aligned with product strategy.
+
+## Goal
+
+Make first-touch Open Scaffold docs understandable with plain-language aliases while preserving precise terms where they remain useful in deeper protocol docs.
+
+## Constraints / Out of scope
+
+- Do not delete load-bearing protocol terms without owner approval.
+- Do not rewrite the whole methodology in this slice.
+- Do not edit `MISSION.md` directly.
+- Do not change runtime boundaries or product strategy while compressing vocabulary.
+- Keep the regulated/auditable traceability promise intact while reducing jargon.
+
+## Files to touch
+
+- `README.md` — use plain-language first-touch vocabulary.
+- `docs/FAQ.md` — align adoption-facing explanations if needed.
+- `docs/GLASS_COCKPIT_PROTOCOL.md` — add alias wording only if owner approves touching deep docs.
+- `docs/SLICE_CLOSE_PROTOCOL.md` — add alias wording only if owner approves touching deep docs.
+- `docs/RUNTIME_BINDING_CONTRACT.md` — add alias wording only if owner approves touching deep docs.
+- `docs/OPEN_SCAFFOLD_SYSTEM.md` — maintain precise ontology while adding newcomer-friendly aliases if needed.
+
+## Acceptance criteria
+
+- [ ] README introduces no more than 10 Open Scaffold-specific terms before the first Quickstart section, measured by a documented term list in the PR or evidence note.
+- [ ] Each retained specialized term in README has a plain-language alias on first use.
+- [ ] Deep protocol docs keep canonical terms but add a plain-language alias on first use for `glass cockpit`, `slice close`, `runtime binding`, `operator surface`, and `run packet` if those terms appear.
+- [ ] A grep/audit note lists every remaining occurrence of `glass cockpit`, `slice close`, `runtime binding`, `operator surface`, and `run packet` in first-touch docs and explains whether it is kept or aliased.
+- [ ] `./verify.sh --standard` exits 0.
+
+## Verification steps
+
+1. Run `./verify.sh --standard`; expected exit 0.
+2. Run `git diff --check`; expected no whitespace errors.
+3. Produce a vocabulary audit command/output in the PR or evidence note, for example `grep -RniE "glass cockpit|slice close|runtime binding|operator surface|run packet" README.md docs/*.md`.
+4. Manually confirm README first-touch section can be read without private Daniel/Hermes context.
+
+## Open questions
+
+- Should aliases live inline in the same docs, or should a separate `docs/GLOSSARY.md` carry them with first-touch docs linking there?
+- Which terms are non-negotiable product vocabulary versus internal/deep-doc vocabulary?


### PR DESCRIPTION
## Summary
- Promote the 2026-05-14 external review into public Open Scaffold backlog plans 018-026.
- Keep mission, roadmap, active plans, done plans, and private research/dev drafts untouched.
- Establish a public backlog source of truth before executing the next slice.

## Verification
- [x] ./verify.sh --standard
- [x] git diff --check

## Notes
- .osc/research/ and .osc-dev/ remain local/private draft space and are intentionally not included.
- Follow-up execution should happen slice-by-slice from main after this PR lands.