### PR TITLE
Seed project wiki knowledge graph

### DIFF
--- a/.osc/plans/active/029-project-wiki-knowledge-seed.md
+++ b/.osc/plans/active/029-project-wiki-knowledge-seed.md
@@ -1,0 +1,85 @@
+# Plan: 029-project-wiki-knowledge-seed
+
+## Status
+
+active
+
+## Context
+
+PR #27 shipped the tiered scaffold initialization slice, and plan 028 created the public `docs/wiki/` skeleton. The next useful milestone is to turn that empty wiki container into a small, curated Open Scaffold body-of-work knowledge graph.
+
+## Goal
+
+Seed `docs/wiki/` with public-safe, interlinked Open Scaffold project knowledge that explains the product's durable concepts without duplicating live task state, release evidence, or private owner context.
+
+## Constraints / Out of scope
+
+- Do not copy private Command Center text, raw agent transcripts, personal owner context, or unpublished strategy into the public repo.
+- Do not turn `docs/wiki/` into a task board, release log, roadmap replacement, or product manual.
+- Do not use the owner's personal name in public wiki pages.
+- Do not rewrite the README or public product positioning beyond minimal links/index updates needed to expose the wiki seed.
+- Do not commit, push, open a PR, or merge without explicit owner approval.
+
+## Files to touch
+
+- `docs/wiki/index.md` — expand the project wiki catalog and page count.
+- `docs/wiki/log.md` — append the knowledge-seed action.
+- `docs/wiki/concepts/*.md` — add durable concept pages for the Open Scaffold ontology.
+- `docs/wiki/comparisons/*.md` — add comparison pages that clarify boundaries versus adjacent methods/tools.
+- `docs/wiki/queries/*.md` — add reusable answer pages for common adoption and agent-orientation questions.
+- `ROADMAP.md` — mark this as the next milestone and keep the public roadmap aligned.
+- `.osc/plans/active/029-project-wiki-knowledge-seed.md` — trace this milestone scope.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Select the exact 8-12 public-safe wiki pages and source docs. | None | A |
+| T2 | Draft concept pages for source-of-truth-first development, repo-native agent operating system, agent resumability, evidence-first development, human-in-the-loop governance, glass cockpit, run packets, and scaffold tiers. | T1 | B |
+| T3 | Draft comparison pages for Open Scaffold versus agent memory, README-driven development, and traditional SDLC. | T1 | B |
+| T4 | Draft query pages answering what Open Scaffold is for, what agents should read first, and why the project matters. | T1 | B |
+| T5 | Update index/log and verify links, public wording, and build/test gates. | T2, T3, T4 | C |
+
+### Parallel groups
+
+- **Group A**: page selection and source review must happen first to keep the seed curated.
+- **Group B**: concepts, comparisons, and query answers can be drafted independently once the page set is fixed.
+- **Group C**: index/log/link/public-safety verification must happen after the pages exist.
+
+### Dependencies
+
+- T2, T3, and T4 depend on T1 so the wiki does not sprawl beyond a curated seed pack.
+- T5 depends on all page drafting because index/log and link verification are integration checks.
+
+### Delegation notes
+
+- This slice is suitable for parallel docs agents only if each agent receives the public-wording rule, page list, source docs, and no-private-context constraint.
+- Final integration should be done by one owner/Hermes pass to keep voice, links, and boundaries coherent.
+
+## Acceptance criteria
+
+- [ ] `docs/wiki/` gains a curated seed pack of 8-12 new pages across concepts, comparisons, and queries.
+- [ ] Every new page has frontmatter matching `docs/wiki/SCHEMA.md`.
+- [ ] Every new page is public-safe, owner-neutral, and avoids personal-name references.
+- [ ] Every new page links to at least two related wiki pages where possible.
+- [ ] `docs/wiki/index.md` lists every new page in the correct section and reports the updated page count.
+- [ ] `docs/wiki/log.md` records the knowledge-seed action.
+- [ ] The wiki explains conceptual project knowledge rather than live PR/task/release state.
+- [ ] `ROADMAP.md` names this as the next milestone and points to this plan.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
+## Verification steps
+
+1. `grep -R "[D]aniel" docs/wiki .osc/plans/active/029-project-wiki-knowledge-seed.md` returns no matches.
+2. Run a wikilink/index consistency check for `docs/wiki/**/*.md` so every listed page exists and every new page is indexed.
+3. `./verify.sh --strict` exits 0.
+4. `npm test` exits 0.
+5. `npm run build` exits 0.
+6. `git diff --check` exits 0.
+
+## Open questions
+
+- Should the first seed link from README immediately, or should the README link wait until after the wiki content passes the PR review gate?
+- Should comparison pages include named external tools/frameworks now, or stay method-level until the project has a stronger comparison doctrine?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -344,6 +344,28 @@ Acceptance direction:
 - Any prototype starts with a fake/local adapter and dispatch receipt, not real autonomous mutation.
 - The final decision must state what Open Scaffold wants to be in one sentence.
 
+### Milestone 17 — Project wiki knowledge seed
+
+Status: next via `.osc/plans/active/029-project-wiki-knowledge-seed.md`; follows the completed project wiki skeleton in `.osc/plans/done/028-project-wiki-skeleton.md`.
+
+Goal: turn the `docs/wiki/` skeleton into a small, public-safe Open Scaffold body-of-work knowledge graph.
+
+Deliverables:
+
+- Seed 8-12 curated wiki pages across concepts, comparisons, and reusable query answers.
+- Prioritize durable project concepts: source-of-truth-first development, repo-native agent operating system, agent resumability, evidence-first development, human-in-the-loop governance, glass cockpit, run packets, and scaffold tiers.
+- Clarify boundaries through comparison pages such as Open Scaffold versus agent memory, README-driven development, and traditional SDLC.
+- Add query pages that help humans and agents answer what Open Scaffold is for, what to read first, and why the project matters.
+- Update `docs/wiki/index.md` and `docs/wiki/log.md` so the wiki remains navigable and traceable.
+
+Acceptance criteria:
+
+- `docs/wiki/` contains a coherent seed pack rather than only a schema/skeleton.
+- Every new page has schema-compatible frontmatter, owner-neutral public wording, and no private owner context.
+- Every new page links to at least two related wiki pages where possible.
+- The wiki explains compiled project knowledge; live task state, PR state, release evidence, and private context stay out of `docs/wiki/`.
+- `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
 ## Parking lot
 
 - MCP bridge for structured harness dispatch/status/artifact retrieval.

--- a/docs/wiki/comparisons/open-scaffold-vs-agent-memory.md
+++ b/docs/wiki/comparisons/open-scaffold-vs-agent-memory.md
@@ -1,0 +1,33 @@
+---
+title: Open Scaffold vs Agent Memory
+created: 2026-05-15
+updated: 2026-05-15
+type: comparison
+tags: [open-scaffold, source-of-truth, agent-orchestration, compiled-knowledge]
+sources: [MISSION.md, ROADMAP.md, docs/wiki/SCHEMA.md]
+confidence: high
+contested: false
+---
+
+# Open Scaffold vs Agent Memory
+
+Open Scaffold and agent memory solve different problems.
+
+Agent memory helps an assistant remember preferences, facts, and prior context. It is useful, but it is usually hidden, model-dependent, and hard to audit.
+
+Open Scaffold makes project truth explicit in the repository. It is useful because humans, agents, and reviewers can inspect the same files and GitHub artifacts.
+
+## Difference
+
+| Question | Agent memory | Open Scaffold |
+|---|---|---|
+| Who remembers? | A specific assistant or memory backend. | The repository and GitHub history. |
+| Who can audit it? | Usually limited. | Anyone with repo access. |
+| Best for | Preferences and recall hints. | Plans, evidence, decisions, handoffs, releases. |
+| Failure mode | Hidden or stale context. | Over-structuring if used without scope discipline. |
+
+## How they work together
+
+Agent memory can point to the repo. It should not replace the repo.
+
+Related: [[source-of-truth-first-development]], [[repo-native-agent-operating-system]], [[body-of-work-wiki]].

--- a/docs/wiki/comparisons/open-scaffold-vs-readme-driven-development.md
+++ b/docs/wiki/comparisons/open-scaffold-vs-readme-driven-development.md
@@ -1,0 +1,31 @@
+---
+title: Open Scaffold vs README-Driven Development
+created: 2026-05-15
+updated: 2026-05-15
+type: comparison
+tags: [open-scaffold, workflow, source-of-truth, evidence]
+sources: [README.md, ROADMAP.md, docs/WORKFLOW.md]
+confidence: high
+contested: false
+---
+
+# Open Scaffold vs README-Driven Development
+
+README-driven development uses the README as the primary product promise and adoption surface. Open Scaffold uses the whole repository as a work operating system.
+
+The README still matters. It is the first-touch explanation. But it should not carry every plan, run, decision, evidence receipt, and reusable concept.
+
+## Difference
+
+| Surface | README-driven development | Open Scaffold |
+|---|---|---|
+| Main artifact | README as product contract. | Mission, roadmap, plans, runs, evidence, releases, wiki. |
+| Strength | Fast first understanding. | Recoverable multi-session work. |
+| Risk | README becomes overloaded. | Protocol can feel heavy if not tiered. |
+| Best use | Simple products and public introduction. | Agent-assisted or long-running work needing traceability. |
+
+## Relationship
+
+Open Scaffold should make the README sharper by moving durable planning and evidence into the right project surfaces.
+
+Related: [[scaffold-tiers]], [[source-of-truth-first-development]], [[what-is-open-scaffold-for]].

--- a/docs/wiki/concepts/agent-resumability.md
+++ b/docs/wiki/concepts/agent-resumability.md
@@ -1,0 +1,39 @@
+---
+title: Agent Resumability
+created: 2026-05-15
+updated: 2026-05-15
+type: concept
+tags: [open-scaffold, agent-orchestration, source-of-truth, workflow]
+sources: [ROADMAP.md, docs/SLICE_CLOSE_PROTOCOL.md, docs/WORKFLOW.md]
+confidence: high
+contested: false
+---
+
+# Agent Resumability
+
+Agent resumability is the ability for a capable agent or orchestrator to re-enter a project, reconstruct the relevant state, and continue bounded work without depending on the previous chat session.
+
+In Open Scaffold, resumability comes from explicit artifacts rather than model memory:
+
+- `MISSION.md` says what matters.
+- `ROADMAP.md` says what direction is next.
+- `.osc/plans/` says what a slice is trying to accomplish.
+- `.osc/runs/` records an execution attempt.
+- evidence and release notes say what actually happened.
+- `docs/wiki/` explains durable concepts that should not be re-derived.
+
+## Good resumability
+
+A resumed agent should be able to answer:
+
+1. What is the goal?
+2. What is in scope and out of scope?
+3. What files are safe to touch?
+4. What verification proves the slice?
+5. What human gate still exists?
+
+## Anti-pattern
+
+If a project can only resume because one person remembers a chat thread, the project is not source-of-truth-first.
+
+Related: [[source-of-truth-first-development]], [[evidence-first-development]], [[what-should-agents-read-first]].

--- a/docs/wiki/concepts/evidence-first-development.md
+++ b/docs/wiki/concepts/evidence-first-development.md
@@ -4,7 +4,7 @@ created: 2026-05-15
 updated: 2026-05-15
 type: concept
 tags: [open-scaffold, evidence, governance, workflow]
-sources: [docs/SLICE_CLOSE_PROTOCOL.md, docs/VERIFICATION.md, ROADMAP.md]
+sources: [docs/SLICE_CLOSE_PROTOCOL.md, docs/WORKFLOW.md, ROADMAP.md]
 confidence: high
 contested: false
 ---

--- a/docs/wiki/concepts/evidence-first-development.md
+++ b/docs/wiki/concepts/evidence-first-development.md
@@ -1,0 +1,30 @@
+---
+title: Evidence-First Development
+created: 2026-05-15
+updated: 2026-05-15
+type: concept
+tags: [open-scaffold, evidence, governance, workflow]
+sources: [docs/SLICE_CLOSE_PROTOCOL.md, docs/VERIFICATION.md, ROADMAP.md]
+confidence: high
+contested: false
+---
+
+# Evidence-First Development
+
+Evidence-first development is the Open Scaffold habit of treating verification artifacts as part of the work, not as an optional afterthought.
+
+A slice is not complete because an agent says it is complete. It is complete when the repository contains enough proof for a reviewer to understand what changed, how it was checked, and what remains unknown.
+
+## Evidence examples
+
+- Passing verification commands.
+- Failing command output with an explicit blocker.
+- Screenshots or manual test notes when visual behavior matters.
+- PR links and review outcomes.
+- Release notes that cite plan, run, verification, and follow-up state.
+
+## Evidence boundary
+
+Evidence is not the same as a wiki page. Evidence records what happened in a slice. The wiki distills what the project learned into reusable concepts.
+
+Related: [[source-of-truth-first-development]], [[human-in-the-loop-governance]], [[run-packets]].

--- a/docs/wiki/concepts/glass-cockpit.md
+++ b/docs/wiki/concepts/glass-cockpit.md
@@ -1,0 +1,32 @@
+---
+title: Glass Cockpit
+created: 2026-05-15
+updated: 2026-05-15
+type: concept
+tags: [open-scaffold, governance, workflow, agent-orchestration]
+sources: [docs/GLASS_COCKPIT_PROTOCOL.md, ROADMAP.md]
+confidence: high
+contested: false
+---
+
+# Glass Cockpit
+
+A glass cockpit is an operator-facing view of agentic work: what is running, what is blocked, what needs approval, and where the durable evidence lives.
+
+Open Scaffold treats chat surfaces, dashboards, and status streams as visibility layers. They are useful because they make work observable, but they do not replace repository truth.
+
+## Typical events
+
+- Nudge or start event.
+- Active session update.
+- Blocker or question.
+- Human answer or approval request.
+- Completion report.
+- Evidence receipt.
+- PR link.
+
+## Boundary
+
+The cockpit points back to durable IDs: issue, task, plan, run, evidence, PR, release note. If a status post cannot be traced back to repo or GitHub truth, it is only a notification.
+
+Related: [[human-in-the-loop-governance]], [[run-packets]], [[repo-native-agent-operating-system]].

--- a/docs/wiki/concepts/human-in-the-loop-governance.md
+++ b/docs/wiki/concepts/human-in-the-loop-governance.md
@@ -1,0 +1,30 @@
+---
+title: Human-in-the-Loop Governance
+created: 2026-05-15
+updated: 2026-05-15
+type: concept
+tags: [open-scaffold, governance, workflow, public-boundary]
+sources: [MISSION.md, ROADMAP.md, docs/SLICE_CLOSE_PROTOCOL.md]
+confidence: high
+contested: false
+---
+
+# Human-in-the-Loop Governance
+
+Human-in-the-loop governance is the Open Scaffold boundary that agents and runtime harnesses can propose, execute, verify, and report, but humans keep final authority over taste, risk, publication, and scope pivots.
+
+This matters because agentic development can move fast enough to blur responsibility. Open Scaffold makes the gate explicit: execution lanes return artifacts and evidence; the human owner or team decides whether the result is accepted, revised, published, or parked.
+
+## Governance surfaces
+
+- Plans define acceptance criteria and non-goals.
+- Run packets define allowed scope and evidence obligations.
+- PRs expose code review and merge gates.
+- Release notes preserve accepted outcomes and known gaps.
+- Operator surfaces can request approval, but they do not become durable truth.
+
+## Good governance
+
+A good slice states what an agent may do, what it may not do, and where human approval is required.
+
+Related: [[evidence-first-development]], [[glass-cockpit]], [[source-of-truth-first-development]].

--- a/docs/wiki/concepts/repo-native-agent-operating-system.md
+++ b/docs/wiki/concepts/repo-native-agent-operating-system.md
@@ -1,0 +1,33 @@
+---
+title: Repo-Native Agent Operating System
+created: 2026-05-15
+updated: 2026-05-15
+type: concept
+tags: [open-scaffold, agent-orchestration, workflow, source-of-truth]
+sources: [MISSION.md, ROADMAP.md, AGENTS.md]
+confidence: high
+contested: false
+---
+
+# Repo-Native Agent Operating System
+
+Open Scaffold treats a repository as the operating substrate for human-plus-agent work. The repo holds the durable protocol: mission, roadmap, plans, handoffs, run packets, evidence, decisions, and release receipts.
+
+The “operating system” metaphor does not mean Open Scaffold is an autonomous agent runtime. It means the repo provides stable conventions that different humans, agents, task systems, and runtime harnesses can use without relying on hidden session state.
+
+## What the repo owns
+
+- Product intent and constraints.
+- Work item scope and acceptance criteria.
+- Evidence and verification receipts.
+- Handoff contracts between orchestrators and execution lanes.
+- Public project knowledge in this wiki.
+
+## What the repo does not own
+
+- Live chat state.
+- Private owner context.
+- Long-running process supervision by default.
+- Credentials or runtime-specific secret state.
+
+Related: [[source-of-truth-first-development]], [[run-packets]], [[open-scaffold-vs-agent-memory]].

--- a/docs/wiki/concepts/run-packets.md
+++ b/docs/wiki/concepts/run-packets.md
@@ -1,0 +1,33 @@
+---
+title: Run Packets
+created: 2026-05-15
+updated: 2026-05-15
+type: concept
+tags: [open-scaffold, workflow, agent-orchestration, evidence]
+sources: [docs/RUNTIME_BINDING_CONTRACT.md, ROADMAP.md, .osc/plans/WORKFLOW.md]
+confidence: high
+contested: false
+---
+
+# Run Packets
+
+A run packet is the bounded execution contract for one attempt at a slice of work. It connects a task or plan to a runtime lane, allowed scope, verification commands, evidence destination, and approval gate.
+
+Open Scaffold separates the work item from the execution attempt:
+
+- `task_id` or issue ID identifies the durable work item.
+- `run_id` identifies one execution attempt.
+- branch and PR identify the versioned implementation path.
+- evidence and release notes identify what was proven.
+
+## What a run packet should contain
+
+- Goal and non-goals.
+- Inputs and files to inspect.
+- Allowed paths and forbidden actions.
+- Runtime or harness lane.
+- Verification commands.
+- Evidence destination.
+- Human gate.
+
+Related: [[agent-resumability]], [[evidence-first-development]], [[glass-cockpit]].

--- a/docs/wiki/concepts/scaffold-tiers.md
+++ b/docs/wiki/concepts/scaffold-tiers.md
@@ -1,0 +1,28 @@
+---
+title: Scaffold Tiers
+created: 2026-05-15
+updated: 2026-05-15
+type: concept
+tags: [open-scaffold, workflow, source-of-truth]
+sources: [docs/MINIMUM_VIABLE_SCAFFOLD.md, ROADMAP.md]
+confidence: medium
+contested: false
+---
+
+# Scaffold Tiers
+
+Scaffold tiers describe how much Open Scaffold structure a project needs. The idea is to avoid forcing every repository into the maximum protocol while still giving serious work enough durable context to survive agents, reviews, and time.
+
+## Tier intuition
+
+- **Minimum**: mission, roadmap, basic plan/evidence conventions.
+- **Standard**: stronger plan/run/release traceability for recurring agent-assisted work.
+- **Maximum**: deeper governance, handoffs, evidence, and cockpit patterns for high-risk or multi-agent work.
+
+The exact tier should match project risk and coordination cost. A tiny experiment does not need the same structure as a client delivery, regulated workflow, or long-running multi-agent build.
+
+## Boundary
+
+Tiers are adoption paths, not quality labels. The right tier is the smallest structure that keeps the work recoverable.
+
+Related: [[repo-native-agent-operating-system]], [[what-is-open-scaffold-for]], [[source-of-truth-first-development]].

--- a/docs/wiki/concepts/source-of-truth-first-development.md
+++ b/docs/wiki/concepts/source-of-truth-first-development.md
@@ -1,0 +1,32 @@
+---
+title: Source-of-Truth-First Development
+created: 2026-05-15
+updated: 2026-05-15
+type: concept
+tags: [open-scaffold, source-of-truth, workflow, evidence]
+sources: [MISSION.md, ROADMAP.md, docs/SLICE_CLOSE_PROTOCOL.md]
+confidence: high
+contested: false
+---
+
+# Source-of-Truth-First Development
+
+Source-of-truth-first development is the Open Scaffold principle that durable project state must live in versioned artifacts before it is trusted by humans or agents.
+
+The practical rule is simple: chat, runtime transcripts, task boards, and model memory can help coordinate work, but they are not final truth. A project should be recoverable from mission, roadmap, plans, run records, evidence, decisions, release notes, and PR history.
+
+## Why it matters
+
+Agent-assisted development often loses context because important decisions are buried in a vanished chat window or a one-off runtime log. Open Scaffold makes context durable by routing each kind of information to the right place:
+
+- mission and product intent -> `MISSION.md` and `ROADMAP.md`;
+- scope and acceptance criteria -> `.osc/plans/`;
+- execution attempts -> `.osc/runs/`;
+- verification and outcomes -> `.osc/releases/`, evidence, CI, and PRs;
+- compiled concepts -> `docs/wiki/`.
+
+## Boundary
+
+This does not mean every thought needs a file. It means meaningful claims should become inspectable artifacts before they shape future work.
+
+Related: [[repo-native-agent-operating-system]], [[evidence-first-development]], [[agent-resumability]].

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,7 +1,7 @@
 # Open Scaffold Project Wiki Index
 
 > Public-safe compiled knowledge for Open Scaffold as a body of work. This is not the task board, release log, or product reference.
-> Last updated: 2026-05-15 | Total pages: 2
+> Last updated: 2026-05-15 | Total pages: 14
 
 ## Meta / Operating Contracts
 
@@ -9,10 +9,24 @@
 
 ## Concepts
 
+- [[agent-resumability]] — How agents can re-enter work without relying on vanished chat context.
 - [[body-of-work-wiki]] — Why Open Scaffold has a scoped project wiki and what belongs here.
+- [[evidence-first-development]] — Why verification artifacts are part of the work.
+- [[glass-cockpit]] — Operator visibility layer for agentic work.
+- [[human-in-the-loop-governance]] — Human gates for taste, risk, publication, and scope.
+- [[repo-native-agent-operating-system]] — The repository as the durable operating substrate.
+- [[run-packets]] — Bounded execution contracts for runtime attempts.
+- [[scaffold-tiers]] — Matching scaffold structure to project risk and coordination cost.
+- [[source-of-truth-first-development]] — Durable project truth before trusted continuation.
 
 ## Entities
 
 ## Comparisons
 
+- [[open-scaffold-vs-agent-memory]] — Why repo truth and assistant memory are complementary but not interchangeable.
+- [[open-scaffold-vs-readme-driven-development]] — Why Open Scaffold extends beyond the README without replacing it.
+
 ## Queries
+
+- [[what-is-open-scaffold-for]] — Short answer for when the project is useful.
+- [[what-should-agents-read-first]] — Entry path for agents entering an Open Scaffold repository.

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -3,6 +3,13 @@
 > Chronological record of project wiki actions. Append-only.
 > Format: `## [YYYY-MM-DD] action | subject`
 
+## [2026-05-15] create | Project wiki knowledge seed
+- Added a curated seed pack of 12 public-safe pages across concepts, comparisons, and reusable query answers.
+- Added durable concepts for source-of-truth-first development, repo-native agent operating system, agent resumability, evidence-first development, human-in-the-loop governance, glass cockpit, run packets, and scaffold tiers.
+- Added comparison pages for Open Scaffold versus agent memory and README-driven development.
+- Added query pages for what Open Scaffold is for and what agents should read first.
+- Updated `docs/wiki/index.md` to list all seed pages.
+
 ## [2026-05-15] create | Project wiki initialized
 - Created `docs/wiki/SCHEMA.md`, `index.md`, and `log.md`.
 - Created `_meta/owner-context.md` and `concepts/body-of-work-wiki.md` as initial boundary pages.

--- a/docs/wiki/queries/what-is-open-scaffold-for.md
+++ b/docs/wiki/queries/what-is-open-scaffold-for.md
@@ -1,0 +1,31 @@
+---
+title: What is Open Scaffold for?
+created: 2026-05-15
+updated: 2026-05-15
+type: query
+tags: [open-scaffold, workflow, agent-orchestration, source-of-truth]
+sources: [MISSION.md, README.md, ROADMAP.md]
+confidence: high
+contested: false
+---
+
+# What is Open Scaffold for?
+
+Open Scaffold is for projects where work must survive beyond a single chat, agent session, or developer's memory.
+
+It is especially useful when a project has:
+
+- multiple AI-assisted sessions;
+- multiple agents or runtime lanes;
+- human approval gates;
+- PR/release evidence requirements;
+- client, team, or stakeholder visibility needs;
+- enough complexity that context loss creates real cost.
+
+It is not automatically the right tool for every script or throwaway experiment. The best Open Scaffold setup is the smallest tier that makes the work recoverable.
+
+## One-sentence answer
+
+Open Scaffold turns a repository into a durable operating substrate for human-led, agent-assisted software work.
+
+Related: [[scaffold-tiers]], [[repo-native-agent-operating-system]], [[source-of-truth-first-development]].

--- a/docs/wiki/queries/what-should-agents-read-first.md
+++ b/docs/wiki/queries/what-should-agents-read-first.md
@@ -1,0 +1,29 @@
+---
+title: What should agents read first?
+created: 2026-05-15
+updated: 2026-05-15
+type: query
+tags: [open-scaffold, agent-orchestration, workflow, source-of-truth]
+sources: [AGENTS.md, MISSION.md, ROADMAP.md, .osc/RULES.md]
+confidence: high
+contested: false
+---
+
+# What should agents read first?
+
+An agent entering an Open Scaffold repository should read the smallest set of files that establishes mission, current direction, rules, and bounded work.
+
+Recommended order:
+
+1. `MISSION.md` — why the project exists and what it must not become.
+2. `ROADMAP.md` — where the project is going and what milestone is next.
+3. `AGENTS.md` or equivalent agent instructions — repo-specific operating rules.
+4. `.osc/RULES.md` — scaffold discipline and plan/evidence rules.
+5. `.osc/plans/active/` — current durable plans, if any.
+6. The specific files named by the task, issue, or run packet.
+
+## What not to do
+
+Do not infer current truth from chat memory, runtime logs, or stale branches when the repo has explicit source-of-truth files.
+
+Related: [[agent-resumability]], [[run-packets]], [[source-of-truth-first-development]].


### PR DESCRIPTION
## Summary
- Adds Milestone 17 for the Open Scaffold project wiki knowledge seed.
- Creates active plan `.osc/plans/active/029-project-wiki-knowledge-seed.md`.
- Seeds `docs/wiki/` with 12 public-safe body-of-work pages across concepts, comparisons, and reusable query answers.
- Updates `docs/wiki/index.md` and `docs/wiki/log.md` for navigation and traceability.

## Traceability
- Roadmap milestone: Milestone 17 — Project wiki knowledge seed
- Plan: `.osc/plans/active/029-project-wiki-knowledge-seed.md`
- Kanban: `t_3401987c`

## Verification
- [x] `grep -R "[D]aniel" docs/wiki .osc/plans/active/029-project-wiki-knowledge-seed.md` — clean
- [x] Wiki index/frontmatter consistency check — 14 content pages indexed, no missing frontmatter
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- [x] `npm test` — 27 passed
- [x] `npm run build` — passed
- [x] `git diff --check` — passed

## Codex review
- Triggered by opening this PR; if no automatic review appears, `@codex review` can be requested.



## Post-Codex follow-up
- Codex second pass found one P2 issue: `docs/wiki/concepts/evidence-first-development.md` referenced missing `docs/VERIFICATION.md` in frontmatter `sources`.
- Fixed in `d68a2f5` by changing the source to existing `docs/WORKFLOW.md`.
- Replied inline and re-triggered `@codex review`.
- Latest Codex connector comment: “Didn't find any major issues.”
- Inline comments after fix: no new unresolved findings.
