### PR TITLE
Add runtime profiles v0

### DIFF
--- a/.osc/plans/done/034-runtime-profiles-v0.md
+++ b/.osc/plans/done/034-runtime-profiles-v0.md
@@ -1,0 +1,59 @@
+# Plan: 034-runtime-profiles-v0
+
+## Status
+
+active — approved by owner after Claude Code read-only architecture consultation in `.osc/runs/20260515T223354-runtime-registry-claude-consult/`.
+
+## Context
+
+Open Scaffold already supports agentic runtime selection at run-packet level for OMC/OMX/plain/human/custom. The next product step is to remove hard-coded runtime assumptions and make runtime selection schema-backed and user-extensible without turning Open Scaffold core into a runtime installer, network registry, or process spawner.
+
+## Goal
+
+Add runtime profile v0: a declarative runtime profile catalog with built-in profiles and project-local custom profiles that `osc run --runtime <id>` can resolve into executor lane, workflow defaults, harness skill, profile source, and evidence-safe boundaries.
+
+## Constraints / Out of scope
+
+- Do not add real runtime spawning, process supervision, auth setup, or install execution.
+- Do not add network registries, marketplace behavior, or `osc runtimes add https://...`.
+- Do not auto-run arbitrary scripts from runtime profile files.
+- Do not claim certified support for external frameworks without conformance evidence.
+- Do not let project-local profiles override reserved built-in IDs.
+- Keep private owner context and local runtime state out of public docs.
+- Leave the existing untracked `033-implementation-architecture-evaluation-lens.md` outside this PR unless separately approved.
+
+## Files to touch
+
+- `src/runtimes.ts` — runtime profile schema/types, built-in catalog, project profile loader, validation.
+- `src/cli.ts` — runtime subcommands and run option resolution through profiles.
+- `src/artifacts.ts` — include profile id/source in `runtimeSelection`.
+- `tests/cli-init.test.ts` or new tests — built-in/custom profile behavior and rejection cases.
+- `docs/RUNTIME_PROFILES.md` — public contract for runtime profile v0.
+- `docs/RUNTIME_SELECTION.md`, `docs/RUNTIME_BINDING_CONTRACT.md`, `docs/OPEN_SCAFFOLD_SYSTEM.md`, `ROADMAP.md` — link/update boundary language as needed.
+- `docs/examples/runtime-profiles/*.json` — example project-local custom profile.
+- `.osc/releases/2026-05-15-runtime-profiles-v0.md` — evidence note.
+
+## Acceptance criteria
+
+- [ ] `osc runtimes list` prints visible built-in profiles with their sources.
+- [ ] `osc runtimes show <id>` prints the selected profile JSON.
+- [ ] `osc run <plan> --runtime omx` and `--runtime omc` preserve existing dispatchable run-packet behavior.
+- [ ] A project-local `.osc/runtimes/<id>.json` profile can be selected with `osc run --runtime <id>` and records `profileId` / `profileSource` in `run.json`.
+- [ ] Project-local profiles cannot override reserved built-in IDs.
+- [ ] Profiles declaring `spawning: true` or executable install behavior are rejected.
+- [ ] Unknown runtime ids are rejected with a clear error.
+- [ ] Docs state that runtime profiles are data-only and that install/launch stays adapter/coordinator-owned.
+
+## Verification steps
+
+1. Run `git diff --check`; expected no whitespace errors.
+2. Run `./verify.sh --strict`; expected exit 0.
+3. Run `npm run osc -- verify`; expected exit 0.
+4. Run `npm test`; expected exit 0.
+5. Run `npm run build`; expected exit 0.
+6. Manually inspect public docs for unsupported install/spawn/certification claims.
+
+## Open questions
+
+- Should per-user XDG runtime profile scope be added later after project-local profiles prove useful?
+- Which external runtime should be first to earn built-in or certified-adapter status through conformance evidence beyond OMC/OMX lane mapping?

--- a/.osc/releases/2026-05-15-runtime-profiles-v0.md
+++ b/.osc/releases/2026-05-15-runtime-profiles-v0.md
@@ -42,7 +42,7 @@ Final verification before PR:
 git diff --check          -> passed
 ./verify.sh --strict      -> 10 pass, 0 fail, 0 warn
 npm run osc -- verify     -> PASS, 0 warnings
-npm test                  -> 8 test files passed, 70 tests passed
+npm test                  -> 8 test files passed, 72 tests passed
 npm run build             -> passed
 ```
 

--- a/.osc/releases/2026-05-15-runtime-profiles-v0.md
+++ b/.osc/releases/2026-05-15-runtime-profiles-v0.md
@@ -42,7 +42,7 @@ Final verification before PR:
 git diff --check          -> passed
 ./verify.sh --strict      -> 10 pass, 0 fail, 0 warn
 npm run osc -- verify     -> PASS, 0 warnings
-npm test                  -> 8 test files passed, 64 tests passed
+npm test                  -> 8 test files passed, 66 tests passed
 npm run build             -> passed
 ```
 

--- a/.osc/releases/2026-05-15-runtime-profiles-v0.md
+++ b/.osc/releases/2026-05-15-runtime-profiles-v0.md
@@ -1,0 +1,57 @@
+# Release / Evidence Note: Runtime profiles v0
+
+Date: 2026-05-15
+
+## Summary
+
+Runtime selection is now schema-backed and project-extensible without changing the core spawning boundary. This slice adds runtime profile v0: built-in runtime profiles, project-local custom profiles, read-only runtime profile CLI commands, and run-packet profile metadata.
+
+## Traceability
+
+- Roadmap item: `ROADMAP.md` — Milestone 9 runtime profile follow-up.
+- Plan: `.osc/plans/done/034-runtime-profiles-v0.md`.
+- Task: `t_fba215ae` — Runtime profiles v0.
+- Branch: `runtime/runtime-profiles-v0`.
+- PR: pending owner review.
+- Run packet: not generated; this was a direct CLI/docs/schema implementation after read-only architecture consultation.
+
+## Evidence
+
+- `src/runtimes.ts` defines `open-scaffold.runtime-profile.v1`, built-in profiles, project-local profile loading from `.osc/runtimes/*.json`, and validation.
+- `src/cli.ts` adds `osc runtimes list`, `osc runtimes show <id>`, and `osc run <plan> --runtime <id>` resolution through runtime profiles.
+- `src/artifacts.ts` adds `profileId` and `profileSource` to `runtimeSelection` in `run.json`.
+- `docs/RUNTIME_PROFILES.md` documents the runtime profile contract, project-local customization, and no-install/no-spawn boundary.
+- `docs/examples/runtime-profiles/company-review-bot.json` gives a user-defined profile example.
+- Runtime docs and roadmap now point to runtime profiles as the v0 interoperability layer.
+
+## Boundary decisions
+
+- Built-in profiles are data, not certified runtime integrations.
+- Project-local profiles are allowed in `.osc/runtimes/*.json`.
+- Built-in profile ids cannot be overridden by project-local profiles.
+- Profiles with `install.auto !== false` are rejected.
+- Profiles with `launch.spawning !== false` are rejected.
+- Open Scaffold core still does not install, authenticate, launch, supervise, or spawn runtimes.
+- GSD and future frameworks can be represented as user-defined profiles, but are not claimed as certified/built-in integrations without conformance evidence.
+
+## Verification
+
+Final verification before PR:
+
+```text
+git diff --check          -> passed
+./verify.sh --strict      -> 10 pass, 0 fail, 0 warn
+npm run osc -- verify     -> PASS, 0 warnings
+npm test                  -> 8 test files passed, 64 tests passed
+npm run build             -> passed
+```
+
+## Outcome
+
+Runtime selection is now a registry/profile contract rather than hard-coded CLI special cases. This creates the safe next step toward runtime interoperability while preserving source-of-truth, evidence, and approval boundaries.
+
+## Follow-up
+
+- Consider per-user XDG runtime profile scope only after project-local profiles prove useful.
+- Add built-in/certified status for more frameworks only after conformance evidence exists.
+- Keep runtime installation, launch, network registries, marketplace behavior, and credential handling behind separate safety-reviewed plans.

--- a/.osc/releases/2026-05-15-runtime-profiles-v0.md
+++ b/.osc/releases/2026-05-15-runtime-profiles-v0.md
@@ -42,7 +42,7 @@ Final verification before PR:
 git diff --check          -> passed
 ./verify.sh --strict      -> 10 pass, 0 fail, 0 warn
 npm run osc -- verify     -> PASS, 0 warnings
-npm test                  -> 8 test files passed, 69 tests passed
+npm test                  -> 8 test files passed, 70 tests passed
 npm run build             -> passed
 ```
 

--- a/.osc/releases/2026-05-15-runtime-profiles-v0.md
+++ b/.osc/releases/2026-05-15-runtime-profiles-v0.md
@@ -42,7 +42,7 @@ Final verification before PR:
 git diff --check          -> passed
 ./verify.sh --strict      -> 10 pass, 0 fail, 0 warn
 npm run osc -- verify     -> PASS, 0 warnings
-npm test                  -> 8 test files passed, 72 tests passed
+npm test                  -> 8 test files passed, 74 tests passed
 npm run build             -> passed
 ```
 

--- a/.osc/releases/2026-05-15-runtime-profiles-v0.md
+++ b/.osc/releases/2026-05-15-runtime-profiles-v0.md
@@ -42,7 +42,7 @@ Final verification before PR:
 git diff --check          -> passed
 ./verify.sh --strict      -> 10 pass, 0 fail, 0 warn
 npm run osc -- verify     -> PASS, 0 warnings
-npm test                  -> 8 test files passed, 66 tests passed
+npm test                  -> 8 test files passed, 67 tests passed
 npm run build             -> passed
 ```
 

--- a/.osc/releases/2026-05-15-runtime-profiles-v0.md
+++ b/.osc/releases/2026-05-15-runtime-profiles-v0.md
@@ -42,7 +42,7 @@ Final verification before PR:
 git diff --check          -> passed
 ./verify.sh --strict      -> 10 pass, 0 fail, 0 warn
 npm run osc -- verify     -> PASS, 0 warnings
-npm test                  -> 8 test files passed, 68 tests passed
+npm test                  -> 8 test files passed, 69 tests passed
 npm run build             -> passed
 ```
 

--- a/.osc/releases/2026-05-15-runtime-profiles-v0.md
+++ b/.osc/releases/2026-05-15-runtime-profiles-v0.md
@@ -42,7 +42,7 @@ Final verification before PR:
 git diff --check          -> passed
 ./verify.sh --strict      -> 10 pass, 0 fail, 0 warn
 npm run osc -- verify     -> PASS, 0 warnings
-npm test                  -> 8 test files passed, 67 tests passed
+npm test                  -> 8 test files passed, 68 tests passed
 npm run build             -> passed
 ```
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-15: closed 034-runtime-profiles-v0 — runtime profiles v0 shipped with schema-backed built-in and project-local runtime selection
 - 2026-05-15: closed 009-runtime-harness-adapter-refresh — runtime adapter refresh audit and conformance lane coverage shipped
 - 2026-05-15: closed 019-comparison-page — comparison page shipped in public trust/readiness bundle
 - 2026-05-15: closed 010-product-packaging-release — packaging readiness evidence shipped in public trust/readiness bundle

--- a/README.md
+++ b/README.md
@@ -129,19 +129,33 @@ cp .osc/plans/handoff-template.md .osc/plans/active/my-first-task.md
 
 Use `./verify.sh --standard` before calling a meaningful slice done.
 
-### 5. Create a run packet when a harness should execute it
+### 5. Select a runtime and create a run packet
 
-Open Scaffold core does not spawn agents. It packages work so a coordinator, adapter, or human can dispatch it:
+Open Scaffold core does not spawn agents. It packages work so a coordinator, adapter, or human can dispatch it.
+
+The runtime flow is:
+
+```text
+User selects runtime
+  -> Open Scaffold reads runtime profile
+  -> Open Scaffold creates the run packet
+  -> Adapter/coordinator launches the actual runtime
+  -> Runtime does the work
+  -> Evidence comes back into Open Scaffold
+```
+
+Example:
 
 ```bash
 npm run osc -- run .osc/plans/active/my-first-task.md \
   --task-id TASK-001 \
-  --executor plain-agent \
+  --runtime omx \
+  --workflow plan \
   --operator-surface github \
   --repo "$PWD"
 ```
 
-See [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md) and [`docs/examples/runtime-binding-dry-run.mjs`](docs/examples/runtime-binding-dry-run.mjs).
+For custom runtimes, add a project-local profile in `.osc/runtimes/<id>.json`, then use `--runtime <id>`. See [`docs/RUNTIME_PROFILES.md`](docs/RUNTIME_PROFILES.md), [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md), and [`docs/examples/runtime-binding-dry-run.mjs`](docs/examples/runtime-binding-dry-run.mjs).
 
 ---
 
@@ -184,7 +198,8 @@ The current focus comes from an independent two-lane review (2026-05-12) which f
 - [`MISSION.md`](MISSION.md) — product goals, non-goals, and scope changelog.
 - [`ROADMAP.md`](ROADMAP.md) — product direction and milestones.
 - [`docs/COMPARISON.md`](docs/COMPARISON.md) — honest orientation against adjacent AI workflow systems.
-- [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — OMC/OMX runtime selection and adapter checklist.
+- [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — runtime selection flow for OMC/OMX-style lanes.
+- [`docs/RUNTIME_PROFILES.md`](docs/RUNTIME_PROFILES.md) — built-in and project-local runtime profile contract.
 - [`.osc/RULES.md`](.osc/RULES.md) — compact operating rules.
 - [`.osc/plans/WORKFLOW.md`](.osc/plans/WORKFLOW.md) — how plans move through backlog, active, done, and blocked.
 - [`docs/WORKFLOW.md`](docs/WORKFLOW.md) — phase-to-tool guide.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -229,6 +229,7 @@ Goal: align OMC/OMX bindings with the public runtime binding contract while keep
 Deliverables:
 
 - Add a core runtime-selection surface for `omc` / `omx` presets that records executor lane and workflow in the run packet.
+- Promote runtime selection into schema-backed runtime profiles, including built-in OMC/OMX/plain/human/custom profiles and project-local `.osc/runtimes/*.json` custom profiles.
 - Keep real OMC/OMX launch behavior in external adapters or coordinators, not core.
 - Ensure adapter evidence returns to `.osc` run/release conventions.
 

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -12,7 +12,7 @@ This document is the full ontology. Most readers do not need every protocol page
 
 - New here? Read the [README](../README.md), then [`docs/EXAMPLES.md`](EXAMPLES.md) for the 60-second viewer demo.
 - Wiring task/run identity into a coordinator or task system: [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md).
-- Writing an adapter that consumes `.osc/runs/<run_id>/run.json`: [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md), then [`docs/RUNTIME_HARNESS_DISPATCH.md`](RUNTIME_HARNESS_DISPATCH.md) for the public dispatch pattern and [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md) for the adapter/runtime boundary.
+- Writing an adapter that consumes `.osc/runs/<run_id>/run.json`: [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md), [`docs/RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md) for selectable runtime profile metadata, then [`docs/RUNTIME_HARNESS_DISPATCH.md`](RUNTIME_HARNESS_DISPATCH.md) for the public dispatch pattern and [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md) for the adapter/runtime boundary.
 - Closing a slice and producing audit-grade evidence: [`docs/SLICE_CLOSE_PROTOCOL.md`](SLICE_CLOSE_PROTOCOL.md).
 - Reading public mentions of named tools (Hermes, OMC, OMX, Discord, etc.): [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md) for the public/private/adapter labels.
 

--- a/docs/RUNTIME_BINDING_CONTRACT.md
+++ b/docs/RUNTIME_BINDING_CONTRACT.md
@@ -25,6 +25,7 @@ Examples:
 
 - a coordinator script that reads `.osc/runs/<run_id>/run.json` and starts an OMX `$ralplan` session;
 - an OMC-specific command that turns a plan into a Claude Code `/team` handoff;
+- a project-local runtime profile in `.osc/runtimes/<id>.json` that tells an adapter which lane/workflow/evidence contract to use;
 - a GitHub bot that assigns a plain agent to a branch and links the PR;
 - a human operator who reads the generated prompt package and performs the work manually.
 

--- a/docs/RUNTIME_PROFILES.md
+++ b/docs/RUNTIME_PROFILES.md
@@ -1,0 +1,150 @@
+# Runtime Profiles
+
+Runtime profiles make Open Scaffold runtime selection declarative and extensible without making Open Scaffold core an installer, marketplace, or process supervisor.
+
+A runtime profile is data. It tells Open Scaffold how a selected runtime lane should be recorded in a run packet. A coordinator or adapter may later consume that run packet and launch the real runtime outside core.
+
+```text
+Open Scaffold core = validate profile + package run intent + preserve evidence gates
+Runtime adapter     = translate run packet + launch selected runtime + return receipt/evidence
+Runtime harness     = execute while alive
+Operator            = approve commit/push/merge/publish gates
+```
+
+## Commands
+
+```bash
+osc runtimes list
+osc runtimes show omx
+osc run .osc/plans/active/001-demo.md --runtime omx --workflow plan
+```
+
+`osc runtimes list` prints the visible profile id, source, executor lane, status, and display name.
+
+`osc runtimes show <id>` prints the selected profile JSON plus its source.
+
+## Profile sources
+
+Runtime profiles currently resolve from two scopes:
+
+1. **Built-in profiles** shipped with Open Scaffold:
+   - `omc` — OMC / oh-my-claudecode lane for Claude Code-oriented workflows.
+   - `omx` — OMX / oh-my-codex lane for Codex-oriented workflows.
+   - `plain` — runtime-neutral prompt package for any capable agent.
+   - `human` — manual execution with evidence gates.
+   - `custom` — placeholder lane for adapter-defined execution.
+2. **Project-local profiles** in `.osc/runtimes/*.json`.
+
+Project-local profiles are checked into the repo and should be reviewed like other project configuration. They are useful for company agents, private wrappers, or experimental runtimes that are not built into Open Scaffold.
+
+Built-in profile ids are reserved. A project-local profile cannot silently override `omc`, `omx`, `plain`, `human`, or `custom`.
+
+## Runtime profile schema
+
+Minimal project-local example:
+
+```json
+{
+  "schemaVersion": "open-scaffold.runtime-profile.v1",
+  "id": "company-review-bot",
+  "displayName": "Company Review Bot",
+  "lane": "plain-agent",
+  "status": "user-defined",
+  "description": "Project-local review bot profile.",
+  "links": {
+    "homepage": "https://internal.example.com/review-bot"
+  },
+  "workflows": {
+    "plan": "company-review-bot plan",
+    "execute": "company-review-bot run"
+  },
+  "defaults": {
+    "workflow": "plan",
+    "harnessSkill": "company-review-bot plan",
+    "operatorSurface": "none"
+  },
+  "install": {
+    "humanHint": "Install through the internal developer portal.",
+    "auto": false
+  },
+  "launch": {
+    "owner": "external-adapter",
+    "commandTemplate": "company-review-bot run <run.json>",
+    "expectedAdapterId": null,
+    "spawning": false
+  },
+  "evidence": {
+    "receiptSchema": "open-scaffold.dispatch-receipt.v1",
+    "expectedPaths": [".osc/runs/<run_id>/dispatch-receipt.json"]
+  },
+  "compatibility": {
+    "minScaffoldSchema": "open-scaffold.run.v1"
+  },
+  "lastReviewed": "2026-05-15",
+  "notes": "User-defined profile. Open Scaffold core validates the package; the adapter owns runtime behavior."
+}
+```
+
+### Required fields
+
+- `schemaVersion`: must be `open-scaffold.runtime-profile.v1`.
+- `id`: lowercase profile id used by `--runtime <id>`.
+- `displayName`: human-readable name.
+- `lane`: one of `omc-claude`, `omx-codex`, `plain-agent`, `human`, or `custom`.
+- `status`: one of `builtin`, `adapter-candidate`, or `user-defined`.
+- `description`: short public-safe description.
+
+### Workflow mapping
+
+`workflows` maps Open Scaffold workflow names to the runtime/harness command token that an adapter should use.
+
+Supported workflow keys are:
+
+- `interview`
+- `plan`
+- `team`
+- `loop`
+- `execute`
+- `goal`
+- `custom`
+
+For example, the built-in `omx` profile maps `plan` to `$ralplan`; the built-in `omc` profile maps `plan` to `/ralplan`.
+
+If a profile has `defaults.workflow`, then `osc run --runtime <id>` can infer the workflow when the user does not provide `--workflow`.
+
+## Security and boundary rules
+
+Runtime profiles are treated as untrusted project configuration.
+
+In v0:
+
+- Profiles are JSON data only.
+- Open Scaffold core validates profiles before use.
+- `install.auto` must be `false`.
+- `launch.spawning` must be `false`.
+- Open Scaffold may display `install.humanHint` or `launch.commandTemplate`, but it does not execute them.
+- Profiles cannot grant commit, push, merge, or publish authority.
+- Runtime-local logs/session state are forensic until promoted into `.osc/runs`, tracked evidence docs, GitHub artifacts, or release notes.
+
+This is deliberate. Open Scaffold's job is to preserve the source-of-truth chain and package dispatchable intent. Runtime-specific adapters own installation, authentication, session lifecycle, tmux/process management, and provider-specific launch details.
+
+## OMC, OMX, GSD, and custom runtimes
+
+OMC and OMX are built-in adapter-candidate profiles because Open Scaffold already has a run-packet selection surface and conformance fixture coverage for those lanes.
+
+GSD and other frameworks can be represented as project-local `user-defined` profiles today. They should not be described as certified or built-in integrations until an adapter has passed the conformance expectations and produced public evidence.
+
+## Non-goals for runtime profiles v0
+
+Runtime profiles v0 does not add:
+
+- `osc runtimes install`
+- `osc runtimes add https://...`
+- hosted registries or marketplace behavior
+- network fetching
+- arbitrary script execution
+- automatic runtime spawning
+- credential handling
+- model/task benchmarking claims
+
+Those are future roadmap questions that require separate safety design, adapter evidence, and owner approval.

--- a/docs/RUNTIME_SELECTION.md
+++ b/docs/RUNTIME_SELECTION.md
@@ -89,3 +89,5 @@ This slice does not:
 - make model/orchestration-lab claims.
 
 The practical next step after this core selection surface is a separate runtime adapter package or coordinator integration that reads the package and performs the launch outside core.
+
+For schema-backed runtime profiles, built-in profile ids, and project-local custom profiles, see [`RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md). Runtime profiles are data-only in v0: they let users select and document an adapter lane, but they do not install or spawn the runtime from core.

--- a/docs/examples/runtime-profiles/company-review-bot.json
+++ b/docs/examples/runtime-profiles/company-review-bot.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": "open-scaffold.runtime-profile.v1",
+  "id": "company-review-bot",
+  "displayName": "Company Review Bot",
+  "lane": "plain-agent",
+  "status": "user-defined",
+  "description": "Example project-local profile for a company-owned review bot.",
+  "links": {
+    "homepage": "https://internal.example.com/review-bot"
+  },
+  "workflows": {
+    "plan": "company-review-bot plan",
+    "execute": "company-review-bot run"
+  },
+  "defaults": {
+    "workflow": "plan",
+    "harnessSkill": "company-review-bot plan",
+    "operatorSurface": "none"
+  },
+  "install": {
+    "humanHint": "Install through the internal developer portal. Open Scaffold core does not execute this install.",
+    "auto": false
+  },
+  "launch": {
+    "owner": "external-adapter",
+    "commandTemplate": "company-review-bot run <run.json>",
+    "expectedAdapterId": null,
+    "spawning": false
+  },
+  "evidence": {
+    "receiptSchema": "open-scaffold.dispatch-receipt.v1",
+    "expectedPaths": [".osc/runs/<run_id>/dispatch-receipt.json"]
+  },
+  "compatibility": {
+    "minScaffoldSchema": "open-scaffold.run.v1"
+  },
+  "lastReviewed": "2026-05-15",
+  "notes": "Example only. User-defined runtime profiles are adapter contracts, not certified runtime support."
+}

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -5,7 +5,7 @@ import type { ParsedPlan } from './scaffold.js';
 export type ArtifactMode = 'delegate' | 'run' | 'review' | 'ultrareview';
 export type ExecutorLane = 'omc-claude' | 'omx-codex' | 'plain-agent' | 'human' | 'custom';
 export type OperatorSurface = 'discord' | 'slack' | 'telegram' | 'github' | 'cli' | 'none' | 'custom';
-export type RuntimePreset = 'omc' | 'omx' | 'plain' | 'human' | 'custom';
+export type RuntimePreset = string;
 export type RuntimeWorkflow = 'interview' | 'plan' | 'team' | 'loop' | 'execute' | 'goal' | 'custom';
 
 export interface RunArtifactOptions {
@@ -15,6 +15,8 @@ export interface RunArtifactOptions {
   harnessSkill?: string;
   runtime?: RuntimePreset;
   workflow?: RuntimeWorkflow;
+  runtimeProfileId?: string;
+  runtimeProfileSource?: string;
   repo?: string;
   worktree?: string;
   branch?: string;
@@ -160,6 +162,8 @@ export function createRunArtifacts(root: string, plan: ParsedPlan, mode: Artifac
     runtimeSelection: {
       runtime: options.runtime ?? null,
       workflow: options.workflow ?? null,
+      profileId: options.runtimeProfileId ?? options.runtime ?? null,
+      profileSource: options.runtimeProfileSource ?? null,
       note: 'Runtime selection records the intended adapter lane. Open Scaffold core still does not spawn the runtime.',
     },
     executor: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
+import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
 import { inspectScaffold, parsePlanFile, planToJson } from './scaffold.js';
 import { validateScaffold } from './validation.js';
 
@@ -20,6 +21,8 @@ Usage:
   osc ultrareview <plan-path> [run binding options]
   osc verify
   osc doctor
+  osc runtimes list
+  osc runtimes show <id>
 
 Run binding options:
   --task-id <id>              Canonical task/card/issue id for this work item
@@ -51,35 +54,7 @@ function requireArg(args: string[], name: string): string {
 
 const EXECUTOR_LANES = ['omc-claude', 'omx-codex', 'plain-agent', 'human', 'custom'] as const;
 const OPERATOR_SURFACES = ['discord', 'slack', 'telegram', 'github', 'cli', 'none', 'custom'] as const;
-const RUNTIME_PRESETS = ['omc', 'omx', 'plain', 'human', 'custom'] as const;
 const RUNTIME_WORKFLOWS = ['interview', 'plan', 'team', 'loop', 'execute', 'goal', 'custom'] as const;
-
-const RUNTIME_EXECUTORS: Record<RuntimePreset, ExecutorLane> = {
-  omc: 'omc-claude',
-  omx: 'omx-codex',
-  plain: 'plain-agent',
-  human: 'human',
-  custom: 'custom',
-};
-
-const WORKFLOW_HARNESS_SKILLS: Record<'omc' | 'omx', Record<Exclude<RuntimeWorkflow, 'custom'>, string>> = {
-  omc: {
-    interview: '/deep-interview',
-    plan: '/ralplan',
-    team: '/team',
-    loop: '/ralph',
-    execute: '/ultrawork',
-    goal: '/ultrawork',
-  },
-  omx: {
-    interview: '$deep-interview',
-    plan: '$ralplan',
-    team: '$team',
-    loop: '$ralph',
-    execute: '$ultrawork',
-    goal: '$ultragoal',
-  },
-};
 
 function parseChoice<T extends readonly string[]>(value: string, choices: T, flag: string): T[number] {
   if ((choices as readonly string[]).includes(value)) return value as T[number];
@@ -87,32 +62,49 @@ function parseChoice<T extends readonly string[]>(value: string, choices: T, fla
   process.exit(2);
 }
 
-function applyRuntimeSelection(options: RunArtifactOptions): void {
+function applyRuntimeSelection(options: RunArtifactOptions, root: string): void {
   if (!options.runtime) return;
-  const selectedExecutor = RUNTIME_EXECUTORS[options.runtime];
-  if (options.executor && options.executor !== selectedExecutor) {
-    console.error(`--runtime ${options.runtime} maps to executor ${selectedExecutor}, but --executor ${options.executor} was also provided`);
+  let resolved: ReturnType<typeof resolveRuntimeProfile>;
+  let available: string[] = [];
+  try {
+    const profiles = loadRuntimeProfiles(root);
+    available = profiles.map((entry) => entry.profile.id);
+    resolved = profiles.find((entry) => entry.profile.id === options.runtime) ?? null;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+  if (!resolved) {
+    console.error(`Unknown runtime profile: ${options.runtime}. Available runtimes: ${available.join(', ') || '(none)'}`);
     process.exit(2);
   }
-  options.executor = selectedExecutor;
 
-  if (!options.workflow && (options.runtime === 'omc' || options.runtime === 'omx')) {
-    options.workflow = 'plan';
+  const { profile, source } = resolved;
+  if (options.executor && options.executor !== profile.lane) {
+    console.error(`--runtime ${options.runtime} maps to executor ${profile.lane}, but --executor ${options.executor} was also provided`);
+    process.exit(2);
   }
-  if (options.workflow && (options.runtime === 'omc' || options.runtime === 'omx')) {
-    if (options.workflow === 'custom') {
-      if (!options.harnessSkill) {
-        console.error(`--runtime ${options.runtime} with --workflow custom requires --harness-skill`);
+  options.executor = profile.lane;
+  options.runtimeProfileId = profile.id;
+  options.runtimeProfileSource = source;
+
+  if (!options.workflow && profile.defaults?.workflow) {
+    options.workflow = profile.defaults.workflow;
+  }
+
+  if (options.workflow) {
+    const expectedHarnessSkill = profile.workflows?.[options.workflow];
+    if (expectedHarnessSkill) {
+      if (options.harnessSkill && options.harnessSkill !== expectedHarnessSkill) {
+        console.error(`--runtime ${options.runtime} with --workflow ${options.workflow} requires --harness-skill ${expectedHarnessSkill}, got ${options.harnessSkill}`);
         process.exit(2);
       }
-      return;
+      options.harnessSkill = expectedHarnessSkill;
+    } else if (profile.defaults?.harnessSkill && !options.harnessSkill) {
+      options.harnessSkill = profile.defaults.harnessSkill;
     }
-    const expectedHarnessSkill = WORKFLOW_HARNESS_SKILLS[options.runtime][options.workflow];
-    if (options.harnessSkill && options.harnessSkill !== expectedHarnessSkill) {
-      console.error(`--runtime ${options.runtime} with --workflow ${options.workflow} requires --harness-skill ${expectedHarnessSkill}, got ${options.harnessSkill}`);
-      process.exit(2);
-    }
-    options.harnessSkill = expectedHarnessSkill;
+  } else if (profile.defaults?.harnessSkill && !options.harnessSkill) {
+    options.harnessSkill = profile.defaults.harnessSkill;
   }
 }
 
@@ -142,7 +134,7 @@ function parseRunOptions(args: string[]): { planPathArg: string; options: RunArt
         i += 1;
         break;
       case '--runtime':
-        options.runtime = parseChoice(takeValue(i, flag), RUNTIME_PRESETS, flag) as RuntimePreset;
+        options.runtime = takeValue(i, flag) as RuntimePreset;
         i += 1;
         break;
       case '--workflow':
@@ -196,7 +188,7 @@ function parseRunOptions(args: string[]): { planPathArg: string; options: RunArt
     }
   }
 
-  applyRuntimeSelection(options);
+  applyRuntimeSelection(options, process.cwd());
   return { planPathArg, options };
 }
 
@@ -298,6 +290,42 @@ function createArtifacts(args: string[], mode: ArtifactMode): void {
   console.log('  Note: generic open-scaffold did not spawn a runtime; dispatch via your coordinator or harness adapter.');
 }
 
+function runtimes(args: string[]): void {
+  const [subcommand, id] = args;
+  if (subcommand === 'list') {
+    try {
+      for (const entry of loadRuntimeProfiles(process.cwd())) {
+        console.log(`${entry.profile.id}\t${entry.source}\t${entry.profile.lane}\t${entry.profile.status}\t${entry.profile.displayName}`);
+      }
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+    return;
+  }
+  if (subcommand === 'show') {
+    if (!id) {
+      console.error('Missing required argument: runtime id');
+      process.exit(2);
+    }
+    let resolved: ReturnType<typeof resolveRuntimeProfile>;
+    try {
+      resolved = resolveRuntimeProfile(process.cwd(), id);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+    if (!resolved) {
+      console.error(`Unknown runtime profile: ${id}`);
+      process.exit(2);
+    }
+    console.log(JSON.stringify({ source: resolved.source, path: resolved.path ?? null, ...resolved.profile }, null, 2));
+    return;
+  }
+  console.error('Usage: osc runtimes list | osc runtimes show <id>');
+  process.exit(2);
+}
+
 function main(): void {
   const [command, ...args] = process.argv.slice(2);
   switch (command) {
@@ -341,6 +369,9 @@ function main(): void {
     case 'doctor':
       status(false);
       console.log('Doctor: generic CLI is installed; adapters must be checked in their own repos.');
+      return;
+    case 'runtimes':
+      runtimes(args);
       return;
     default:
       console.error(`Unknown command: ${command}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,6 +91,13 @@ function applyRuntimeSelection(options: RunArtifactOptions, root: string): void 
   if (!options.workflow && profile.defaults?.workflow) {
     options.workflow = profile.defaults.workflow;
   }
+  if (!options.operatorSurface && profile.defaults?.operatorSurface) {
+    if (!(OPERATOR_SURFACES as readonly string[]).includes(profile.defaults.operatorSurface)) {
+      console.error(`Runtime profile ${profile.id} has unsupported defaults.operatorSurface: ${profile.defaults.operatorSurface}`);
+      process.exit(1);
+    }
+    options.operatorSurface = profile.defaults.operatorSurface as OperatorSurface;
+  }
 
   if (options.workflow) {
     const expectedHarnessSkill = profile.workflows?.[options.workflow];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -329,7 +329,7 @@ function runtimes(args: string[]): void {
       console.error(`Unknown runtime profile: ${id}`);
       process.exit(2);
     }
-    console.log(JSON.stringify({ source: resolved.source, path: resolved.path ?? null, ...resolved.profile }, null, 2));
+    console.log(JSON.stringify({ ...resolved.profile, source: resolved.source, path: resolved.path ?? null }, null, 2));
     return;
   }
   console.error('Usage: osc runtimes list | osc runtimes show <id>');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,8 +100,11 @@ function applyRuntimeSelection(options: RunArtifactOptions, root: string): void 
         process.exit(2);
       }
       options.harnessSkill = expectedHarnessSkill;
-    } else if (profile.defaults?.harnessSkill && !options.harnessSkill) {
+    } else if (profile.defaults?.harnessSkill && options.workflow === profile.defaults.workflow && !options.harnessSkill) {
       options.harnessSkill = profile.defaults.harnessSkill;
+    } else if (profile.defaults?.harnessSkill && !options.harnessSkill) {
+      console.error(`--runtime ${options.runtime} does not define workflow ${options.workflow}; provide --harness-skill explicitly or choose a supported workflow`);
+      process.exit(2);
     }
   } else if (profile.defaults?.harnessSkill && !options.harnessSkill) {
     options.harnessSkill = profile.defaults.harnessSkill;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -191,7 +191,7 @@ function parseRunOptions(args: string[]): { planPathArg: string; options: RunArt
     }
   }
 
-  applyRuntimeSelection(options, process.cwd());
+  applyRuntimeSelection(options, options.repo ? resolve(options.repo) : process.cwd());
   return { planPathArg, options };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,13 +100,16 @@ function applyRuntimeSelection(options: RunArtifactOptions, root: string): void 
   }
 
   if (options.workflow) {
-    const expectedHarnessSkill = profile.workflows?.[options.workflow];
-    if (expectedHarnessSkill) {
+    const hasWorkflowMapping = Boolean(profile.workflows && Object.prototype.hasOwnProperty.call(profile.workflows, options.workflow));
+    const expectedHarnessSkill = hasWorkflowMapping ? profile.workflows?.[options.workflow] : undefined;
+    if (typeof expectedHarnessSkill === 'string') {
       if (options.harnessSkill && options.harnessSkill !== expectedHarnessSkill) {
         console.error(`--runtime ${options.runtime} with --workflow ${options.workflow} requires --harness-skill ${expectedHarnessSkill}, got ${options.harnessSkill}`);
         process.exit(2);
       }
       options.harnessSkill = expectedHarnessSkill;
+    } else if (hasWorkflowMapping) {
+      // Explicit null mapping means the workflow is supported but has no inferred harness skill.
     } else if (profile.defaults?.harnessSkill && options.workflow === profile.defaults.workflow && !options.harnessSkill) {
       options.harnessSkill = profile.defaults.harnessSkill;
     } else if (profile.defaults?.harnessSkill && !options.harnessSkill) {

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -242,6 +242,7 @@ function readProjectProfiles(root: string): ResolvedRuntimeProfile[] {
   const dir = join(root, '.osc', 'runtimes');
   if (!existsSync(dir)) return [];
   const profiles: ResolvedRuntimeProfile[] = [];
+  const seenProjectIds = new Set<string>();
   for (const entry of readdirSync(dir).sort()) {
     if (!entry.endsWith('.json')) continue;
     const path = join(dir, entry);
@@ -258,6 +259,10 @@ function readProjectProfiles(root: string): ResolvedRuntimeProfile[] {
     if (RESERVED_RUNTIME_PROFILE_IDS.has(validation.profile.id)) {
       throw new Error(`Project runtime profile ${path} uses reserved built-in id: ${validation.profile.id}`);
     }
+    if (seenProjectIds.has(validation.profile.id)) {
+      throw new Error(`Duplicate project runtime profile id: ${validation.profile.id}`);
+    }
+    seenProjectIds.add(validation.profile.id);
     profiles.push({ profile: validation.profile, source: 'project', path });
   }
   return profiles;

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -60,6 +60,7 @@ const PROFILE_SCHEMA_VERSION = 'open-scaffold.runtime-profile.v1';
 const SUPPORTED_LANES: ExecutorLane[] = ['omc-claude', 'omx-codex', 'plain-agent', 'human', 'custom'];
 const SUPPORTED_WORKFLOWS: RuntimeWorkflow[] = ['interview', 'plan', 'team', 'loop', 'execute', 'goal', 'custom'];
 const SUPPORTED_STATUSES: RuntimeProfileStatus[] = ['builtin', 'adapter-candidate', 'user-defined'];
+const SUPPORTED_OPERATOR_SURFACES = ['discord', 'slack', 'telegram', 'github', 'cli', 'none', 'custom'];
 
 export const BUILT_IN_RUNTIME_PROFILES: RuntimeProfile[] = [
   {
@@ -225,6 +226,9 @@ export function validateRuntimeProfile(value: unknown): { ok: true; profile: Run
     }
     if (value.defaults.harnessSkill !== undefined && value.defaults.harnessSkill !== null && typeof value.defaults.harnessSkill !== 'string') {
       errors.push('defaults.harnessSkill must be a string or null');
+    }
+    if (value.defaults.operatorSurface !== undefined && value.defaults.operatorSurface !== null && !SUPPORTED_OPERATOR_SURFACES.includes(String(value.defaults.operatorSurface))) {
+      errors.push(`defaults.operatorSurface must be one of: ${SUPPORTED_OPERATOR_SURFACES.join(', ')}`);
     }
   }
 

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -238,8 +238,14 @@ export function validateRuntimeProfile(value: unknown): { ok: true; profile: Run
     }
   }
 
+  if (value.install !== undefined && !isRecord(value.install)) {
+    errors.push('install must be an object');
+  }
   if (isRecord(value.install) && value.install.auto !== undefined && value.install.auto !== false) {
     errors.push('install.auto must be false; Open Scaffold core does not execute runtime installers in v0');
+  }
+  if (value.launch !== undefined && !isRecord(value.launch)) {
+    errors.push('launch must be an object');
   }
   if (isRecord(value.launch) && value.launch.spawning !== undefined && value.launch.spawning !== false) {
     errors.push('launch.spawning must be false; Open Scaffold core does not spawn runtimes in v0');

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -219,6 +219,9 @@ export function validateRuntimeProfile(value: unknown): { ok: true; profile: Run
 
   validateWorkflows(value.workflows, errors);
 
+  if (value.defaults !== undefined && !isRecord(value.defaults)) {
+    errors.push('defaults must be an object');
+  }
   if (isRecord(value.defaults)) {
     const workflow = value.defaults.workflow;
     if (workflow !== undefined && workflow !== null && !SUPPORTED_WORKFLOWS.includes(workflow as RuntimeWorkflow)) {

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -227,6 +227,9 @@ export function validateRuntimeProfile(value: unknown): { ok: true; profile: Run
     if (value.defaults.harnessSkill !== undefined && value.defaults.harnessSkill !== null && typeof value.defaults.harnessSkill !== 'string') {
       errors.push('defaults.harnessSkill must be a string or null');
     }
+    if (typeof value.defaults.harnessSkill === 'string' && !value.defaults.harnessSkill.trim()) {
+      errors.push('defaults.harnessSkill must not be an empty string');
+    }
     if (value.defaults.operatorSurface !== undefined && value.defaults.operatorSurface !== null && !SUPPORTED_OPERATOR_SURFACES.includes(String(value.defaults.operatorSurface))) {
       errors.push(`defaults.operatorSurface must be one of: ${SUPPORTED_OPERATOR_SURFACES.join(', ')}`);
     }

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -1,0 +1,275 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ExecutorLane, RuntimeWorkflow } from './artifacts.js';
+
+export type RuntimeProfileSource = 'builtin' | 'project';
+export type RuntimeProfileStatus = 'builtin' | 'adapter-candidate' | 'user-defined';
+
+export interface RuntimeProfile {
+  schemaVersion: 'open-scaffold.runtime-profile.v1';
+  id: string;
+  displayName: string;
+  lane: ExecutorLane;
+  status: RuntimeProfileStatus;
+  description: string;
+  links?: {
+    homepage?: string | null;
+    docs?: string | null;
+  };
+  workflows?: Partial<Record<RuntimeWorkflow, string | null>>;
+  defaults?: {
+    workflow?: RuntimeWorkflow | null;
+    harnessSkill?: string | null;
+    operatorSurface?: string | null;
+  };
+  authorityDefaults?: {
+    sandboxPolicy?: string[];
+    commitPolicy?: string;
+    pushPolicy?: string;
+    mergePolicy?: string;
+    approvalPolicy?: string;
+  };
+  install?: {
+    humanHint?: string;
+    auto?: false;
+  };
+  launch?: {
+    owner?: 'external-adapter' | 'manual' | 'none';
+    commandTemplate?: string | null;
+    expectedAdapterId?: string | null;
+    spawning?: false;
+  };
+  evidence?: {
+    receiptSchema?: 'open-scaffold.dispatch-receipt.v1';
+    expectedPaths?: string[];
+  };
+  compatibility?: {
+    minScaffoldSchema?: 'open-scaffold.run.v1';
+  };
+  lastReviewed?: string;
+  notes?: string;
+}
+
+export interface ResolvedRuntimeProfile {
+  profile: RuntimeProfile;
+  source: RuntimeProfileSource;
+  path?: string;
+}
+
+const PROFILE_SCHEMA_VERSION = 'open-scaffold.runtime-profile.v1';
+const SUPPORTED_LANES: ExecutorLane[] = ['omc-claude', 'omx-codex', 'plain-agent', 'human', 'custom'];
+const SUPPORTED_WORKFLOWS: RuntimeWorkflow[] = ['interview', 'plan', 'team', 'loop', 'execute', 'goal', 'custom'];
+const SUPPORTED_STATUSES: RuntimeProfileStatus[] = ['builtin', 'adapter-candidate', 'user-defined'];
+
+export const BUILT_IN_RUNTIME_PROFILES: RuntimeProfile[] = [
+  {
+    schemaVersion: PROFILE_SCHEMA_VERSION,
+    id: 'omc',
+    displayName: 'OMC / oh-my-claudecode',
+    lane: 'omc-claude',
+    status: 'adapter-candidate',
+    description: 'Claude Code + OMC / oh-my-claudecode workflow harness lane.',
+    links: { homepage: 'https://github.com/Yeachan-Heo/oh-my-claudecode' },
+    workflows: {
+      interview: '/deep-interview',
+      plan: '/ralplan',
+      team: '/team',
+      loop: '/ralph',
+      execute: '/ultrawork',
+      goal: '/ultrawork',
+    },
+    defaults: { workflow: 'plan', harnessSkill: '/ralplan', operatorSurface: 'none' },
+    authorityDefaults: {
+      sandboxPolicy: ['write_artifacts_only'],
+      commitPolicy: 'commit_forbidden_without_operator_approval',
+      pushPolicy: 'push_forbidden_without_operator_approval',
+      mergePolicy: 'merge_forbidden_without_operator_approval',
+      approvalPolicy: 'human_approval_required',
+    },
+    install: { humanHint: 'Install OMC from https://github.com/Yeachan-Heo/oh-my-claudecode; configure Claude Code authentication separately.', auto: false },
+    launch: { owner: 'external-adapter', commandTemplate: null, expectedAdapterId: null, spawning: false },
+    evidence: { receiptSchema: 'open-scaffold.dispatch-receipt.v1', expectedPaths: ['.osc/runs/<run_id>/dispatch-receipt.json'] },
+    compatibility: { minScaffoldSchema: 'open-scaffold.run.v1' },
+    lastReviewed: '2026-05-15',
+    notes: 'Adapter candidate. Open Scaffold core packages the run; OMC/Claude execution remains adapter-owned.',
+  },
+  {
+    schemaVersion: PROFILE_SCHEMA_VERSION,
+    id: 'omx',
+    displayName: 'OMX / oh-my-codex',
+    lane: 'omx-codex',
+    status: 'adapter-candidate',
+    description: 'Codex + OMX / oh-my-codex workflow harness lane.',
+    links: { homepage: 'https://github.com/Yeachan-Heo/oh-my-codex' },
+    workflows: {
+      interview: '$deep-interview',
+      plan: '$ralplan',
+      team: '$team',
+      loop: '$ralph',
+      execute: '$ultrawork',
+      goal: '$ultragoal',
+    },
+    defaults: { workflow: 'plan', harnessSkill: '$ralplan', operatorSurface: 'none' },
+    authorityDefaults: {
+      sandboxPolicy: ['write_artifacts_only'],
+      commitPolicy: 'commit_forbidden_without_operator_approval',
+      pushPolicy: 'push_forbidden_without_operator_approval',
+      mergePolicy: 'merge_forbidden_without_operator_approval',
+      approvalPolicy: 'human_approval_required',
+    },
+    install: { humanHint: 'Install OMX from https://github.com/Yeachan-Heo/oh-my-codex; configure Codex authentication separately.', auto: false },
+    launch: { owner: 'external-adapter', commandTemplate: null, expectedAdapterId: null, spawning: false },
+    evidence: { receiptSchema: 'open-scaffold.dispatch-receipt.v1', expectedPaths: ['.osc/runs/<run_id>/dispatch-receipt.json'] },
+    compatibility: { minScaffoldSchema: 'open-scaffold.run.v1' },
+    lastReviewed: '2026-05-15',
+    notes: 'Adapter candidate. Open Scaffold core packages the run; OMX/Codex execution remains adapter-owned.',
+  },
+  {
+    schemaVersion: PROFILE_SCHEMA_VERSION,
+    id: 'plain',
+    displayName: 'Plain agent',
+    lane: 'plain-agent',
+    status: 'builtin',
+    description: 'Runtime-neutral prompt package for any capable agent or human-operated CLI.',
+    defaults: { workflow: null, harnessSkill: null, operatorSurface: 'none' },
+    install: { humanHint: 'Use any agent/runtime capable of consuming the generated prompt package.', auto: false },
+    launch: { owner: 'manual', commandTemplate: null, expectedAdapterId: null, spawning: false },
+    evidence: { receiptSchema: 'open-scaffold.dispatch-receipt.v1', expectedPaths: ['.osc/runs/<run_id>/dispatch-receipt.json'] },
+    compatibility: { minScaffoldSchema: 'open-scaffold.run.v1' },
+    lastReviewed: '2026-05-15',
+  },
+  {
+    schemaVersion: PROFILE_SCHEMA_VERSION,
+    id: 'human',
+    displayName: 'Human/manual',
+    lane: 'human',
+    status: 'builtin',
+    description: 'Manual execution while preserving Open Scaffold evidence and approval gates.',
+    defaults: { workflow: null, harnessSkill: null, operatorSurface: 'none' },
+    install: { humanHint: 'No runtime install required.', auto: false },
+    launch: { owner: 'manual', commandTemplate: null, expectedAdapterId: null, spawning: false },
+    evidence: { receiptSchema: 'open-scaffold.dispatch-receipt.v1', expectedPaths: ['.osc/runs/<run_id>/dispatch-receipt.json'] },
+    compatibility: { minScaffoldSchema: 'open-scaffold.run.v1' },
+    lastReviewed: '2026-05-15',
+  },
+  {
+    schemaVersion: PROFILE_SCHEMA_VERSION,
+    id: 'custom',
+    displayName: 'Custom adapter',
+    lane: 'custom',
+    status: 'builtin',
+    description: 'Placeholder lane for adapter-defined execution. Prefer a project-local profile for repeatable custom runtimes.',
+    defaults: { workflow: 'custom', harnessSkill: null, operatorSurface: 'none' },
+    install: { humanHint: 'Define adapter-specific setup outside Open Scaffold core.', auto: false },
+    launch: { owner: 'external-adapter', commandTemplate: null, expectedAdapterId: null, spawning: false },
+    evidence: { receiptSchema: 'open-scaffold.dispatch-receipt.v1', expectedPaths: ['.osc/runs/<run_id>/dispatch-receipt.json'] },
+    compatibility: { minScaffoldSchema: 'open-scaffold.run.v1' },
+    lastReviewed: '2026-05-15',
+  },
+];
+
+export const RESERVED_RUNTIME_PROFILE_IDS = new Set(BUILT_IN_RUNTIME_PROFILES.map((profile) => profile.id));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireString(record: Record<string, unknown>, key: string, errors: string[]): string | undefined {
+  const value = record[key];
+  if (typeof value === 'string' && value.trim()) return value;
+  errors.push(`${key} must be a non-empty string`);
+  return undefined;
+}
+
+function validateWorkflows(value: unknown, errors: string[]): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) {
+    errors.push('workflows must be an object');
+    return;
+  }
+  for (const [workflow, harnessSkill] of Object.entries(value)) {
+    if (!SUPPORTED_WORKFLOWS.includes(workflow as RuntimeWorkflow)) {
+      errors.push(`workflows.${workflow} is not a supported workflow`);
+    }
+    if (harnessSkill !== null && typeof harnessSkill !== 'string') {
+      errors.push(`workflows.${workflow} must be a string or null`);
+    }
+  }
+}
+
+export function validateRuntimeProfile(value: unknown): { ok: true; profile: RuntimeProfile } | { ok: false; errors: string[] } {
+  const errors: string[] = [];
+  if (!isRecord(value)) return { ok: false, errors: ['profile must be a JSON object'] };
+
+  const schemaVersion = requireString(value, 'schemaVersion', errors);
+  const id = requireString(value, 'id', errors);
+  requireString(value, 'displayName', errors);
+  const lane = requireString(value, 'lane', errors);
+  const status = requireString(value, 'status', errors);
+  requireString(value, 'description', errors);
+
+  if (schemaVersion && schemaVersion !== PROFILE_SCHEMA_VERSION) errors.push(`schemaVersion must be ${PROFILE_SCHEMA_VERSION}`);
+  if (id && !/^[a-z][a-z0-9._-]*$/.test(id)) errors.push('id must start with a lowercase letter and contain only lowercase letters, numbers, dot, underscore, or hyphen');
+  if (lane && !SUPPORTED_LANES.includes(lane as ExecutorLane)) errors.push(`lane must be one of: ${SUPPORTED_LANES.join(', ')}`);
+  if (status && !SUPPORTED_STATUSES.includes(status as RuntimeProfileStatus)) errors.push(`status must be one of: ${SUPPORTED_STATUSES.join(', ')}`);
+
+  validateWorkflows(value.workflows, errors);
+
+  if (isRecord(value.defaults)) {
+    const workflow = value.defaults.workflow;
+    if (workflow !== undefined && workflow !== null && !SUPPORTED_WORKFLOWS.includes(workflow as RuntimeWorkflow)) {
+      errors.push(`defaults.workflow must be one of: ${SUPPORTED_WORKFLOWS.join(', ')}`);
+    }
+    if (value.defaults.harnessSkill !== undefined && value.defaults.harnessSkill !== null && typeof value.defaults.harnessSkill !== 'string') {
+      errors.push('defaults.harnessSkill must be a string or null');
+    }
+  }
+
+  if (isRecord(value.install) && value.install.auto !== undefined && value.install.auto !== false) {
+    errors.push('install.auto must be false; Open Scaffold core does not execute runtime installers in v0');
+  }
+  if (isRecord(value.launch) && value.launch.spawning !== undefined && value.launch.spawning !== false) {
+    errors.push('launch.spawning must be false; Open Scaffold core does not spawn runtimes in v0');
+  }
+  if (isRecord(value.launch) && value.launch.commandTemplate !== undefined && value.launch.commandTemplate !== null && typeof value.launch.commandTemplate !== 'string') {
+    errors.push('launch.commandTemplate must be a string or null');
+  }
+
+  return errors.length ? { ok: false, errors } : { ok: true, profile: value as unknown as RuntimeProfile };
+}
+
+function readProjectProfiles(root: string): ResolvedRuntimeProfile[] {
+  const dir = join(root, '.osc', 'runtimes');
+  if (!existsSync(dir)) return [];
+  const profiles: ResolvedRuntimeProfile[] = [];
+  for (const entry of readdirSync(dir).sort()) {
+    if (!entry.endsWith('.json')) continue;
+    const path = join(dir, entry);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(path, 'utf8'));
+    } catch (error) {
+      throw new Error(`Invalid runtime profile JSON at ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    const validation = validateRuntimeProfile(parsed);
+    if (validation.ok === false) {
+      throw new Error(`Invalid runtime profile at ${path}: ${validation.errors.join('; ')}`);
+    }
+    if (RESERVED_RUNTIME_PROFILE_IDS.has(validation.profile.id)) {
+      throw new Error(`Project runtime profile ${path} uses reserved built-in id: ${validation.profile.id}`);
+    }
+    profiles.push({ profile: validation.profile, source: 'project', path });
+  }
+  return profiles;
+}
+
+export function loadRuntimeProfiles(root: string): ResolvedRuntimeProfile[] {
+  return [
+    ...BUILT_IN_RUNTIME_PROFILES.map((profile) => ({ profile, source: 'builtin' as const })),
+    ...readProjectProfiles(root),
+  ];
+}
+
+export function resolveRuntimeProfile(root: string, id: string): ResolvedRuntimeProfile | null {
+  return loadRuntimeProfiles(root).find((entry) => entry.profile.id === id) ?? null;
+}

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -194,6 +194,9 @@ function validateWorkflows(value: unknown, errors: string[]): void {
     if (harnessSkill !== null && typeof harnessSkill !== 'string') {
       errors.push(`workflows.${workflow} must be a string or null`);
     }
+    if (typeof harnessSkill === 'string' && !harnessSkill.trim()) {
+      errors.push(`workflows.${workflow} must not be an empty string`);
+    }
   }
 }
 

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -112,7 +112,7 @@ describe('osc init CLI', () => {
     expect(runId).toBeTruthy();
     const manifest = JSON.parse(readFileSync(join(runsDir, runId!, 'run.json'), 'utf8'));
 
-    expect(manifest.runtimeSelection).toMatchObject({ runtime: 'omx', workflow: 'plan' });
+    expect(manifest.runtimeSelection).toMatchObject({ runtime: 'omx', workflow: 'plan', profileId: 'omx', profileSource: 'builtin' });
     expect(manifest.executor).toMatchObject({ lane: 'omx-codex', harnessSkill: '$ralplan', spawning: false });
   }, 15_000);
 
@@ -128,7 +128,7 @@ describe('osc init CLI', () => {
     expect(runId).toBeTruthy();
     const manifest = JSON.parse(readFileSync(join(runsDir, runId!, 'run.json'), 'utf8'));
 
-    expect(manifest.runtimeSelection).toMatchObject({ runtime: 'omx', workflow: 'plan' });
+    expect(manifest.runtimeSelection).toMatchObject({ runtime: 'omx', workflow: 'plan', profileId: 'omx', profileSource: 'builtin' });
     expect(manifest.executor).toMatchObject({ lane: 'omx-codex', harnessSkill: '$ralplan', spawning: false });
   }, 15_000);
 
@@ -145,6 +145,95 @@ describe('osc init CLI', () => {
 
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('--runtime omx with --workflow plan requires --harness-skill $ralplan');
+  }, 15_000);
+
+  it('lists and shows runtime profiles with source labels', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+
+    const list = execFileSync(tsx, [cli, 'runtimes', 'list'], { cwd: target, encoding: 'utf8' });
+    expect(list).toContain('omx\tbuiltin\tomx-codex\tadapter-candidate');
+
+    const shown = JSON.parse(execFileSync(tsx, [cli, 'runtimes', 'show', 'omx'], { cwd: target, encoding: 'utf8' }));
+    expect(shown).toMatchObject({ id: 'omx', source: 'builtin', lane: 'omx-codex' });
+  }, 15_000);
+
+  it('uses a project-local runtime profile in run packets', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    const planPath = writeRuntimeSelectionPlan(target, 'Demo custom runtime profile.');
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/review-bot.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'review-bot',
+      displayName: 'Review Bot',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Project-local review bot profile.',
+      workflows: { plan: 'review-bot plan' },
+      defaults: { workflow: 'plan', harnessSkill: 'review-bot plan' },
+      install: { humanHint: 'Install through the project developer portal.', auto: false },
+      launch: { owner: 'external-adapter', commandTemplate: 'review-bot run <run.json>', spawning: false },
+      evidence: { receiptSchema: 'open-scaffold.dispatch-receipt.v1' },
+    }, null, 2));
+
+    execFileSync(tsx, [cli, 'run', planPath, '--runtime', 'review-bot', '--repo', target], { cwd: target, encoding: 'utf8' });
+    const runsDir = join(target, '.osc/runs');
+    const runId = readdirSync(runsDir).sort().at(-1);
+    const manifest = JSON.parse(readFileSync(join(runsDir, runId!, 'run.json'), 'utf8'));
+
+    expect(manifest.runtimeSelection).toMatchObject({ runtime: 'review-bot', workflow: 'plan', profileId: 'review-bot', profileSource: 'project' });
+    expect(manifest.executor).toMatchObject({ lane: 'plain-agent', harnessSkill: 'review-bot plan', spawning: false });
+  }, 15_000);
+
+  it('rejects project profiles that override reserved built-in ids', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/omx.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'omx',
+      displayName: 'Fake OMX',
+      lane: 'custom',
+      status: 'user-defined',
+      description: 'Should not override built-in OMX.',
+      launch: { spawning: false },
+    }, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'runtimes', 'list'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('uses reserved built-in id: omx');
+  }, 15_000);
+
+  it('rejects runtime profiles that try to enable spawning or installer execution', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/spawner.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'spawner',
+      displayName: 'Spawner',
+      lane: 'custom',
+      status: 'user-defined',
+      description: 'Unsafe profile.',
+      install: { auto: true },
+      launch: { spawning: true },
+    }, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'runtimes', 'show', 'spawner'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('install.auto must be false');
+    expect(result.stderr).toContain('launch.spawning must be false');
+  }, 15_000);
+
+  it('rejects unknown runtime ids', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    const planPath = writeRuntimeSelectionPlan(target, 'Demo unknown runtime rejection.');
+
+    const result = spawnSync(tsx, [cli, 'run', planPath, '--runtime', 'missing-runtime', '--repo', target], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Unknown runtime profile: missing-runtime');
   }, 15_000);
 
 });

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -206,6 +206,33 @@ describe('osc init CLI', () => {
     expect(manifest.executor).toMatchObject({ lane: 'plain-agent', harnessSkill: 'review-bot plan', spawning: false });
   }, 15_000);
 
+  it('resolves project-local runtime profiles from --repo when launched outside that repo', () => {
+    const target = tempTarget();
+    const coordinator = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    const planPath = writeRuntimeSelectionPlan(target, 'Demo external coordinator runtime profile resolution.');
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/external-agent.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'external-agent',
+      displayName: 'External Agent',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Project-local profile resolved through --repo.',
+      workflows: { plan: 'external-agent plan' },
+      defaults: { workflow: 'plan', harnessSkill: 'external-agent plan' },
+      launch: { owner: 'external-adapter', commandTemplate: 'external-agent run <run.json>', spawning: false },
+    }, null, 2));
+
+    execFileSync(tsx, [cli, 'run', planPath, '--runtime', 'external-agent', '--repo', target], { cwd: coordinator, encoding: 'utf8' });
+    const runsDir = join(coordinator, '.osc/runs');
+    const runId = readdirSync(runsDir).sort().at(-1);
+    const manifest = JSON.parse(readFileSync(join(runsDir, runId!, 'run.json'), 'utf8'));
+
+    expect(manifest.runtimeSelection).toMatchObject({ runtime: 'external-agent', workflow: 'plan', profileId: 'external-agent', profileSource: 'project' });
+    expect(manifest.executor).toMatchObject({ lane: 'plain-agent', harnessSkill: 'external-agent plan', spawning: false });
+  }, 15_000);
+
   it('rejects project profiles that override reserved built-in ids', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -191,7 +191,7 @@ describe('osc init CLI', () => {
       status: 'user-defined',
       description: 'Project-local review bot profile.',
       workflows: { plan: 'review-bot plan' },
-      defaults: { workflow: 'plan', harnessSkill: 'review-bot plan' },
+      defaults: { workflow: 'plan', harnessSkill: 'review-bot plan', operatorSurface: 'github' },
       install: { humanHint: 'Install through the project developer portal.', auto: false },
       launch: { owner: 'external-adapter', commandTemplate: 'review-bot run <run.json>', spawning: false },
       evidence: { receiptSchema: 'open-scaffold.dispatch-receipt.v1' },
@@ -204,6 +204,7 @@ describe('osc init CLI', () => {
 
     expect(manifest.runtimeSelection).toMatchObject({ runtime: 'review-bot', workflow: 'plan', profileId: 'review-bot', profileSource: 'project' });
     expect(manifest.executor).toMatchObject({ lane: 'plain-agent', harnessSkill: 'review-bot plan', spawning: false });
+    expect(manifest.bindings).toMatchObject({ operatorSurface: 'github' });
   }, 15_000);
 
   it('resolves project-local runtime profiles from --repo when launched outside that repo', () => {
@@ -292,6 +293,26 @@ describe('osc init CLI', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('install.auto must be false');
     expect(result.stderr).toContain('launch.spawning must be false');
+  }, 15_000);
+
+  it('rejects empty workflow command tokens in runtime profiles', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/empty-workflow.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'empty-workflow',
+      displayName: 'Empty Workflow',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Invalid empty workflow token.',
+      workflows: { plan: '' },
+      launch: { spawning: false },
+    }, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'runtimes', 'show', 'empty-workflow'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('workflows.plan must not be an empty string');
   }, 15_000);
 
   it('rejects unknown runtime ids', () => {

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -335,6 +335,26 @@ describe('osc init CLI', () => {
     expect(result.stderr).toContain('defaults.operatorSurface must be one of');
   }, 15_000);
 
+  it('rejects empty default harness skills in runtime profiles', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/empty-default-harness.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'empty-default-harness',
+      displayName: 'Empty Default Harness',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Invalid empty default harness skill.',
+      defaults: { workflow: 'plan', harnessSkill: '' },
+      launch: { spawning: false },
+    }, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'runtimes', 'show', 'empty-default-harness'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('defaults.harnessSkill must not be an empty string');
+  }, 15_000);
+
   it('rejects unknown runtime ids', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -167,6 +167,30 @@ describe('osc init CLI', () => {
     expect(manifest.executor).toMatchObject({ lane: 'omx-codex', harnessSkill: '$custom', spawning: false });
   }, 15_000);
 
+  it('honors explicit null workflow mappings as supported workflows without inferred harness skills', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    const planPath = writeRuntimeSelectionPlan(target, 'Demo null workflow mapping.');
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/no-harness.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'no-harness',
+      displayName: 'No Harness',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Supports plan workflow without inferred harness skill.',
+      workflows: { plan: null },
+      launch: { spawning: false },
+    }, null, 2));
+
+    execFileSync(tsx, [cli, 'run', planPath, '--runtime', 'no-harness', '--workflow', 'plan', '--repo', target], { cwd: target, encoding: 'utf8' });
+    const runsDir = join(target, '.osc/runs');
+    const runId = readdirSync(runsDir).sort().at(-1);
+    const manifest = JSON.parse(readFileSync(join(runsDir, runId!, 'run.json'), 'utf8'));
+    expect(manifest.runtimeSelection).toMatchObject({ runtime: 'no-harness', workflow: 'plan', profileId: 'no-harness', profileSource: 'project' });
+    expect(manifest.executor).toMatchObject({ lane: 'plain-agent', harnessSkill: null, spawning: false });
+  }, 15_000);
+
   it('lists and shows runtime profiles with source labels', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
@@ -293,6 +317,27 @@ describe('osc init CLI', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('install.auto must be false');
     expect(result.stderr).toContain('launch.spawning must be false');
+  }, 15_000);
+
+  it('rejects non-object install and launch blocks in runtime profiles', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/bad-blocks.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'bad-blocks',
+      displayName: 'Bad Blocks',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Invalid install and launch blocks.',
+      install: 'portal',
+      launch: [],
+    }, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'runtimes', 'show', 'bad-blocks'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('install must be an object');
+    expect(result.stderr).toContain('launch must be an object');
   }, 15_000);
 
   it('rejects empty workflow command tokens in runtime profiles', () => {

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -355,6 +355,47 @@ describe('osc init CLI', () => {
     expect(result.stderr).toContain('defaults.harnessSkill must not be an empty string');
   }, 15_000);
 
+  it('rejects non-object defaults in runtime profiles', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/bad-defaults.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'bad-defaults',
+      displayName: 'Bad Defaults',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Invalid defaults block.',
+      defaults: 'plan',
+      launch: { spawning: false },
+    }, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'runtimes', 'show', 'bad-defaults'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('defaults must be an object');
+  }, 15_000);
+
+  it('preserves trusted runtime profile source metadata in show output', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/spoof.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'spoof',
+      displayName: 'Spoof',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Attempts to spoof trusted output metadata.',
+      source: 'builtin',
+      path: '/trusted',
+      launch: { spawning: false },
+    }, null, 2));
+
+    const shown = JSON.parse(execFileSync(tsx, [cli, 'runtimes', 'show', 'spoof'], { cwd: target, encoding: 'utf8' }));
+    expect(shown).toMatchObject({ id: 'spoof', source: 'project' });
+    expect(shown.path).toContain('.osc/runtimes/spoof.json');
+  }, 15_000);
+
   it('rejects unknown runtime ids', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -315,6 +315,26 @@ describe('osc init CLI', () => {
     expect(result.stderr).toContain('workflows.plan must not be an empty string');
   }, 15_000);
 
+  it('rejects unsupported default operator surfaces in runtime profiles', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    writeFileSync(join(target, '.osc/runtimes/bad-surface.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'bad-surface',
+      displayName: 'Bad Surface',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Invalid default operator surface.',
+      defaults: { operatorSurface: 'matrix' },
+      launch: { spawning: false },
+    }, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'runtimes', 'show', 'bad-surface'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('defaults.operatorSurface must be one of');
+  }, 15_000);
+
   it('rejects unknown runtime ids', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -147,6 +147,26 @@ describe('osc init CLI', () => {
     expect(result.stderr).toContain('--runtime omx with --workflow plan requires --harness-skill $ralplan');
   }, 15_000);
 
+  it('rejects unmapped workflows for runtime profiles unless harness skill is explicit', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    const planPath = writeRuntimeSelectionPlan(target, 'Demo unmapped workflow rejection.');
+
+    const result = spawnSync(tsx, [cli, 'run', planPath, '--runtime', 'omx', '--workflow', 'custom', '--repo', target], {
+      cwd: target,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('--runtime omx does not define workflow custom');
+
+    execFileSync(tsx, [cli, 'run', planPath, '--runtime', 'omx', '--workflow', 'custom', '--harness-skill', '$custom', '--repo', target], { cwd: target, encoding: 'utf8' });
+    const runsDir = join(target, '.osc/runs');
+    const runId = readdirSync(runsDir).sort().at(-1);
+    const manifest = JSON.parse(readFileSync(join(runsDir, runId!, 'run.json'), 'utf8'));
+    expect(manifest.executor).toMatchObject({ lane: 'omx-codex', harnessSkill: '$custom', spawning: false });
+  }, 15_000);
+
   it('lists and shows runtime profiles with source labels', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
@@ -203,6 +223,27 @@ describe('osc init CLI', () => {
     const result = spawnSync(tsx, [cli, 'runtimes', 'list'], { cwd: target, encoding: 'utf8' });
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('uses reserved built-in id: omx');
+  }, 15_000);
+
+  it('rejects duplicate project runtime profile ids', () => {
+    const target = tempTarget();
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+    mkdirSync(join(target, '.osc/runtimes'), { recursive: true });
+    const profile = {
+      schemaVersion: 'open-scaffold.runtime-profile.v1',
+      id: 'dupe-agent',
+      displayName: 'Dupe Agent',
+      lane: 'plain-agent',
+      status: 'user-defined',
+      description: 'Duplicate id fixture.',
+      launch: { spawning: false },
+    };
+    writeFileSync(join(target, '.osc/runtimes/a.json'), JSON.stringify(profile, null, 2));
+    writeFileSync(join(target, '.osc/runtimes/b.json'), JSON.stringify(profile, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'runtimes', 'list'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Duplicate project runtime profile id: dupe-agent');
   }, 15_000);
 
   it('rejects runtime profiles that try to enable spawning or installer execution', () => {


### PR DESCRIPTION
## Summary

Adds runtime profiles v0 so Open Scaffold runtime selection is schema-backed and project-extensible instead of hard-coded CLI special cases.

- Adds `open-scaffold.runtime-profile.v1` runtime profile types, built-in profile catalog, project-local `.osc/runtimes/*.json` profile loading, and validation.
- Adds `osc runtimes list` and `osc runtimes show <id>`.
- Resolves `osc run <plan> --runtime <id>` through the runtime profile catalog, preserving OMC/OMX behavior while allowing project-local profiles.
- Records `profileId` and `profileSource` in generated `run.json` runtime selection metadata.
- Documents runtime profiles as data-only contracts: no install execution, no network registry, no runtime spawning in core.
- Adds the layman runtime flow to the README: user selects runtime → Open Scaffold reads profile → creates run packet → adapter/coordinator launches runtime → evidence returns.
- Adds a project-local profile example and closes plan `034-runtime-profiles-v0`.

## Boundary

This PR intentionally does **not** add:

- runtime install/spawn/dispatch execution;
- network/hosted registries or marketplace behavior;
- arbitrary script execution from profiles;
- credentials/auth handling;
- certified GSD or other third-party support claims without conformance evidence.

## Codex fixes

- Rejects unmapped workflow/profile combinations unless `--harness-skill` is explicit, preserving the old safe `custom` workflow behavior for OMC/OMX.
- Rejects duplicate project-local runtime profile ids so runtime resolution is never ambiguous.
- Resolves project-local profiles from `--repo` when provided, so external coordinator workspaces can select target-repo `.osc/runtimes/*.json` profiles.
- Applies `defaults.operatorSurface` from runtime profiles when `--operator-surface` is omitted.
- Rejects empty workflow command tokens during profile validation.
- Validates `defaults.operatorSurface` during profile validation.
- Rejects empty `defaults.harnessSkill` values during profile validation.
- Rejects non-object `defaults`, `install`, and `launch` blocks.
- Preserves trusted `source`/`path` metadata in `osc runtimes show` output.
- Honors explicit `null` workflow mappings as supported workflows without inferred harness skills.

## Traceability

- Plan: `.osc/plans/done/034-runtime-profiles-v0.md`
- Release/evidence note: `.osc/releases/2026-05-15-runtime-profiles-v0.md`
- Roadmap: Milestone 9 runtime profile follow-up
- Task: `t_fba215ae`

## Verification

- [x] `git diff --check`
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- [x] `npm run osc -- verify` — PASS, 0 warnings
- [x] `npm test` — 8 files passed, 74 tests passed
- [x] `npm run build`
