### PR TITLE
Simplify runtime docs and roadmap hypotheses

### DIFF
--- a/.osc/plans/done/035-runtime-docs-simplification.md
+++ b/.osc/plans/done/035-runtime-docs-simplification.md
@@ -1,0 +1,68 @@
+# Plan: 035-runtime-docs-simplification
+
+## Status
+
+active — docs simplification and runtime hypothesis reconciliation after runtime profiles v0 shipped.
+
+## Context
+
+Open Scaffold now has the runtime substrate that earlier strategy slices were circling: runtime selection, schema-backed runtime profiles, built-in OMC/OMX/plain/human/custom profiles, project-local `.osc/runtimes/*.json`, and run packets that record the chosen profile without spawning runtimes from core.
+
+The public docs still risk making a fresh reader assemble the product story from many protocol documents. The clearest story is now:
+
+```text
+User selects runtime
+  -> Open Scaffold reads runtime profile
+  -> Open Scaffold creates the run packet
+  -> Adapter/coordinator launches the actual runtime
+  -> Runtime does the work
+  -> Evidence comes back into Open Scaffold
+```
+
+## Goal
+
+Simplify the public narrative around runtime selection/profiles and reconcile older runtime/orchestration hypotheses with the shipped state, without adding runtime spawning, install behavior, marketplace semantics, or model-lab claims.
+
+## Constraints / Out of scope
+
+- Do not add real runtime install/spawn/check commands.
+- Do not add hosted registries, marketplaces, network imports, or package-manager behavior.
+- Do not claim OMC/OMX/GSD certified integrations beyond what the repo proves.
+- Do not promote model benchmarking, model routing, or multi-agent spawning into core.
+- Do not leak private owner context or local execution details.
+- Do not edit completed plan history in place.
+
+## Files to touch
+
+- `README.md` — lead with the simple product/runtime flow and a shorter first path.
+- `docs/OPEN_SCAFFOLD_SYSTEM.md` — clarify progressive-disclosure map.
+- `docs/RUNTIME_SELECTION.md` — keep runtime choice as the user-facing selection layer.
+- `docs/RUNTIME_PROFILES.md` — keep profile catalog as the configuration layer.
+- `docs/RUNTIME_BINDING_CONTRACT.md` — keep binding as adapter/coordinator execution layer.
+- `docs/examples/README.md` — route fresh readers quickly to downstream walkthrough and runtime-profile example.
+- `ROADMAP.md` — mark runtime selection/profile state as shipped and keep remaining orchestration/model-lab items as future hypotheses, not current promises.
+- `.osc/releases/` — add evidence note for this slice.
+
+## Acceptance criteria
+
+- [ ] README explains Open Scaffold in plain language before protocol detail.
+- [ ] Runtime docs follow progressive disclosure: select runtime -> resolve profile -> create run packet -> adapter/coordinator executes -> evidence returns.
+- [ ] Duplicate runtime explanations are reduced across runtime selection/profile/binding docs.
+- [ ] ROADMAP no longer makes backlog `030` / `031` look like the next implementation priority after PR #37; remaining runtime/orchestration/model-lab work is framed as future hypothesis or explicit follow-up.
+- [ ] Fresh-user example navigation points to the downstream walkthrough and runtime profile example quickly.
+- [ ] Public docs avoid private context, unsupported certified-integration claims, real spawning claims, and model-performance claims.
+- [ ] Verification passes: `git diff --check`, `./verify.sh --strict`, `npm run osc -- verify`, `npm test`, and `npm run build`.
+
+## Verification steps
+
+1. Run `git diff --check`.
+2. Run `./verify.sh --strict`.
+3. Run `npm run osc -- verify`.
+4. Run `npm test`.
+5. Run `npm run build`.
+6. Search touched public docs for private/local leakage and unsupported runtime/certification claims.
+
+## Open questions
+
+- Should backlog plans `030` and `031` be closed/superseded in this PR, or left as visible hypotheses after the roadmap clarifies their status?
+- Should future work add `osc runtimes check <id>` as a dry-run adapter-readiness command, or should docs simplification land first?

--- a/.osc/releases/2026-05-16-runtime-docs-simplification.md
+++ b/.osc/releases/2026-05-16-runtime-docs-simplification.md
@@ -1,0 +1,56 @@
+# Release evidence: runtime docs simplification
+
+## Summary
+
+Simplified the public runtime narrative after runtime profiles v0 shipped. The docs now lead with the plain flow:
+
+```text
+User selects runtime
+  -> Open Scaffold reads runtime profile
+  -> Open Scaffold creates the run packet
+  -> Adapter/coordinator launches the actual runtime
+  -> Runtime does the work
+  -> Evidence comes back into Open Scaffold
+```
+
+## Scope
+
+- Plan: `.osc/plans/done/035-runtime-docs-simplification.md`
+- Roadmap area: runtime selection/profile clarity and hypothesis reconciliation after PR #37
+- Branch: `docs/runtime-docs-simplification`
+
+## Traceability
+
+- Operator task: `t_14b40621`
+- Plan: `.osc/plans/done/035-runtime-docs-simplification.md`
+- Run ID: not applicable; local docs slice
+- PR: pending operator approval
+- Evidence: this release note plus verification commands below
+
+## Changes
+
+- README leads with the runtime handoff flow and a shorter plain-language product story.
+- Runtime docs are organized as progressive disclosure:
+  1. `docs/RUNTIME_SELECTION.md` — user-facing runtime/workflow choice.
+  2. `docs/RUNTIME_PROFILES.md` — built-in and project-local runtime profile data.
+  3. `docs/RUNTIME_BINDING_CONTRACT.md` — adapter/coordinator execution responsibilities.
+- `docs/OPEN_SCAFFOLD_SYSTEM.md` and examples route fresh readers through the same selection → profile → run packet → adapter → evidence chain.
+- `ROADMAP.md` clarifies that older runtime/orchestration hypotheses are not the next implementation queue; shipped runtime selection/profile support remains non-spawning and adapter-mediated.
+
+## Verification
+
+- `git diff --check` — passed
+- `./verify.sh --strict` — passed, 10 pass / 0 fail / 0 warn
+- `npm run osc -- verify` — passed, 0 warnings
+- `npm test` — passed, 8 files / 74 tests
+- `npm run build` — passed
+- Added-line private/secrets scan — passed
+- Added-line unsupported positive-claims scan — passed
+
+## Outcome
+
+Public docs should be easier to read without making unsupported claims about runtime spawning, hosted registries, certified integrations, or model/task benchmarking.
+
+## Follow-up
+
+Future runtime work should be a concrete adapter/evidence slice, not another broad runtime vision branch. Candidate follow-up: dry-run `osc runtimes check <id>` or a conformance proof for one external adapter.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-16: closed 035-runtime-docs-simplification — runtime docs simplification and hypothesis reconciliation shipped
 - 2026-05-15: closed 034-runtime-profiles-v0 — runtime profiles v0 shipped with schema-backed built-in and project-local runtime selection
 - 2026-05-15: closed 009-runtime-harness-adapter-refresh — runtime adapter refresh audit and conformance lane coverage shipped
 - 2026-05-15: closed 019-comparison-page — comparison page shipped in public trust/readiness bundle

--- a/README.md
+++ b/README.md
@@ -10,13 +10,26 @@
 
 </div>
 
-Open Scaffold gives solo developers and small teams a lightweight way to keep AI coding work traceable. It stores mission, roadmap, plans, run packets (execution packages), evidence, decisions, and handoff notes in the repo so humans and agents can see what was asked, changed, verified, and approved.
+Open Scaffold gives solo developers and small teams a lightweight way to keep AI coding work traceable. It stores mission, roadmap, plans, run packets, evidence, decisions, and handoff notes in the repo so humans and agents can see what was asked, changed, verified, and approved.
 
 Use it when AI work spans sessions, PRs, agents, or review gates — especially when you need proof without a documentation swamp.
 
-> **What it is:** a repo-native protocol (files, folders, helper scripts, a verification check) that any agent or orchestrator can operate on.
+> **What it is:** a repo-native source-of-truth protocol that packages work for humans, agents, coordinators, and runtime adapters.
 >
-> **What it is not:** an agent runtime, a Discord bot, a daemon, a task database, a model ranker, or a code reviewer. Those live in tools you choose; the scaffold is what they read and write.
+> **What it is not:** an agent runtime, Discord bot, daemon, task database, model ranker, or code reviewer. Those live in tools you choose; the scaffold is what they read and write.
+
+The runtime handoff is intentionally simple:
+
+```text
+User selects runtime
+  -> Open Scaffold reads runtime profile
+  -> Open Scaffold creates the run packet
+  -> Adapter/coordinator launches the actual runtime
+  -> Runtime does the work
+  -> Evidence comes back into Open Scaffold
+```
+
+Plain English: Open Scaffold keeps the work truth in the repo. You choose an agent runtime. Open Scaffold packages the work. A runtime adapter executes it outside core. Evidence comes back. Humans approve.
 
 ---
 
@@ -50,15 +63,15 @@ For a non-recursive version of the same loop, read the [downstream walkthrough](
 
 ## What you get
 
-- **Mission and roadmap** — `MISSION.md` and `ROADMAP.md` keep direction visible.
-- **Plans** — `.osc/plans/` holds small specs with context, goal, constraints, acceptance criteria, verification, and open questions.
-- **Amendments** — scope changes become add-on records instead of silent rewrites.
-- **Run packets** — `.osc/runs/<run_id>/run.json` can bind a plan to a task, branch, lane, surface, and evidence path.
-- **Evidence and releases** — `.osc/releases/` records what shipped, how it was verified, and what follows.
-- **Verification** — `./verify.sh` and `osc` catch missing mission, stale plans, broken amendments, and release/evidence drift.
-- **Agent entry points** — `AGENTS.md` and `CLAUDE.md` tell coding agents how to operate without fresh explanations.
+- **Direction:** `MISSION.md` and `ROADMAP.md` keep intent visible.
+- **Work specs:** `.osc/plans/` holds small, immutable plans with acceptance criteria.
+- **Change history:** amendments record scope changes without rewriting the original plan.
+- **Run packets:** `.osc/runs/<run_id>/run.json` packages a plan for a chosen runtime lane.
+- **Evidence:** `.osc/releases/` records what shipped, how it was verified, and what follows.
+- **Checks:** `./verify.sh` and `osc verify` catch stale state, broken evidence, and plan drift.
+- **Agent entry points:** `AGENTS.md` and `CLAUDE.md` tell coding agents how to operate without fresh explanations.
 
-Short version:
+The loop:
 
 ```text
 Roadmap or issue
@@ -155,7 +168,11 @@ npm run osc -- run .osc/plans/active/my-first-task.md \
   --repo "$PWD"
 ```
 
-For custom runtimes, add a project-local profile in `.osc/runtimes/<id>.json`, then use `--runtime <id>`. See [`docs/RUNTIME_PROFILES.md`](docs/RUNTIME_PROFILES.md), [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md), and [`docs/examples/runtime-binding-dry-run.mjs`](docs/examples/runtime-binding-dry-run.mjs).
+For custom runtimes, add a project-local profile in `.osc/runtimes/<id>.json`, then use `--runtime <id>`. Read this in layers:
+
+1. [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — choosing `--runtime` and `--workflow`;
+2. [`docs/RUNTIME_PROFILES.md`](docs/RUNTIME_PROFILES.md) — built-in and project-local runtime profiles;
+3. [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md) — what an adapter/coordinator must do after the packet exists.
 
 ---
 
@@ -188,7 +205,9 @@ It is overkill for one-off scripts, disposable prototypes, or tasks that fit in 
 
 ## Where the roadmap is going
 
-The current focus comes from an independent two-lane review (2026-05-12) which found the core thesis valid but the adoption gap real. Public roadmap priorities are: undeniable examples, adapter proof, packaging, and docs compression — not turning Open Scaffold core into an agent runtime. See the [review addendum](ROADMAP.md#independent-review-addendum--make-the-useful-parts-undeniable) for the milestone list.
+The current product direction is: make the source-of-truth loop undeniable, then let external runtimes plug into it through profiles and adapters. Open Scaffold now supports runtime selection and runtime profiles, but core still does not install, spawn, supervise, or benchmark runtimes.
+
+Near-term roadmap work should improve clarity, adapter evidence, and validation. Real runtime launching, hosted registries, marketplace behavior, and model/task recommendations remain future hypotheses until separately designed and proven. See the [roadmap](ROADMAP.md) for the current milestone list.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -233,6 +233,12 @@ Deliverables:
 - Keep real OMC/OMX launch behavior in external adapters or coordinators, not core.
 - Ensure adapter evidence returns to `.osc` run/release conventions.
 
+Runtime status after PR #36/#37:
+
+- Runtime selection and runtime profiles are shipped as a run-packet/profile layer, not as core spawning.
+- Backlog hypotheses `030-agent-runtime-selection-vision` and `031-agentic-orchestration-model-lab-vision` are not the next implementation queue. Their useful near-term conclusion has been narrowed to: keep Open Scaffold as the source-of-truth/control plane, let adapters/coordinators launch real runtimes, and require evidence before promoting model-lab or native-runtime claims.
+- Future runtime work should start from a specific adapter/evidence slice such as `osc runtimes check <id>` or a fake/local conformance proof, not from broad orchestration promises.
+
 ### Milestone 10 — Product packaging and releases
 
 Status: complete for the current readiness slice via `.osc/plans/done/010-product-packaging-release.md`, `.osc/releases/2026-05-15-packaging-release-readiness.md`, and `.osc/releases/2026-05-15-public-trust-readiness.md`. `v0.3.0` baseline release evidence exists at `.osc/releases/2026-05-12-v0.3.0-runtime-neutral-baseline.md`; npm-registry publishing remains parked until a fresh adoption signal.
@@ -378,6 +384,7 @@ Acceptance criteria:
 ## Parking lot
 
 - Deferred compliance-grade agentic OS / hashgraph-style regulated-SDLC exploration; reopen only through an explicit ADR/plan.
+- Runtime/model-lab hypotheses from `030` and `031`: future work only after adapter evidence, explicit safety design, and clear separation between Open Scaffold core, runtime adapters, and model evaluation.
 - MCP bridge for structured harness dispatch/status/artifact retrieval.
 - Repository-local task database option for users without Hermes Kanban/GitHub Issues.
 - Visual dashboard beyond Discord posts.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -2,7 +2,7 @@
 
 Short examples for understanding Open Scaffold without reading every protocol page.
 
-For four worked example modes — solo developer, team control-room, GitHub-only workflow, and runtime harness handoff — see [`examples/README.md`](examples/README.md). The 60-second demo below is the solo-developer reading path.
+For four worked example modes — solo developer, team control-room, GitHub-only workflow, and runtime harness handoff — see [`examples/README.md`](examples/README.md). The 60-second demo below is the solo-developer reading path; the runtime handoff path now starts with `--runtime` selection and project-local runtime profiles.
 
 For the next reproducible proof layer, see [Lifecycle E2E Smoke Strategy](E2E_SMOKE.md). It defines and links the local smoke test that proves a fresh downstream project can move through mission → plan → verification → evidence → close without Hermes, Discord, or private infrastructure.
 

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -12,8 +12,8 @@ This document is the full ontology. Most readers do not need every protocol page
 
 - New here? Read the [README](../README.md), then [`docs/EXAMPLES.md`](EXAMPLES.md) for the 60-second viewer demo.
 - Wiring task/run identity into a coordinator or task system: [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md).
-- Writing an adapter that consumes `.osc/runs/<run_id>/run.json`: [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md), [`docs/RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md) for selectable runtime profile metadata, then [`docs/RUNTIME_HARNESS_DISPATCH.md`](RUNTIME_HARNESS_DISPATCH.md) for the public dispatch pattern and [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md) for the adapter/runtime boundary.
-- Closing a slice and producing audit-grade evidence: [`docs/SLICE_CLOSE_PROTOCOL.md`](SLICE_CLOSE_PROTOCOL.md).
+- Understanding runtime handoff progressively: [`docs/RUNTIME_SELECTION.md`](RUNTIME_SELECTION.md) for choosing a lane, [`docs/RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md) for profile metadata, then [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) and [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md) for adapter/runtime responsibilities.
+- Closing a slice and producing evidence: [`docs/SLICE_CLOSE_PROTOCOL.md`](SLICE_CLOSE_PROTOCOL.md).
 - Reading public mentions of named tools (Hermes, OMC, OMX, Discord, etc.): [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md) for the public/private/adapter labels.
 
 ## Layers
@@ -205,13 +205,13 @@ Multiple coordinators/runtimes can mutate the same worktree at once safely.
 A clean coordinator-to-runtime flow looks like this:
 
 ```text
-Open Scaffold roadmap/plan or external task card
-  -> coordinator chooses executor lane: OMC, OMX, plain agent, or manual
-  -> coordinator dispatches a bounded prompt/artifact/run packet
-  -> executor produces result artifact, diff, PR, status, or blocker
-  -> coordinator updates task state, asks the operator, or nudges next step
-  -> evidence and decisions are promoted back into Open Scaffold/GitHub
-  -> slice close records acceptance-gate status, approval strength, corrections, and next-slice inheritance
+User selects runtime
+  -> Open Scaffold reads runtime profile
+  -> Open Scaffold creates the run packet
+  -> Adapter/coordinator launches the actual runtime
+  -> Runtime does the work
+  -> Evidence comes back into Open Scaffold
+  -> Slice close records approval, corrections, or next-slice inheritance
 ```
 
 Rules:

--- a/docs/RUNTIME_BINDING_CONTRACT.md
+++ b/docs/RUNTIME_BINDING_CONTRACT.md
@@ -1,5 +1,7 @@
 # Runtime Binding Contract
 
+This is the execution boundary layer. Runtime selection chooses a lane; runtime profiles describe that lane; the binding contract says what an external adapter/coordinator must do with the run packet.
+
 Named harnesses in this contract, including OMC and OMX, are runtime lanes or adapter candidates rather than Open Scaffold core dependencies. Use [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md) for public/private/future reference labels.
 
 Open Scaffold core creates bounded run packages. Runtime bindings — execution adapters for a chosen lane — consume those packages and launch outside core. This document defines the contract between the repo-native Open Scaffold package and any coordinator, adapter, harness, agent, or human lane that executes it.
@@ -8,8 +10,7 @@ Open Scaffold core creates bounded run packages. Runtime bindings — execution 
 
 ```text
 Open Scaffold core packages.
-A coordinator decides.
-A binding launches.
+A coordinator/adapter launches outside core.
 A harness or human executes.
 Evidence returns.
 Postflight closes.

--- a/docs/RUNTIME_PROFILES.md
+++ b/docs/RUNTIME_PROFILES.md
@@ -1,15 +1,23 @@
 # Runtime Profiles
 
-Runtime profiles make Open Scaffold runtime selection declarative and extensible without making Open Scaffold core an installer, marketplace, or process supervisor.
+Runtime profiles are the configuration layer behind `--runtime`. They make runtime selection declarative and extensible without making Open Scaffold core an installer, marketplace, or process supervisor.
 
-A runtime profile is data. It tells Open Scaffold how a selected runtime lane should be recorded in a run packet. A coordinator or adapter may later consume that run packet and launch the real runtime outside core.
+A profile is data. It tells Open Scaffold how a selected runtime lane should be recorded in a run packet. A coordinator or adapter may later consume that run packet and launch the real runtime outside core.
 
 ```text
-Open Scaffold core = validate profile + package run intent + preserve evidence gates
-Runtime adapter     = translate run packet + launch selected runtime + return receipt/evidence
-Runtime harness     = execute while alive
-Operator            = approve commit/push/merge/publish gates
+User selects runtime
+  -> Open Scaffold reads runtime profile
+  -> Open Scaffold creates the run packet
+  -> Adapter/coordinator launches the actual runtime
+  -> Runtime does the work
+  -> Evidence comes back into Open Scaffold
 ```
+
+Layer map:
+
+- [`RUNTIME_SELECTION.md`](RUNTIME_SELECTION.md) — user-facing `--runtime` / `--workflow` choice.
+- `RUNTIME_PROFILES.md` — profile schema, built-ins, and project-local `.osc/runtimes/*.json`.
+- [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) — adapter/coordinator responsibilities after the packet exists.
 
 ## Commands
 

--- a/docs/RUNTIME_SELECTION.md
+++ b/docs/RUNTIME_SELECTION.md
@@ -1,8 +1,17 @@
-# Agentic runtime selection
+# Runtime selection
 
-Open Scaffold should let a user choose an agentic runtime lane without turning Open Scaffold core into that runtime.
+Runtime selection is the user-facing layer of Open Scaffold's runtime story. It answers one question: **which lane should this run packet target?**
 
-This page is the corrected scope for plan `009-runtime-harness-adapter-refresh`: not ownership cleanup for old adapter repositories, but a runtime-selection surface for OMC / oh-my-claudecode and OMX / oh-my-codex style execution.
+```text
+User selects runtime
+  -> Open Scaffold reads runtime profile
+  -> Open Scaffold creates the run packet
+  -> Adapter/coordinator launches the actual runtime
+  -> Runtime does the work
+  -> Evidence comes back into Open Scaffold
+```
+
+This page covers the first two Open Scaffold steps: `--runtime`, `--workflow`, and the run-packet fields they create. For profile schema and custom project-local runtimes, read [`RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md). For the external adapter/coordinator contract, read [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
 
 ## Product intent
 
@@ -61,7 +70,7 @@ Runtime harness     = execute while alive
 Operator            = approve merge/publish gates
 ```
 
-Open Scaffold core owns the run-packet contract. Runtime-specific adapters own process launch, authentication, tmux/session lifecycle, hooks, and runtime logs. Runtime state is forensic until promoted into `.osc/runs`, tracked evidence docs, PRs, issues, or release notes.
+Open Scaffold core owns the run-packet contract. Runtime-specific adapters own process launch, authentication, tmux/session lifecycle, hooks, and runtime logs. Runtime state is forensic until promoted into `.osc/runs`, tracked evidence docs, PRs, issues, or release notes. This boundary is the same one enforced by runtime profiles and the binding contract; this page only describes the selection surface.
 
 ## Adapter checklist
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -96,8 +96,10 @@ When a runtime lane (Claude Code, Codex, OMC, OMX, a custom adapter, or a human 
 
 Reading path:
 
+- [`docs/RUNTIME_SELECTION.md`](../RUNTIME_SELECTION.md) — choosing `--runtime` and `--workflow`.
+- [`docs/RUNTIME_PROFILES.md`](../RUNTIME_PROFILES.md) — built-in and project-local runtime profile metadata.
 - [`docs/RUNTIME_BINDING_CONTRACT.md`](../RUNTIME_BINDING_CONTRACT.md) — lifecycle/responsibilities for any binding that consumes a run packet.
-- [`docs/RUNTIME_HARNESS_DISPATCH.md`](../RUNTIME_HARNESS_DISPATCH.md) — dispatch hypotheses and adapter shape.
+- [`runtime-profiles/company-review-bot.json`](runtime-profiles/company-review-bot.json) — example project-local profile.
 - [`runtime-binding-conformance/README.md`](runtime-binding-conformance/README.md) — fake/local adapter conformance fixture.
 
 ### Generate a run packet
@@ -107,7 +109,8 @@ From a repository checkout with dependencies installed:
 ```bash
 npm run osc -- run .osc/plans/done/013-binding-example.md \
   --task-id plan:013-binding-example-verification \
-  --executor plain-agent \
+  --runtime omx \
+  --workflow plan \
   --operator-surface cli \
   --repo "$PWD" \
   --worktree "$PWD" \
@@ -127,7 +130,7 @@ node docs/examples/runtime-binding-dry-run.mjs "$RUN_JSON"
 Expected result:
 
 - exits `0` for an executable package;
-- prints run id, plan path, executor lane, optional harness skill, repo/worktree/branch, and commit policy;
+- prints run id, plan path, executor lane, optional harness skill, operator surface, repo/worktree/branch, and commit policy;
 - states that no runtime was launched;
 - exits nonzero if the packet is not executable, has blockers, requests unsupported lanes, or violates the `spawning: false` boundary.
 


### PR DESCRIPTION
## Summary

- Simplifies the public runtime story around the flow: select runtime -> read profile -> create run packet -> adapter/coordinator launches -> runtime works -> evidence returns.
- Reorganizes runtime docs as progressive disclosure: runtime selection, runtime profiles, then binding contract.
- Updates examples and system ontology to route fresh readers through the same selection/profile/run-packet path.
- Reconciles runtime/orchestration hypotheses in the roadmap so `030`/`031` are future hypotheses, not the next implementation queue.

## Traceability

- Plan: `.osc/plans/done/035-runtime-docs-simplification.md`
- Evidence: `.osc/releases/2026-05-16-runtime-docs-simplification.md`
- Kanban: `t_14b40621`

## Out of scope

- No runtime install/spawn/check commands.
- No hosted registry, marketplace, network import, or package-manager behavior.
- No certified OMC/OMX/GSD integration claims.
- No model benchmarking/routing/model-lab claims.

## Verification

- [x] `git diff --check`
- [x] `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- [x] `npm run osc -- verify` — 0 warnings
- [x] `npm test` — 8 files / 74 tests
- [x] `npm run build`
- [x] Added-line private/secrets scan
- [x] Added-line unsupported positive-claims scan

## Codex review

Triggered after PR creation.
