### PR TITLE
Add evaluation envelope CLI

### DIFF
--- a/.osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md
+++ b/.osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-done — shipped in this slice with `osc eval init` / `osc eval check`, release evidence, and local verification.
+backlog — follow-up implementation candidate after PR #39's architecture-direction rescope. Do not start until the architecture direction is reviewed and approved.
 
 ## Context
 
@@ -38,13 +38,13 @@ Likely candidates:
 
 ## Acceptance criteria
 
-- [x] `osc eval init <run-or-plan>` or equivalent generates an evaluation-envelope template with acceptance criteria, evaluator placeholders, evidence placeholders, decision, and improvement routing.
-- [x] `osc eval check <evaluation-path>` or equivalent validates that every criterion has a status, evidence or rationale, evaluator source, and correction route when status is not `pass`.
-- [x] Validation distinguishes schema/coverage checks from domain correctness; it never claims the result is correct, compliant, or production-grade.
-- [x] The command works for plans without explicit AC IDs by generating stable display IDs for the envelope.
-- [x] Tests cover pass, partial, fail, blocked, and not-evaluated criteria; weak approval; missing evidence; and missing improvement route.
-- [x] Docs and CLI help use owner-neutral, public-safe wording and preserve runtime/adapters/human approval boundaries.
-- [x] Release evidence records verification, scope, non-goals, and follow-up work.
+- [ ] `osc eval init <run-or-plan>` or equivalent generates an evaluation-envelope template with acceptance criteria, evaluator placeholders, evidence placeholders, decision, and improvement routing.
+- [ ] `osc eval check <evaluation-path>` or equivalent validates that every criterion has a status, evidence or rationale, evaluator source, and correction route when status is not `pass`.
+- [ ] Validation distinguishes schema/coverage checks from domain correctness; it never claims the result is correct, compliant, or production-grade.
+- [ ] The command works for plans without explicit AC IDs by generating stable display IDs for the envelope.
+- [ ] Tests cover pass, partial, fail, blocked, and not-evaluated criteria; weak approval; missing evidence; and missing improvement route.
+- [ ] Docs and CLI help use owner-neutral, public-safe wording and preserve runtime/adapters/human approval boundaries.
+- [ ] Release evidence records verification, scope, non-goals, and follow-up work.
 
 ## Verification steps
 

--- a/.osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md
+++ b/.osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog — follow-up implementation candidate after PR #39's architecture-direction rescope. Do not start until the architecture direction is reviewed and approved.
+done — shipped in this slice with `osc eval init` / `osc eval check`, release evidence, and local verification.
 
 ## Context
 
@@ -38,13 +38,13 @@ Likely candidates:
 
 ## Acceptance criteria
 
-- [ ] `osc eval init <run-or-plan>` or equivalent generates an evaluation-envelope template with acceptance criteria, evaluator placeholders, evidence placeholders, decision, and improvement routing.
-- [ ] `osc eval check <evaluation-path>` or equivalent validates that every criterion has a status, evidence or rationale, evaluator source, and correction route when status is not `pass`.
-- [ ] Validation distinguishes schema/coverage checks from domain correctness; it never claims the result is correct, compliant, or production-grade.
-- [ ] The command works for plans without explicit AC IDs by generating stable display IDs for the envelope.
-- [ ] Tests cover pass, partial, fail, blocked, and not-evaluated criteria; weak approval; missing evidence; and missing improvement route.
-- [ ] Docs and CLI help use owner-neutral, public-safe wording and preserve runtime/adapters/human approval boundaries.
-- [ ] Release evidence records verification, scope, non-goals, and follow-up work.
+- [x] `osc eval init <run-or-plan>` or equivalent generates an evaluation-envelope template with acceptance criteria, evaluator placeholders, evidence placeholders, decision, and improvement routing.
+- [x] `osc eval check <evaluation-path>` or equivalent validates that every criterion has a status, evidence or rationale, evaluator source, and correction route when status is not `pass`.
+- [x] Validation distinguishes schema/coverage checks from domain correctness; it never claims the result is correct, compliant, or production-grade.
+- [x] The command works for plans without explicit AC IDs by generating stable display IDs for the envelope.
+- [x] Tests cover pass, partial, fail, blocked, and not-evaluated criteria; weak approval; missing evidence; and missing improvement route.
+- [x] Docs and CLI help use owner-neutral, public-safe wording and preserve runtime/adapters/human approval boundaries.
+- [x] Release evidence records verification, scope, non-goals, and follow-up work.
 
 ## Verification steps
 

--- a/.osc/releases/2026-05-17-evaluation-envelope-schema.md
+++ b/.osc/releases/2026-05-17-evaluation-envelope-schema.md
@@ -1,0 +1,84 @@
+# Release evidence: evaluation envelope schema and osc eval
+
+## Summary
+
+This slice turns the PR #39 evaluation-envelope architecture into the first small, testable CLI mechanic.
+
+It adds `osc eval init` and `osc eval check` for JSON-backed `open-scaffold.evaluation.v1` envelopes. The command can draft an evaluation envelope from a plan or run packet, then validate schema, acceptance-criterion coverage, evidence/rationale presence, evaluator source, decision consistency, feedback target IDs, and correction routing.
+
+The command is intentionally structure-only. It does not judge domain correctness, certify compliance, benchmark models, run verification commands, approve release/merge, spawn runtimes, or anchor evidence externally.
+
+## Scope
+
+- Plan: `.osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md`.
+- Branch: `feat/evaluation-envelope-schema`.
+- Parent architecture: PR #39 / `.osc/plans/done/033-implementation-architecture-evaluation-lens-amendment-1.md`.
+- Operator card: Hermes Kanban `t_83cb2410`.
+
+## Traceability
+
+- Plan: `.osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md`.
+- Parent architecture release note: `.osc/releases/2026-05-17-implementation-architecture-lens.md`.
+- New implementation module: `src/evaluation.ts`.
+- CLI integration: `src/cli.ts`.
+- Tests: `tests/evaluation.test.ts`, `tests/cli-eval.test.ts`.
+- PR: pending owner review.
+
+## Changes
+
+- Added JSON envelope generation from:
+  - plan acceptance criteria;
+  - `open-scaffold.run.v1` run packets.
+- Added deterministic fallback criterion IDs (`AC1`, `AC2`, etc.) without mutating immutable plan files.
+- Added Bellman-informed identity/correlation hooks:
+  - `evaluation_id`;
+  - `idempotency_key`;
+  - `subject`;
+  - `correlation`;
+  - feedback target validation.
+- Added validation for:
+  - schema presence;
+  - criterion IDs and duplicate IDs;
+  - allowed statuses: `pass`, `partial`, `fail`, `blocked`, `not_evaluated`;
+  - evaluator source;
+  - evidence/rationale coverage;
+  - pass criteria needing evidence;
+  - non-pass criteria needing correction routes;
+  - approval not allowed while non-pass criteria remain;
+  - weak approvals carrying explicit caution;
+  - local evidence path existence;
+  - feedback references to known criterion IDs.
+- Updated public protocol docs to state that v1 CLI emits/checks JSON envelopes while preserving the no-judgment/no-compliance/no-runtime boundary.
+
+## Verification
+
+Completed verification before PR creation:
+
+- `npm test` — passed, 10 files / 92 tests.
+- `npm run build` — passed.
+- `npm run --silent osc -- eval init .osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md` — passed; generated the structure-only JSON envelope template.
+- `npm run --silent osc -- eval check /tmp/osc-036-evaluation.json` — passed after filling the generated template with local verification evidence; 7 criterion evaluations / 0 warnings.
+- `npm run osc -- verify` — passed, 0 warnings.
+- `./verify.sh --standard` — passed, 6 pass / 0 fail / 0 warn.
+- `git diff --check` — passed.
+- Manual wording scan — passed for structure-only wording and no domain correctness, compliance certification, model benchmarking, runtime spawning, or external-ledger/anchor claims.
+
+Final PR/Codex verification is recorded in the pull request after push.
+
+## Outcome
+
+Open Scaffold now has a concrete evaluation-envelope mechanic: users can generate the record that maps acceptance criteria to evidence and check whether the record is structurally complete before close/postflight.
+
+The result makes the closed feedback loop more real without expanding Open Scaffold core into evaluator, model lab, compliance product, runtime, or ledger provider.
+
+## Follow-up
+
+Audit-envelope digest/Merkle/anchor mechanics remain a separate future slice.
+
+Potential future refinements, after adopter evidence:
+
+- optional JSON schema export;
+- tracked default evidence location guidance;
+- evaluation-event JSONL replay/dedupe;
+- audit-envelope generation/checking;
+- explicit integration from `osc verify` if/when repo-wide evaluation checks stop being surprising.

--- a/.osc/releases/2026-05-17-evaluation-envelope-schema.md
+++ b/.osc/releases/2026-05-17-evaluation-envelope-schema.md
@@ -52,9 +52,9 @@ The command is intentionally structure-only. It does not judge domain correctnes
 
 ## Verification
 
-Completed verification before PR creation:
+Completed verification for the PR branch:
 
-- `npm test` — passed, 10 files / 93 tests.
+- `npm test` — passed, 10 files / 94 tests.
 - `npm run build` — passed.
 - `npm run --silent osc -- eval init .osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md` — passed; generated the structure-only JSON envelope template.
 - `npm run --silent osc -- eval check /tmp/osc-036-evaluation.json` — passed after filling the generated template with local verification evidence; 7 criterion evaluations / 0 warnings.

--- a/.osc/releases/2026-05-17-evaluation-envelope-schema.md
+++ b/.osc/releases/2026-05-17-evaluation-envelope-schema.md
@@ -54,7 +54,7 @@ The command is intentionally structure-only. It does not judge domain correctnes
 
 Completed verification before PR creation:
 
-- `npm test` — passed, 10 files / 92 tests.
+- `npm test` — passed, 10 files / 93 tests.
 - `npm run build` — passed.
 - `npm run --silent osc -- eval init .osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md` — passed; generated the structure-only JSON envelope template.
 - `npm run --silent osc -- eval check /tmp/osc-036-evaluation.json` — passed after filling the generated template with local verification evidence; 7 criterion evaluations / 0 warnings.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-17: closed 036-evaluation-envelope-schema-and-osc-eval — added structure-only evaluation envelope schema and osc eval init/check mechanics
 - 2026-05-17: rescope PR39 around evaluation and audit envelope standards — see .osc/plans/done/033-implementation-architecture-evaluation-lens-amendment-1.md
 - 2026-05-17: closed 033-implementation-architecture-evaluation-lens — implementation architecture lens shipped
 - 2026-05-16: closed 035-runtime-docs-simplification — runtime docs simplification and hypothesis reconciliation shipped

--- a/docs/SLICE_CLOSE_PROTOCOL.md
+++ b/docs/SLICE_CLOSE_PROTOCOL.md
@@ -170,8 +170,14 @@ acceptance_criteria:
       kind: human | automated-check | adapter | domain-oracle | external-review
       name: "optional"
     evidence:
-      - path/or/link
+      - kind: path | url | command | pr | issue | ci | screenshot | manual-review | comment | other
+        ref: docs/evidence/example.md
+        summary: "What this evidence proves."
     rationale: "Why this status was assigned."
+    correction:
+      route: close | retry_run | amend_plan | create_next_slice | open_issue | update_roadmap | block
+      target: .osc/plans/backlog/002-next-slice.md
+      rationale: "How non-pass outcomes are routed, or why pass can close."
     confidence: high | medium | low
     gaps:
       - "Known limitation or uncertainty."
@@ -189,6 +195,15 @@ improvement:
 ```
 
 The evaluation envelope is a record of judgment and routing, not an automatic claim of correctness. Domain/business-rule evaluators, model benchmarks, production scoring, and compliance decisions can feed it, but they do not become Open Scaffold core by default.
+
+The v1 CLI surface emits and checks JSON envelopes so the first implementation can stay dependency-light and deterministic:
+
+```bash
+osc eval init <run-or-plan> [--out <path>]
+osc eval check <evaluation-path>
+```
+
+`osc eval init` drafts the envelope from plan acceptance criteria or a run packet. `osc eval check` validates schema, criterion coverage, evidence/rationale presence, evaluator source, decision consistency, and correction routing. It does not run verification commands, judge domain correctness, benchmark models, certify compliance, approve release/merge, spawn runtimes, or anchor evidence externally.
 
 ## Audit envelope
 

--- a/docs/wiki/concepts/implementation-architecture-lens.md
+++ b/docs/wiki/concepts/implementation-architecture-lens.md
@@ -148,7 +148,7 @@ Those may become adapter, evaluator, runtime, ledger-anchor, or future-product w
 
 ## Follow-up candidates
 
-Structured evaluation mechanics, such as a future `osc eval` surface, should start as template generation and validation: create an evaluation envelope, check that every acceptance criterion has evidence/status/rationale, and require a correction route for non-pass outcomes. It should not automatically certify domain correctness, benchmark models, or replace human/product approval.
+Structured evaluation mechanics now start with `osc eval init` and `osc eval check`: generate a JSON evaluation envelope, check that every acceptance criterion has evidence/status/rationale/evaluator coverage, and require a correction route for non-pass outcomes. This still does not automatically certify domain correctness, benchmark models, or replace human/product approval.
 
 Tamper-evident audit mechanics should start with a vendor-neutral `open-scaffold.audit-envelope.v1` and `open-scaffold.anchor-receipt.v1` shape for promoted evidence artifacts: artifact digests, envelope digests, parent links, optional Merkle batch roots, and optional external-anchor receipts. Hedera Consensus Service, Sigstore/Rekor, RFC3161 timestamping, Git signed tags, or other ledgers/notaries belong in optional adapters, not Open Scaffold core.
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -3,6 +3,10 @@
 > Chronological record of project wiki actions. Append-only.
 > Format: `## [YYYY-MM-DD] action | subject`
 
+## [2026-05-17] implement | Evaluation envelope CLI
+- Added `osc eval init` / `osc eval check` as the first JSON-backed evaluation-envelope mechanics.
+- Kept the command structure-only: no domain correctness judgment, compliance certification, model benchmarking, runtime spawning, or external anchoring.
+
 ## [2026-05-17] amend | Implementation architecture envelopes
 - Expanded `docs/wiki/concepts/implementation-architecture-lens.md` with audit envelope, evaluation envelope, closed evaluation loop, and feedback-based improvement direction.
 - Cross-linked the direction to slice-close and runtime-binding boundaries without adding runtime spawning, compliance certification, or model-benchmarking claims.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { createRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
 import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
@@ -310,6 +310,20 @@ function printEvalUsage(): void {
   console.error('Usage: osc eval init <run-or-plan> [--out <path>] | osc eval check <evaluation-path>');
 }
 
+function findScaffoldRoot(start: string): string | null {
+  let current = resolve(start);
+  while (true) {
+    if (existsSync(join(current, '.osc')) || existsSync(join(current, '.git'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function evaluationRootFor(envelopePath: string): string {
+  return findScaffoldRoot(dirname(envelopePath)) ?? findScaffoldRoot(process.cwd()) ?? process.cwd();
+}
+
 function takeEvalValue(args: string[], index: number, flag: string): string {
   const value = args[index + 1];
   if (!value || value.startsWith('--')) {
@@ -382,7 +396,7 @@ function evalCommand(args: string[]): void {
       process.exit(2);
     }
     const envelopePath = resolve(sourceOrPath);
-    const result = validateEvaluationEnvelopeFile(envelopePath, process.cwd());
+    const result = validateEvaluationEnvelopeFile(envelopePath, evaluationRootFor(envelopePath));
     for (const failure of result.failures) {
       console.error(`FAIL ${failure.code}: ${failure.message}${failure.path ? ` (${failure.path})` : ''}`);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
+import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
 import { inspectScaffold, parsePlanFile, planToJson } from './scaffold.js';
@@ -19,6 +20,8 @@ Usage:
   osc run <plan-path> [run binding options]
   osc review <plan-path> [run binding options]
   osc ultrareview <plan-path> [run binding options]
+  osc eval init <run-or-plan> [--out <path>]
+  osc eval check <evaluation-path>
   osc verify
   osc doctor
   osc runtimes list
@@ -303,6 +306,101 @@ function createArtifacts(args: string[], mode: ArtifactMode): void {
   console.log('  Note: generic open-scaffold did not spawn a runtime; dispatch via your coordinator or harness adapter.');
 }
 
+function printEvalUsage(): void {
+  console.error('Usage: osc eval init <run-or-plan> [--out <path>] | osc eval check <evaluation-path>');
+}
+
+function takeEvalValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    console.error(`Missing value for ${flag}`);
+    process.exit(2);
+  }
+  return value;
+}
+
+function evalCommand(args: string[]): void {
+  const [subcommand, sourceOrPath, ...rest] = args;
+  if (subcommand === 'init') {
+    if (!sourceOrPath) {
+      printEvalUsage();
+      process.exit(2);
+    }
+    let outPath: string | null = null;
+    let force = false;
+    for (let i = 0; i < rest.length; i += 1) {
+      const flag = rest[i];
+      switch (flag) {
+        case '--out':
+        case '--output':
+          outPath = takeEvalValue(rest, i, flag);
+          i += 1;
+          break;
+        case '--force':
+          force = true;
+          break;
+        default:
+          console.error(`Unknown option for eval init: ${flag}`);
+          printEvalUsage();
+          process.exit(2);
+      }
+    }
+    try {
+      if (!outPath) {
+        const source = loadEvaluationSource(sourceOrPath, process.cwd());
+        process.stdout.write(renderEvaluationEnvelope(source));
+        return;
+      }
+      const absoluteOut = resolve(outPath);
+      if (existsSync(absoluteOut) && !force) {
+        console.error(`Refusing to overwrite existing evaluation envelope: ${absoluteOut}`);
+        process.exit(1);
+      }
+      if (force && existsSync(absoluteOut)) {
+        const source = loadEvaluationSource(sourceOrPath, process.cwd());
+        writeFileSync(absoluteOut, renderEvaluationEnvelope(source), 'utf8');
+      } else {
+        writeEvaluationEnvelope(sourceOrPath, absoluteOut, process.cwd());
+      }
+      console.log(`Created evaluation envelope: ${absoluteOut}`);
+      console.log('Note: this is a structure/coverage template only; fill evidence, evaluator, decision, and routing before check/close.');
+      return;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  }
+
+  if (subcommand === 'check') {
+    if (!sourceOrPath) {
+      printEvalUsage();
+      process.exit(2);
+    }
+    const envelopePath = resolve(sourceOrPath);
+    const result = validateEvaluationEnvelopeFile(envelopePath, process.cwd());
+    for (const failure of result.failures) {
+      console.error(`FAIL ${failure.code}: ${failure.message}${failure.path ? ` (${failure.path})` : ''}`);
+    }
+    for (const warning of result.warnings) {
+      console.warn(`WARN ${warning.code}: ${warning.message}${warning.path ? ` (${warning.path})` : ''}`);
+    }
+    if (!result.ok) process.exit(1);
+    let criterionCount = 0;
+    try {
+      const parsed = JSON.parse(readFileSync(envelopePath, 'utf8')) as { acceptance_criteria?: unknown[] };
+      criterionCount = Array.isArray(parsed.acceptance_criteria) ? parsed.acceptance_criteria.length : 0;
+    } catch {
+      criterionCount = 0;
+    }
+    console.log(`PASS evaluation envelope structure valid; ${criterionCount} criterion evaluation(s); ${result.warnings.length} warning(s)`);
+    console.log('Note: this check validates schema/coverage/routing only; it does not judge correctness, compliance, production readiness, or model quality.');
+    return;
+  }
+
+  printEvalUsage();
+  process.exit(2);
+}
+
 function runtimes(args: string[]): void {
   const [subcommand, id] = args;
   if (subcommand === 'list') {
@@ -364,6 +462,9 @@ function main(): void {
     case 'review':
     case 'ultrareview':
       createArtifacts(args, command);
+      return;
+    case 'eval':
+      evalCommand(args);
       return;
     case 'verify': {
       const result = validateScaffold(process.cwd());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -376,6 +376,11 @@ function evalCommand(args: string[]): void {
       printEvalUsage();
       process.exit(2);
     }
+    if (rest.length > 0) {
+      console.error(`Unknown option for eval check: ${rest[0]}`);
+      printEvalUsage();
+      process.exit(2);
+    }
     const envelopePath = resolve(sourceOrPath);
     const result = validateEvaluationEnvelopeFile(envelopePath, process.cwd());
     for (const failure of result.failures) {

--- a/src/evaluation.ts
+++ b/src/evaluation.ts
@@ -1,0 +1,435 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
+import { basename, extname, isAbsolute, relative, resolve } from 'node:path';
+import { parsePlanFile } from './scaffold.js';
+import type { ValidationIssue, ValidationResult } from './validation.js';
+
+export const EVALUATION_SCHEMA = 'open-scaffold.evaluation.v1';
+const RUN_SCHEMA = 'open-scaffold.run.v1';
+
+const CRITERION_STATUSES = new Set(['pass', 'partial', 'fail', 'blocked', 'not_evaluated']);
+const EVALUATOR_KINDS = new Set(['human', 'maintainer', 'reviewer', 'ci', 'automated-check', 'adapter', 'domain-tool', 'domain-oracle', 'external-evaluator', 'external-review']);
+const DECISION_STATUSES = new Set(['approved', 'weak_approved', 'rejected', 'blocked']);
+const IMPROVEMENT_ROUTES = new Set(['close', 'retry_run', 'amend_plan', 'create_next_slice', 'open_issue', 'update_roadmap', 'block']);
+const NON_PASS_ROUTES = new Set(['retry_run', 'amend_plan', 'create_next_slice', 'open_issue', 'update_roadmap', 'block']);
+const EVIDENCE_KINDS = new Set(['path', 'url', 'command', 'pr', 'issue', 'ci', 'screenshot', 'manual-review', 'comment', 'other']);
+
+export interface EvaluationSource {
+  kind: 'plan' | 'run';
+  sourcePath: string;
+  planPath: string;
+  planSlug: string;
+  taskId: string | null;
+  runId: string | null;
+  runPacketPath: string | null;
+  acceptanceCriteria: string[];
+  evidencePaths: string[];
+}
+
+export interface RenderEvaluationOptions {
+  now?: Date;
+}
+
+interface CriterionIdentity {
+  id: string;
+  idSource: 'explicit' | 'fallback';
+  text: string;
+  sourceIndex: number;
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function pathRelativeToRoot(root: string, path: string): string {
+  const absolute = isAbsolute(path) ? path : resolve(root, path);
+  const comparableRoot = existsSync(root) ? realpathSync(root) : resolve(root);
+  const comparablePath = existsSync(absolute) ? realpathSync(absolute) : absolute;
+  const rel = relative(comparableRoot, comparablePath);
+  if (!rel || rel.startsWith('..')) return path;
+  return rel;
+}
+
+function timestampId(now: Date): string {
+  return now.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function digest(parts: string[]): string {
+  return createHash('sha256').update(parts.join('\n'), 'utf8').digest('hex').slice(0, 16);
+}
+
+function stripExplicitId(text: string): { id: string | null; text: string } {
+  const patterns = [
+    /^\s*`?(AC[-_]?\d+)`?\s*[:—-]\s*(.+)$/i,
+    /^\s*\[(AC[-_]?\d+)\]\s*(.+)$/i,
+  ];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) return { id: match[1].replace(/[-_]/g, '').toUpperCase(), text: match[2].trim() };
+  }
+  return { id: null, text };
+}
+
+function criterionIdentities(criteria: string[]): CriterionIdentity[] {
+  const used = new Set<string>();
+  return criteria.map((raw, index) => {
+    const parsed = stripExplicitId(raw);
+    let id = parsed.id ?? `AC${index + 1}`;
+    if (used.has(id)) {
+      let candidate = 1;
+      do {
+        id = `AC${candidate}`;
+        candidate += 1;
+      } while (used.has(id));
+    }
+    used.add(id);
+    return {
+      id,
+      idSource: parsed.id ? 'explicit' : 'fallback',
+      text: parsed.text,
+      sourceIndex: index + 1,
+    };
+  });
+}
+
+function sourceFromRunPacket(sourcePath: string, root: string): EvaluationSource {
+  const packet = readJson(sourcePath);
+  if (!isRecord(packet) || packet.schemaVersion !== RUN_SCHEMA) {
+    throw new Error(`Run packet must declare schemaVersion: ${RUN_SCHEMA}`);
+  }
+  const plan = isRecord(packet.plan) ? packet.plan : {};
+  const artifacts = isRecord(packet.artifacts) ? packet.artifacts : {};
+  const planPath = asString(plan.path) ?? '(unknown plan)';
+  return {
+    kind: 'run',
+    sourcePath: pathRelativeToRoot(root, sourcePath),
+    planPath,
+    planSlug: asString(plan.slug) ?? basename(planPath, extname(planPath)),
+    taskId: asString(packet.taskId),
+    runId: asString(packet.runId),
+    runPacketPath: pathRelativeToRoot(root, sourcePath),
+    acceptanceCriteria: asStringArray(plan.acceptanceCriteria),
+    evidencePaths: asStringArray(artifacts.evidence),
+  };
+}
+
+function sourceFromPlan(sourcePath: string, root: string): EvaluationSource {
+  const plan = parsePlanFile(sourcePath);
+  return {
+    kind: 'plan',
+    sourcePath: pathRelativeToRoot(root, sourcePath),
+    planPath: pathRelativeToRoot(root, sourcePath),
+    planSlug: plan.slug,
+    taskId: null,
+    runId: null,
+    runPacketPath: null,
+    acceptanceCriteria: plan.acceptanceCriteria,
+    evidencePaths: [],
+  };
+}
+
+export function loadEvaluationSource(sourcePath: string, root = process.cwd()): EvaluationSource {
+  const absolute = isAbsolute(sourcePath) ? sourcePath : resolve(root, sourcePath);
+  if (!existsSync(absolute)) throw new Error(`Evaluation source not found: ${sourcePath}`);
+  if (extname(absolute).toLowerCase() === '.json') return sourceFromRunPacket(absolute, root);
+  return sourceFromPlan(absolute, root);
+}
+
+export function renderEvaluationEnvelope(source: EvaluationSource, options: RenderEvaluationOptions = {}): string {
+  const now = options.now ?? new Date();
+  const createdAt = now.toISOString();
+  const stamp = timestampId(now);
+  const criteria = criterionIdentities(source.acceptanceCriteria);
+  const envelope = {
+    schema: EVALUATION_SCHEMA,
+    evaluation_id: `${stamp}-${source.runId ?? source.planSlug}-eval`,
+    idempotency_key: `eval:${source.kind}:${source.runId ?? source.planSlug}:${digest(source.acceptanceCriteria)}`,
+    created_at: createdAt,
+    evaluated_at: null,
+    subject: {
+      source: source.kind,
+      plan: source.planPath,
+      plan_slug: source.planSlug,
+      task_id: source.taskId,
+      run_id: source.runId,
+      run_packet: source.runPacketPath,
+    },
+    correlation: {
+      task_id: source.taskId,
+      run_id: source.runId,
+      evidence_receipt_ids: [],
+      feedback_ids: [],
+    },
+    inputs: {
+      run_packet: source.runPacketPath,
+      evidence: source.evidencePaths.map((ref) => ({ kind: 'path', ref, summary: 'Evidence from run packet.' })),
+      feedback: [],
+    },
+    acceptance_criteria: criteria.map((criterion) => ({
+      id: criterion.id,
+      id_source: criterion.idSource,
+      source_index: criterion.sourceIndex,
+      text: criterion.text,
+      status: 'not_evaluated',
+      evaluator: {
+        kind: 'unspecified',
+        name: null,
+        ref: null,
+      },
+      evidence: [],
+      rationale: '',
+      confidence: 'low',
+      gaps: [],
+      feedback_refs: [],
+      correction: {
+        route: null,
+        target: null,
+        rationale: '',
+      },
+    })),
+    verification: [],
+    decision: {
+      status: null,
+      approver: null,
+      rationale: '',
+    },
+    improvement: {
+      route: null,
+      target: null,
+      carried_forward: [],
+      do_not_assume: ['This envelope does not certify correctness, compliance, production readiness, or model quality.'],
+    },
+    notes: [
+      'This envelope records acceptance-criteria-to-evidence coverage and routing. It does not certify correctness, compliance, production readiness, or model quality.',
+    ],
+  };
+  return `${JSON.stringify(envelope, null, 2)}\n`;
+}
+
+export function writeEvaluationEnvelope(sourcePath: string, outPath: string, root = process.cwd(), options: RenderEvaluationOptions = {}): { path: string } {
+  const source = loadEvaluationSource(sourcePath, root);
+  const absoluteOut = isAbsolute(outPath) ? outPath : resolve(root, outPath);
+  writeFileSync(absoluteOut, renderEvaluationEnvelope(source, options), { encoding: 'utf8', flag: 'wx' });
+  return { path: absoluteOut };
+}
+
+function issue(level: 'fail' | 'warn', code: string, message: string, path?: string): ValidationIssue {
+  return { level, code, message, path };
+}
+
+function meaningfulString(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const cleaned = value.trim();
+  if (!cleaned) return false;
+  if (/^(todo|tbd|n\/a|none|path\/or\/link|approved \| weak_approved \| rejected \| blocked)$/i.test(cleaned)) return false;
+  return true;
+}
+
+function hasEvidence(criteria: Record<string, unknown>): boolean {
+  if (!Array.isArray(criteria.evidence)) return false;
+  return criteria.evidence.some((item) => {
+    if (!isRecord(item)) return false;
+    const kind = asString(item.kind) ?? 'path';
+    return EVIDENCE_KINDS.has(kind) && meaningfulString(item.ref);
+  });
+}
+
+function routeOf(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  return asString(value.route);
+}
+
+function isInsideRoot(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function validateEvidencePaths(criteria: Record<string, unknown>, failures: ValidationIssue[], warnings: ValidationIssue[], envelopePath: string | undefined, root: string): void {
+  const evidence = Array.isArray(criteria.evidence) ? criteria.evidence : [];
+  const rootReal = existsSync(root) ? realpathSync(root) : resolve(root);
+  for (const item of evidence) {
+    if (!isRecord(item)) {
+      failures.push(issue('fail', 'evaluation.evidence.invalid', 'Evidence entries must be objects.', envelopePath));
+      continue;
+    }
+    const kind = asString(item.kind) ?? 'path';
+    const ref = asString(item.ref);
+    if (!EVIDENCE_KINDS.has(kind)) {
+      failures.push(issue('fail', 'evaluation.evidence.invalid_kind', `Unsupported evidence kind: ${kind}`, envelopePath));
+      continue;
+    }
+    if (!meaningfulString(ref)) {
+      failures.push(issue('fail', 'evaluation.evidence.missing_ref', 'Evidence entry is missing a ref.', envelopePath));
+      continue;
+    }
+    if (kind === 'path') {
+      const evidencePath = isAbsolute(ref) ? ref : resolve(rootReal, ref);
+      if (!isInsideRoot(rootReal, evidencePath)) {
+        failures.push(issue('fail', 'evaluation.evidence.path_outside_root', `Local evidence path escapes the repo root: ${ref}`, envelopePath));
+        continue;
+      }
+      if (!existsSync(evidencePath)) {
+        failures.push(issue('fail', 'evaluation.evidence.path_missing', `Local evidence path does not exist: ${ref}`, envelopePath));
+        continue;
+      }
+      const evidenceReal = realpathSync(evidencePath);
+      if (!isInsideRoot(rootReal, evidenceReal)) {
+        failures.push(issue('fail', 'evaluation.evidence.path_outside_root', `Local evidence path escapes the repo root: ${ref}`, envelopePath));
+      }
+    } else if (['url', 'pr', 'issue', 'ci'].includes(kind)) {
+      warnings.push(issue('warn', 'evaluation.evidence.external_unverified', `External evidence ref was not fetched: ${ref}`, envelopePath));
+    }
+  }
+}
+
+export function validateEvaluationEnvelopeText(text: string, path?: string, root = process.cwd()): ValidationResult {
+  const failures: ValidationIssue[] = [];
+  const warnings: ValidationIssue[] = [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch (error) {
+    failures.push(issue('fail', 'evaluation.json.invalid', error instanceof Error ? error.message : 'Invalid JSON.', path));
+    return { ok: false, failures, warnings };
+  }
+
+  if (!isRecord(parsed)) {
+    failures.push(issue('fail', 'evaluation.schema.invalid', 'Evaluation envelope must be a JSON object.', path));
+    return { ok: false, failures, warnings };
+  }
+
+  const schema = asString(parsed.schema) ?? asString(parsed.schemaVersion);
+  if (schema !== EVALUATION_SCHEMA) {
+    failures.push(issue('fail', 'evaluation.schema.missing', `Evaluation envelope must declare schema: ${EVALUATION_SCHEMA}.`, path));
+  }
+
+  const criteria = Array.isArray(parsed.acceptance_criteria) ? parsed.acceptance_criteria : null;
+  if (!criteria || criteria.length === 0) {
+    failures.push(issue('fail', 'evaluation.criteria.missing', 'Evaluation envelope must include acceptance_criteria.', path));
+  }
+
+  const criterionIds = new Set<string>();
+  let hasNonPass = false;
+  if (criteria) {
+    for (let index = 0; index < criteria.length; index += 1) {
+      const rawCriterion = criteria[index];
+      if (!isRecord(rawCriterion)) {
+        failures.push(issue('fail', 'evaluation.criteria.invalid', `Criterion ${index + 1} must be an object.`, path));
+        continue;
+      }
+      const id = asString(rawCriterion.id);
+      if (!meaningfulString(id)) {
+        failures.push(issue('fail', 'evaluation.criteria.missing_id', `Criterion ${index + 1} is missing id.`, path));
+      } else if (criterionIds.has(id)) {
+        failures.push(issue('fail', 'evaluation.criteria.duplicate_id', `Duplicate criterion id: ${id}`, path));
+      } else {
+        criterionIds.add(id);
+      }
+
+      const status = asString(rawCriterion.status);
+      if (!meaningfulString(status)) {
+        failures.push(issue('fail', 'evaluation.criteria.missing_status', `Criterion ${id ?? index + 1} is missing status.`, path));
+      } else if (!CRITERION_STATUSES.has(status)) {
+        failures.push(issue('fail', 'evaluation.criteria.invalid_status', `Criterion ${id ?? index + 1} has invalid status: ${status}`, path));
+      } else if (status !== 'pass') {
+        hasNonPass = true;
+      }
+
+      const evaluator = isRecord(rawCriterion.evaluator) ? rawCriterion.evaluator : null;
+      const evaluatorKind = evaluator ? asString(evaluator.kind) : null;
+      if (!evaluatorKind || evaluatorKind === 'unspecified' || !EVALUATOR_KINDS.has(evaluatorKind)) {
+        failures.push(issue('fail', 'evaluation.criteria.missing_evaluator', `Criterion ${id ?? index + 1} must record a valid evaluator source.`, path));
+      }
+
+      const rationale = rawCriterion.rationale;
+      const hasRationale = meaningfulString(rationale);
+      const criterionHasEvidence = hasEvidence(rawCriterion);
+      if (!criterionHasEvidence && !hasRationale) {
+        failures.push(issue('fail', 'evaluation.criteria.missing_evidence_or_rationale', `Criterion ${id ?? index + 1} must include evidence or rationale.`, path));
+      }
+      if (status === 'pass' && !criterionHasEvidence) {
+        failures.push(issue('fail', 'evaluation.criteria.pass_missing_evidence', `Criterion ${id ?? index + 1} has status pass but no evidence.`, path));
+      }
+      validateEvidencePaths(rawCriterion, failures, warnings, path, root);
+
+      if (status && status !== 'pass') {
+        const route = routeOf(rawCriterion.correction);
+        if (!route || !NON_PASS_ROUTES.has(route)) {
+          failures.push(issue('fail', 'evaluation.criteria.missing_correction_route', `Criterion ${id ?? index + 1} must route non-pass outcomes to retry, amendment, next slice, issue, roadmap, or block.`, path));
+        }
+      }
+    }
+  }
+
+  const feedback = isRecord(parsed.inputs) && Array.isArray(parsed.inputs.feedback) ? parsed.inputs.feedback : [];
+  const feedbackIds = new Set<string>();
+  for (const item of feedback) {
+    if (!isRecord(item)) continue;
+    const id = asString(item.id) ?? asString(item.idempotency_key);
+    if (id) {
+      if (feedbackIds.has(id)) failures.push(issue('fail', 'evaluation.feedback.duplicate_id', `Duplicate feedback id: ${id}`, path));
+      feedbackIds.add(id);
+    }
+    const target = asString(item.target);
+    if (target && !criterionIds.has(target)) {
+      failures.push(issue('fail', 'evaluation.feedback.unknown_target', `Feedback target does not match a criterion id: ${target}`, path));
+    }
+  }
+
+  const decision = isRecord(parsed.decision) ? parsed.decision : null;
+  const decisionStatus = decision ? asString(decision.status) : null;
+  if (!decisionStatus || !DECISION_STATUSES.has(decisionStatus)) {
+    failures.push(issue('fail', 'evaluation.decision.invalid_status', 'Decision status must be approved, weak_approved, rejected, or blocked.', path));
+  }
+  if (decisionStatus === 'approved' && hasNonPass) {
+    failures.push(issue('fail', 'evaluation.decision.approved_with_non_pass', 'Decision cannot be approved while any criterion is partial, fail, blocked, or not_evaluated.', path));
+  }
+  const improvement = isRecord(parsed.improvement) ? parsed.improvement : null;
+  const improvementRoute = improvement ? asString(improvement.route) : null;
+  if (!improvementRoute || !IMPROVEMENT_ROUTES.has(improvementRoute)) {
+    failures.push(issue('fail', 'evaluation.improvement.missing_route', 'Improvement route must be close, retry_run, amend_plan, create_next_slice, open_issue, update_roadmap, or block.', path));
+  }
+  if (hasNonPass && (!improvementRoute || !NON_PASS_ROUTES.has(improvementRoute))) {
+    failures.push(issue('fail', 'evaluation.improvement.non_pass_close', 'Non-pass criteria require a non-close improvement route.', path));
+  }
+  if (decisionStatus === 'weak_approved') {
+    warnings.push(issue('warn', 'evaluation.decision.weak_approval', 'Weak approval is explicit and must be carried forward as caution.', path));
+    const carriedForward = improvement && Array.isArray(improvement.carried_forward) ? improvement.carried_forward : [];
+    const doNotAssume = improvement && Array.isArray(improvement.do_not_assume) ? improvement.do_not_assume : [];
+    if (carriedForward.length === 0 && doNotAssume.length === 0) {
+      failures.push(issue('fail', 'evaluation.decision.weak_approval_missing_caution', 'Weak approval must carry forward a caution or do_not_assume note.', path));
+    }
+  }
+
+  return { ok: failures.length === 0, failures, warnings };
+}
+
+export function validateEvaluationEnvelopeFile(path: string, root = process.cwd()): ValidationResult {
+  if (!existsSync(path)) {
+    return { ok: false, failures: [issue('fail', 'evaluation.file_missing', `Evaluation envelope not found: ${path}`, path)], warnings: [] };
+  }
+  try {
+    if (!statSync(path).isFile()) {
+      return { ok: false, failures: [issue('fail', 'evaluation.file_not_file', `Evaluation envelope path is not a file: ${path}`, path)], warnings: [] };
+    }
+    return validateEvaluationEnvelopeText(readFileSync(path, 'utf8'), path, root);
+  } catch (error) {
+    return {
+      ok: false,
+      failures: [issue('fail', 'evaluation.file_unreadable', error instanceof Error ? error.message : `Could not read evaluation envelope: ${path}`, path)],
+      warnings: [],
+    };
+  }
+}

--- a/tests/cli-eval.test.ts
+++ b/tests/cli-eval.test.ts
@@ -147,6 +147,18 @@ describe('osc eval CLI', () => {
     expect(result.stderr).not.toContain('at Object');
   });
 
+  it('rejects trailing arguments for eval check instead of silently ignoring them', () => {
+    const { root } = tempRepo();
+    const evalPath = join(root, 'docs/evidence/evaluation.json');
+    writeFileSync(evalPath, JSON.stringify(validEnvelope(root), null, 2));
+
+    const result = spawnSync(tsx, [cli, 'eval', 'check', evalPath, '--bogus'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Unknown option for eval check: --bogus');
+    expect(result.stderr).toContain('Usage: osc eval init');
+  });
+
   it('rejects unknown eval subcommands as argument errors', () => {
     const { root } = tempRepo();
 

--- a/tests/cli-eval.test.ts
+++ b/tests/cli-eval.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'osc-cli-eval-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, 'docs/evidence'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild the thing.\n');
+  const planPath = join(root, '.osc/plans/active/036-demo.md');
+  writeFileSync(planPath, `# Plan: 036-demo
+
+## Status
+
+active
+
+## Context
+
+Demo.
+
+## Goal
+
+Evaluate a slice.
+
+## Constraints / Out of scope
+
+- Do not judge domain correctness.
+
+## Files to touch
+
+- src/evaluation.ts
+
+## Acceptance criteria
+
+- [ ] First criterion passes with evidence.
+- [ ] Second criterion routes feedback.
+
+## Verification steps
+
+1. Run tests.
+
+## Open questions
+
+- None.
+`);
+  writeFileSync(join(root, 'docs/evidence/proof.md'), 'proof');
+  return { root, planPath };
+}
+
+function validEnvelope(root: string) {
+  return {
+    schema: 'open-scaffold.evaluation.v1',
+    evaluation_id: 'eval-cli-001',
+    idempotency_key: 'eval:cli-demo',
+    created_at: '2026-05-17T12:00:00.000Z',
+    evaluated_at: '2026-05-17T12:05:00.000Z',
+    subject: { source: 'plan', plan: '.osc/plans/active/036-demo.md', plan_slug: '036-demo', task_id: null, run_id: null, run_packet: null },
+    correlation: { task_id: null, run_id: null, evidence_receipt_ids: [], feedback_ids: [] },
+    inputs: { evidence: [], feedback: [] },
+    acceptance_criteria: [
+      {
+        id: 'AC1',
+        id_source: 'fallback',
+        source_index: 1,
+        text: 'First criterion passes with evidence.',
+        status: 'pass',
+        evaluator: { kind: 'human', name: 'maintainer', ref: null },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Proof.' }],
+        rationale: 'Evidence reviewed.',
+        confidence: 'high',
+        gaps: [],
+        feedback_refs: [],
+        correction: { route: null, target: null, rationale: '' },
+      },
+    ],
+    verification: [],
+    decision: { status: 'approved', approver: 'human', rationale: 'All criteria passed.' },
+    improvement: { route: 'close', target: null, carried_forward: [], do_not_assume: ['This does not certify compliance or domain correctness.'] },
+    notes: ['This envelope records acceptance-criteria-to-evidence coverage and routing. It does not certify correctness, compliance, production readiness, or model quality.'],
+  };
+}
+
+describe('osc eval CLI', () => {
+  it('prints an evaluation template for a plan without spawning runtimes', () => {
+    const { root, planPath } = tempRepo();
+
+    const output = execFileSync(tsx, [cli, 'eval', 'init', planPath], { cwd: root, encoding: 'utf8' });
+    const envelope = JSON.parse(output);
+
+    expect(envelope.schema).toBe('open-scaffold.evaluation.v1');
+    expect(envelope.subject).toMatchObject({ source: 'plan', plan: '.osc/plans/active/036-demo.md' });
+    expect(envelope.acceptance_criteria.map((criterion: any) => criterion.id)).toEqual(['AC1', 'AC2']);
+    expect(output).not.toContain('spawn');
+  });
+
+  it('writes an evaluation template with --out and refuses to overwrite existing files', () => {
+    const { root, planPath } = tempRepo();
+    const outPath = join(root, 'docs/evidence/evaluation.json');
+
+    const output = execFileSync(tsx, [cli, 'eval', 'init', planPath, '--out', outPath], { cwd: root, encoding: 'utf8' });
+
+    expect(output).toContain('Created evaluation envelope:');
+    expect(existsSync(outPath)).toBe(true);
+    const overwrite = spawnSync(tsx, [cli, 'eval', 'init', planPath, '--out', outPath], { cwd: root, encoding: 'utf8' });
+    expect(overwrite.status).toBe(1);
+    expect(overwrite.stderr).toContain('Refusing to overwrite');
+  });
+
+  it('checks a valid evaluation envelope with structure-only PASS wording', () => {
+    const { root } = tempRepo();
+    const evalPath = join(root, 'docs/evidence/evaluation.json');
+    writeFileSync(evalPath, JSON.stringify(validEnvelope(root), null, 2));
+
+    const output = execFileSync(tsx, [cli, 'eval', 'check', evalPath], { cwd: root, encoding: 'utf8' });
+
+    expect(output).toContain('PASS evaluation envelope structure valid');
+    expect(output).toContain('does not judge correctness, compliance, production readiness, or model quality');
+  });
+
+  it('reports structural evaluation failures with FAIL prefixes and exit 1', () => {
+    const { root } = tempRepo();
+    const evalPath = join(root, 'docs/evidence/evaluation.json');
+    const envelope = validEnvelope(root) as any;
+    envelope.acceptance_criteria[0].evidence = [];
+    writeFileSync(evalPath, JSON.stringify(envelope, null, 2));
+
+    const result = spawnSync(tsx, [cli, 'eval', 'check', evalPath], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('FAIL evaluation.criteria.pass_missing_evidence');
+  });
+
+  it('reports directory inputs without dumping a Node stack trace', () => {
+    const { root } = tempRepo();
+
+    const result = spawnSync(tsx, [cli, 'eval', 'check', '.'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('FAIL evaluation.file_not_file');
+    expect(result.stderr).not.toContain('node:fs');
+    expect(result.stderr).not.toContain('at Object');
+  });
+
+  it('rejects unknown eval subcommands as argument errors', () => {
+    const { root } = tempRepo();
+
+    const result = spawnSync(tsx, [cli, 'eval', 'judge'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Usage: osc eval init <run-or-plan> [--out <path>] | osc eval check <evaluation-path>');
+  });
+});

--- a/tests/cli-eval.test.ts
+++ b/tests/cli-eval.test.ts
@@ -123,6 +123,18 @@ describe('osc eval CLI', () => {
     expect(output).toContain('does not judge correctness, compliance, production readiness, or model quality');
   });
 
+  it('checks envelopes from subdirectories using the repo root for local evidence paths', () => {
+    const { root } = tempRepo();
+    const evalPath = join(root, 'docs/evidence/evaluation.json');
+    const subdir = join(root, 'docs/subdir');
+    mkdirSync(subdir, { recursive: true });
+    writeFileSync(evalPath, JSON.stringify(validEnvelope(root), null, 2));
+
+    const output = execFileSync(tsx, [cli, 'eval', 'check', '../evidence/evaluation.json'], { cwd: subdir, encoding: 'utf8' });
+
+    expect(output).toContain('PASS evaluation envelope structure valid');
+  });
+
   it('reports structural evaluation failures with FAIL prefixes and exit 1', () => {
     const { root } = tempRepo();
     const evalPath = join(root, 'docs/evidence/evaluation.json');

--- a/tests/evaluation.test.ts
+++ b/tests/evaluation.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import {
+  EVALUATION_SCHEMA,
+  loadEvaluationSource,
+  renderEvaluationEnvelope,
+  validateEvaluationEnvelopeText,
+} from '../src/evaluation.js';
+
+function tempRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'osc-evaluation-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/runs/demo-run'), { recursive: true });
+  mkdirSync(join(root, 'docs/evidence'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild the thing.\n');
+  return root;
+}
+
+function writePlan(root: string, criteria = ['First thing works.', 'Second thing routes feedback.']) {
+  const planPath = join(root, '.osc/plans/active/036-demo.md');
+  writeFileSync(planPath, `# Plan: 036-demo
+
+## Status
+
+active
+
+## Context
+
+Demo.
+
+## Goal
+
+Generate evaluation envelopes.
+
+## Constraints / Out of scope
+
+- Do not judge domain correctness.
+
+## Files to touch
+
+- src/evaluation.ts
+
+## Acceptance criteria
+
+${criteria.map((criterion) => `- [ ] ${criterion}`).join('\n')}
+
+## Verification steps
+
+1. Run tests.
+
+## Open questions
+
+- None.
+`);
+  return planPath;
+}
+
+function validCriterion(id: string, status = 'pass') {
+  return {
+    id,
+    id_source: 'fallback',
+    source_index: Number(id.replace(/\D/g, '')) || 1,
+    text: `${id} text`,
+    status,
+    evaluator: { kind: 'human', name: 'maintainer', ref: null },
+    evidence: status === 'pass' ? [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Proof.' }] : [],
+    rationale: status === 'pass' ? 'Evidence reviewed.' : 'Not fully satisfied yet.',
+    confidence: 'medium',
+    gaps: status === 'pass' ? [] : ['Follow-up needed.'],
+    feedback_refs: [],
+    correction: status === 'pass' ? { route: null, target: null, rationale: '' } : { route: 'create_next_slice', target: '.osc/plans/backlog/next.md', rationale: 'Needs follow-up.' },
+  };
+}
+
+function validEnvelope(root: string, overrides: Record<string, unknown> = {}) {
+  writeFileSync(join(root, 'docs/evidence/proof.md'), 'proof');
+  return {
+    schema: EVALUATION_SCHEMA,
+    evaluation_id: 'eval-001',
+    idempotency_key: 'eval:demo',
+    created_at: '2026-05-17T12:00:00.000Z',
+    evaluated_at: '2026-05-17T12:05:00.000Z',
+    subject: {
+      source: 'plan',
+      plan: '.osc/plans/active/036-demo.md',
+      plan_slug: '036-demo',
+      task_id: 'task-1',
+      run_id: null,
+      run_packet: null,
+    },
+    correlation: {
+      task_id: 'task-1',
+      run_id: null,
+      evidence_receipt_ids: [],
+      feedback_ids: [],
+    },
+    inputs: { evidence: [], feedback: [] },
+    acceptance_criteria: [validCriterion('AC1')],
+    verification: [],
+    decision: { status: 'approved', approver: 'human', rationale: 'All criteria passed.' },
+    improvement: { route: 'close', target: null, carried_forward: [], do_not_assume: ['This does not certify compliance or domain correctness.'] },
+    notes: ['This envelope records acceptance-criteria-to-evidence coverage and routing. It does not certify correctness, compliance, production readiness, or model quality.'],
+    ...overrides,
+  };
+}
+
+describe('evaluation envelope generation', () => {
+  it('renders a JSON evaluation envelope template from a plan with deterministic fallback AC ids', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+
+    const envelope = JSON.parse(renderEvaluationEnvelope(loadEvaluationSource(planPath, root), { now: new Date('2026-05-17T12:00:00.000Z') }));
+
+    expect(envelope.schema).toBe(EVALUATION_SCHEMA);
+    expect(envelope.subject).toMatchObject({ source: 'plan', plan: '.osc/plans/active/036-demo.md', plan_slug: '036-demo' });
+    expect(envelope.acceptance_criteria.map((criterion: any) => criterion.id)).toEqual(['AC1', 'AC2']);
+    expect(envelope.acceptance_criteria[0]).toMatchObject({ id_source: 'fallback', source_index: 1, text: 'First thing works.', status: 'not_evaluated' });
+    expect(envelope.idempotency_key).toMatch(/^eval:plan:036-demo:/);
+    expect(envelope.notes.join('\n')).toContain('does not certify correctness, compliance, production readiness, or model quality');
+  });
+
+  it('renders a run-bound evaluation envelope from an open-scaffold run packet', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root, ['Run criterion.']);
+    const runPath = join(root, '.osc/runs/demo-run/run.json');
+    writeFileSync(runPath, JSON.stringify({
+      schemaVersion: 'open-scaffold.run.v1',
+      runId: 'demo-run',
+      taskId: 'task-123',
+      plan: { slug: '036-demo', path: '.osc/plans/active/036-demo.md', acceptanceCriteria: ['Run criterion.'] },
+      artifacts: { evidence: ['docs/evidence/run-proof.md'] },
+    }, null, 2));
+
+    const envelope = JSON.parse(renderEvaluationEnvelope(loadEvaluationSource(runPath, root), { now: new Date('2026-05-17T12:00:00.000Z') }));
+
+    expect(existsSync(planPath)).toBe(true);
+    expect(envelope.subject).toMatchObject({ source: 'run', task_id: 'task-123', run_id: 'demo-run', run_packet: '.osc/runs/demo-run/run.json' });
+    expect(envelope.inputs.evidence).toEqual([{ kind: 'path', ref: 'docs/evidence/run-proof.md', summary: 'Evidence from run packet.' }]);
+    expect(envelope.acceptance_criteria[0].id).toBe('AC1');
+  });
+});
+
+describe('evaluation envelope validation', () => {
+  it('accepts pass, partial, fail, blocked, and not_evaluated criteria when evidence/rationale, evaluator, and correction routes are present', () => {
+    const root = tempRepo();
+    const envelope = validEnvelope(root, {
+      acceptance_criteria: [
+        validCriterion('AC1', 'pass'),
+        validCriterion('AC2', 'partial'),
+        validCriterion('AC3', 'fail'),
+        validCriterion('AC4', 'blocked'),
+        validCriterion('AC5', 'not_evaluated'),
+      ],
+      decision: { status: 'blocked', approver: 'human', rationale: 'Some criteria require follow-up.' },
+      improvement: { route: 'create_next_slice', target: '.osc/plans/backlog/next.md', carried_forward: ['Follow up non-pass criteria.'], do_not_assume: ['Non-pass criteria remain unresolved.'] },
+    });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('allows weak approval only when the caution is carried forward', () => {
+    const root = tempRepo();
+    const envelope = validEnvelope(root, {
+      decision: { status: 'weak_approved', approver: 'human', rationale: 'Accepted with explicit caution.' },
+      improvement: { route: 'close', target: null, carried_forward: ['Carry product caution into the next slice.'], do_not_assume: ['Weak approval is not proof of product quality.'] },
+    });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings.map((warning) => warning.code)).toContain('evaluation.decision.weak_approval');
+  });
+
+  it('fails when a passing criterion has no durable evidence', () => {
+    const root = tempRepo();
+    const criterion = { ...validCriterion('AC1', 'pass'), evidence: [] };
+    const envelope = validEnvelope(root, { acceptance_criteria: [criterion] });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toContain('evaluation.criteria.pass_missing_evidence');
+  });
+
+  it('fails when a non-pass criterion has no correction route', () => {
+    const root = tempRepo();
+    const criterion = { ...validCriterion('AC1', 'fail'), correction: { route: null, target: null, rationale: '' } };
+    const envelope = validEnvelope(root, {
+      acceptance_criteria: [criterion],
+      decision: { status: 'rejected', approver: 'human', rationale: 'Rejected.' },
+      improvement: { route: 'retry_run', target: null, carried_forward: [], do_not_assume: [] },
+    });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toContain('evaluation.criteria.missing_correction_route');
+  });
+
+  it('fails when non-pass criteria have no top-level improvement route', () => {
+    const root = tempRepo();
+    const envelope = validEnvelope(root, {
+      acceptance_criteria: [validCriterion('AC1', 'fail')],
+      decision: { status: 'rejected', approver: 'human', rationale: 'Rejected.' },
+      improvement: { route: null, target: null, carried_forward: [], do_not_assume: [] },
+    });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toContain('evaluation.improvement.missing_route');
+  });
+
+  it('fails when evidence kind is unsupported', () => {
+    const root = tempRepo();
+    const criterion = { ...validCriterion('AC1', 'pass'), evidence: [{ kind: 'not-a-kind', ref: 'docs/evidence/proof.md', summary: 'Invalid kind.' }] };
+    const envelope = validEnvelope(root, { acceptance_criteria: [criterion] });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toContain('evaluation.evidence.invalid_kind');
+  });
+
+  it('fails when local evidence path escapes the repo root', () => {
+    const root = tempRepo();
+    const outside = join(tmpdir(), `osc-outside-proof-${process.pid}.md`);
+    writeFileSync(outside, 'outside proof');
+    const criterion = { ...validCriterion('AC1', 'pass'), evidence: [{ kind: 'path', ref: relative(root, outside), summary: 'Outside proof.' }] };
+    const envelope = validEnvelope(root, { acceptance_criteria: [criterion] });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toContain('evaluation.evidence.path_outside_root');
+  });
+
+  it('fails when evaluator source is missing or unspecified', () => {
+    const root = tempRepo();
+    const criterion = { ...validCriterion('AC1', 'pass'), evaluator: { kind: 'unspecified', name: null, ref: null } };
+    const envelope = validEnvelope(root, { acceptance_criteria: [criterion] });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toContain('evaluation.criteria.missing_evaluator');
+  });
+
+  it('fails when feedback targets an unknown acceptance criterion', () => {
+    const root = tempRepo();
+    const envelope = validEnvelope(root, {
+      inputs: { evidence: [], feedback: [{ id: 'FB1', source: 'human', kind: 'defect', target: 'AC404', severity: 'major', summary: 'Wrong target.' }] },
+    });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toContain('evaluation.feedback.unknown_target');
+  });
+
+  it('fails when approval is claimed while non-pass criteria remain', () => {
+    const root = tempRepo();
+    const envelope = validEnvelope(root, {
+      acceptance_criteria: [validCriterion('AC1', 'blocked')],
+      decision: { status: 'approved', approver: 'human', rationale: 'Approved anyway.' },
+      improvement: { route: 'create_next_slice', target: '.osc/plans/backlog/next.md', carried_forward: ['Blocked.'], do_not_assume: [] },
+    });
+
+    const result = validateEvaluationEnvelopeText(JSON.stringify(envelope, null, 2), join(root, 'evaluation.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toContain('evaluation.decision.approved_with_non_pass');
+  });
+});


### PR DESCRIPTION
## Summary

- adds `osc eval init` to generate `open-scaffold.evaluation.v1` JSON envelopes from plans or run packets
- adds `osc eval check` to validate structure, criterion coverage, evaluator/evidence/rationale, decision consistency, feedback targets, and correction routing
- closes plan `036-evaluation-envelope-schema-and-osc-eval` with release evidence and public protocol/wiki updates

## Boundaries

This is structure/coverage validation only. It does not judge domain correctness, certify compliance, benchmark models, approve release/merge, spawn runtimes, or anchor evidence externally.

## Bellman/control-room lessons folded in

- deterministic envelope IDs and idempotency keys
- explicit subject/correlation references
- evidence receipts instead of chat/operator surface truth
- PASS/BLOCKED/FAIL-style routing discipline
- correction routes before close

## Verification

- `npm test` — 10 files / 94 tests passed
- `npm run build` — passed
- `npm run --silent osc -- eval init .osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md` — generated JSON envelope template
- `npm run --silent osc -- eval check /tmp/osc-036-evaluation.json` — passed after filling local evidence, 7 criteria / 0 warnings
- `npm run osc -- verify` — passed, 0 warnings
- `./verify.sh --standard` — passed, 6 pass / 0 fail / 0 warn
- `git diff --check` — passed
- public-boundary scan — no owner-name leakage or unsupported compliance/model/runtime/ledger claims

## Review state

Codex latest-head review for `c7b3197` returned clean at 2026-05-17T13:09:11Z: “Didn't find any major issues.” Earlier inline findings were fixed before the latest trigger. Merge remains owner-gated.
