### PR TITLE
Add audit envelope digest manifests

### DIFF
--- a/.osc/plans/done/037-audit-envelope-digest-manifest.md
+++ b/.osc/plans/done/037-audit-envelope-digest-manifest.md
@@ -1,0 +1,100 @@
+# Plan: 037-audit-envelope-digest-manifest
+
+## Status
+
+active
+
+## Context
+
+PR #39 established audit/evaluation envelopes as Open Scaffold core standards, and PR #40 shipped the first structure-only `osc eval` mechanics for evaluation envelopes. The next smallest implementation slice is to make audit envelopes reconstructable through deterministic artifact manifests and local digests, while preserving the boundary that Open Scaffold is not a compliance certifier, domain evaluator, runtime spawner, or external anchor provider.
+
+## Goal
+
+Add the smallest useful structure-only audit-envelope digest manifest surface so a user can record and check which local plan/run/evaluation/evidence artifacts existed for a slice and whether their content digests still match.
+
+## Constraints / Out of scope
+
+- Do not add automated domain correctness judgment, legal/compliance certification, or production audit sufficiency claims.
+- Do not add model benchmarking, model/task-fit scoring, LLM-as-judge orchestration, or runtime spawning.
+- Do not add Hedera/hashgraph, Sigstore, timestamping, notarization, external anchor adapters, or provider SDK integration in this slice.
+- Do not make raw private/runtime logs public product truth; manifests should point to curated local/public evidence paths only.
+- Keep the UX lightweight for solo developers and small teams: local generation/checking first, no server, no daemon, no credentials.
+- Preserve runtime/adapters/human approval boundaries: the manifest proves artifact presence/digest consistency, not that the work was correct or approved.
+
+## Files to touch
+
+- `src/cli.ts` — expose audit-manifest generation/checking through the existing CLI if the implementation confirms the right command shape.
+- `src/audit.ts` or a focused equivalent module — generate and validate `open-scaffold.audit-envelope.v1` / digest-manifest data.
+- `src/evaluation.ts` — reuse evaluation envelope identity/path handling only if needed; avoid coupling audit checks to evaluation judgment.
+- `tests/*audit*.test.ts` and/or CLI tests — cover manifest generation, digest checks, missing files, changed files, duplicate artifact IDs, unsupported paths, and boundary wording.
+- `docs/SLICE_CLOSE_PROTOCOL.md` — clarify local audit manifest semantics if the CLI surface changes the protocol wording.
+- `docs/wiki/concepts/implementation-architecture-lens.md` — update only if needed to reflect the structure-only manifest mechanic.
+- `.osc/releases/<date>-audit-envelope-digest-manifest.md` — release/evidence note for the implementation slice.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Inspect current `osc eval`, run packet, and protocol code paths to choose the smallest audit-manifest command shape. | None | A |
+| T2 | Add failing tests for manifest generation/checking and boundary cases. | T1 | B |
+| T3 | Implement audit manifest generation/checking with deterministic local file digests. | T2 | C |
+| T4 | Update only the minimal docs/release evidence needed to make the mechanic understandable. | T3 | D |
+| T5 | Run verification, close the plan via `close.sh`, and prepare PR evidence without merging. | T3, T4 | E |
+
+### Parallel groups
+
+- **Group A**: T1 — discovery before implementation.
+- **Group B**: T2 — tests define the structure-only behavior.
+- **Group C**: T3 — implementation follows tests.
+- **Group D**: T4 — docs/release wording follows the final command shape.
+- **Group E**: T5 — verification and close after code/docs stabilize.
+
+### Dependencies
+
+- T2 depends on T1 so tests encode the chosen command shape instead of guessing.
+- T3 depends on T2 to keep the slice test-driven.
+- T4 depends on T3 so public wording matches actual behavior.
+- T5 depends on T3/T4 so evidence reflects the final artifact set.
+
+### Delegation notes
+
+- This is small enough for one implementation worker. If delegated, keep a single branch/workspace and require local verification evidence before any PR.
+- Do not split docs and code into separate PRs unless implementation expands beyond this plan's boundaries.
+
+## Implementation Architecture Coverage
+
+- Strengthens: audit trails, recovery/ownership, evaluation.
+- Audit envelope: plan path, branch, generated manifest path, cited artifact paths, local digests, verification commands, PR/release evidence, and any evaluation-envelope path used for close/postflight.
+- Evaluation envelope: acceptance criteria are checked by tests, CLI validation output, `verify.sh`, build/test commands, and manual boundary wording review; the manifest itself does not evaluate correctness.
+- Feedback routing: failed digest checks route to re-run evidence generation, fix cited artifact paths, add missing curated evidence, or create a follow-up plan if external anchoring/audit mechanics are desired.
+- Boundary: runtime enforcement, credentials, system-of-record permissions, compliance certification, legal audit sufficiency, model benchmarking, production rollback, external ledger/notary anchoring, and raw private/runtime log storage remain outside this slice.
+
+## Acceptance criteria
+
+- [ ] A documented CLI surface, likely `osc audit init` / `osc audit check` or equivalent, can generate and validate a local audit-envelope digest manifest for a plan/run/evaluation/evidence artifact set.
+- [ ] The manifest records schema/version, subject identity, artifact IDs, artifact roles, relative paths, digest algorithm, digests, generated timestamp, and boundary/non-claim metadata.
+- [ ] Validation detects missing files, changed digests, duplicate artifact IDs, malformed artifact entries, unsafe/out-of-repo paths where applicable, and missing required subject identity.
+- [ ] Validation distinguishes artifact/digest integrity from acceptance correctness, compliance certification, approval, runtime execution, and external anchoring.
+- [ ] Tests cover pass, missing artifact, changed artifact, duplicate ID, malformed manifest, unsafe path, and no-regression behavior for existing `osc eval` commands.
+- [ ] Docs/CLI help use owner-neutral, public-safe wording and avoid unsupported compliance, audit-certification, model-benchmarking, runtime-spawning, or ledger-provider claims.
+- [ ] Release evidence records verification, scope, non-goals, and follow-up work such as external anchor adapters only as future possibilities.
+
+## Verification steps
+
+1. Run `npm test`; expected exit 0.
+2. Run `npm run build`; expected exit 0.
+3. Run the new audit manifest init/check smoke commands; expected manifest generation and clean validation for curated local evidence.
+4. Run `npm run --silent osc -- eval init .osc/plans/active/037-audit-envelope-digest-manifest.md`; expected existing eval flow still works.
+5. Run `npm run osc -- verify`; expected exit 0 with no unexpected warnings.
+6. Run `./verify.sh --standard`; expected exit 0.
+7. Run `git diff --check`; expected no whitespace errors.
+8. Manually inspect CLI/docs/release wording for unsupported claims about compliance, legal audit sufficiency, model benchmarking, runtime spawning, or external-ledger anchoring.
+
+## Open questions
+
+- Should the public command be `osc audit`, `osc evidence manifest`, or another name that avoids implying legal audit sufficiency?
+- Should the first manifest be JSON-only, or should it also support Markdown release/evidence note summaries?
+- Should manifest files live under `.osc/runs/<run_id>/audit-manifest.json`, `.osc/evidence/`, or a caller-provided path by default?
+- Should JSON schema export be included here or kept as a later refinement after adopter evidence?

--- a/.osc/releases/2026-05-17-audit-envelope-digest-manifest.md
+++ b/.osc/releases/2026-05-17-audit-envelope-digest-manifest.md
@@ -1,0 +1,91 @@
+# Release evidence: audit envelope digest manifest
+
+## Summary
+
+This slice turns the audit-envelope direction from PR #39 and the evaluation-envelope mechanics from PR #40 into the first small, testable audit-integrity mechanic.
+
+It adds `osc audit init` and `osc audit check` for JSON-backed `open-scaffold.audit-envelope.v1` manifests. The command records explicitly curated local artifacts, repo-relative paths, roles, and sha256 digests, then validates manifest structure, subject identity, artifact roles/IDs, local file presence, private-path boundaries, and digest consistency.
+
+The command is intentionally structure-only and local. It does not judge domain correctness, certify compliance, approve release/merge, benchmark models, spawn runtimes, or anchor evidence externally.
+
+## Scope
+
+- Plan: `.osc/plans/done/037-audit-envelope-digest-manifest.md`.
+- Branch: `feat/audit-envelope-digest-manifest`.
+- Parent architecture: PR #39 / `.osc/plans/done/033-implementation-architecture-evaluation-lens-amendment-1.md`.
+- Prior implementation: PR #40 / `.osc/plans/done/036-evaluation-envelope-schema-and-osc-eval.md`.
+- Operator card: Hermes Kanban `t_fb2b0323`.
+
+## Traceability
+
+- Plan: `.osc/plans/done/037-audit-envelope-digest-manifest.md`.
+- Roadmap direction: `ROADMAP.md` / Implementation architecture direction — audit and evaluation envelopes.
+- Parent architecture release note: `.osc/releases/2026-05-17-implementation-architecture-lens.md`.
+- Prior evaluation release note: `.osc/releases/2026-05-17-evaluation-envelope-schema.md`.
+- Run packet: not generated; this was a direct Hermes implementation/postflight slice on the feature branch, with verification promoted into this release note and the PR.
+- New implementation module: `src/audit.ts`.
+- CLI integration: `src/cli.ts`.
+- Tests: `tests/audit.test.ts`, `tests/cli-audit.test.ts`.
+- PR: pending owner review.
+
+## Changes
+
+- Added JSON audit-manifest generation from:
+  - plan files;
+  - `open-scaffold.run.v1` run packets.
+- Added explicit curated artifact inputs via `--artifact <role> <path>`.
+- Added deterministic artifact records with:
+  - artifact IDs;
+  - roles;
+  - repo-relative paths;
+  - sha256 digests;
+  - byte sizes.
+- Added validation for:
+  - schema and audit envelope ID;
+  - subject identity;
+  - run-bound identity requirements;
+  - artifact IDs and duplicate IDs;
+  - allowed artifact roles;
+  - repo-relative local paths;
+  - missing files;
+  - digest mismatch;
+  - digest algorithm/value shape;
+  - private/internal workspace paths such as `.osc/research/` and `.osc-dev/`;
+  - unsupported boundary claims.
+- Updated public protocol/docs to state that v1 audit manifests are local digest-integrity checks, not compliance/audit certification or external anchoring.
+
+## Verification
+
+Completed verification for the PR branch:
+
+- `npm test` — passed, 12 files / 116 tests.
+- `npm run build` — passed.
+- `npm run --silent osc -- audit init .osc/plans/done/037-audit-envelope-digest-manifest.md --artifact changed_file src/audit.ts --artifact changed_file src/cli.ts --artifact evidence tests/audit.test.ts --artifact evidence tests/cli-audit.test.ts --artifact evidence docs/SLICE_CLOSE_PROTOCOL.md --artifact release_note .osc/releases/2026-05-17-audit-envelope-digest-manifest.md --out /tmp/osc-037-audit-final.json --force` — passed after plan close; generated the structure-only local audit manifest.
+- `npm run --silent osc -- audit check /tmp/osc-037-audit-final.json` — passed, 7 artifacts / 0 warnings.
+- `npm run --silent osc -- eval init .osc/plans/done/037-audit-envelope-digest-manifest.md` — passed after plan close; existing evaluation-envelope flow still worked.
+- `npm run osc -- verify` — passed, 0 warnings.
+- `./verify.sh --standard` — passed, 6 pass / 0 fail / 0 warn.
+- `git diff --check` — passed.
+- Manual wording scan — passed for structure-only wording and no domain correctness, compliance certification, model benchmarking, runtime spawning, or external-ledger/anchor claims.
+
+Final PR/Codex verification is recorded in the pull request after push.
+
+## Outcome
+
+Open Scaffold now has a concrete audit-envelope digest mechanic: users can generate a local manifest that ties a plan or run packet to explicitly curated evidence/artifact files, then check whether those files still exist and match their recorded sha256 digests.
+
+The result strengthens the audit-trail side of the closed feedback loop without expanding Open Scaffold core into a domain evaluator, compliance product, runtime, model lab, or ledger provider.
+
+## Follow-up
+
+External anchor adapters remain a separate future slice.
+
+Potential future refinements, after adopter evidence:
+
+- envelope self-digests;
+- parent links;
+- optional Merkle batch roots;
+- optional external-anchor receipt shapes;
+- JSON schema export;
+- tracked default evidence/audit-manifest location guidance;
+- explicit integration from `osc verify` if repo-wide audit checks stop being surprising.

--- a/.osc/releases/2026-05-17-audit-envelope-digest-manifest.md
+++ b/.osc/releases/2026-05-17-audit-envelope-digest-manifest.md
@@ -58,7 +58,7 @@ The command is intentionally structure-only and local. It does not judge domain 
 
 Completed verification for the PR branch:
 
-- `npm test` — passed, 12 files / 116 tests.
+- `npm test` — passed, 12 files / 117 tests.
 - `npm run build` — passed.
 - `npm run --silent osc -- audit init .osc/plans/done/037-audit-envelope-digest-manifest.md --artifact changed_file src/audit.ts --artifact changed_file src/cli.ts --artifact evidence tests/audit.test.ts --artifact evidence tests/cli-audit.test.ts --artifact evidence docs/SLICE_CLOSE_PROTOCOL.md --artifact release_note .osc/releases/2026-05-17-audit-envelope-digest-manifest.md --out /tmp/osc-037-audit-final.json --force` — passed after plan close; generated the structure-only local audit manifest.
 - `npm run --silent osc -- audit check /tmp/osc-037-audit-final.json` — passed, 7 artifacts / 0 warnings.

--- a/.osc/releases/2026-05-17-audit-envelope-digest-manifest.md
+++ b/.osc/releases/2026-05-17-audit-envelope-digest-manifest.md
@@ -58,7 +58,7 @@ The command is intentionally structure-only and local. It does not judge domain 
 
 Completed verification for the PR branch:
 
-- `npm test` — passed, 12 files / 117 tests.
+- `npm test` — passed, 12 files / 119 tests.
 - `npm run build` — passed.
 - `npm run --silent osc -- audit init .osc/plans/done/037-audit-envelope-digest-manifest.md --artifact changed_file src/audit.ts --artifact changed_file src/cli.ts --artifact evidence tests/audit.test.ts --artifact evidence tests/cli-audit.test.ts --artifact evidence docs/SLICE_CLOSE_PROTOCOL.md --artifact release_note .osc/releases/2026-05-17-audit-envelope-digest-manifest.md --out /tmp/osc-037-audit-final.json --force` — passed after plan close; generated the structure-only local audit manifest.
 - `npm run --silent osc -- audit check /tmp/osc-037-audit-final.json` — passed, 7 artifacts / 0 warnings.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-17: closed 037-audit-envelope-digest-manifest — added structure-only audit envelope digest manifest CLI mechanics
 - 2026-05-17: closed 036-evaluation-envelope-schema-and-osc-eval — added structure-only evaluation envelope schema and osc eval init/check mechanics
 - 2026-05-17: rescope PR39 around evaluation and audit envelope standards — see .osc/plans/done/033-implementation-architecture-evaluation-lens-amendment-1.md
 - 2026-05-17: closed 033-implementation-architecture-evaluation-lens — implementation architecture lens shipped

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -196,11 +196,11 @@ Public roadmap commitments should stay legible: keep at most five planned/backlo
 
 ### Implementation architecture direction — audit and evaluation envelopes
 
-Status: direction captured through PR #39 scope amendment; implementation mechanics remain follow-up work.
+Status: direction captured through PR #39 scope amendment; first structure-only CLI mechanics shipped through PR #40 (`osc eval init/check`) and the local audit digest-manifest slice (`osc audit init/check`).
 
 Open Scaffold core should own portable standards for audit envelopes, evaluation envelopes, closed evaluation loops, and feedback-based improvement routing. This strengthens the existing slice-close protocol and runtime binding contract: a run should produce enough durable evidence for a postflight to evaluate acceptance criteria, capture human/reviewer feedback, route corrections, and reconstruct what was planned, executed, verified, approved, or carried forward.
 
-Near-term scope is protocol and documentation: envelope vocabulary, evidence expectations, feedback routing, and boundary clarity. Future mechanics such as schema-backed envelope validation, `osc eval` template generation, digest/Merkle audit manifests, or external anchor adapters require separate plans and tests.
+Current mechanics are intentionally lightweight and structure-only: `osc eval` drafts/checks acceptance-criteria evaluation envelopes, and `osc audit` drafts/checks local artifact digest manifests. Future mechanics such as envelope self-digests, parent links, Merkle audit manifests, external anchor adapters, or provider-specific receipt submission require separate plans and tests.
 
 This direction does not promote native runtime ownership, model-lab benchmarking, automated compliance judgment, legal audit certification, runtime data permissions, or provider-specific ledger dependencies into core.
 

--- a/docs/SLICE_CLOSE_PROTOCOL.md
+++ b/docs/SLICE_CLOSE_PROTOCOL.md
@@ -209,37 +209,47 @@ osc eval check <evaluation-path>
 
 An audit envelope is the integrity-oriented companion to the evaluation envelope. It identifies the durable artifacts needed to reconstruct what was planned, run, evidenced, reviewed, approved, and carried forward.
 
-Minimum concepts:
+The v1 CLI surface starts with local digest manifests:
+
+```bash
+osc audit init <run-or-plan> [--artifact <role> <path>]... [--out <path>]
+osc audit check <audit-manifest-path>
+```
+
+`osc audit init` records a JSON `open-scaffold.audit-envelope.v1` manifest for a plan or run packet plus explicitly supplied curated artifacts. `osc audit check` validates the manifest shape, subject identity, artifact IDs/roles, repo-relative paths, local file presence, and sha256 digest consistency.
+
+Minimum manifest concepts:
 
 ```yaml
 schema: open-scaffold.audit-envelope.v1
-envelope_id: audit:20260512T090000Z-docs-runtime-dispatch
+audit_envelope_id: 20260517T120000Z-docs-runtime-dispatch-audit
 subject:
+  source: plan | run
   task_id: issue:42
   run_id: 20260512T090000Z-docs-runtime-dispatch
   plan: .osc/plans/done/001-example.md
-  evaluation: .osc/runs/20260512T090000Z-docs-runtime-dispatch/evaluation.md
-  evidence_receipt: .osc/runs/20260512T090000Z-docs-runtime-dispatch/evidence.md
-  pr: 12
+  plan_slug: 001-example
+  run_packet: .osc/runs/20260512T090000Z-docs-runtime-dispatch/run.json
 artifacts:
-  - path: docs/RUNTIME_HARNESS_DISPATCH.md
-    role: changed_file | evidence | release_note | postflight | dispatch_receipt
+  - id: plan:.osc/plans/done/001-example.md
+    role: plan | run_packet | evaluation | evidence | postflight | release_note | changed_file | verification | review | other
+    path: .osc/plans/done/001-example.md
     digest:
       alg: sha256
       value: "lowercase-hex"
-    privacy: public | redacted | private_not_anchored
-parents:
-  - envelope_digest: sha256:previous-envelope-digest
-    reason: previous_run | merge_parent | release_batch
-artifact_merkle:
-  alg: sha256
-  manifest_digest: sha256:manifest-digest
-  root: sha256:root-digest
-anchor_receipts:
-  - .osc/runs/<run_id>/anchors/provider-receipt.json
+boundary:
+  digest_integrity_only: true
+  local_files_only: true
+  compliance_certification: false
+  approval_or_release_decision: false
+  runtime_spawning: false
+  model_benchmarking: false
+  external_anchoring: false
 ```
 
-Core can define artifact digests, parent links, Merkle batch roots, and external-anchor receipt shape. Provider submission, key custody, network retries, legal attestation, runtime event capture, and systems-of-record audit logs belong to optional adapters or external systems.
+This check proves only local artifact presence and byte-level digest consistency at check time. It does not run verification commands, judge domain correctness, certify compliance, approve release/merge, spawn runtimes, benchmark models, or anchor evidence externally.
+
+Future work can define parent links, Merkle batch roots, envelope self-digests, and external-anchor receipt shape. Provider submission, key custody, network retries, legal attestation, runtime event capture, and systems-of-record audit logs belong to optional adapters or external systems.
 
 ## Postflight checklist
 

--- a/docs/wiki/concepts/implementation-architecture-lens.md
+++ b/docs/wiki/concepts/implementation-architecture-lens.md
@@ -38,7 +38,7 @@ For runtime lane labels and public/private reference wording, use `docs/REFERENC
 | Data access | out of scope / system-of-record-owned | Documentation boundaries and run-packet scope can state which data must not be touched. | Runtime row/field permissions, data warehouse access, secrets, customer data controls, and system-of-record authorization. |
 | Authority | partial / adapter-owned | Commit policy, approval gates, allowed paths, human-in-the-loop expectations, and plan constraints make authority visible. | Runtime sandbox enforcement, credential delegation, business-action approval, production rollback authority, and provider-specific permission models. |
 | Evaluation / feedback / improvement | owned for loop contract; external for domain judgment | Acceptance criteria, evaluation-envelope shape, evidence requirements, user/reviewer feedback capture, approval taxonomy, correction routing, and next-slice inheritance. | Domain/business-rule evaluators, model benchmarks, production-quality scoring, automated compliance judgment, and final taste/risk decisions. |
-| Audit trails | owned for repo work and envelope standards | Git history, plans, amendments, run packets, evidence notes, release notes, PR links, artifact digests, audit-envelope vocabulary, parent links, and optional anchor-receipt shape. | External ledger submission, provider SDKs, key custody, legal audit certification, runtime event capture from external systems, raw private/runtime log anchoring, and compliance attestation. |
+| Audit trails | owned for repo work and envelope standards | Git history, plans, amendments, run packets, evidence notes, release notes, PR links, artifact digests, local audit manifests, and audit-envelope vocabulary. Parent links, Merkle roots, and external-anchor receipt shapes are future extension points. | External ledger submission, provider SDKs, key custody, legal audit certification, runtime event capture from external systems, raw private/runtime log anchoring, and compliance attestation. |
 | Recovery / ownership | owned for project continuation | Agent-readable mission, roadmap, active plans, task/run identity, evidence, evaluation records, audit envelopes, and handoff files let a human or agent resume work without vanished chat context. | Runtime session replay, live process recovery, production incident reversal, and business transaction compensation. |
 
 ## Audit envelope
@@ -57,7 +57,9 @@ A minimal audit envelope should reference:
 - decision: `approved`, `weak_approved`, `rejected`, or `blocked`;
 - exclusions: secrets, customer data, raw private runtime transcripts, and external system audit logs unless deliberately promoted and safe.
 
-A future tamper-evident version can add artifact digests, envelope digests, parent links, Merkle batch roots, and external-anchor receipts. Core can define that portable shape. External notaries or ledger systems remain optional adapters.
+The first structure-only implementation is local and vendor-neutral: `osc audit init` / `osc audit check` can generate a JSON `open-scaffold.audit-envelope.v1` manifest for a plan or run packet plus explicitly supplied curated artifacts, then verify repo-relative paths and sha256 digest consistency. That proves byte-level local artifact integrity only. It does not certify correctness, compliance, approval, runtime execution, model quality, or external anchoring.
+
+Future tamper-evident versions can add envelope self-digests, parent links, Merkle batch roots, and external-anchor receipts. Core can define that portable shape. External notaries or ledger systems remain optional adapters.
 
 ## Evaluation envelope
 
@@ -148,8 +150,10 @@ Those may become adapter, evaluator, runtime, ledger-anchor, or future-product w
 
 ## Follow-up candidates
 
-Structured evaluation mechanics now start with `osc eval init` and `osc eval check`: generate a JSON evaluation envelope, check that every acceptance criterion has evidence/status/rationale/evaluator coverage, and require a correction route for non-pass outcomes. This still does not automatically certify domain correctness, benchmark models, or replace human/product approval.
+Structured evaluation mechanics start with `osc eval init` and `osc eval check`: generate a JSON evaluation envelope, check that every acceptance criterion has evidence/status/rationale/evaluator coverage, and require a correction route for non-pass outcomes. This still does not automatically certify domain correctness, benchmark models, or replace human/product approval.
 
-Tamper-evident audit mechanics should start with a vendor-neutral `open-scaffold.audit-envelope.v1` and `open-scaffold.anchor-receipt.v1` shape for promoted evidence artifacts: artifact digests, envelope digests, parent links, optional Merkle batch roots, and optional external-anchor receipts. Hedera Consensus Service, Sigstore/Rekor, RFC3161 timestamping, Git signed tags, or other ledgers/notaries belong in optional adapters, not Open Scaffold core.
+Local audit manifest mechanics start with `osc audit init` and `osc audit check`: generate a JSON audit-envelope digest manifest for curated local artifacts, then check repo-relative paths and sha256 digest consistency. This still does not certify compliance, approve release/merge, prove domain correctness, spawn runtimes, benchmark models, or anchor evidence externally.
+
+Future audit work can define envelope self-digests, parent links, optional Merkle batch roots, and optional external-anchor receipt shapes. Hedera Consensus Service, Sigstore/Rekor, RFC3161 timestamping, Git signed tags, or other ledgers/notaries belong in optional adapters, not Open Scaffold core.
 
 Related: [[source-of-truth-first-development]], [[evidence-first-development]], [[human-in-the-loop-governance]], [[run-packets]], [[agentic-orchestration]].

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -3,6 +3,10 @@
 > Chronological record of project wiki actions. Append-only.
 > Format: `## [YYYY-MM-DD] action | subject`
 
+## [2026-05-17] implement | Audit envelope digest manifest
+- Added `osc audit init` / `osc audit check` as the first JSON-backed audit-envelope digest-manifest mechanics.
+- Kept the command local and structure-only: no domain correctness judgment, compliance certification, approval decision, model benchmarking, runtime spawning, or external anchoring.
+
 ## [2026-05-17] implement | Evaluation envelope CLI
 - Added `osc eval init` / `osc eval check` as the first JSON-backed evaluation-envelope mechanics.
 - Kept the command structure-only: no domain correctness judgment, compliance certification, model benchmarking, runtime spawning, or external anchoring.

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -149,7 +149,10 @@ function sourceFromRunPacket(sourcePath: string, root: string): AuditSubject {
     throw new Error(`Run packet must declare schemaVersion: ${RUN_SCHEMA}`);
   }
   const plan = isRecord(packet.plan) ? packet.plan : {};
-  const planPath = asString(plan.path) ?? '(unknown plan)';
+  const planPath = asString(plan.path);
+  if (!meaningfulString(planPath) || planPath === '(unknown plan)') {
+    throw new Error('Run packet must include plan.path for audit traceability.');
+  }
   return {
     source: 'run',
     sourcePath: pathRelativeToRoot(root, sourcePath),
@@ -335,8 +338,9 @@ function validateSubject(parsed: Record<string, unknown>, failures: ValidationIs
   if (source !== 'plan' && source !== 'run') {
     failures.push(issue('fail', 'audit.subject.invalid_source', 'Audit subject source must be plan or run.', path));
   }
-  if (!meaningfulString(subject.plan)) {
-    failures.push(issue('fail', 'audit.subject.missing_plan', 'Audit subject must include a plan path.', path));
+  const planPath = asString(subject.plan);
+  if (!meaningfulString(planPath) || planPath === '(unknown plan)') {
+    failures.push(issue('fail', 'audit.subject.missing_plan', 'Audit subject must include a concrete plan path.', path));
   }
   if (!meaningfulString(subject.plan_slug)) {
     failures.push(issue('fail', 'audit.subject.missing_plan_slug', 'Audit subject must include plan_slug.', path));

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -107,7 +107,7 @@ function isInsideRoot(root: string, candidate: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
-function normalizeRepoRelative(root: string, path: string): { relativePath: string; absolutePath: string } {
+function normalizeRepoRelative(root: string, path: string): { relativePath: string; canonicalRelativePath: string; absolutePath: string } {
   const realRoot = rootRealpath(root);
   const absolute = isAbsolute(path) ? path : resolve(realRoot, path);
   if (!isInsideRoot(realRoot, absolute)) {
@@ -123,7 +123,11 @@ function normalizeRepoRelative(root: string, path: string): { relativePath: stri
   if (!statSync(realArtifact).isFile()) {
     throw new Error(`Audit artifact path is not a file: ${path}`);
   }
-  return { relativePath: toPosix(relative(realRoot, absolute)), absolutePath: realArtifact };
+  return {
+    relativePath: toPosix(relative(realRoot, absolute)),
+    canonicalRelativePath: toPosix(relative(realRoot, realArtifact)),
+    absolutePath: realArtifact,
+  };
 }
 
 function pathRelativeToRoot(root: string, path: string): string {
@@ -197,9 +201,12 @@ function resolveArtifact(input: AuditArtifactInput, root: string): ResolvedArtif
   if (!meaningfulString(input.path)) {
     throw new Error('Audit artifact path is required.');
   }
-  const { relativePath, absolutePath } = normalizeRepoRelative(root, input.path);
+  const { relativePath, canonicalRelativePath, absolutePath } = normalizeRepoRelative(root, input.path);
   if (isPrivatePath(relativePath)) {
     throw new Error(`Audit artifact path points at private/internal workspace state: ${relativePath}`);
+  }
+  if (isPrivatePath(canonicalRelativePath)) {
+    throw new Error(`Audit artifact path points at private/internal workspace state: ${canonicalRelativePath}`);
   }
   return {
     id: input.id ?? `${input.role}:${relativePath}`,

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,0 +1,461 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
+import { basename, extname, isAbsolute, relative, resolve } from 'node:path';
+import { parsePlanFile } from './scaffold.js';
+import type { ValidationIssue, ValidationResult } from './validation.js';
+
+export const AUDIT_SCHEMA = 'open-scaffold.audit-envelope.v1';
+const RUN_SCHEMA = 'open-scaffold.run.v1';
+const DIGEST_ALG = 'sha256';
+
+const ARTIFACT_ROLES = new Set([
+  'plan',
+  'run_packet',
+  'evaluation',
+  'evidence',
+  'postflight',
+  'release_note',
+  'changed_file',
+  'verification',
+  'review',
+  'other',
+]);
+
+const PRIVATE_PATH_PREFIXES = [
+  '.git/',
+  '.osc/state/',
+  '.osc/research/',
+  '.osc-dev/',
+  '.hermes/',
+  'node_modules/',
+];
+
+const UNSUPPORTED_BOUNDARY_TRUE_FIELDS = [
+  'domain_correctness_judgment',
+  'compliance_certification',
+  'approval_or_release_decision',
+  'runtime_spawning',
+  'model_benchmarking',
+  'external_anchoring',
+];
+
+export interface AuditArtifactInput {
+  role: string;
+  path: string;
+  id?: string;
+}
+
+export interface AuditSubject {
+  source: 'plan' | 'run';
+  sourcePath: string;
+  planPath: string;
+  planSlug: string;
+  taskId: string | null;
+  runId: string | null;
+  runPacketPath: string | null;
+}
+
+export interface RenderAuditOptions {
+  now?: Date;
+}
+
+interface ResolvedArtifact {
+  id: string;
+  role: string;
+  path: string;
+  absolutePath: string;
+}
+
+function issue(level: 'fail' | 'warn', code: string, message: string, path?: string): ValidationIssue {
+  return { level, code, message, path };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function meaningfulString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0 && !/^(todo|tbd|n\/a|none)$/i.test(value.trim());
+}
+
+function toPosix(value: string): string {
+  return value.split('\\').join('/');
+}
+
+function timestampId(now: Date): string {
+  return now.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function shortDigest(parts: string[]): string {
+  return createHash('sha256').update(parts.join('\n'), 'utf8').digest('hex').slice(0, 16);
+}
+
+function fileDigest(path: string): string {
+  return createHash(DIGEST_ALG).update(readFileSync(path)).digest('hex');
+}
+
+function rootRealpath(root: string): string {
+  return existsSync(root) ? realpathSync(root) : resolve(root);
+}
+
+function isInsideRoot(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function normalizeRepoRelative(root: string, path: string): { relativePath: string; absolutePath: string } {
+  const realRoot = rootRealpath(root);
+  const absolute = isAbsolute(path) ? path : resolve(realRoot, path);
+  if (!isInsideRoot(realRoot, absolute)) {
+    throw new Error(`Audit artifact path escapes the repo root: ${path}`);
+  }
+  if (!existsSync(absolute)) {
+    throw new Error(`Audit artifact path does not exist: ${path}`);
+  }
+  const realArtifact = realpathSync(absolute);
+  if (!isInsideRoot(realRoot, realArtifact)) {
+    throw new Error(`Audit artifact path escapes the repo root: ${path}`);
+  }
+  if (!statSync(realArtifact).isFile()) {
+    throw new Error(`Audit artifact path is not a file: ${path}`);
+  }
+  return { relativePath: toPosix(relative(realRoot, absolute)), absolutePath: realArtifact };
+}
+
+function pathRelativeToRoot(root: string, path: string): string {
+  const realRoot = rootRealpath(root);
+  const absolute = isAbsolute(path) ? path : resolve(realRoot, path);
+  const comparablePath = existsSync(absolute) ? realpathSync(absolute) : absolute;
+  const rel = relative(realRoot, comparablePath);
+  if (!rel || rel.startsWith('..')) return toPosix(path);
+  return toPosix(rel);
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown;
+}
+
+function sourceFromRunPacket(sourcePath: string, root: string): AuditSubject {
+  const packet = readJson(sourcePath);
+  if (!isRecord(packet) || packet.schemaVersion !== RUN_SCHEMA) {
+    throw new Error(`Run packet must declare schemaVersion: ${RUN_SCHEMA}`);
+  }
+  const plan = isRecord(packet.plan) ? packet.plan : {};
+  const planPath = asString(plan.path) ?? '(unknown plan)';
+  return {
+    source: 'run',
+    sourcePath: pathRelativeToRoot(root, sourcePath),
+    planPath,
+    planSlug: asString(plan.slug) ?? basename(planPath, extname(planPath)),
+    taskId: asString(packet.taskId),
+    runId: asString(packet.runId),
+    runPacketPath: pathRelativeToRoot(root, sourcePath),
+  };
+}
+
+function sourceFromPlan(sourcePath: string, root: string): AuditSubject {
+  const plan = parsePlanFile(sourcePath);
+  return {
+    source: 'plan',
+    sourcePath: pathRelativeToRoot(root, sourcePath),
+    planPath: pathRelativeToRoot(root, sourcePath),
+    planSlug: plan.slug,
+    taskId: null,
+    runId: null,
+    runPacketPath: null,
+  };
+}
+
+export function loadAuditSubject(sourcePath: string, root = process.cwd()): AuditSubject {
+  const absolute = isAbsolute(sourcePath) ? sourcePath : resolve(root, sourcePath);
+  if (!existsSync(absolute)) throw new Error(`Audit source not found: ${sourcePath}`);
+  if (!statSync(absolute).isFile()) throw new Error(`Audit source is not a file: ${sourcePath}`);
+  if (extname(absolute).toLowerCase() === '.json') return sourceFromRunPacket(absolute, root);
+  return sourceFromPlan(absolute, root);
+}
+
+function defaultSourceArtifact(subject: AuditSubject): AuditArtifactInput {
+  if (subject.source === 'run') {
+    return { role: 'run_packet', path: subject.runPacketPath ?? subject.sourcePath };
+  }
+  return { role: 'plan', path: subject.planPath };
+}
+
+function isPrivatePath(relativePath: string): boolean {
+  const normalized = toPosix(relativePath).replace(/^\.\//, '');
+  return PRIVATE_PATH_PREFIXES.some((prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix));
+}
+
+function resolveArtifact(input: AuditArtifactInput, root: string): ResolvedArtifact {
+  if (!ARTIFACT_ROLES.has(input.role)) {
+    throw new Error(`Unsupported audit artifact role: ${input.role}`);
+  }
+  if (!meaningfulString(input.path)) {
+    throw new Error('Audit artifact path is required.');
+  }
+  const { relativePath, absolutePath } = normalizeRepoRelative(root, input.path);
+  if (isPrivatePath(relativePath)) {
+    throw new Error(`Audit artifact path points at private/internal workspace state: ${relativePath}`);
+  }
+  return {
+    id: input.id ?? `${input.role}:${relativePath}`,
+    role: input.role,
+    path: relativePath,
+    absolutePath,
+  };
+}
+
+function artifactRecord(artifact: ResolvedArtifact) {
+  const stats = statSync(artifact.absolutePath);
+  return {
+    id: artifact.id,
+    role: artifact.role,
+    path: artifact.path,
+    digest: {
+      alg: DIGEST_ALG,
+      value: fileDigest(artifact.absolutePath),
+    },
+    size_bytes: stats.size,
+  };
+}
+
+export function renderAuditManifest(sourcePath: string, artifacts: AuditArtifactInput[] = [], root = process.cwd(), options: RenderAuditOptions = {}): string {
+  const now = options.now ?? new Date();
+  const subject = loadAuditSubject(sourcePath, root);
+  const resolved = [defaultSourceArtifact(subject), ...artifacts].map((artifact) => resolveArtifact(artifact, root));
+  const seen = new Set<string>();
+  for (const artifact of resolved) {
+    if (seen.has(artifact.id)) throw new Error(`Duplicate audit artifact id: ${artifact.id}`);
+    seen.add(artifact.id);
+  }
+  const stamp = timestampId(now);
+  const artifactRecords = resolved.map(artifactRecord);
+  const envelope = {
+    schema: AUDIT_SCHEMA,
+    audit_envelope_id: `${stamp}-${subject.runId ?? subject.planSlug}-audit`,
+    idempotency_key: `audit:${subject.source}:${subject.runId ?? subject.planSlug}:${shortDigest(artifactRecords.map((artifact) => `${artifact.role}:${artifact.path}:${artifact.digest.value}`))}`,
+    created_at: now.toISOString(),
+    subject: {
+      source: subject.source,
+      plan: subject.planPath,
+      plan_slug: subject.planSlug,
+      task_id: subject.taskId,
+      run_id: subject.runId,
+      run_packet: subject.runPacketPath,
+    },
+    artifacts: artifactRecords,
+    boundary: {
+      digest_integrity_only: true,
+      local_files_only: true,
+      domain_correctness_judgment: false,
+      compliance_certification: false,
+      approval_or_release_decision: false,
+      runtime_spawning: false,
+      model_benchmarking: false,
+      external_anchoring: false,
+    },
+    notes: [
+      'This audit manifest records local artifact paths and sha256 content digests. It does not certify correctness, compliance, approval, runtime execution, model quality, or external anchoring.',
+    ],
+  };
+  return `${JSON.stringify(envelope, null, 2)}\n`;
+}
+
+export function writeAuditManifest(sourcePath: string, artifacts: AuditArtifactInput[], outPath: string, root = process.cwd(), options: RenderAuditOptions = {}): { path: string } {
+  const absoluteOut = isAbsolute(outPath) ? outPath : resolve(root, outPath);
+  writeFileSync(absoluteOut, renderAuditManifest(sourcePath, artifacts, root, options), { encoding: 'utf8', flag: 'wx' });
+  return { path: absoluteOut };
+}
+
+function validateArtifactPath(rawPath: string, failures: ValidationIssue[], manifestPath: string | undefined, root: string): string | null {
+  if (isAbsolute(rawPath)) {
+    failures.push(issue('fail', 'audit.artifact.path_absolute', `Audit artifact path must be repo-relative, not absolute: ${rawPath}`, manifestPath));
+    return null;
+  }
+  const normalized = toPosix(rawPath).replace(/^\.\//, '');
+  if (!meaningfulString(normalized)) {
+    failures.push(issue('fail', 'audit.artifact.missing_path', 'Audit artifact is missing path.', manifestPath));
+    return null;
+  }
+  let privatePath = false;
+  if (isPrivatePath(normalized)) {
+    failures.push(issue('fail', 'audit.artifact.private_path', `Audit artifact path points at private/internal workspace state: ${normalized}`, manifestPath));
+    privatePath = true;
+  }
+  const realRoot = rootRealpath(root);
+  const absolute = resolve(realRoot, normalized);
+  if (!isInsideRoot(realRoot, absolute)) {
+    failures.push(issue('fail', 'audit.artifact.path_outside_root', `Audit artifact path escapes the repo root: ${rawPath}`, manifestPath));
+    return null;
+  }
+  if (!existsSync(absolute)) {
+    failures.push(issue('fail', 'audit.artifact.path_missing', `Audit artifact path does not exist: ${rawPath}`, manifestPath));
+    return null;
+  }
+  let realArtifact: string;
+  try {
+    realArtifact = realpathSync(absolute);
+  } catch (error) {
+    failures.push(issue('fail', 'audit.artifact.path_unreadable', error instanceof Error ? error.message : `Could not read artifact path: ${rawPath}`, manifestPath));
+    return null;
+  }
+  if (!isInsideRoot(realRoot, realArtifact)) {
+    failures.push(issue('fail', 'audit.artifact.path_outside_root', `Audit artifact path escapes the repo root: ${rawPath}`, manifestPath));
+    return null;
+  }
+  const canonicalRelative = toPosix(relative(realRoot, realArtifact));
+  if (!privatePath && isPrivatePath(canonicalRelative)) {
+    failures.push(issue('fail', 'audit.artifact.private_path', `Audit artifact path points at private/internal workspace state: ${canonicalRelative}`, manifestPath));
+  }
+  if (!statSync(realArtifact).isFile()) {
+    failures.push(issue('fail', 'audit.artifact.path_not_file', `Audit artifact path is not a file: ${rawPath}`, manifestPath));
+    return null;
+  }
+  return realArtifact;
+}
+
+function validateSubject(parsed: Record<string, unknown>, failures: ValidationIssue[], path: string | undefined): void {
+  const subject = isRecord(parsed.subject) ? parsed.subject : null;
+  if (!subject) {
+    failures.push(issue('fail', 'audit.subject.missing', 'Audit manifest must include subject identity.', path));
+    return;
+  }
+  const source = asString(subject.source);
+  if (source !== 'plan' && source !== 'run') {
+    failures.push(issue('fail', 'audit.subject.invalid_source', 'Audit subject source must be plan or run.', path));
+  }
+  if (!meaningfulString(subject.plan)) {
+    failures.push(issue('fail', 'audit.subject.missing_plan', 'Audit subject must include a plan path.', path));
+  }
+  if (!meaningfulString(subject.plan_slug)) {
+    failures.push(issue('fail', 'audit.subject.missing_plan_slug', 'Audit subject must include plan_slug.', path));
+  }
+  if (source === 'run' && (!meaningfulString(subject.run_id) || !meaningfulString(subject.run_packet))) {
+    failures.push(issue('fail', 'audit.subject.missing_run_identity', 'Run-bound audit subject must include run_id and run_packet.', path));
+  }
+}
+
+function validateBoundary(parsed: Record<string, unknown>, failures: ValidationIssue[], path: string | undefined): void {
+  const boundary = isRecord(parsed.boundary) ? parsed.boundary : null;
+  if (!boundary) {
+    failures.push(issue('fail', 'audit.boundary.missing', 'Audit manifest must include boundary/non-claim metadata.', path));
+    return;
+  }
+  if (boundary.digest_integrity_only !== true || boundary.local_files_only !== true) {
+    failures.push(issue('fail', 'audit.boundary.unsupported_claim', 'Audit manifest must declare digest_integrity_only and local_files_only as true.', path));
+  }
+  for (const field of UNSUPPORTED_BOUNDARY_TRUE_FIELDS) {
+    if (boundary[field] !== false) {
+      failures.push(issue('fail', 'audit.boundary.unsupported_claim', `Audit manifest cannot claim ${field}.`, path));
+    }
+  }
+}
+
+export function validateAuditManifestText(text: string, path?: string, root = process.cwd()): ValidationResult {
+  const failures: ValidationIssue[] = [];
+  const warnings: ValidationIssue[] = [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch (error) {
+    failures.push(issue('fail', 'audit.json.invalid', error instanceof Error ? error.message : 'Invalid JSON.', path));
+    return { ok: false, failures, warnings };
+  }
+
+  if (!isRecord(parsed)) {
+    failures.push(issue('fail', 'audit.schema.invalid', 'Audit manifest must be a JSON object.', path));
+    return { ok: false, failures, warnings };
+  }
+
+  const schema = asString(parsed.schema) ?? asString(parsed.schemaVersion);
+  if (schema !== AUDIT_SCHEMA) {
+    failures.push(issue('fail', 'audit.schema.missing', `Audit manifest must declare schema: ${AUDIT_SCHEMA}.`, path));
+  }
+  if (!meaningfulString(parsed.audit_envelope_id)) {
+    failures.push(issue('fail', 'audit.id.missing', 'Audit manifest must include audit_envelope_id.', path));
+  }
+  const createdAt = asString(parsed.created_at);
+  if (!meaningfulString(createdAt) || Number.isNaN(Date.parse(createdAt))) {
+    failures.push(issue('fail', 'audit.created_at.missing', 'Audit manifest must include a parseable created_at timestamp.', path));
+  }
+  if (!meaningfulString(parsed.idempotency_key)) {
+    failures.push(issue('fail', 'audit.idempotency_key.missing', 'Audit manifest must include idempotency_key.', path));
+  }
+  validateSubject(parsed, failures, path);
+  validateBoundary(parsed, failures, path);
+
+  const artifacts = Array.isArray(parsed.artifacts) ? parsed.artifacts : null;
+  if (!artifacts || artifacts.length === 0) {
+    failures.push(issue('fail', 'audit.artifact.missing', 'Audit manifest must include at least one artifact.', path));
+    return { ok: false, failures, warnings };
+  }
+
+  const ids = new Set<string>();
+  for (let index = 0; index < artifacts.length; index += 1) {
+    const artifact = artifacts[index];
+    if (!isRecord(artifact)) {
+      failures.push(issue('fail', 'audit.artifact.invalid', `Artifact ${index + 1} must be an object.`, path));
+      continue;
+    }
+    const id = asString(artifact.id);
+    if (!meaningfulString(id)) {
+      failures.push(issue('fail', 'audit.artifact.missing_id', `Artifact ${index + 1} is missing id.`, path));
+    } else if (ids.has(id)) {
+      failures.push(issue('fail', 'audit.artifact.duplicate_id', `Duplicate artifact id: ${id}`, path));
+    } else {
+      ids.add(id);
+    }
+
+    const role = asString(artifact.role);
+    if (!role || !ARTIFACT_ROLES.has(role)) {
+      failures.push(issue('fail', 'audit.artifact.invalid_role', `Unsupported or missing audit artifact role: ${role ?? '(missing)'}`, path));
+    }
+
+    const digest = isRecord(artifact.digest) ? artifact.digest : null;
+    const alg = digest ? asString(digest.alg) : null;
+    const value = digest ? asString(digest.value) : null;
+    if (alg !== DIGEST_ALG) {
+      failures.push(issue('fail', 'audit.artifact.digest_unsupported_alg', `Audit artifact digest alg must be ${DIGEST_ALG}.`, path));
+    }
+    if (!value || !/^[a-f0-9]{64}$/.test(value)) {
+      failures.push(issue('fail', 'audit.artifact.digest_invalid', 'Audit artifact digest value must be a 64-character lowercase sha256 hex string.', path));
+    }
+
+    const rawPath = asString(artifact.path);
+    if (!rawPath) {
+      failures.push(issue('fail', 'audit.artifact.missing_path', `Artifact ${id ?? index + 1} is missing path.`, path));
+      continue;
+    }
+    const realArtifact = validateArtifactPath(rawPath, failures, path, root);
+    if (realArtifact && alg === DIGEST_ALG && value && /^[a-f0-9]{64}$/.test(value)) {
+      const actual = fileDigest(realArtifact);
+      if (actual !== value) {
+        failures.push(issue('fail', 'audit.artifact.digest_mismatch', `Artifact digest mismatch for ${rawPath}.`, path));
+      }
+    }
+  }
+
+  return { ok: failures.length === 0, failures, warnings };
+}
+
+export function validateAuditManifestFile(path: string, root = process.cwd()): ValidationResult {
+  if (!existsSync(path)) {
+    return { ok: false, failures: [issue('fail', 'audit.file_missing', `Audit manifest not found: ${path}`, path)], warnings: [] };
+  }
+  try {
+    if (!statSync(path).isFile()) {
+      return { ok: false, failures: [issue('fail', 'audit.file_not_file', `Audit manifest path is not a file: ${path}`, path)], warnings: [] };
+    }
+    return validateAuditManifestText(readFileSync(path, 'utf8'), path, root);
+  } catch (error) {
+    return {
+      ok: false,
+      failures: [issue('fail', 'audit.file_unreadable', error instanceof Error ? error.message : `Could not read audit manifest: ${path}`, path)],
+      warnings: [],
+    };
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { renderAuditManifest, validateAuditManifestFile, writeAuditManifest, type AuditArtifactInput } from './audit.js';
 import { createRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
 import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
@@ -22,6 +23,8 @@ Usage:
   osc ultrareview <plan-path> [run binding options]
   osc eval init <run-or-plan> [--out <path>]
   osc eval check <evaluation-path>
+  osc audit init <run-or-plan> [--artifact <role> <path>]... [--out <path>]
+  osc audit check <audit-manifest-path>
   osc verify
   osc doctor
   osc runtimes list
@@ -306,6 +309,127 @@ function createArtifacts(args: string[], mode: ArtifactMode): void {
   console.log('  Note: generic open-scaffold did not spawn a runtime; dispatch via your coordinator or harness adapter.');
 }
 
+function printAuditUsage(): void {
+  console.error('Usage: osc audit init <run-or-plan> [--artifact <role> <path>]... [--out <path>] | osc audit check <audit-manifest-path>');
+}
+
+function takeAuditValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    console.error(`Missing value for ${flag}`);
+    process.exit(2);
+  }
+  return value;
+}
+
+function auditRootFor(manifestPath: string): string {
+  return findScaffoldRoot(dirname(manifestPath)) ?? findScaffoldRoot(process.cwd()) ?? process.cwd();
+}
+
+function auditRootForSource(sourcePath: string): string {
+  const resolvedSource = resolve(sourcePath);
+  return findScaffoldRoot(dirname(resolvedSource)) ?? findScaffoldRoot(process.cwd()) ?? process.cwd();
+}
+
+function auditCommand(args: string[]): void {
+  const [subcommand, sourceOrPath, ...rest] = args;
+  if (subcommand === 'init') {
+    if (!sourceOrPath) {
+      printAuditUsage();
+      process.exit(2);
+    }
+    let outPath: string | null = null;
+    let force = false;
+    const artifacts: AuditArtifactInput[] = [];
+    for (let i = 0; i < rest.length; i += 1) {
+      const flag = rest[i];
+      switch (flag) {
+        case '--artifact': {
+          const role = takeAuditValue(rest, i, flag);
+          const path = rest[i + 2];
+          if (!path || path.startsWith('--')) {
+            console.error('Missing path for --artifact <role> <path>');
+            process.exit(2);
+          }
+          artifacts.push({ role, path });
+          i += 2;
+          break;
+        }
+        case '--out':
+        case '--output':
+          outPath = takeAuditValue(rest, i, flag);
+          i += 1;
+          break;
+        case '--force':
+          force = true;
+          break;
+        default:
+          console.error(`Unknown option for audit init: ${flag}`);
+          printAuditUsage();
+          process.exit(2);
+      }
+    }
+    const auditRoot = auditRootForSource(sourceOrPath);
+    const auditSource = resolve(sourceOrPath);
+    try {
+      if (!outPath) {
+        process.stdout.write(renderAuditManifest(auditSource, artifacts, auditRoot));
+        return;
+      }
+      const absoluteOut = resolve(outPath);
+      if (existsSync(absoluteOut) && !force) {
+        console.error(`Refusing to overwrite existing audit manifest: ${absoluteOut}`);
+        process.exit(1);
+      }
+      if (force && existsSync(absoluteOut)) {
+        writeFileSync(absoluteOut, renderAuditManifest(auditSource, artifacts, auditRoot), 'utf8');
+      } else {
+        writeAuditManifest(auditSource, artifacts, absoluteOut, auditRoot);
+      }
+      console.log(`Created audit manifest: ${absoluteOut}`);
+      console.log('Note: this is a local digest-integrity manifest only; it does not certify correctness, compliance, approval, runtime execution, model quality, or external anchoring.');
+      return;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  }
+
+  if (subcommand === 'check') {
+    if (!sourceOrPath) {
+      printAuditUsage();
+      process.exit(2);
+    }
+    if (rest.length > 0) {
+      console.error(`Unknown option for audit check: ${rest[0]}`);
+      printAuditUsage();
+      process.exit(2);
+    }
+    const manifestPath = resolve(sourceOrPath);
+    const result = validateAuditManifestFile(manifestPath, auditRootFor(manifestPath));
+    for (const failure of result.failures) {
+      console.error(`FAIL ${failure.code}: ${failure.message}${failure.path ? ` (${failure.path})` : ''}`);
+    }
+    for (const warning of result.warnings) {
+      console.warn(`WARN ${warning.code}: ${warning.message}${warning.path ? ` (${warning.path})` : ''}`);
+    }
+    if (!result.ok) process.exit(1);
+    let artifactCount = 0;
+    try {
+      const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as { artifacts?: unknown[] };
+      artifactCount = Array.isArray(parsed.artifacts) ? parsed.artifacts.length : 0;
+    } catch {
+      artifactCount = 0;
+    }
+    console.log(`PASS audit manifest structure/digests valid; ${artifactCount} artifact(s); ${result.warnings.length} warning(s)`);
+    console.log('Note: this check validates local artifact presence and sha256 digest consistency only; it does not judge correctness, compliance, approval, runtime execution, model quality, or external anchoring.');
+    return;
+  }
+
+  printAuditUsage();
+  process.exit(2);
+}
+
 function printEvalUsage(): void {
   console.error('Usage: osc eval init <run-or-plan> [--out <path>] | osc eval check <evaluation-path>');
 }
@@ -484,6 +608,9 @@ function main(): void {
       return;
     case 'eval':
       evalCommand(args);
+      return;
+    case 'audit':
+      auditCommand(args);
       return;
     case 'verify': {
       const result = validateScaffold(process.cwd());

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -118,6 +118,18 @@ describe('audit manifest generation', () => {
     expect(validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root).ok).toBe(true);
   });
 
+  it('rejects symlinked artifacts that resolve into private/internal workspace paths during generation', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    mkdirSync(join(root, '.osc-dev'), { recursive: true });
+    writeFileSync(join(root, '.osc-dev/private.md'), 'private draft\n');
+    symlinkSync('../../.osc-dev/private.md', join(root, 'docs/evidence/private-link.md'));
+
+    expect(() => renderAuditManifest(planPath, [
+      { role: 'evidence', path: 'docs/evidence/private-link.md' },
+    ], root, { now: new Date('2026-05-17T12:00:00.000Z') })).toThrow(/private\/internal workspace state: \.osc-dev\/private\.md/);
+  });
+
   it('renders a run-bound manifest without judging evaluation correctness', () => {
     const root = tempRepo();
     const { runPath } = writeRunPacket(root);

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import {
+  AUDIT_SCHEMA,
+  renderAuditManifest,
+  validateAuditManifestText,
+} from '../src/audit.js';
+
+function tempRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'osc-audit-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/runs/demo-run'), { recursive: true });
+  mkdirSync(join(root, 'docs/evidence'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild the thing.\n');
+  return root;
+}
+
+function writePlan(root: string) {
+  const planPath = join(root, '.osc/plans/active/037-demo.md');
+  writeFileSync(planPath, `# Plan: 037-demo
+
+## Status
+
+active
+
+## Context
+
+Demo.
+
+## Goal
+
+Generate audit manifests.
+
+## Constraints / Out of scope
+
+- Do not certify compliance.
+
+## Files to touch
+
+- src/audit.ts
+
+## Acceptance criteria
+
+- [ ] Manifest records local artifact digests.
+- [ ] Check detects drift.
+
+## Verification steps
+
+1. Run tests.
+
+## Open questions
+
+- None.
+`);
+  return planPath;
+}
+
+function writeRunPacket(root: string) {
+  const planPath = writePlan(root);
+  const runPath = join(root, '.osc/runs/demo-run/run.json');
+  writeFileSync(runPath, JSON.stringify({
+    schemaVersion: 'open-scaffold.run.v1',
+    runId: 'demo-run',
+    taskId: 'task-123',
+    plan: { slug: '037-demo', path: '.osc/plans/active/037-demo.md', acceptanceCriteria: ['Manifest records local artifact digests.'] },
+    artifacts: { evidence: ['docs/evidence/proof.md'] },
+  }, null, 2));
+  return { planPath, runPath };
+}
+
+function validManifest(root: string, overrides: Record<string, unknown> = {}) {
+  const planPath = writePlan(root);
+  writeFileSync(join(root, 'docs/evidence/proof.md'), 'proof\n');
+  const manifest = JSON.parse(renderAuditManifest(planPath, [
+    { role: 'evidence', path: 'docs/evidence/proof.md' },
+  ], root, { now: new Date('2026-05-17T12:00:00.000Z') }));
+  return { ...manifest, ...overrides };
+}
+
+function failCodes(result: ReturnType<typeof validateAuditManifestText>) {
+  return result.failures.map((failure) => failure.code);
+}
+
+describe('audit manifest generation', () => {
+  it('renders a deterministic local digest manifest from a plan and curated artifacts', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    writeFileSync(join(root, 'docs/evidence/proof.md'), 'proof\n');
+
+    const manifest = JSON.parse(renderAuditManifest(planPath, [
+      { role: 'evidence', path: 'docs/evidence/proof.md' },
+    ], root, { now: new Date('2026-05-17T12:00:00.000Z') }));
+
+    expect(manifest.schema).toBe(AUDIT_SCHEMA);
+    expect(manifest.audit_envelope_id).toBe('20260517T120000Z-037-demo-audit');
+    expect(manifest.subject).toMatchObject({ source: 'plan', plan: '.osc/plans/active/037-demo.md', plan_slug: '037-demo', task_id: null, run_id: null, run_packet: null });
+    expect(manifest.artifacts.map((artifact: any) => artifact.role)).toEqual(['plan', 'evidence']);
+    expect(manifest.artifacts[0]).toMatchObject({ id: 'plan:.osc/plans/active/037-demo.md', role: 'plan', path: '.osc/plans/active/037-demo.md', digest: { alg: 'sha256' } });
+    expect(manifest.artifacts[0].digest.value).toMatch(/^[a-f0-9]{64}$/);
+    expect(manifest.artifacts[1]).toMatchObject({ id: 'evidence:docs/evidence/proof.md', role: 'evidence', path: 'docs/evidence/proof.md', digest: { alg: 'sha256' } });
+    expect(manifest.boundary).toMatchObject({ digest_integrity_only: true, compliance_certification: false, runtime_spawning: false, model_benchmarking: false, external_anchoring: false });
+    expect(manifest.notes.join('\n')).toContain('does not certify correctness, compliance, approval, runtime execution, model quality, or external anchoring');
+  });
+
+  it('preserves the user-supplied repo-relative symlink path while still hashing the target bytes', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    writeFileSync(join(root, 'docs/evidence/proof.md'), 'proof\n');
+    symlinkSync('proof.md', join(root, 'docs/evidence/link.md'));
+
+    const manifest = JSON.parse(renderAuditManifest(planPath, [
+      { role: 'evidence', path: 'docs/evidence/link.md' },
+    ], root, { now: new Date('2026-05-17T12:00:00.000Z') }));
+
+    expect(manifest.artifacts[1]).toMatchObject({ id: 'evidence:docs/evidence/link.md', role: 'evidence', path: 'docs/evidence/link.md' });
+    expect(validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root).ok).toBe(true);
+  });
+
+  it('renders a run-bound manifest without judging evaluation correctness', () => {
+    const root = tempRepo();
+    const { runPath } = writeRunPacket(root);
+    writeFileSync(join(root, 'docs/evidence/proof.md'), 'proof\n');
+
+    const manifest = JSON.parse(renderAuditManifest(runPath, [
+      { role: 'evidence', path: 'docs/evidence/proof.md' },
+    ], root, { now: new Date('2026-05-17T12:00:00.000Z') }));
+
+    expect(manifest.subject).toMatchObject({ source: 'run', task_id: 'task-123', run_id: 'demo-run', run_packet: '.osc/runs/demo-run/run.json' });
+    expect(manifest.artifacts.map((artifact: any) => artifact.role)).toEqual(['run_packet', 'evidence']);
+    expect(manifest.boundary.approval_or_release_decision).toBe(false);
+  });
+});
+
+describe('audit manifest validation', () => {
+  it('accepts a clean manifest when all local artifact digests still match', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root);
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('fails when a cited artifact is missing', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root);
+    manifest.artifacts[1].path = 'docs/evidence/missing.md';
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.artifact.path_missing');
+  });
+
+  it('fails when a cited artifact content digest changed', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root);
+    writeFileSync(join(root, 'docs/evidence/proof.md'), 'changed\n');
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.artifact.digest_mismatch');
+  });
+
+  it('fails on duplicate artifact ids', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root);
+    manifest.artifacts.push({ ...manifest.artifacts[1] });
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.artifact.duplicate_id');
+  });
+
+  it('fails on malformed artifact entries and unsupported roles', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root);
+    manifest.artifacts = [{ id: 'bad', role: 'compliance_certificate', path: 'docs/evidence/proof.md', digest: { alg: 'md5', value: 'not-a-sha' } }];
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.artifact.invalid_role');
+    expect(failCodes(result)).toContain('audit.artifact.digest_unsupported_alg');
+    expect(failCodes(result)).toContain('audit.artifact.digest_invalid');
+  });
+
+  it('fails when an artifact path escapes the repo root', () => {
+    const root = tempRepo();
+    const outside = join(tmpdir(), `osc-audit-outside-${process.pid}.md`);
+    writeFileSync(outside, 'outside\n');
+    const manifest = validManifest(root);
+    manifest.artifacts[1].path = relative(root, outside);
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.artifact.path_outside_root');
+  });
+
+  it('fails when an artifact points at private/internal workspace paths', () => {
+    const root = tempRepo();
+    mkdirSync(join(root, '.osc/research'), { recursive: true });
+    writeFileSync(join(root, '.osc/research/raw.md'), 'private draft\n');
+    const manifest = validManifest(root);
+    manifest.artifacts[1].path = '.osc/research/raw.md';
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.artifact.private_path');
+  });
+
+  it('fails when traversal aliases point at private/internal workspace paths', () => {
+    const root = tempRepo();
+    mkdirSync(join(root, '.osc-dev'), { recursive: true });
+    mkdirSync(join(root, '.osc/research'), { recursive: true });
+    mkdirSync(join(root, 'node_modules/pkg'), { recursive: true });
+    writeFileSync(join(root, '.osc-dev/private.md'), 'private draft\n');
+    writeFileSync(join(root, '.osc/research/raw.md'), 'research draft\n');
+    writeFileSync(join(root, 'node_modules/pkg/index.js'), 'module draft\n');
+    const manifest = validManifest(root);
+    manifest.artifacts = [
+      { ...manifest.artifacts[0] },
+      { ...manifest.artifacts[1], id: 'private:dev', path: 'docs/../.osc-dev/private.md', digest: { alg: 'sha256', value: '0'.repeat(64) } },
+      { ...manifest.artifacts[1], id: 'private:research', path: 'docs/../.osc/research/raw.md', digest: { alg: 'sha256', value: '0'.repeat(64) } },
+      { ...manifest.artifacts[1], id: 'private:node_modules', path: 'docs/../node_modules/pkg/index.js', digest: { alg: 'sha256', value: '0'.repeat(64) } },
+    ];
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result).filter((code) => code === 'audit.artifact.private_path')).toHaveLength(3);
+  });
+
+  it('fails when required subject identity is missing', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root, { subject: { source: 'run', plan: '.osc/plans/active/037-demo.md', plan_slug: '037-demo', task_id: 'task-1' } });
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.subject.missing_run_identity');
+  });
+
+  it('fails when generated timestamp or idempotency identity is missing', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root);
+    delete manifest.created_at;
+    delete manifest.idempotency_key;
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.created_at.missing');
+    expect(failCodes(result)).toContain('audit.idempotency_key.missing');
+  });
+
+  it('fails when the manifest claims judgment or external anchoring boundaries', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root);
+    manifest.boundary.compliance_certification = true;
+    manifest.boundary.external_anchoring = true;
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.boundary.unsupported_claim');
+  });
+});

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -143,6 +143,19 @@ describe('audit manifest generation', () => {
     expect(manifest.artifacts.map((artifact: any) => artifact.role)).toEqual(['run_packet', 'evidence']);
     expect(manifest.boundary.approval_or_release_decision).toBe(false);
   });
+
+  it('rejects run packets without a concrete plan path during generation', () => {
+    const root = tempRepo();
+    const runPath = join(root, '.osc/runs/demo-run/run.json');
+    writeFileSync(runPath, JSON.stringify({
+      schemaVersion: 'open-scaffold.run.v1',
+      runId: 'demo-run',
+      taskId: 'task-123',
+      plan: { slug: '037-demo', acceptanceCriteria: ['Manifest records local artifact digests.'] },
+    }, null, 2));
+
+    expect(() => renderAuditManifest(runPath, [], root, { now: new Date('2026-05-17T12:00:00.000Z') })).toThrow(/plan\.path/);
+  });
 });
 
 describe('audit manifest validation', () => {
@@ -258,6 +271,24 @@ describe('audit manifest validation', () => {
 
     expect(result.ok).toBe(false);
     expect(failCodes(result)).toContain('audit.subject.missing_run_identity');
+  });
+
+  it('fails when a run-bound subject uses an unknown placeholder plan', () => {
+    const root = tempRepo();
+    const manifest = validManifest(root);
+    manifest.subject = {
+      source: 'run',
+      plan: '(unknown plan)',
+      plan_slug: '037-demo',
+      task_id: 'task-1',
+      run_id: 'demo-run',
+      run_packet: '.osc/runs/demo-run/run.json',
+    };
+
+    const result = validateAuditManifestText(JSON.stringify(manifest, null, 2), join(root, 'audit.json'), root);
+
+    expect(result.ok).toBe(false);
+    expect(failCodes(result)).toContain('audit.subject.missing_plan');
   });
 
   it('fails when generated timestamp or idempotency identity is missing', () => {

--- a/tests/cli-audit.test.ts
+++ b/tests/cli-audit.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'osc-cli-audit-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, 'docs/evidence'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild the thing.\n');
+  const planPath = join(root, '.osc/plans/active/037-demo.md');
+  writeFileSync(planPath, `# Plan: 037-demo
+
+## Status
+
+active
+
+## Context
+
+Demo.
+
+## Goal
+
+Audit a slice.
+
+## Constraints / Out of scope
+
+- Do not certify compliance.
+
+## Files to touch
+
+- src/audit.ts
+
+## Acceptance criteria
+
+- [ ] First artifact has a digest.
+- [ ] Drift routes to follow-up.
+
+## Verification steps
+
+1. Run tests.
+
+## Open questions
+
+- None.
+`);
+  writeFileSync(join(root, 'docs/evidence/proof.md'), 'proof\n');
+  return { root, planPath };
+}
+
+describe('osc audit CLI', () => {
+  it('prints a local digest audit manifest for a plan and explicit curated artifact', () => {
+    const { root, planPath } = tempRepo();
+
+    const output = execFileSync(tsx, [cli, 'audit', 'init', planPath, '--artifact', 'evidence', 'docs/evidence/proof.md'], { cwd: root, encoding: 'utf8' });
+    const manifest = JSON.parse(output);
+
+    expect(manifest.schema).toBe('open-scaffold.audit-envelope.v1');
+    expect(manifest.subject).toMatchObject({ source: 'plan', plan: '.osc/plans/active/037-demo.md' });
+    expect(manifest.artifacts.map((artifact: any) => artifact.role)).toEqual(['plan', 'evidence']);
+    expect(manifest.artifacts[0].digest.value).toMatch(/^[a-f0-9]{64}$/);
+    expect(manifest.boundary.runtime_spawning).toBe(false);
+    expect(output).toContain('does not certify correctness, compliance, approval, runtime execution, model quality, or external anchoring');
+  });
+
+  it('writes an audit manifest with --out and refuses to overwrite existing files', () => {
+    const { root, planPath } = tempRepo();
+    const outPath = join(root, 'docs/evidence/audit.json');
+
+    const output = execFileSync(tsx, [cli, 'audit', 'init', planPath, '--artifact', 'evidence', 'docs/evidence/proof.md', '--out', outPath], { cwd: root, encoding: 'utf8' });
+
+    expect(output).toContain('Created audit manifest:');
+    expect(existsSync(outPath)).toBe(true);
+    const manifest = JSON.parse(readFileSync(outPath, 'utf8'));
+    expect(manifest.artifacts).toHaveLength(2);
+    const overwrite = spawnSync(tsx, [cli, 'audit', 'init', planPath, '--artifact', 'evidence', 'docs/evidence/proof.md', '--out', outPath], { cwd: root, encoding: 'utf8' });
+    expect(overwrite.status).toBe(1);
+    expect(overwrite.stderr).toContain('Refusing to overwrite');
+  });
+
+  it('checks a valid audit manifest with digest-only PASS wording', () => {
+    const { root, planPath } = tempRepo();
+    const auditPath = join(root, 'docs/evidence/audit.json');
+    execFileSync(tsx, [cli, 'audit', 'init', planPath, '--artifact', 'evidence', 'docs/evidence/proof.md', '--out', auditPath], { cwd: root, encoding: 'utf8' });
+
+    const output = execFileSync(tsx, [cli, 'audit', 'check', auditPath], { cwd: root, encoding: 'utf8' });
+
+    expect(output).toContain('PASS audit manifest structure/digests valid; 2 artifact(s); 0 warning(s)');
+    expect(output).toContain('does not judge correctness, compliance, approval, runtime execution, model quality, or external anchoring');
+  });
+
+  it('initializes audit manifests from subdirectories using the repo root for artifact paths', () => {
+    const { root, planPath } = tempRepo();
+    const subdir = join(root, 'docs/subdir');
+    mkdirSync(subdir, { recursive: true });
+
+    const output = execFileSync(tsx, [cli, 'audit', 'init', relative(subdir, planPath), '--artifact', 'evidence', 'docs/evidence/proof.md'], { cwd: subdir, encoding: 'utf8' });
+    const manifest = JSON.parse(output);
+
+    expect(manifest.subject.plan).toBe('.osc/plans/active/037-demo.md');
+    expect(manifest.artifacts[1]).toMatchObject({ role: 'evidence', path: 'docs/evidence/proof.md' });
+  });
+
+  it('fails audit check when an artifact digest has drifted', () => {
+    const { root, planPath } = tempRepo();
+    const auditPath = join(root, 'docs/evidence/audit.json');
+    execFileSync(tsx, [cli, 'audit', 'init', planPath, '--artifact', 'evidence', 'docs/evidence/proof.md', '--out', auditPath], { cwd: root, encoding: 'utf8' });
+    writeFileSync(join(root, 'docs/evidence/proof.md'), 'changed\n');
+
+    const result = spawnSync(tsx, [cli, 'audit', 'check', auditPath], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('FAIL audit.artifact.digest_mismatch');
+  });
+
+  it('reports directory inputs without dumping a Node stack trace', () => {
+    const { root } = tempRepo();
+
+    const result = spawnSync(tsx, [cli, 'audit', 'check', '.'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('FAIL audit.file_not_file');
+    expect(result.stderr).not.toContain('node:fs');
+    expect(result.stderr).not.toContain('at Object');
+  });
+
+  it('rejects trailing arguments for audit check instead of silently ignoring them', () => {
+    const { root, planPath } = tempRepo();
+    const auditPath = join(root, 'docs/evidence/audit.json');
+    execFileSync(tsx, [cli, 'audit', 'init', planPath, '--artifact', 'evidence', 'docs/evidence/proof.md', '--out', auditPath], { cwd: root, encoding: 'utf8' });
+
+    const result = spawnSync(tsx, [cli, 'audit', 'check', auditPath, '--bogus'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Unknown option for audit check: --bogus');
+    expect(result.stderr).toContain('Usage: osc audit init');
+  });
+
+  it('keeps existing eval init behavior available after adding audit commands', () => {
+    const { root, planPath } = tempRepo();
+
+    const output = execFileSync(tsx, [cli, 'eval', 'init', planPath], { cwd: root, encoding: 'utf8' });
+    const envelope = JSON.parse(output);
+
+    expect(envelope.schema).toBe('open-scaffold.evaluation.v1');
+    expect(envelope.subject.plan).toBe('.osc/plans/active/037-demo.md');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first structure-only audit envelope mechanic for Open Scaffold:

- `osc audit init <plan-or-run> [--artifact <role> <path>]... [--out <path>] [--force]`
- `osc audit check <audit-manifest-path>`
- JSON `open-scaffold.audit-envelope.v1` manifests with curated artifacts, repo-relative paths, SHA-256 digests, and explicit boundary flags
- plan closure and release evidence for `.osc/plans/done/037-audit-envelope-digest-manifest.md`

## Scope boundaries

This is local digest integrity only. It does **not** certify correctness, compliance, approval, runtime execution, model quality, or external anchoring.

Deferred follow-ups remain separate: envelope self-digests, parent links, Merkle roots, external anchor receipts/adapters, and provider-specific notary integration.

## Verification

- `npm test` — 12 files / 119 tests passed
- `npm run build` — passed
- `npm run --silent osc -- audit init .osc/plans/done/037-audit-envelope-digest-manifest.md --artifact changed_file src/audit.ts --artifact changed_file src/cli.ts --artifact evidence tests/audit.test.ts --artifact evidence tests/cli-audit.test.ts --artifact evidence docs/SLICE_CLOSE_PROTOCOL.md --artifact release_note .osc/releases/2026-05-17-audit-envelope-digest-manifest.md --out /tmp/osc-037-audit-final.json --force` — passed
- `npm run --silent osc -- audit check /tmp/osc-037-audit-final.json` — passed, 7 artifacts / 0 warnings
- `npm run --silent osc -- eval init .osc/plans/done/037-audit-envelope-digest-manifest.md >/tmp/osc-037-eval-final.json` — passed JSON smoke
- `npm run osc -- verify` — passed, 0 warnings
- `./verify.sh --standard` — 6 pass / 0 fail / 0 warn
- `git diff --check` — passed

## Review notes

Read-only review and Codex review findings were fixed before owner merge gate:

- hand-authored manifests cannot bypass private/internal path checks with traversal aliases such as `docs/../.osc-dev/...`
- generated manifests reject non-private symlink paths that resolve into private/internal targets such as `.osc-dev/...`
- run-bound manifests require a concrete `plan.path`; no `(unknown plan)` placeholder can pass generation or validation

Operator card: Hermes Kanban `t_fb2b0323`.

Merge remains gated on owner approval.