### PR TITLE
Add five-Opus review backlog plans

### DIFF
--- a/.osc/plans/backlog/038-first-run-adoption-hardening.md
+++ b/.osc/plans/backlog/038-first-run-adoption-hardening.md
@@ -1,0 +1,91 @@
+# Plan: 038-first-run-adoption-hardening
+
+## Status
+
+backlog
+
+## Context
+
+A 2026-05-17 external multi-lane review found that Open Scaffold's strongest adoption blockers happen before the protocol can prove its value: public docs advertise a package install path that is not currently published, `standard` initialization can copy Open Scaffold's own product identity into downstream projects, and package dry-runs include dogfood history as install baggage. This plan converts that critique into a narrow first-run trust hardening slice.
+
+## Goal
+
+Make the default first-run path mechanically truthful, downstream-neutral, and package-clean enough that a new user can try Open Scaffold without inheriting Open Scaffold's own project history.
+
+## Constraints / Out of scope
+
+- Do not add runtime spawning, adapter launch, credentials, daemons, or process supervision to core.
+- Do not claim npm publication exists unless the package is actually published and verified.
+- Do not copy private owner context, local paths, or product dogfood history into generated downstream projects.
+- Do not rewrite the whole documentation corpus; only touch first-run/install/init/package truth needed for this slice.
+- Do not make compliance, enterprise, or adapter-marketplace claims.
+
+## Files to touch
+
+- `README.md` — make primary install/try path match what works today.
+- `docs/MINIMUM_VIABLE_SCAFFOLD.md` — align minimum path with current install truth and downstream-neutral flow.
+- `src/init.ts` — make `standard` tier generate or copy neutral downstream root docs.
+- `tests/init.test.ts` and/or `tests/cli-init.test.ts` — cover standard-tier neutrality and install/init behavior.
+- `package.json` — trim package payload if dogfood history is being shipped unintentionally.
+- `docs/examples/` — update only if examples cite stale first-run commands.
+- `AGENTS.md` and `CLAUDE.md` — only if paired root instructions need a narrow note about product-vs-template boundaries.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Audit every first-run/install command and package payload entry | None | A |
+| T2 | Decide truthful primary install path: publish npm now or demote `npx` until publication | T1 | B |
+| T3 | Make standard-tier downstream docs project-neutral | T1 | B |
+| T4 | Trim package payload so product dogfood history is not default install baggage | T1 | B |
+| T5 | Add regression tests and temp-init smoke checks | T2, T3, T4 | C |
+| T6 | Run full verification and update concise release/PR evidence | T5 | D |
+
+### Parallel groups
+
+- **Group A**: audit only; no mutations.
+- **Group B**: install docs, init templates, and package payload can be worked independently after the audit.
+- **Group C**: tests must reflect the chosen implementation.
+- **Group D**: final verification after all mutations.
+
+### Dependencies
+
+- T2 depends on T1 because docs must not be changed until the exact npm/package reality is verified.
+- T5 depends on T2-T4 because tests should lock the final chosen behavior, not an intermediate guess.
+
+### Delegation notes
+
+- A documentation-focused worker can handle T2 while a code/test worker handles T3/T4.
+- Keep one owner/Hermes pass for the final first-run story so README and generated templates do not drift.
+
+## Implementation Architecture Coverage
+
+- Strengthens: workflow design, recovery/ownership, adoption trust.
+- Audit envelope: PR should cite external-review ingest, this plan, temp-init smoke path, npm/package dry-run output, and verification commands.
+- Evaluation envelope: verify install truth, generated downstream root docs, package payload, and normal test/build gates.
+- Feedback routing: if npm publication is not approved, route the npm decision as an owner gate instead of silently publishing.
+- Boundary: runtime enforcement, adapter packages, compliance claims, model benchmarking, and hosted dashboards remain outside this slice.
+
+## Acceptance criteria
+
+- [ ] Primary public docs do not advertise `npx open-scaffold` as the default path unless `npm view open-scaffold version --json` succeeds for the intended package.
+- [ ] A fresh `osc init --tier standard --target <tmp>` produces downstream root docs that do not identify the downstream project as Open Scaffold.
+- [ ] Generated downstream files contain no private owner-local paths, personal names, or private owner-workspace references.
+- [ ] `npm pack --dry-run --json` no longer includes `.osc/plans/done/*.md`, backlog hypothesis plans, or dated `.osc/releases/2026-*.md` as default package payload unless a deliberate curated example exception is documented.
+- [ ] Existing min-tier behavior remains intact.
+- [ ] `npm run build`, `npm test`, `./verify.sh --strict`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run `npm view open-scaffold version --json`; pass if it succeeds when `npx open-scaffold` remains primary, or if primary docs no longer depend on it.
+2. Run `npm pack --dry-run --json`; pass if package contents exclude unintended dogfood history.
+3. Run `npm run build` and `npm test`; pass on clean exits.
+4. Run `tmp="$(mktemp -d)" && node dist/cli.js init --tier standard --target "$tmp" && ! grep -R "This project is .*open-scaffold\\|/Users/\\|owner-local\\|private workspace" "$tmp"`; pass if grep finds no downstream leakage.
+5. Run `./verify.sh --strict` and `git diff --check`; pass on clean outputs.
+
+## Open questions
+
+- Should npm publication happen in this slice, or should docs use a currently true GitHub/template/local path until publication has a separate gate?
+- Should a small vocabulary cleanup be included only where first-run docs are touched, or should full vocabulary compression v2 remain the next plan?

--- a/.osc/plans/backlog/039-session-2-aha-walkthrough.md
+++ b/.osc/plans/backlog/039-session-2-aha-walkthrough.md
@@ -1,0 +1,86 @@
+# Plan: 039-session-2-aha-walkthrough
+
+## Status
+
+backlog
+
+## Context
+
+The same external review found that Open Scaffold's real value does not appear at install time; it appears when a later human or agent can resume from repo truth without prior chat context. Existing examples prove mechanics, but the first public adoption path still underplays the session-2 payoff.
+
+## Goal
+
+Ship a concise public walkthrough that demonstrates a fresh session resuming work from Open Scaffold files alone.
+
+## Constraints / Out of scope
+
+- Do not require Hermes, Discord, OMC, OMX, Claude Code, Codex, or any private owner setup.
+- Do not add runtime adapter implementation.
+- Do not add broad new ontology docs.
+- Do not claim compliance certification; describe evidence/recovery in plain language.
+- Do not duplicate the entire README or downstream example; make the walkthrough an entry point or focused extension.
+
+## Files to touch
+
+- `docs/examples/downstream-walkthrough.md` — add or reshape a session-2 resume path.
+- `docs/examples/README.md` — point fresh users to the walkthrough.
+- `docs/MINIMUM_VIABLE_SCAFFOLD.md` — connect minimum scaffold to session-2 payoff.
+- `README.md` — add only a small pointer if needed.
+- `docs/wiki/queries/what-is-open-scaffold-for.md` — optional compiled-knowledge alignment if the public wiki should reference the session-2 value.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Audit existing example flow for where session-2 resume is missing | None | A |
+| T2 | Draft minimal day-1 -> day-2 walkthrough | T1 | B |
+| T3 | Add persona-specific entry cues: solo dev, small team/GitHub-only, consultant/client evidence | T1 | B |
+| T4 | Patch docs links without broad rewrites | T2, T3 | C |
+| T5 | Verify owner-neutral wording and command truth | T4 | D |
+
+### Parallel groups
+
+- **Group A**: read-only audit.
+- **Group B**: walkthrough and persona cues can be drafted independently.
+- **Group C**: link integration after text stabilizes.
+- **Group D**: final verification.
+
+### Dependencies
+
+- T2 and T3 depend on T1 so they reuse existing examples instead of creating a parallel doc maze.
+- T4 depends on T2/T3 to avoid linking to unstable headings.
+
+### Delegation notes
+
+- A documentation worker can draft the walkthrough; Hermes should final-review for public-safe owner-neutral wording and product positioning.
+
+## Implementation Architecture Coverage
+
+- Strengthens: recovery/ownership, workflow design, adoption trust.
+- Audit envelope: PR should cite this plan, the walkthrough path, and verification commands.
+- Evaluation envelope: a reviewer should be able to answer goal, current state, accepted evidence, and next action from files alone.
+- Feedback routing: if the walkthrough exposes missing CLI support, route that to `044-cli-friction-reduction` instead of expanding this slice.
+- Boundary: runtime adapters, dashboards, and hosted state remain outside this slice.
+
+## Acceptance criteria
+
+- [ ] The walkthrough shows a day-1 setup/work slice and a day-2 fresh-session resume without relying on chat history.
+- [ ] A reader can identify mission, active/backlog/done state, verification evidence, and next action from repo files alone.
+- [ ] The default path requires no private tools, no unpublished package assumptions, and no runtime adapter.
+- [ ] The walkthrough states when Open Scaffold is overkill for small one-shot work.
+- [ ] Wording remains owner-neutral and public-safe.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Follow the walkthrough commands in a temp directory; pass if the documented file state appears as described.
+2. Start from the documented day-2 section with no prior chat context; pass if the next action is reconstructable from files alone.
+3. Run `! git diff -U0 origin/main...HEAD -- README.md docs | grep '^+' | grep -E "/Users/|owner-local|private workspace"`; pass if no newly added private-context leaks are introduced.
+4. Run `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check`; pass on clean outputs.
+
+## Open questions
+
+- Should the session-2 demo be purely docs, or should it include a tiny fixture project that verification can execute?
+- Should persona cues live in this walkthrough or in a later adoption/persona page?

--- a/.osc/plans/backlog/040-vocabulary-compression-v2.md
+++ b/.osc/plans/backlog/040-vocabulary-compression-v2.md
@@ -1,0 +1,88 @@
+# Plan: 040-vocabulary-compression-v2
+
+## Status
+
+backlog
+
+## Context
+
+Plan `026-vocabulary-compression` shipped a first pass, but a later external fresh-read review still found a major vocabulary cliff. The issue is not that the project failed to notice vocabulary; the issue is that the previous pass undershot first-touch comprehension.
+
+## Goal
+
+Reduce first-touch Open Scaffold vocabulary to plain-language terms while preserving precise protocol terms where they are genuinely needed.
+
+## Constraints / Out of scope
+
+- Do not churn JSON schema fields, historical plan names, release notes, or established file names just to rename concepts.
+- Do not remove `run packet` if it remains useful; instead alias it immediately as the `run.json` manifest/package.
+- Do not create a larger ontology document as the answer to jargon criticism.
+- Do not edit done plans for wording cleanup.
+- Do not weaken runtime/core boundary accuracy.
+
+## Files to touch
+
+- `README.md` — plain-language first-touch wording.
+- `docs/MINIMUM_VIABLE_SCAFFOLD.md` — keep beginner path light.
+- `docs/WHY_OPEN_SCAFFOLD.md` and/or `docs/FAQ.md` — translate terms where they appear before context.
+- `docs/WORKFLOW.md` — use plain aliases in workflow guidance.
+- `docs/RUNTIME_SELECTION.md`, `docs/RUNTIME_PROFILES.md`, `docs/RUNTIME_BINDING_CONTRACT.md`, `docs/SPAWNING_BOUNDARY.md` — alias advanced runtime terms without changing boundaries.
+- Optional `docs/GLOSSARY.md` or a small existing-doc glossary section — only if it replaces repeated explanations.
+- `AGENTS.md` and `CLAUDE.md` — only if paired entrypoint vocabulary needs the same first-touch clarification.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Audit first-touch docs for jargon terms and contexts | None | A |
+| T2 | Define approved aliases and terms to keep | T1 | B |
+| T3 | Patch README/minimum/why/FAQ first | T2 | C |
+| T4 | Patch runtime docs for aliases without boundary drift | T2 | C |
+| T5 | Run grep audit and adjust over/under-renames | T3, T4 | D |
+
+### Parallel groups
+
+- **Group A**: audit only.
+- **Group B**: alias decision.
+- **Group C**: first-touch and runtime docs can be patched in parallel once aliases are set.
+- **Group D**: final consistency pass.
+
+### Dependencies
+
+- T3/T4 depend on T2 to avoid inconsistent rename choices.
+- T5 depends on all edits.
+
+### Delegation notes
+
+- A docs worker can patch first-touch pages while a runtime-boundary reviewer checks advanced docs for accidental semantic changes.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adoption trust, workflow design, recovery/ownership.
+- Audit envelope: PR should include before/after grep counts for key jargon terms in first-touch docs.
+- Evaluation envelope: reviewers should understand the README and minimum path without learning the whole ontology first.
+- Feedback routing: if a term must stay for schema/history reasons, document the rationale instead of hiding it.
+- Boundary: schema migrations, runtime behavior, and historical artifact rewrites remain outside this slice.
+
+## Acceptance criteria
+
+- [ ] README and minimum first-use docs use plain language before protocol language.
+- [ ] `run packet` is kept only with an immediate alias such as `run.json manifest/package` in first-touch contexts.
+- [ ] First-touch docs avoid or immediately translate: `glass cockpit`, `operator surface`, `runtime binding`, `dispatch receipt`, `harness skill`, `slice close`, `task bridge`, `evaluation envelope`, and `audit envelope`.
+- [ ] Advanced docs may retain precise terms, but first mention provides a plain-language alias.
+- [ ] A grep/audit summary records remaining high-friction terms and why they remain.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run `grep -RniE "glass cockpit|operator surface|runtime binding|dispatch receipt|harness skill|slice close|task bridge|evaluation envelope|audit envelope" README.md docs/*.md`; pass if first-touch occurrences are removed or aliased.
+2. Run `wc -c README.md`; pass if size is intentionally reduced or any remaining size is justified by the slice evidence.
+3. Run `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check`; pass on clean outputs.
+4. Manually read README through Quickstart; pass if a new user can understand the value without knowing the full protocol vocabulary.
+
+## Open questions
+
+- Should `glass cockpit` remain as a branded advanced concept, or should first-touch docs consistently prefer `operator dashboard` / `control room`?
+- Should README regain a hard byte target, or should the acceptance bar be comprehension and command truth rather than size alone?

--- a/.osc/plans/backlog/041-adapter-conformance-contract-v1.md
+++ b/.osc/plans/backlog/041-adapter-conformance-contract-v1.md
@@ -1,0 +1,87 @@
+# Plan: 041-adapter-conformance-contract-v1
+
+## Status
+
+backlog
+
+## Context
+
+External review correctly identified a run-packet adoption deadlock: `osc run` can create a `run.json`, but no production adapter is guaranteed to consume it. Current Open Scaffold code and docs also correctly preserve the boundary that core must not become a runtime spawner by drift. This plan makes the adapter contract sharper before any sister package or real runtime adapter work.
+
+## Goal
+
+Freeze a small v1 adapter conformance contract that proves consume-run-packet -> write adapter receipt -> write evidence without adding spawning to core.
+
+## Constraints / Out of scope
+
+- Do not add real process spawning, credentials, provider SDKs, network registry behavior, or runtime install logic to core.
+- Do not certify OMC, OMX, Claude Code, Codex, OpenCode, or any runtime as supported without reproducible adapter evidence.
+- Do not create a marketplace or package discovery system.
+- Do not change `spawning: false` requirements in core runtime profiles.
+- Do not make fake/local adapter output sound like proof of task correctness.
+
+## Files to touch
+
+- `docs/RUNTIME_BINDING_CONTRACT.md` — clarify adapter responsibilities and receipt/evidence contract.
+- `docs/SPAWNING_BOUNDARY.md` — reinforce core/adapters/sibling-package split.
+- `docs/RUNTIME_SELECTION.md` and/or `docs/RUNTIME_PROFILES.md` — distinguish data profiles from tested adapters.
+- `docs/examples/runtime-binding-conformance/` — promote fixture as conformance target, not production adapter.
+- `tests/runtime-binding-conformance.test.ts` — lock receipt/evidence expectations.
+- Optional `src/` validation files — only for schema/receipt validation, not launch behavior.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Audit current run packet, receipt, evidence, and fake/local fixture fields | None | A |
+| T2 | Define the minimum v1 adapter receipt/evidence contract | T1 | B |
+| T3 | Patch docs to distinguish profiles, adapters, and runtime launch | T2 | C |
+| T4 | Add or tighten tests around conformance fixture output | T2 | C |
+| T5 | Verify core still rejects spawning runtime profiles | T3, T4 | D |
+
+### Parallel groups
+
+- **Group A**: read-only audit.
+- **Group B**: contract decision.
+- **Group C**: docs and tests can proceed together after contract fields are fixed.
+- **Group D**: final boundary verification.
+
+### Dependencies
+
+- T3/T4 depend on T2 so docs and tests describe the same contract.
+- T5 depends on docs/tests to catch accidental runtime creep.
+
+### Delegation notes
+
+- Use a boundary reviewer for docs to ensure no wording implies certified runtime support.
+- Use a code/test worker only if receipt validation or fixture test changes are needed.
+
+## Implementation Architecture Coverage
+
+- Strengthens: runtime boundaries, audit trails, evaluation, recovery/ownership.
+- Audit envelope: PR should include sample run packet, adapter receipt, evidence artifact, and tests proving no spawn.
+- Evaluation envelope: conformance is structural/factual only; correctness of runtime work remains a later evaluation step.
+- Feedback routing: missing production launch support should feed `042-reference-adapter-package-no-spawn` or `043-one-real-runtime-adapter-spike`, not core spawning.
+- Boundary: runtime install, auth, process lifecycle, remote execution, and commit/push/merge authority remain outside core.
+
+## Acceptance criteria
+
+- [ ] Docs define a small v1 adapter receipt/evidence contract in plain language.
+- [ ] Runtime profiles remain data-only and `spawning: false` in core.
+- [ ] Fake/local conformance fixture is documented as a contract target, not a production adapter.
+- [ ] Tests prove run packet consumption, receipt creation, evidence creation, and no-spawn behavior.
+- [ ] Public wording avoids certified integration claims for runtimes without real adapter evidence.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run `npm test -- tests/runtime-binding-conformance.test.ts tests/runtime-binding-dry-run.test.ts`; pass if conformance and no-spawn cases are green.
+2. Run `! git diff -U0 origin/main...HEAD -- docs/RUNTIME_BINDING_CONTRACT.md docs/SPAWNING_BOUNDARY.md docs/RUNTIME_SELECTION.md docs/RUNTIME_PROFILES.md src | grep '^+' | grep -E "certified integration|officially supported|spawning: true|spawned: true"`; pass if no newly added unsupported integration claims or core spawning paths appear, with any intentional negative examples reviewed explicitly.
+3. Run `npm run build`, `npm test`, `./verify.sh --strict`, and `git diff --check`; pass on clean outputs.
+
+## Open questions
+
+- Should core expose a receipt validation command, or should validation remain in tests/examples until the reference adapter package exists?
+- What exact field name should become stable for the adapter receipt: `dispatch-receipt`, `adapter-receipt`, or a backwards-compatible alias?

--- a/.osc/plans/backlog/042-reference-adapter-package-no-spawn.md
+++ b/.osc/plans/backlog/042-reference-adapter-package-no-spawn.md
@@ -1,0 +1,87 @@
+# Plan: 042-reference-adapter-package-no-spawn
+
+## Status
+
+backlog
+
+## Context
+
+Once the adapter conformance contract is clear, Open Scaffold needs a safe sister/reference package that proves the package boundary without launching real agents. This responds to the run-packet IOU critique while preserving the core no-spawn stance.
+
+## Goal
+
+Create an optional no-spawn reference adapter package that reads an Open Scaffold `run.json` and writes an adapter receipt plus evidence artifact.
+
+## Constraints / Out of scope
+
+- Do not add real Claude Code, Codex, OMC, OMX, OpenCode, or shell spawning.
+- Do not add credential handling, daemon behavior, process supervision, tmux, network registries, or remote execution.
+- Do not make the package a marketplace or certified runtime integration.
+- Do not move Open Scaffold core into a monorepo unless explicitly approved during execution.
+- Do not grant commit, push, merge, or publish authority to the adapter.
+
+## Files to touch
+
+- Separate package/repo path TBD — reference adapter package source, tests, README, and package metadata.
+- `docs/examples/runtime-binding-conformance/` — source fixture to extract or mirror from.
+- `docs/RUNTIME_BINDING_CONTRACT.md` — link to package only after it exists.
+- `docs/RUNTIME_SELECTION.md` and/or `docs/RUNTIME_PROFILES.md` — explain optional adapter package boundary.
+- `.osc/releases/` — release/evidence note if this lands as an Open Scaffold public slice.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Decide package location: sibling repo, npm scope, or docs-only extraction | None | A |
+| T2 | Create minimal package that reads `run.json` and validates required fields | T1 | B |
+| T3 | Write adapter receipt and deterministic evidence artifact | T2 | C |
+| T4 | Add tests against sample run packets and failure cases | T2, T3 | C |
+| T5 | Document package as reference/conformance adapter, not runtime support | T3 | C |
+| T6 | Link from core docs only after package proof exists | T4, T5 | D |
+
+### Parallel groups
+
+- **Group A**: owner/package-location decision.
+- **Group B**: package skeleton.
+- **Group C**: output behavior, tests, and docs can proceed together after skeleton.
+- **Group D**: core docs integration after proof.
+
+### Dependencies
+
+- T1 gates all implementation because repo/package location affects commands and verification.
+- T6 waits for proof to avoid linking an aspirational package.
+
+### Delegation notes
+
+- A package worker can build the no-spawn adapter while Hermes owns boundary wording and final Open Scaffold integration.
+
+## Implementation Architecture Coverage
+
+- Strengthens: runtime boundaries, audit trails, recovery/ownership, adoption trust.
+- Audit envelope: package repository/commit or package path, sample run packet, receipt, evidence artifact, and test output.
+- Evaluation envelope: package proves structural adapter roundtrip only; it does not evaluate task correctness.
+- Feedback routing: real runtime demand routes to `043-one-real-runtime-adapter-spike` after this proof.
+- Boundary: core remains no-spawn; real runtime launch, credentials, and provider support remain outside this package.
+
+## Acceptance criteria
+
+- [ ] A reference adapter package exists outside Open Scaffold core or in an explicitly approved package boundary.
+- [ ] It accepts a path to `.osc/runs/<run_id>/run.json` and validates the minimum run-packet fields.
+- [ ] It writes an adapter receipt and deterministic evidence artifact back under the run directory or an explicitly documented output path.
+- [ ] It never launches a runtime, opens a network connection, reads credentials, or mutates source files outside its output artifacts.
+- [ ] Tests cover valid run packets, missing required fields, unsafe output paths, and no-spawn behavior.
+- [ ] Docs label it as a reference/conformance adapter, not production runtime support.
+
+## Verification steps
+
+1. Run the package's test suite; pass if all valid/error/no-spawn cases are green.
+2. Run the adapter against a sample run packet; pass if receipt and evidence are created with deterministic content.
+3. Run a source scan for spawning/network APIs in the package; pass if none exist except explicitly mocked test fixtures.
+4. If core docs are touched, run Open Scaffold `npm test`, `npm run build`, `./verify.sh --strict`, and `git diff --check`.
+
+## Open questions
+
+- Should the reference adapter live under a Graphanov-owned sibling repo, an npm scoped package, or a packages directory introduced later?
+- What package name should be used without overclaiming: `open-scaffold-adapter-reference`, `@open-scaffold/adapter-reference`, or another neutral name?

--- a/.osc/plans/backlog/043-one-real-runtime-adapter-spike.md
+++ b/.osc/plans/backlog/043-one-real-runtime-adapter-spike.md
@@ -1,0 +1,92 @@
+# Plan: 043-one-real-runtime-adapter-spike
+
+## Status
+
+backlog
+
+## Context
+
+After a no-spawn reference adapter proves the package boundary, Open Scaffold can test whether one real runtime adapter meaningfully reduces the run-packet adoption deadlock. The external review and owner direction both warn against turning core into a runtime or bundling several runtimes at once.
+
+## Goal
+
+Spike one real runtime adapter that consumes an Open Scaffold run packet, launches only with explicit permission, and returns factual receipt/evidence without commit authority.
+
+## Constraints / Out of scope
+
+- Do not implement more than one real runtime in this slice.
+- Do not add spawning to Open Scaffold core.
+- Do not add default launch behavior; dry-run must be the default unless explicit `--allow-spawn` or equivalent is provided.
+- Do not grant commit, push, merge, release, credential-management, or destructive filesystem authority.
+- Do not claim certified runtime support beyond the one tested path.
+- Do not support complex team modes, marketplace discovery, or model/task ranking.
+
+## Files to touch
+
+- Separate adapter package/repo path TBD — one-runtime adapter source, tests, docs.
+- `docs/SPAWNING_BOUNDARY.md` — only if core docs need a link to proven external adapter evidence.
+- `docs/RUNTIME_SELECTION.md` and/or `docs/RUNTIME_PROFILES.md` — clarify tested adapter vs candidate profile after proof exists.
+- `.osc/releases/` — release/evidence note if core docs change.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Choose the one runtime target and justify why it is first | None | A |
+| T2 | Define safety model: dry-run default, explicit spawn flag, worktree/branch policy, redaction | T1 | B |
+| T3 | Implement dry-run command rendering and receipt preview | T2 | C |
+| T4 | Implement explicit allowed launch path for the selected runtime | T3 | D |
+| T5 | Capture receipt, exit status, logs path, and evidence artifact | T4 | D |
+| T6 | Test success, failure, cancellation/timeout, and no-commit-authority cases | T4, T5 | E |
+| T7 | Patch core docs only after adapter proof exists | T6 | F |
+
+### Parallel groups
+
+- **Group A/B**: decision and safety design.
+- **Group C**: dry-run proof before real launch.
+- **Group D**: real launch and evidence capture.
+- **Group E**: tests after behavior exists.
+- **Group F**: core docs integration only after proof.
+
+### Dependencies
+
+- T1 gates the whole slice because multi-runtime scope is explicitly out.
+- T4 depends on dry-run proof to avoid accidental launch-first design.
+- T7 depends on tested proof to avoid aspirational docs.
+
+### Delegation notes
+
+- Use a security/boundary reviewer before enabling any real launch path.
+- Hermes should verify no core spawning or commit/publish authority was introduced.
+
+## Implementation Architecture Coverage
+
+- Strengthens: runtime boundaries, authority, audit trails, recovery/ownership.
+- Audit envelope: selected runtime, adapter command, dry-run receipt, launch receipt, exit status, logs/evidence paths, and safety checks.
+- Evaluation envelope: adapter evaluates only dispatch/evidence capture; task correctness remains a separate verification/evaluation step.
+- Feedback routing: support-matrix gaps route to future one-runtime plans, not into a mega-adapter.
+- Boundary: Open Scaffold core, model benchmarking, runtime marketplace, and autonomous commit/publish authority remain outside this slice.
+
+## Acceptance criteria
+
+- [ ] Exactly one runtime target is selected and documented.
+- [ ] Adapter dry-run is default and produces the command/receipt preview without launching.
+- [ ] Real launch requires an explicit opt-in flag and refuses unsafe/missing workspace conditions.
+- [ ] Adapter writes factual receipt/evidence including command redaction, runtime identity, exit status, output/log path, and no-commit-authority statement.
+- [ ] Tests cover dry-run, allowed launch, refusal without opt-in, failure exit, unsafe path, and no commit/push/merge behavior.
+- [ ] Open Scaffold core remains free of runtime launch code.
+
+## Verification steps
+
+1. Run adapter test suite; pass if all safety and receipt cases are green.
+2. Run dry-run against a sample run packet; pass if no process launches and receipt preview is produced.
+3. Run explicit allowed launch in a disposable fixture; pass if receipt/evidence are produced and source files are not committed/pushed/merged.
+4. Scan Open Scaffold core for new spawn/process APIs if core docs are touched; pass if none are introduced.
+5. Run Open Scaffold `npm test`, `npm run build`, `./verify.sh --strict`, and `git diff --check` if core changes land.
+
+## Open questions
+
+- Which runtime should be first: Claude Code, Codex, OMC, OMX, or OpenCode?
+- Is this spike intended for public package publication, private proof, or docs-only evidence first?

--- a/.osc/plans/backlog/044-cli-friction-reduction.md
+++ b/.osc/plans/backlog/044-cli-friction-reduction.md
@@ -1,0 +1,87 @@
+# Plan: 044-cli-friction-reduction
+
+## Status
+
+backlog
+
+## Context
+
+External review praised Open Scaffold's methodology mechanics but called out per-slice ceremony and manual template friction. After first-run path and vocabulary are hardened, the next product improvement is to make common scaffold actions easier without hiding the plan/evidence discipline.
+
+## Goal
+
+Add small CLI helpers that reduce first-plan and evidence-note ceremony while preserving explicit acceptance criteria and verification.
+
+## Constraints / Out of scope
+
+- Do not replace shell helpers wholesale in this slice.
+- Do not implement `osc amend` and `osc close` parity until `plan new` / `evidence new` behavior is proven.
+- Do not hide or auto-invent acceptance criteria.
+- Do not add runtime launch behavior.
+- Do not create a wizard that writes vague plans without human review.
+
+## Files to touch
+
+- `src/cli.ts` — route new CLI commands.
+- `src/scaffold.ts` and/or new CLI helper modules — create plan/evidence files safely.
+- `tests/cli-*.test.ts`, `tests/scaffold.test.ts`, and/or `tests/validation.test.ts` — cover command behavior.
+- `.osc/plans/handoff-template.md` — only if template wording needs command compatibility clarification.
+- `README.md`, `docs/MINIMUM_VIABLE_SCAFFOLD.md`, and `docs/WORKFLOW.md` — document the new minimal commands.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Audit manual friction points in first plan and evidence creation | None | A |
+| T2 | Implement `osc plan new <slug> --stage <stage>` with overwrite refusal | T1 | B |
+| T3 | Implement `osc evidence new <slug>` or equivalent release/evidence skeleton command | T1 | B |
+| T4 | Add tests for safe paths, duplicate refusal, stage validation, and generated structure | T2, T3 | C |
+| T5 | Patch docs to use helpers without hiding required human content | T4 | D |
+| T6 | Run full verification | T5 | E |
+
+### Parallel groups
+
+- **Group A**: audit only.
+- **Group B**: plan and evidence helpers can be implemented in parallel if they do not share risky internals.
+- **Group C**: tests after command behavior exists.
+- **Group D/E**: docs and final verification.
+
+### Dependencies
+
+- T2/T3 depend on T1 so command scope stays minimal.
+- T5 depends on tests to avoid documenting unproven behavior.
+
+### Delegation notes
+
+- Code worker can implement commands; Hermes should review generated plan/evidence wording for public-safe clarity.
+
+## Implementation Architecture Coverage
+
+- Strengthens: workflow design, adoption trust, evidence, recovery/ownership.
+- Audit envelope: PR should include before/after first-plan command path, generated file examples, and test output.
+- Evaluation envelope: generated files must still require human-filled goals, constraints, ACs, and verification; command success is not task success.
+- Feedback routing: requests for amend/close parity route to a later plan after helper adoption is proven.
+- Boundary: runtime launching, automatic task execution, and autonomous plan generation remain outside this slice.
+
+## Acceptance criteria
+
+- [ ] `osc plan new <slug> --stage active|backlog|blocked` creates a schema-compatible plan skeleton in the correct folder and refuses overwrite.
+- [ ] The generated plan contains all required sections and explicit TODO/fill-in prompts without hallucinated acceptance criteria.
+- [ ] `osc evidence new <slug>` or equivalent creates a release/evidence skeleton with Summary, Traceability, Verification, Outcome, and Follow-up sections.
+- [ ] Commands reject unsafe paths, invalid stages, duplicate files, and missing scaffold roots with actionable errors.
+- [ ] Shell helpers remain available and documented as compatibility floor.
+- [ ] `npm run build`, `npm test`, `./verify.sh --strict`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run `npm test` for CLI/scaffold/validation suites; pass if new helper behavior and error cases are covered.
+2. In a temp initialized project, run `node dist/cli.js plan new 001-first-task --stage active`; pass if `./verify.sh --quick` can see the plan structure after required fields are filled.
+3. Run evidence helper in a temp project; pass if the skeleton has required sections and no false proof claims.
+4. Run `npm run build`, `npm test`, `./verify.sh --strict`, and `git diff --check`; pass on clean outputs.
+
+## Open questions
+
+- Should evidence helper create `.osc/releases/<date>-<slug>.md`, a task/run evidence file, or both depending on flags?
+- Should `osc amend` / `osc close` parity be the immediate follow-up once these helpers land?


### PR DESCRIPTION
## Summary
- Promotes the 2026-05-17 five-Opus external review ingest into seven public-safe backlog plans.
- Preserves follow-up work after `038-first-run-adoption-hardening` so the review does not disappear into private research notes.
- Keeps this PR scoped to backlog planning only; no implementation, runtime spawning, package publication, mission/roadmap edits, or private research artifacts are included.

## Added backlog plans
- `038-first-run-adoption-hardening` — fix install truth, neutral standard init, and package payload trust.
- `039-session-2-aha-walkthrough` — show fresh-session resume from repo truth.
- `040-vocabulary-compression-v2` — repair the remaining first-touch jargon cliff.
- `041-adapter-conformance-contract-v1` — freeze the no-spawn adapter receipt/evidence boundary.
- `042-reference-adapter-package-no-spawn` — prove the sister-package split safely.
- `043-one-real-runtime-adapter-spike` — test one real runtime adapter later, with explicit launch permission only.
- `044-cli-friction-reduction` — reduce manual plan/evidence ceremony after first-run trust is fixed.

## Boundaries
- No core runtime spawning.
- No certified adapter/runtime claims.
- No compliance, hashgraph, model-lab, or hosted-product expansion.
- No raw external-review text or private owner context committed.
- No Kanban mirror of every backlog item.

## Verification
- [x] `git diff --check`
- [x] `./verify.sh --strict` → 10 pass, 0 fail, 0 warn
- [x] `npm run build`
- [x] `npm test -- --run` → 12 files / 119 tests passed
- [x] private marker / token scan on new plans

## Codex review
- Opening the PR should allow the connector to review if enabled. This PR is planning-only and intentionally small.