### PR TITLE
Harden first-run adoption package

### DIFF
--- a/.osc/plans/done/038-first-run-adoption-hardening.md
+++ b/.osc/plans/done/038-first-run-adoption-hardening.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+active
 
 ## Context
 

--- a/.osc/releases/2026-05-17-first-run-adoption-hardening.md
+++ b/.osc/releases/2026-05-17-first-run-adoption-hardening.md
@@ -1,0 +1,36 @@
+# Release / Evidence Note: first-run adoption hardening
+
+## Summary
+
+Open Scaffold's first-run path was hardened so the npm package and generated starter projects are cleaner for new adopters.
+
+## Traceability
+
+- Plan: `.osc/plans/done/038-first-run-adoption-hardening.md`
+- Branch: `product/first-run-adoption-hardening`
+- Package: `open-scaffold@0.4.1`
+- npm: https://www.npmjs.com/package/open-scaffold/v/0.4.1
+- Kanban: `t_028271b0`
+
+## Verification
+
+- `npm run build` → pass
+- `npm test` → 14 files / 124 tests passed
+- `npm pack --dry-run --json --ignore-scripts` → 82 files, forbidden product-history payload count `0`
+- `node dist/cli.js init --tier standard --target <tmp>` plus leakage grep → pass
+- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn
+- `git diff --check` → pass
+- `npm publish --dry-run --ignore-scripts` → pass
+- `npm publish --access public --ignore-scripts` → published `open-scaffold@0.4.1`
+- `/tmp` smoke: `npx --yes --prefer-online open-scaffold@0.4.1 init --tier min --target <tmp>` → generated `MISSION.md` and `.osc/plans/handoff-template.md`
+
+## Outcome
+
+- The package is published on npm as `open-scaffold@0.4.1`.
+- Public docs can truthfully show `npx open-scaffold init --tier min --target <repo>` as the normal first-run path.
+- Generated standard-tier root docs are downstream-neutral rather than Open Scaffold product-repo copies.
+- The npm payload excludes `.osc/plans/{active,backlog,done,blocked}` product history and dated `.osc/releases/2026-*` notes.
+
+## Follow-up
+
+Open a GitHub PR for the repo changes so GitHub main catches up with the already-published npm package. Merge remains owner-gated.

--- a/.osc/releases/2026-05-17-first-run-adoption-hardening.md
+++ b/.osc/releases/2026-05-17-first-run-adoption-hardening.md
@@ -16,12 +16,12 @@ Open Scaffold's first-run path was hardened so the npm package and generated sta
 
 - `npm run build` → pass
 - `npm test` → 14 files / 124 tests passed
-- `npm pack --dry-run --json --ignore-scripts` → 82 files, forbidden product-history payload count `0`
+- `npm pack --dry-run --json` → 82 files, forbidden product-history payload count `0`
 - `node dist/cli.js init --tier standard --target <tmp>` plus leakage grep → pass
 - `./verify.sh --strict` → 10 pass / 0 fail / 0 warn
 - `git diff --check` → pass
-- `npm publish --dry-run --ignore-scripts` → pass
-- `npm publish --access public --ignore-scripts` → published `open-scaffold@0.4.1`
+- `npm publish --dry-run` → pass
+- `npm publish --access public --ignore-scripts` → published `open-scaffold@0.4.1` from a prebuilt local dist
 - `/tmp` smoke: `npx --yes --prefer-online open-scaffold@0.4.1 init --tier min --target <tmp>` → generated `MISSION.md` and `.osc/plans/handoff-template.md`
 
 ## Outcome

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-17: closed 038-first-run-adoption-hardening — first-run adoption hardening shipped and npm package published
 - 2026-05-17: closed 037-audit-envelope-digest-manifest — added structure-only audit envelope digest manifest CLI mechanics
 - 2026-05-17: closed 036-evaluation-envelope-schema-and-osc-eval — added structure-only evaluation envelope schema and osc eval init/check mechanics
 - 2026-05-17: rescope PR39 around evaluation and audit envelope standards — see .osc/plans/done/033-implementation-architecture-evaluation-lens-amendment-1.md

--- a/README.md
+++ b/README.md
@@ -88,10 +88,21 @@ Roadmap or issue
 
 ### 1. Initialize the scaffold tier you need
 
-Use the CLI when Node is available:
+Use npm for the normal first run:
 
 ```bash
 npx open-scaffold init --tier min --target <your-project>
+cd <your-project>
+```
+
+If you want to run from a source checkout instead:
+
+```bash
+git clone https://github.com/graphanov/open-scaffold open-scaffold
+cd open-scaffold
+npm install
+npm run build
+node dist/cli.js init --tier min --target <your-project>
 cd <your-project>
 ```
 

--- a/docs/MINIMUM_VIABLE_SCAFFOLD.md
+++ b/docs/MINIMUM_VIABLE_SCAFFOLD.md
@@ -13,10 +13,21 @@ What evidence proves it closed?
 
 ## The five-step adoption path
 
-Start by generating the tier that fits the repo:
+Start by generating the tier that fits the repo with npm:
 
 ```bash
 npx open-scaffold init --tier min --target <repo>
+# or: --tier standard / --tier max
+```
+
+Source checkout fallback:
+
+```bash
+git clone https://github.com/graphanov/open-scaffold open-scaffold
+cd open-scaffold
+npm install
+npm run build
+node dist/cli.js init --tier min --target <repo>
 # or: --tier standard / --tier max
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "MIT",
       "bin": {
         "osc": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "type": "module",
   "bin": {
-    "osc": "dist/cli.js"
+    "osc": "dist/cli.js",
+    "open-scaffold": "dist/cli.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
@@ -17,17 +18,19 @@
   "files": [
     "dist",
     ".osc/RULES.md",
-    ".osc/plans",
-    ".osc/releases",
-    ".osc/specs",
+    ".osc/plans/WORKFLOW.md",
+    ".osc/plans/README.md",
+    ".osc/plans/handoff-template.md",
+    ".osc/releases/README.md",
+    ".osc/specs/.gitkeep",
     "docs",
-    "AGENTS.md",
-    "CLAUDE.md",
-    "MISSION.md",
-    "ROADMAP.md",
     "README.md",
     "LICENSE",
-    "*.sh"
+    "amend.sh",
+    "bootstrap.sh",
+    "close.sh",
+    "delegate.sh",
+    "verify.sh"
   ],
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"

--- a/src/init.ts
+++ b/src/init.ts
@@ -82,6 +82,274 @@ function missionTemplate(): string {
   return `# Mission\n\n<!-- mission:unset -->\n\nTODO: define mission.\n\nDescribe what this repository is trying to accomplish, the non-goals, and the owner-visible definition of done before starting substantial work.\n`;
 }
 
+function downstreamReadmeTemplate(): string {
+  return [
+    '# Project README',
+    '',
+    'TODO: replace this with your project overview.',
+    '',
+    '## How this repo uses Open Scaffold',
+    '',
+    'This repository uses Open Scaffold to keep AI-assisted work traceable in files instead of lost in chat history.',
+    '',
+    'The basic loop is:',
+    '',
+    '1. Define the mission in `MISSION.md`.',
+    '2. Put the current slice in `.osc/plans/active/` using `.osc/plans/handoff-template.md`.',
+    '3. Do the work and run the project checks.',
+    '4. Record evidence in `.osc/releases/`.',
+    '5. Close the plan with `./close.sh <plan-slug>`.',
+    '',
+    '## First useful commands',
+    '',
+    '```bash',
+    './bootstrap.sh',
+    './verify.sh --quick',
+    './verify.sh --standard',
+    '```',
+    '',
+    '## Project status',
+    '',
+    '- Mission: fill in `MISSION.md` before substantial work.',
+    '- Current work: keep one active plan under `.osc/plans/active/`.',
+    '- Evidence: add concise notes under `.osc/releases/` when meaningful slices close.',
+    '',
+    'Keep this README about the downstream project. Link to Open Scaffold docs only when the methodology itself needs explanation.',
+  ].join('\n') + '\n';
+}
+
+function downstreamRoadmapTemplate(): string {
+  return [
+    '# Roadmap',
+    '',
+    'TODO: replace this with the downstream project roadmap.',
+    '',
+    'Use this file for product direction, not live task status. Live/current work belongs in `.osc/plans/active/`, GitHub Issues, or the project task board.',
+    '',
+    '## Now',
+    '',
+    '- Define the mission in `MISSION.md`.',
+    '- Create one first active plan under `.osc/plans/active/`.',
+    '',
+    '## Next',
+    '',
+    '- TODO: add the next small, reviewable slice.',
+    '',
+    '## Later',
+    '',
+    '- TODO: add larger ideas only after they are accepted as real roadmap pressure.',
+  ].join('\n') + '\n';
+}
+
+function downstreamAgentInstructionsTemplate(file: 'AGENTS.md' | 'CLAUDE.md'): string {
+  return [
+    `# ${file}`,
+    '',
+    'This repository uses Open Scaffold. It is not the Open Scaffold product repository.',
+    '',
+    '## Project facts',
+    '',
+    '- `MISSION.md` is the source of truth for what this project is trying to do.',
+    '- `.osc/plans/` stores immutable plans in `active/`, `backlog/`, `done/`, and `blocked/`.',
+    '- `.osc/RULES.md` is the compact rule sheet. Re-read it before structural changes.',
+    '- `.osc/plans/WORKFLOW.md` explains how plan files move between stages.',
+    '- `.osc/releases/` stores concise evidence/release notes for meaningful closed slices.',
+    '- `verify.sh` checks scaffold health before claiming work is done.',
+    '',
+    '## Operating rules',
+    '',
+    '1. Read `MISSION.md` before meaningful work. If the mission is still unset, help the owner define it first.',
+    '2. Check `.osc/plans/active/` before starting new work. Continue active work unless the owner says otherwise.',
+    '3. Do not silently rewrite committed plans. New information becomes an amendment, follow-up plan, or evidence note.',
+    '4. Keep work small enough to review. One plan should map to one clear slice.',
+    '5. Verify against acceptance criteria, then record evidence before closing a plan.',
+    '6. Treat chat and agent transcripts as working context, not durable truth. Promote important facts into repo files.',
+    '',
+    '## First task bootstrap',
+    '',
+    'If this is a new repo, ask the owner:',
+    '',
+    '1. What is this project in one sentence?',
+    '2. What should it achieve first?',
+    '3. What should it explicitly not do yet?',
+    '',
+    'Then update `MISSION.md` and create the first active plan from `.osc/plans/handoff-template.md`.',
+  ].join('\n') + '\n';
+}
+
+function downstreamMinimumScaffoldDocTemplate(): string {
+  return [
+    '# Minimum Viable Scaffold',
+    '',
+    'This repo has the minimum Open Scaffold loop needed for a human and an agent to answer:',
+    '',
+    'In plain terms: this is the minimum viable scaffold for this project.',
+    '',
+    '- What are we building?',
+    '- What is the current slice?',
+    '- How will we verify it?',
+    '- What evidence proves it closed?',
+    '',
+    '## Five-step loop',
+    '',
+    '1. Define the project mission in `MISSION.md`.',
+    '2. Create one active plan under `.osc/plans/active/` from `.osc/plans/handoff-template.md`.',
+    '3. Execute the work and run the project checks.',
+    '4. Run `./verify.sh --standard` before calling the slice done.',
+    '5. Record evidence under `.osc/releases/`, then close the plan with `./close.sh <plan-slug>`.',
+    '',
+    '## First-user checklist',
+    '',
+    '- [ ] `MISSION.md` describes this project.',
+    '- [ ] `.osc/plans/active/` has one current plan before first verification.',
+    '- [ ] `.osc/plans/done/` contains only this project\'s completed work.',
+    '- [ ] `.osc/releases/` contains only this project\'s evidence notes.',
+    '- [ ] `./verify.sh --standard` passes.',
+  ].join('\n') + '\n';
+}
+
+function downstreamBootstrapTemplate(): string {
+  return `#!/usr/bin/env bash
+# open-scaffold bootstrap for a downstream project
+# Tested on macOS system bash (3.2). Avoids GNU-only date flags.
+# Idempotent: safe to run any number of times.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+TODAY="$(date +%Y-%m-%d)"
+MISSION="$ROOT/MISSION.md"
+
+stamp_changelog() {
+  if [ ! -f "$MISSION" ]; then
+    return 0
+  fi
+  STAMP="$TODAY: bootstrap run"
+  if ! grep -Fq "$STAMP" "$MISSION"; then
+    ANCHOR='<!-- append YYYY-MM-DD entries below this line -->'
+    if grep -Fq "$ANCHOR" "$MISSION"; then
+      TMPFILE=$(mktemp)
+      while IFS= read -r line || [ -n "$line" ]; do
+        printf '%s\\n' "$line"
+        if printf '%s' "$line" | grep -Fq "$ANCHOR"; then
+          printf -- '- %s\\n' "$STAMP"
+        fi
+      done < "$MISSION" > "$TMPFILE"
+      mv "$TMPFILE" "$MISSION"
+    else
+      printf -- '- %s\\n' "$STAMP" >> "$MISSION"
+    fi
+  fi
+}
+
+mkdir -p "$ROOT/.osc/research"
+mkdir -p "$ROOT/.osc/state"
+mkdir -p "$ROOT/.osc/plans/active"
+mkdir -p "$ROOT/.osc/plans/backlog"
+mkdir -p "$ROOT/.osc/plans/done"
+mkdir -p "$ROOT/.osc/plans/blocked"
+mkdir -p "$ROOT/.osc/releases"
+
+if [ -f "$MISSION" ] && grep -Fq 'mission:unset' "$MISSION"; then
+  if [ -t 0 ]; then
+    printf '\\n'
+    printf '=== open-scaffold: Define Your Mission ===\\n'
+    printf '\\n'
+    printf 'What is this project? (one sentence)\\n> '
+    read -r USER_MISSION
+    printf '\\n'
+    printf 'What should it achieve? (main outcomes — separate multiple with semicolons)\\n> '
+    read -r USER_GOALS
+    printf '\\n'
+    printf 'What should this project NOT do? (separate multiple with semicolons)\\n> '
+    read -r USER_NONGOALS
+    printf '\\n'
+
+    if [ -n "$USER_MISSION" ]; then
+      GOALS_LIST=""
+      if [ -n "$USER_GOALS" ]; then
+        GOALS_LIST=$(printf '%s' "$USER_GOALS" | tr ',;' '\\n\\n' | while read -r item; do
+          trimmed=$(printf '%s' "$item" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          if [ -n "$trimmed" ]; then
+            printf '- %s\\n' "$trimmed"
+          fi
+        done)
+      fi
+      if [ -z "$GOALS_LIST" ]; then
+        GOALS_LIST="- TODO: define your project's goals"
+      fi
+
+      NONGOALS_LIST=""
+      if [ -n "$USER_NONGOALS" ]; then
+        NONGOALS_LIST=$(printf '%s' "$USER_NONGOALS" | tr ',;' '\\n\\n' | while read -r item; do
+          trimmed=$(printf '%s' "$item" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          if [ -n "$trimmed" ]; then
+            printf '- %s\\n' "$trimmed"
+          fi
+        done)
+      fi
+      if [ -z "$NONGOALS_LIST" ]; then
+        NONGOALS_LIST="- TODO: define your project's non-goals"
+      fi
+
+      cat > "$MISSION" << MISSION_EOF
+# Mission
+
+$USER_MISSION
+
+## Goals
+
+$GOALS_LIST
+
+## Non-Goals
+
+$NONGOALS_LIST
+
+## Changelog
+
+One-line dated entries for every scope pivot. Format: \`YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>\`. Append entries in chronological order. Never rewrite history here.
+
+<!-- append YYYY-MM-DD entries below this line -->
+MISSION_EOF
+
+      stamp_changelog
+      printf 'Mission defined! Your MISSION.md has been updated.\\n'
+    else
+      printf 'No mission entered. You can edit MISSION.md manually later.\\n'
+      stamp_changelog
+    fi
+  else
+    stamp_changelog
+  fi
+else
+  stamp_changelog
+fi
+
+if [ -x "$ROOT/verify.sh" ]; then
+  printf '\\n'
+  "$ROOT/verify.sh" --quick || true
+fi
+
+if [ -f "$ROOT/docs/WORKFLOW.md" ]; then
+  NEXT_READ="$ROOT/docs/WORKFLOW.md"
+elif [ -f "$ROOT/.osc/plans/WORKFLOW.md" ]; then
+  NEXT_READ="$ROOT/.osc/plans/WORKFLOW.md"
+else
+  NEXT_READ="$ROOT/.osc/RULES.md"
+fi
+printf '\\nBootstrap complete.\\nRead: %s\\n' "$NEXT_READ"
+`;
+}
+
+function downstreamTemplateFor(file: string, tier: ScaffoldTier): string | null {
+  if (file === 'bootstrap.sh') return downstreamBootstrapTemplate();
+  if (tier === 'min') return null;
+  if (file === 'README.md') return downstreamReadmeTemplate();
+  if (file === 'ROADMAP.md') return downstreamRoadmapTemplate();
+  if (file === 'AGENTS.md' || file === 'CLAUDE.md') return downstreamAgentInstructionsTemplate(file);
+  if (file === 'docs/MINIMUM_VIABLE_SCAFFOLD.md') return downstreamMinimumScaffoldDocTemplate();
+  return null;
+}
+
 function minRulesTemplate(): string {
   return `# Open Scaffold — Rules (Minimum Tier)
 
@@ -298,8 +566,11 @@ export function initializeScaffold(options: InitializeScaffoldOptions): Initiali
     const destination = join(target, file);
     mkdirSync(dirname(destination), { recursive: true });
 
+    const generatedTemplate = downstreamTemplateFor(file, options.tier);
     const source = sourcePathFor(file);
-    if (source === null) {
+    if (generatedTemplate !== null) {
+      writeFileSync(destination, generatedTemplate);
+    } else if (source === null) {
       writeFileSync(destination, file === 'MISSION.md' ? missionTemplate() : '');
     } else if (file === '.osc/RULES.md' && options.tier === 'min') {
       writeFileSync(destination, minRulesTemplate());

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -10,6 +10,19 @@ const cli = join(repoRoot, 'src/cli.ts');
 
 function tempTarget() {
   return mkdtempSync(join(tmpdir(), 'osc-cli-init-'));
+}
+
+function filesUnder(root: string): string[] {
+  const files: string[] = [];
+  function visit(dir: string): void {
+    for (const entry of readdirSync(dir)) {
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) visit(path);
+      else files.push(path);
+    }
+  }
+  visit(root);
+  return files.sort();
 }
 
 function writeRuntimeSelectionPlan(target: string, goal = 'Demo runtime selection.') {
@@ -70,6 +83,37 @@ describe('osc init CLI', () => {
 
     expect(existsSync(join(target, 'README.md'))).toBe(true);
     expect(existsSync(join(target, 'docs/SLICE_CLOSE_PROTOCOL.md'))).toBe(true);
+  });
+
+  it('generates standard-tier root docs as neutral downstream starter files', () => {
+    const target = tempTarget();
+
+    execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });
+
+    const checkedFiles = ['README.md', 'ROADMAP.md', 'AGENTS.md', 'CLAUDE.md'] as const;
+    for (const file of checkedFiles) {
+      const text = readFileSync(join(target, file), 'utf8');
+      expect(text, file).not.toContain('This project is [open-scaffold]');
+      expect(text, file).not.toContain('Open Scaffold is a runtime-neutral, repo-native operating system');
+      expect(text, file).not.toContain('graphanov/open-scaffold/generate');
+      expect(text, file).not.toContain('/Users/');
+      expect(text, file).not.toContain('Daniel');
+      expect(text, file).not.toContain('.osc-dev');
+    }
+
+    for (const path of filesUnder(target)) {
+      const text = readFileSync(path, 'utf8');
+      expect(text, path).not.toContain('/Users/');
+      expect(text, path).not.toContain('owner-local');
+      expect(text, path).not.toContain('private workspace');
+      expect(text, path).not.toContain('graphanov/open-scaffold/generate');
+      expect(text, path).not.toContain('Open Scaffold is a runtime-neutral, repo-native operating system');
+      expect(text, path).not.toContain('Daniel');
+      expect(text, path).not.toContain('.osc-dev');
+    }
+
+    expect(readFileSync(join(target, 'README.md'), 'utf8')).toContain('TODO: replace this with your project overview.');
+    expect(readFileSync(join(target, 'AGENTS.md'), 'utf8')).toContain('This repository uses Open Scaffold. It is not the Open Scaffold product repository.');
   });
 
   it('exits non-zero rather than overwriting an existing file', () => {

--- a/tests/first-run-docs.test.ts
+++ b/tests/first-run-docs.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(process.cwd());
+
+function read(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf8');
+}
+
+describe('first-run documentation truth', () => {
+  it('advertises the published npx command as the default first-run path', () => {
+    const docs = [
+      ['README.md', read('README.md')],
+      ['docs/MINIMUM_VIABLE_SCAFFOLD.md', read('docs/MINIMUM_VIABLE_SCAFFOLD.md')],
+    ] as const;
+
+    for (const [path, text] of docs) {
+      expect(text, path).toContain('npx open-scaffold init --tier min');
+    }
+  });
+
+  it('keeps a source-checkout fallback path for users who do not want npx', () => {
+    const readme = read('README.md');
+    const minimum = read('docs/MINIMUM_VIABLE_SCAFFOLD.md');
+
+    for (const [path, text] of [['README.md', readme], ['docs/MINIMUM_VIABLE_SCAFFOLD.md', minimum]] as const) {
+      expect(text, path).toContain('git clone https://github.com/graphanov/open-scaffold');
+      expect(text, path).toContain('npm install');
+      expect(text, path).toContain('npm run build');
+      expect(text, path).toContain('node dist/cli.js init');
+    }
+  });
+
+  it('exposes a package-name binary alias so npx open-scaffold runs the CLI', () => {
+    const packageJson = JSON.parse(read('package.json')) as { bin?: Record<string, string> };
+
+    expect(packageJson.bin).toMatchObject({
+      'open-scaffold': 'dist/cli.js',
+      osc: 'dist/cli.js',
+    });
+  });
+});

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -14,7 +14,7 @@ const repoRoot = resolve(process.cwd());
 
 describe('npm package payload', () => {
   it('ships package/template assets without product dogfood plan and release history', () => {
-    const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+    const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
       cwd: repoRoot,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+interface PackedFile {
+  path: string;
+}
+
+interface PackResult {
+  files: PackedFile[];
+}
+
+const repoRoot = resolve(process.cwd());
+
+describe('npm package payload', () => {
+  it('ships package/template assets without product dogfood plan and release history', () => {
+    const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const [pack] = JSON.parse(output) as PackResult[];
+    const paths = pack.files.map((file) => file.path).sort();
+
+    expect(paths).toContain('.osc/RULES.md');
+    expect(paths).toContain('.osc/plans/WORKFLOW.md');
+    expect(paths).toContain('.osc/plans/README.md');
+    expect(paths).toContain('.osc/plans/handoff-template.md');
+    expect(paths).toContain('.osc/releases/README.md');
+    expect(paths).toContain('dist/cli.js');
+    expect(paths).toContain('README.md');
+
+    const forbidden = paths.filter((path) =>
+      path.startsWith('.osc/plans/active/') ||
+      path.startsWith('.osc/plans/backlog/') ||
+      path.startsWith('.osc/plans/done/') ||
+      path.startsWith('.osc/plans/blocked/') ||
+      /^\.osc\/releases\/2026-/.test(path)
+    );
+
+    expect(forbidden).toEqual([]);
+  }, 20_000);
+});


### PR DESCRIPTION
## Summary
- publishes and reconciles the first npm package path as `open-scaffold@0.4.1`
- adds the `open-scaffold` bin alias alongside `osc` so `npx open-scaffold ...` works
- makes standard-tier generated starter docs downstream-neutral instead of copying Open Scaffold product identity
- trims npm payload to curated package/template assets, excluding product plan/release history
- closes plan `038-first-run-adoption-hardening` and adds release evidence

## Traceability
- Plan: `.osc/plans/done/038-first-run-adoption-hardening.md`
- Release evidence: `.osc/releases/2026-05-17-first-run-adoption-hardening.md`
- Kanban: `t_028271b0`
- npm: https://www.npmjs.com/package/open-scaffold/v/0.4.1

## Verification
- [x] `npm run build`
- [x] `npm test` — 14 files / 124 tests passed
- [x] `npm pack --dry-run --json` — runs `prepack`, 82 files, forbidden product-history payload count `0`
- [x] `node dist/cli.js init --tier standard --target <tmp>` plus leakage grep
- [x] `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- [x] `git diff --check`
- [x] `npm publish --dry-run`
- [x] `npm publish --access public --ignore-scripts` — published `open-scaffold@0.4.1` from a prebuilt local dist
- [x] `/tmp` smoke: `npx --yes --prefer-online open-scaffold@0.4.1 init --tier min --target <tmp>`

## Notes
`open-scaffold@0.4.0` was published first but did not expose a package-name bin for the plain `npx open-scaffold` command. `0.4.1` is the functional first-run package and is now the latest npm dist-tag.

Codex review: first pass found a valid stale-dist/rebuild concern; fixed in `ee07e09` by making the package-payload regression use normal `npm pack`/`prepack` instead of `--ignore-scripts`. Latest-head re-review requested.
