### PR TITLE
Show the session-2 resume payoff

### DIFF
--- a/.osc/plans/done/039-session-2-aha-walkthrough.md
+++ b/.osc/plans/done/039-session-2-aha-walkthrough.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+active
 
 ## Context
 

--- a/.osc/releases/2026-05-17-session-2-aha-walkthrough.md
+++ b/.osc/releases/2026-05-17-session-2-aha-walkthrough.md
@@ -1,0 +1,32 @@
+# Release / Evidence Note: session-2 aha walkthrough
+
+## Summary
+
+The downstream Tiny Notes walkthrough now makes the Open Scaffold payoff explicit: a second session can recover project intent, current/done state, verification evidence, and next action from repo files alone instead of old chat context.
+
+## Traceability
+
+- Plan: `.osc/plans/active/039-session-2-aha-walkthrough.md`
+- Branch: `docs/session-2-aha-walkthrough`
+- Kanban: `t_60a8f2b2`
+- Primary walkthrough: `docs/examples/downstream-walkthrough.md`
+
+## Verification
+
+- Documented Tiny Notes walkthrough command sequence in a temp directory → pass, including day-2 recovery inspection.
+- `npm run smoke:e2e` → pass.
+- Added-line private-context leak scan for `README.md docs` → pass.
+- `npm run build` → pass.
+- `npm test` → 14 files / 124 tests passed.
+- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn.
+- `git diff --check` → pass.
+
+## Outcome
+
+- The walkthrough now shows day-1 execution and day-2 resume/recovery.
+- The examples index, minimum viable scaffold guide, README pointer, and wiki query point readers toward the session-2 value.
+- No runtime adapter, private coordinator, Discord/Hermes dependency, or compliance certification claim was added.
+
+## Follow-up
+
+Vocabulary friction remains a separate backlog item (`040-vocabulary-compression-v2`). CLI helper friction remains a separate backlog item (`044-cli-friction-reduction`).

--- a/.osc/releases/2026-05-17-session-2-aha-walkthrough.md
+++ b/.osc/releases/2026-05-17-session-2-aha-walkthrough.md
@@ -6,7 +6,7 @@ The downstream Tiny Notes walkthrough now makes the Open Scaffold payoff explici
 
 ## Traceability
 
-- Plan: `.osc/plans/active/039-session-2-aha-walkthrough.md`
+- Plan: `.osc/plans/done/039-session-2-aha-walkthrough.md`
 - Branch: `docs/session-2-aha-walkthrough`
 - Kanban: `t_60a8f2b2`
 - Primary walkthrough: `docs/examples/downstream-walkthrough.md`

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-17: closed 039-session-2-aha-walkthrough — session-2 aha walkthrough shipped
 - 2026-05-17: closed 038-first-run-adoption-hardening — first-run adoption hardening shipped and npm package published
 - 2026-05-17: closed 037-audit-envelope-digest-manifest — added structure-only audit envelope digest manifest CLI mechanics
 - 2026-05-17: closed 036-evaluation-envelope-schema-and-osc-eval — added structure-only evaluation envelope schema and osc eval init/check mechanics

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Want the loop before the theory? Read [`docs/EXAMPLES.md`](docs/EXAMPLES.md#60-s
 Mission -> plan -> verification -> evidence/status
 ```
 
-For a non-recursive version of the same loop, read the [downstream walkthrough](docs/examples/downstream-walkthrough.md): a tiny shell CLI carried through mission, plan, run packet, evidence, and close. For broader usage shapes — solo developer, team control-room, GitHub-only workflow, and runtime harness handoff — see the [examples index](docs/examples/README.md).
+For a non-recursive version of the same loop, read the [downstream walkthrough](docs/examples/downstream-walkthrough.md): a tiny shell CLI carried through mission, plan, run packet, evidence, close, and a day-2 resume check from repo files alone. For broader usage shapes — solo developer, team control-room, GitHub-only workflow, and runtime harness handoff — see the [examples index](docs/examples/README.md).
 
 ---
 

--- a/docs/MINIMUM_VIABLE_SCAFFOLD.md
+++ b/docs/MINIMUM_VIABLE_SCAFFOLD.md
@@ -41,6 +41,8 @@ Then follow the loop:
 4. **Record evidence** — add a short `.osc/releases/<date>-<slug>.md` note with summary, traceability, verification, and outcome.
 5. **Close the plan** — run `./close.sh <slug> --message "<what shipped>"` so the plan moves to `done/` and `MISSION.md` is stamped.
 
+The payoff appears in the next session. If someone opens the repo later with no chat history, they can read `MISSION.md`, `.osc/plans/active/`, `.osc/plans/done/`, and `.osc/releases/` to see what the project is, whether work is still active, what was verified, and whether the next action is to continue, stop, or write a new plan.
+
 Everything else is optional until the project needs it.
 
 ## Core vs optional artifacts

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -9,7 +9,7 @@ The four modes:
 3. [GitHub-only workflow](#3-github-only-workflow) — issue → plan → PR → evidence with no chat coordinator.
 4. [Runtime harness handoff](#4-runtime-harness-handoff) — packaging work for an external runtime lane to execute.
 
-If you want one complete non-recursive example first, start with [`downstream-walkthrough.md`](downstream-walkthrough.md). It shows the full mission → plan → run packet → evidence → close loop on a tiny shell CLI that is not Open Scaffold itself.
+If you want one complete non-recursive example first, start with [`downstream-walkthrough.md`](downstream-walkthrough.md). It shows the full mission → plan → run packet → evidence → close loop on a tiny shell CLI that is not Open Scaffold itself, then shows how a second session reconstructs the current state from files alone.
 
 Open Scaffold core ships the protocol, the run packet schema, the verification scripts, and dry-run/conformance examples. It does not spawn agents, run a coordinator daemon, or own runtime credentials. Each mode below stays inside that boundary.
 
@@ -25,7 +25,7 @@ Reading path:
 
 - [`README.md` Quickstart](../../README.md#quickstart) — initialize the scaffold, bootstrap a mission, write the first plan, run `./verify.sh`.
 - [`docs/EXAMPLES.md` 60-second viewer demo](../EXAMPLES.md#60-second-viewer-demo) — mission → plan → verification → evidence in four shell commands.
-- [`downstream-walkthrough.md`](downstream-walkthrough.md) — the same loop on Tiny Notes, a small non-Open-Scaffold project with concrete commands and expected outputs.
+- [`downstream-walkthrough.md`](downstream-walkthrough.md) — the same loop on Tiny Notes, a small non-Open-Scaffold project with concrete commands, expected outputs, and a day-2 resume check that works without chat history.
 - [`examples/lifecycle-e2e-smoke/`](../../examples/lifecycle-e2e-smoke/README.md) — boring downstream fixture that proves the loop on a non-Open-Scaffold project. Run it with `npm run smoke:e2e`.
 
 Loop in shell:

--- a/docs/examples/downstream-walkthrough.md
+++ b/docs/examples/downstream-walkthrough.md
@@ -2,6 +2,8 @@
 
 A fresh reader can clone Open Scaffold, read the protocol docs, and still walk away unsure whether the discipline is worth carrying into their own project. This page closes that gap on a project that is **not** Open Scaffold itself: a 20-line shell CLI called **Tiny Notes** that appends one note to a text file.
 
+The point is not the script. The point is the **second session**: a fresh human or agent can open the repo later, read the mission, plan folders, and evidence note, and know whether work is active, done, blocked, or ready for a new slice without asking for old chat history.
+
 The same fixture is exercised mechanically by `npm run smoke:e2e` (see [`E2E_SMOKE.md`](../E2E_SMOKE.md)). This page narrates the same lifecycle so a human can read it in one sitting, copy the artifacts, and decide whether Open Scaffold pays for itself on their next task.
 
 No private credentials, no private coordinator, no chat surface, no runtime harness, and no network access are required.
@@ -13,7 +15,7 @@ No private credentials, no private coordinator, no chat surface, no runtime harn
 The walkthrough moves through Open Scaffold's canonical identity chain on Tiny Notes:
 
 ```text
-mission -> plan -> implementation -> verification -> run packet -> evidence -> close -> final verify
+mission -> plan -> implementation -> verification -> run packet -> evidence -> close -> session-2 resume
 ```
 
 Every step has a concrete file, a concrete command, and an expected observable. The artifacts already live under `examples/lifecycle-e2e-smoke/` in this repo — you can read them in place, or copy them into a clean temp directory and run the loop yourself.
@@ -268,7 +270,7 @@ cd "$TMP"
 bash test.sh
 ./verify.sh --standard
 
-# Optional: write a one-line evidence note, then close the plan.
+# Write a short evidence note, then close the plan.
 mkdir -p .osc/releases
 cat > .osc/releases/$(date -u +%Y-%m-%d)-add-note-command.md <<'EOF'
 # Release / Evidence Note: tiny-notes add-note command
@@ -276,9 +278,19 @@ cat > .osc/releases/$(date -u +%Y-%m-%d)-add-note-command.md <<'EOF'
 ## Summary
 add-note works and is locally verified.
 
+## Traceability
+- Plan: `.osc/plans/active/001-add-note-command.md` before close.
+- Task: local walkthrough.
+
 ## Verification
 - `bash test.sh` -> `tiny-notes test passed`.
 - `./verify.sh --standard` -> `0 fail`.
+
+## Outcome
+The add-note command meets the plan acceptance criteria.
+
+## Follow-up
+None for this slice.
 EOF
 
 ./close.sh 001-add-note-command
@@ -288,6 +300,47 @@ EOF
 Expected: every command exits `0`. No network call, no private credential, no Hermes/OMC/OMX/Codex/Discord dependency.
 
 The mechanical version of these steps is exercised by `npm run smoke:e2e` from the Open Scaffold repo root.
+
+---
+
+## 9. Day 2: resume from repo truth, not memory
+
+Now pretend the first session is gone. No chat transcript, no terminal scrollback, no person explaining what happened. A fresh human or agent gets only the repo.
+
+From the temp Tiny Notes project after step 8, inspect the durable truth:
+
+```bash
+printf 'Mission:\n'
+sed -n '1,24p' MISSION.md
+
+printf '\nPlan folders:\n'
+for stage in active backlog blocked done; do
+  printf '%s:\n' "$stage"
+  find ".osc/plans/$stage" -maxdepth 1 -type f -name '*.md' -print | sort
+done
+
+printf '\nEvidence notes:\n'
+find .osc/releases -maxdepth 1 -type f -name '*.md' ! -name README.md -print -exec sed -n '1,80p' {} \;
+```
+
+Expected reading:
+
+- `MISSION.md` says Tiny Notes is a local shell CLI, with no web app, database, or hosted-service scope.
+- `.osc/plans/active/` is empty after close, so there is no hidden in-flight work.
+- `.osc/plans/done/001-add-note-command.md` exists, so the add-note slice is closed.
+- `.osc/releases/<date>-add-note-command.md` records the verification: `bash test.sh` and `./verify.sh --standard`.
+- The next action is not “continue whatever the chat was doing.” The next action is either **stop** or write a fresh plan for the next explicit slice, such as search, sync, or multi-file notes.
+
+That is the session-2 payoff. The repo answers the four recovery questions:
+
+```text
+What are we building?        -> MISSION.md
+What was the slice?          -> .osc/plans/done/001-add-note-command.md
+How was it verified?         -> .osc/releases/<date>-add-note-command.md
+What should happen next?     -> no active plan; create a new plan before new scope
+```
+
+If you stop before closing the slice, the same recovery check points at `.osc/plans/active/001-add-note-command.md` instead. That tells the next session the work is still active and lists the acceptance criteria and verification commands to finish it.
 
 ---
 

--- a/docs/wiki/queries/what-is-open-scaffold-for.md
+++ b/docs/wiki/queries/what-is-open-scaffold-for.md
@@ -1,7 +1,7 @@
 ---
 title: What is Open Scaffold for?
 created: 2026-05-15
-updated: 2026-05-15
+updated: 2026-05-17
 type: query
 tags: [open-scaffold, workflow, agent-orchestration, source-of-truth]
 sources: [MISSION.md, README.md, ROADMAP.md]
@@ -11,7 +11,7 @@ contested: false
 
 # What is Open Scaffold for?
 
-Open Scaffold is for projects where work must survive beyond a single chat, agent session, or developer's memory.
+Open Scaffold is for projects where work must survive beyond a single chat, agent session, or developer's memory. Its clearest payoff appears in the next session: someone can open the repository, read mission, plan folders, and evidence notes, and know whether to continue active work, trust a closed slice, or write a new plan.
 
 It is especially useful when a project has:
 


### PR DESCRIPTION
## Summary
- makes the downstream Tiny Notes walkthrough explicitly show the session-2 payoff: a fresh human/agent can recover state from repo files alone
- adds a day-2 recovery inspection covering mission, plan folders, evidence, and next action
- links the session-2 value from the examples index, minimum viable scaffold guide, README pointer, and wiki query
- closes plan `039-session-2-aha-walkthrough` and adds release/evidence notes

## Traceability
- Plan: `.osc/plans/done/039-session-2-aha-walkthrough.md`
- Evidence: `.osc/releases/2026-05-17-session-2-aha-walkthrough.md`
- Kanban: `t_60a8f2b2`

## Verification
- [x] Documented Tiny Notes walkthrough command sequence in a temp directory, including day-2 recovery inspection
- [x] `npm run smoke:e2e`
- [x] Added-line private-context leak scan for `README.md docs`
- [x] `npm run build`
- [x] `npm test` — 14 files / 124 tests passed
- [x] `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- [x] `git diff --check`

## Out of scope
- no runtime adapter implementation
- no broad ontology rewrite
- no private Hermes/Discord dependency
- no compliance certification claim

Codex review: requested after PR creation.
