### PR TITLE
Compress first-touch vocabulary

### DIFF
--- a/.osc/plans/done/040-vocabulary-compression-v2.md
+++ b/.osc/plans/done/040-vocabulary-compression-v2.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+active
 
 ## Context
 

--- a/.osc/releases/2026-05-17-vocabulary-compression-v2.md
+++ b/.osc/releases/2026-05-17-vocabulary-compression-v2.md
@@ -1,0 +1,55 @@
+# Release / Evidence Note: vocabulary compression v2
+
+## Summary
+
+Open Scaffold first-touch and runtime docs now lead with plain-language explanations before protocol vocabulary. The slice keeps precise runtime terms where they are useful, but aliases them near first mention so new readers can follow the README, minimum path, workflow docs, and examples without learning the full ontology first.
+
+## Traceability
+
+- Plan: `.osc/plans/done/040-vocabulary-compression-v2.md`
+- Branch: `docs/vocabulary-compression-v2`
+- Kanban: `t_323cabd0`
+- Primary docs: `README.md`, `docs/MINIMUM_VIABLE_SCAFFOLD.md`, `docs/WHY_OPEN_SCAFFOLD.md`, `docs/WORKFLOW.md`, `docs/RUNTIME_SELECTION.md`, `docs/RUNTIME_PROFILES.md`, `docs/RUNTIME_BINDING_CONTRACT.md`, `docs/SPAWNING_BOUNDARY.md`, `docs/examples/`
+- Audit artifacts: `/tmp/osc040_jargon_before.txt`, `/tmp/osc040_jargon_after.txt`
+
+## Vocabulary audit
+
+First-touch scope: `README.md`, `docs/MINIMUM_VIABLE_SCAFFOLD.md`, `docs/WHY_OPEN_SCAFFOLD.md`, `docs/FAQ.md`, `docs/WORKFLOW.md`, and `docs/examples/**/*.md`.
+
+| Term | Before (`origin/main`) | After | Delta | Rationale for remaining occurrences |
+| --- | ---: | ---: | ---: | --- |
+| `glass cockpit` | 2 | 1 | -1 | Remaining occurrence is an advanced/table label immediately translated as status/control-room events. |
+| `operator surface` | 9 | 7 | -2 | Remaining occurrences are parenthetical aliases after `status/approval channel`, `chat/status channel`, or equivalent plain wording. |
+| `runtime binding` | 3 | 3 | 0 | Remaining occurrences are in runtime-adapter contract contexts and are paired with `runtime adapter contract` or `external launch glue`. |
+| `dispatch receipt` | 1 | 0 | -1 | Removed from first-touch docs; advanced docs use adapter/handoff proof wording where needed. |
+| `harness skill` | 3 | 3 | 0 | Remaining occurrences are paired with `runtime command/mode`. |
+| `slice close` | 1 | 0 | -1 | Removed from first-touch phrasing in favor of completion/closed-work wording. |
+| `task bridge` | 1 | 1 | 0 | Remaining occurrence is a diagram alias after `task trackers/coordinators`. |
+| `evaluation envelope` | 0 | 0 | 0 | No first-touch occurrence. |
+| `audit envelope` | 0 | 0 | 0 | No first-touch occurrence. |
+| `run packet` | 32 | 16 | -16 | Remaining occurrences are immediate aliases for ``run.json` work package` or schema/history context. |
+
+README size: `10448` bytes on `origin/main` → `10342` bytes after this slice. The slice is comprehension-first, so README reduction is evidence, not a hard byte gate.
+
+## Outcome
+
+- README explains the optional runtime handoff as a `run.json` work package before using protocol language.
+- Minimum viable scaffold docs keep beginner setup focused on mission, plan, verification, evidence, and optional run packages.
+- Runtime docs preserve the boundary: Open Scaffold selects/packages/records evidence expectations; adapters/runtimes launch and execute outside core; humans approve merge/publish gates.
+- Source-checkout fallback commands remain in README and minimum docs because first-run tests assert them.
+- No schema fields, historical plans, runtime behavior, or compliance claims were changed.
+
+## Verification
+
+- Jargon before/after audit for first-touch docs → pass; recorded above.
+- `wc -c README.md` → `10342 README.md`.
+- Manual README → Quickstart read-through anchors → pass; npx path, source fallback, optional runtime package, and non-spawning boundary remain visible.
+- `npm run build` → pass.
+- `npm test` → 14 files / 124 tests passed.
+- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn before plan close.
+- `npm run osc -- verify` → pass.
+- `git diff --check` → pass.
+
+## Follow-up
+
+No immediate follow-up is required for this slice. Future docs simplification should be separate from runtime behavior, schema migrations, or launch/spawn implementation work.

--- a/.osc/releases/2026-05-17-vocabulary-compression-v2.md
+++ b/.osc/releases/2026-05-17-vocabulary-compression-v2.md
@@ -10,7 +10,7 @@ Open Scaffold first-touch and runtime docs now lead with plain-language explanat
 - Branch: `docs/vocabulary-compression-v2`
 - Kanban: `t_323cabd0`
 - Primary docs: `README.md`, `docs/MINIMUM_VIABLE_SCAFFOLD.md`, `docs/WHY_OPEN_SCAFFOLD.md`, `docs/WORKFLOW.md`, `docs/RUNTIME_SELECTION.md`, `docs/RUNTIME_PROFILES.md`, `docs/RUNTIME_BINDING_CONTRACT.md`, `docs/SPAWNING_BOUNDARY.md`, `docs/examples/`
-- Audit artifacts: `/tmp/osc040_jargon_before.txt`, `/tmp/osc040_jargon_after.txt`
+- Audit artifacts: `/tmp/osc040_jargon_before.txt`, `/tmp/osc040_jargon_after.txt`, `/tmp/osc040_jargon_after_fix.txt`
 
 ## Vocabulary audit
 
@@ -29,7 +29,7 @@ First-touch scope: `README.md`, `docs/MINIMUM_VIABLE_SCAFFOLD.md`, `docs/WHY_OPE
 | `audit envelope` | 0 | 0 | 0 | No first-touch occurrence. |
 | `run packet` | 32 | 16 | -16 | Remaining occurrences are immediate aliases for ``run.json` work package` or schema/history context. |
 
-README size: `10448` bytes on `origin/main` → `10342` bytes after this slice. The slice is comprehension-first, so README reduction is evidence, not a hard byte gate.
+README size: `10448` bytes on `origin/main` → `10360` bytes after this slice. The slice is comprehension-first, so README reduction is evidence, not a hard byte gate.
 
 ## Outcome
 
@@ -42,7 +42,7 @@ README size: `10448` bytes on `origin/main` → `10342` bytes after this slice. 
 ## Verification
 
 - Jargon before/after audit for first-touch docs → pass; recorded above.
-- `wc -c README.md` → `10342 README.md`.
+- `wc -c README.md` → `10360 README.md`.
 - Manual README → Quickstart read-through anchors → pass; npx path, source fallback, optional runtime package, and non-spawning boundary remain visible.
 - `npm run build` → pass.
 - `npm test` → 14 files / 124 tests passed.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-17: closed 040-vocabulary-compression-v2 — compressed first-touch vocabulary while preserving runtime boundaries
 - 2026-05-17: closed 039-session-2-aha-walkthrough — session-2 aha walkthrough shipped
 - 2026-05-17: closed 038-first-run-adoption-hardening — first-run adoption hardening shipped and npm package published
 - 2026-05-17: closed 037-audit-envelope-digest-manifest — added structure-only audit envelope digest manifest CLI mechanics

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ cd open-scaffold
 npm install
 npm run build
 node dist/cli.js init --tier min --target <your-project>
+cd <your-project>
 ```
 
 Tiers:

--- a/README.md
+++ b/README.md
@@ -10,26 +10,15 @@
 
 </div>
 
-Open Scaffold gives solo developers and small teams a lightweight way to keep AI coding work traceable. It stores mission, roadmap, plans, run packets, evidence, decisions, and handoff notes in the repo so humans and agents can see what was asked, changed, verified, and approved.
+Open Scaffold gives solo devs and small teams repo files and rules for AI coding work. It stores the mission, roadmap, plans, evidence, decisions, and handoff notes where humans and agents can see what was asked, changed, verified, and approved.
 
-Use it when AI work spans sessions, PRs, agents, or review gates — especially when you need proof without a documentation swamp.
+Use it when AI work spans sessions, PRs, agents, or review gates — when you need proof without a documentation swamp.
 
-> **What it is:** a repo-native source-of-truth protocol that packages work for humans, agents, coordinators, and runtime adapters.
+> **What it is:** a repo-native source of truth: files and rules that package work for humans, agents, coordinators, and runtime adapters.
 >
 > **What it is not:** an agent runtime, Discord bot, daemon, task database, model ranker, or code reviewer. Those live in tools you choose; the scaffold is what they read and write.
 
-The runtime handoff is intentionally simple:
-
-```text
-User selects runtime
-  -> Open Scaffold reads runtime profile
-  -> Open Scaffold creates the run packet
-  -> Adapter/coordinator launches the actual runtime
-  -> Runtime does the work
-  -> Evidence comes back into Open Scaffold
-```
-
-Plain English: Open Scaffold keeps the work truth in the repo. You choose an agent runtime. Open Scaffold packages the work. A runtime adapter executes it outside core. Evidence comes back. Humans approve.
+Runtime handoff is optional: Open Scaffold writes a `run.json` work package, an external adapter/runtime works outside core, evidence comes back, and humans approve. See [Step 5](#5-optional-package-a-plan-for-an-agentruntime).
 
 ---
 
@@ -57,7 +46,7 @@ Want the loop before the theory? Read [`docs/EXAMPLES.md`](docs/EXAMPLES.md#60-s
 Mission -> plan -> verification -> evidence/status
 ```
 
-For a non-recursive version of the same loop, read the [downstream walkthrough](docs/examples/downstream-walkthrough.md): a tiny shell CLI carried through mission, plan, run packet, evidence, close, and a day-2 resume check from repo files alone. For broader usage shapes — solo developer, team control-room, GitHub-only workflow, and runtime harness handoff — see the [examples index](docs/examples/README.md).
+For a full non-recursive loop, read the [downstream walkthrough](docs/examples/downstream-walkthrough.md): mission, plan, optional `run.json` package, evidence, close, and day-2 resume. Broader shapes live in the [examples index](docs/examples/README.md).
 
 ---
 
@@ -66,7 +55,7 @@ For a non-recursive version of the same loop, read the [downstream walkthrough](
 - **Direction:** `MISSION.md` and `ROADMAP.md` keep intent visible.
 - **Work specs:** `.osc/plans/` holds small, immutable plans with acceptance criteria.
 - **Change history:** amendments record scope changes without rewriting the original plan.
-- **Run packets:** `.osc/runs/<run_id>/run.json` packages a plan for a chosen runtime lane.
+- **Work packages (run packets):** `.osc/runs/<run_id>/run.json` packages a plan for a chosen runtime lane.
 - **Evidence:** `.osc/releases/` records what shipped, how it was verified, and what follows.
 - **Checks:** `./verify.sh` and `osc verify` catch stale state, broken evidence, and plan drift.
 - **Agent entry points:** `AGENTS.md` and `CLAUDE.md` tell coding agents how to operate without fresh explanations.
@@ -76,7 +65,7 @@ The loop:
 ```text
 Roadmap or issue
   -> plan
-  -> run packet / task id
+  -> run.json package / task id
   -> branch / PR
   -> verification evidence
   -> approval / amendment / next slice
@@ -86,16 +75,16 @@ Roadmap or issue
 
 ## Quickstart
 
-### 1. Initialize the scaffold tier you need
+### 1. Choose how many Open Scaffold files to add
 
-Use npm for the normal first run:
+Use npm for the normal first run. Use `--target .` to add scaffold files to the current repo, or `--target my-app` to create/init a project folder named `my-app`:
 
 ```bash
 npx open-scaffold init --tier min --target <your-project>
 cd <your-project>
 ```
 
-If you want to run from a source checkout instead:
+Source checkout fallback:
 
 ```bash
 git clone https://github.com/graphanov/open-scaffold open-scaffold
@@ -103,25 +92,17 @@ cd open-scaffold
 npm install
 npm run build
 node dist/cli.js init --tier min --target <your-project>
-cd <your-project>
 ```
 
 Tiers:
 
-- `min` — mission, rules, plan workflow/template, release evidence folder, and shell helpers.
-- `standard` — `min` plus README/roadmap, agent instructions, amendment helper, and core docs.
-- `max` — `standard` plus GitHub/glass-cockpit/runtime docs, delegation helper, and advanced `.osc/` folders.
+- `min` — smallest useful setup: mission, rules, plan template/workflow, evidence folder, verification, and close helper.
+- `standard` — recommended starter: `min` plus README/roadmap, agent instructions, amendment helper, and core docs.
+- `max` — advanced/team setup: `standard` plus GitHub, runtime, status/control-room docs, delegation helper, and advanced `.osc/` folders.
 
 The initializer is local-only: it does not require network access after the package is present, does not call GitHub or agent services, and refuses to overwrite existing files unless `--force` is supplied.
 
-If you prefer GitHub's template flow:
-
-```bash
-gh repo create <your-project> --template graphanov/open-scaffold --clone
-cd <your-project>
-```
-
-Or use GitHub's **Use this template** button.
+Prefer the npm path above for first use. If you prefer GitHub's template flow, use GitHub's **Use this template** button or `gh repo create <your-project> --template graphanov/open-scaffold --clone`.
 
 ### 2. Bootstrap the mission
 
@@ -139,7 +120,7 @@ If the goal is clear, tell your agent:
 Write a plan in .osc/plans/active/ for <task> using .osc/plans/handoff-template.md.
 ```
 
-If the goal is fuzzy, ask the agent to interview you first, then write the plan. Or copy the template manually:
+If the goal is fuzzy, ask the agent to interview you first, then write the plan. Fill the template with short bullets; the important parts are goal, acceptance criteria, and verification. Or copy the template manually:
 
 ```bash
 cp .osc/plans/handoff-template.md .osc/plans/active/my-first-task.md
@@ -153,25 +134,14 @@ cp .osc/plans/handoff-template.md .osc/plans/active/my-first-task.md
 
 Use `./verify.sh --standard` before calling a meaningful slice done.
 
-### 5. Select a runtime and create a run packet
+### 5. Optional: package a plan for an agent/runtime
 
-Open Scaffold core does not spawn agents. It packages work so a coordinator, adapter, or human can dispatch it.
-
-The runtime flow is:
-
-```text
-User selects runtime
-  -> Open Scaffold reads runtime profile
-  -> Open Scaffold creates the run packet
-  -> Adapter/coordinator launches the actual runtime
-  -> Runtime does the work
-  -> Evidence comes back into Open Scaffold
-```
+You can stop after verification and evidence. Only create a `run.json` work package — the run packet — when another tool, adapter, or human needs a structured handoff file. Open Scaffold still does not spawn agents.
 
 Example:
 
 ```bash
-npm run osc -- run .osc/plans/active/my-first-task.md \
+npx open-scaffold run .osc/plans/active/my-first-task.md \
   --task-id TASK-001 \
   --runtime omx \
   --workflow plan \
@@ -179,11 +149,11 @@ npm run osc -- run .osc/plans/active/my-first-task.md \
   --repo "$PWD"
 ```
 
-For custom runtimes, add a project-local profile in `.osc/runtimes/<id>.json`, then use `--runtime <id>`. Read this in layers:
+Here `--operator-surface` means the place humans see status and approvals, such as GitHub comments, chat, or a CLI. For custom runtimes, add a project-local profile in `.osc/runtimes/<id>.json`, then use `--runtime <id>`. Read this in layers:
 
 1. [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — choosing `--runtime` and `--workflow`;
 2. [`docs/RUNTIME_PROFILES.md`](docs/RUNTIME_PROFILES.md) — built-in and project-local runtime profiles;
-3. [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md) — what an adapter/coordinator must do after the packet exists.
+3. [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md) — what an adapter/coordinator must do after the `run.json` package exists.
 
 ---
 
@@ -193,8 +163,8 @@ Open Scaffold is not an agent runtime, Discord bot, PR reviewer, or task databas
 
 - **Coordinators / task state:** GitHub Issues, Linear/Jira, custom bots, or private deployment examples such as Hermes Kanban decide what should happen next.
 - **Runtime lanes:** Claude Code, Codex, Cursor, Gemini, OMC, OMX, Aider, or a human terminal can execute bounded work outside Open Scaffold core.
-- **Operator surfaces:** Discord, Slack, Telegram, GitHub comments, or CLI dashboards can show status and collect approvals.
-- **Core truth:** mission, plans, amendments, run packets, evidence, decisions, and release notes stay in the repo.
+- **Status / approval channels (operator surfaces):** Discord, Slack, Telegram, GitHub comments, or CLI dashboards can show status and collect approvals.
+- **Core truth:** mission, plans, amendments, `run.json` work packages, evidence, decisions, and release notes stay in the repo.
 
 Full map: [`docs/OPEN_SCAFFOLD_SYSTEM.md`](docs/OPEN_SCAFFOLD_SYSTEM.md), [`docs/TASK_RUN_MODEL.md`](docs/TASK_RUN_MODEL.md), [`docs/GITHUB_WORKFLOW.md`](docs/GITHUB_WORKFLOW.md), and [`docs/REFERENCE_TRUTH.md`](docs/REFERENCE_TRUTH.md).
 
@@ -210,7 +180,7 @@ Open Scaffold is useful when work needs to survive context loss:
 - multi-agent handoffs where chat history is not enough;
 - projects where "done" needs acceptance criteria and verification, not vibes.
 
-It is overkill for one-off scripts, disposable prototypes, or tasks that fit in a single clean session. The scaffold is the substrate; it does not replace SOC 2, ISO, or formal audit tooling — it gives those processes durable repo artifacts to point at.
+It is overkill for one-off scripts, disposable prototypes, or tasks that fit in a single clean session. The scaffold is the repo foundation; it does not replace SOC 2, ISO, or formal audit tooling — it gives those processes durable repo artifacts to point at.
 
 ---
 
@@ -233,8 +203,8 @@ Near-term roadmap work should improve clarity, adapter evidence, and validation.
 - [`.osc/RULES.md`](.osc/RULES.md) — compact operating rules.
 - [`.osc/plans/WORKFLOW.md`](.osc/plans/WORKFLOW.md) — how plans move through backlog, active, done, and blocked.
 - [`docs/WORKFLOW.md`](docs/WORKFLOW.md) — phase-to-tool guide.
-- [`docs/SLICE_CLOSE_PROTOCOL.md`](docs/SLICE_CLOSE_PROTOCOL.md) — evidence-backed slice closure.
-- [`docs/GLASS_COCKPIT_PROTOCOL.md`](docs/GLASS_COCKPIT_PROTOCOL.md) — chat/control-room surfaces.
+- [`docs/SLICE_CLOSE_PROTOCOL.md`](docs/SLICE_CLOSE_PROTOCOL.md) — evidence-backed completion / slice closure.
+- [`docs/GLASS_COCKPIT_PROTOCOL.md`](docs/GLASS_COCKPIT_PROTOCOL.md) — chat/control-room status surfaces.
 - [`docs/FAQ.md`](docs/FAQ.md) — deeper explanations.
 - [`docs/REFERENCE_TRUTH.md`](docs/REFERENCE_TRUTH.md) — labels for public, private, future, and adapter tool references.
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -6,11 +6,11 @@ For the current OMC/OMX runtime selection surface and the minimum refreshed-adap
 
 This page uses precise language:
 
-- **Coordinators/orchestrators** decide what should happen next and may maintain or bridge package/task state.
+- **Coordinators/orchestrators** — controllers/deciders — decide what should happen next and may maintain or bridge package/task state.
 - **Agents** perform work directly when bounded by the Open Scaffold contract.
-- **Runtime harnesses** extend a base agent with workflow modes such as teams, planning, persistence, and verification.
-- **Task/state bridges** track live operational state.
-- **Operator surfaces** expose status and human interaction.
+- **Runtime harnesses** — workflow wrappers around agents — extend a base agent with workflow modes such as teams, planning, persistence, and verification.
+- **Task/state bridges** — work queues/status boards — track live operational state.
+- **Operator surfaces** — chats/dashboards for human interaction — expose status and approvals.
 
 For the full taxonomy, see [`docs/OPEN_SCAFFOLD_SYSTEM.md`](OPEN_SCAFFOLD_SYSTEM.md). For public/private/future tool availability labels, see [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md).
 
@@ -50,9 +50,9 @@ OMC is a **runtime lane / adapter candidate** for Claude Code execution/orchestr
 
 Responsibilities when used with Open Scaffold:
 
-- Execute Claude Code-native workflows against a bounded Open Scaffold plan or run packet.
+- Execute Claude Code-native workflows against a bounded Open Scaffold plan or `run.json` work package (run packet).
 - Use workflows such as `/deep-interview`, `/ralplan`, `/team`, `/ralph`, and `/ultrawork` where appropriate.
-- Keep OMC runtime state forensic unless promoted into `.osc/runs/`, docs, issues, or PRs.
+- Keep OMC runtime state forensic — useful for investigation, not durable project truth — unless promoted into `.osc/runs/`, docs, issues, or PRs.
 - Return evidence and status back to the Open Scaffold source-of-truth chain.
 
 Use OMC when the chosen execution lane is Claude Code plus OMC workflow skills.
@@ -66,9 +66,9 @@ OMX is a **runtime lane / adapter candidate** for Codex execution/orchestration.
 
 Responsibilities when used with Open Scaffold:
 
-- Execute Codex-native planning, team, persistence, and verification workflows against a bounded Open Scaffold plan or run packet.
+- Execute Codex-native planning, team, persistence, and verification workflows against a bounded Open Scaffold plan or `run.json` work package (run packet).
 - Use workflows such as `$deep-interview`, `$ralplan`, `$team`, `$ralph`, `$ultrawork`, and `$ultragoal` where appropriate.
-- Keep OMX runtime state forensic unless promoted into `.osc/runs/`, docs, issues, or PRs.
+- Keep OMX runtime state forensic — useful for investigation, not durable project truth — unless promoted into `.osc/runs/`, docs, issues, or PRs.
 - Return evidence and status back to the Open Scaffold source-of-truth chain.
 
 Use OMX when the chosen execution lane is Codex plus OMX workflow skills.
@@ -91,12 +91,12 @@ The preferred bridge is a task/run split:
 
 ```text
 Task system owns task_id and live lifecycle.
-Open Scaffold run packet owns run_id, executor choice, context package, bindings, and evidence paths.
+Open Scaffold `run.json` work package owns run_id, executor choice, context package, bindings, and evidence paths.
 Harness/runtime owns execution while alive.
 Operator surface mirrors/questions/approves through a binding.
 ```
 
-Use `osc run <plan> --task-id <id> --executor <lane> --harness-skill <skill> ...` to create a runtime-neutral `.osc/runs/<run_id>/run.json` package. The core still does not spawn; adapters/coordinators consume that package according to the runtime binding contract. See [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md) and [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
+Use `osc run <plan> --task-id <id> --executor <lane> --harness-skill <skill> ...` to create a runtime-neutral `.osc/runs/<run_id>/run.json` package. The core still does not spawn; adapters/coordinators consume that package according to the runtime adapter contract (runtime binding contract). See [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md) and [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
 
 ## Event/session routing glue
 
@@ -107,7 +107,7 @@ It may:
 - bind a chat thread or session id to a canonical `run_id`
 - forward active-session and completion events
 - route blockers/questions to Discord or another cockpit
-- attach session/log/status metadata to a task or run packet
+- attach session/log/status metadata to a task or `run.json` work package
 
 It should not:
 
@@ -118,7 +118,7 @@ It should not:
 - become the task database
 - replace Open Scaffold/GitHub/task-system evidence
 
-## Operator surfaces / glass cockpits
+## Operator surfaces / glass cockpits — human dashboards/control rooms
 
 Operator surfaces display and route human interaction:
 
@@ -156,7 +156,7 @@ OMC = Claude Code execution/orchestration lane.
 OMX = Codex execution/orchestration lane.
 Event routers = session/status transport.
 Task bridges = live operational state.
-Operator surfaces = glass cockpit.
+Operator surfaces = glass cockpit / human control room.
 GitHub = public/versioned implementation layer.
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@ Questions that did not fit in the main README but are still worth answering.
 
 ### Is this useful for consulting, client delivery, or compliance/audit work?
 
-> Yes, with caveats. Consulting and client delivery benefit because the mission, plans, amendments, evidence receipts, and slice-close protocol make it possible to answer "what did you actually do, why, and how do you know it worked?" months later without reconstructing a chat log. Compliance and audit work benefit because every meaningful change traces back to a plan, acceptance criteria, verification commands, and an approval decision — all in version control. **What this is not:** a substitute for SOC 2, ISO 27001, HIPAA, GDPR, or any formal compliance regime. The scaffold gives those processes durable, reviewable repo artifacts to point at; it does not implement controls, encryption, access policy, or auditor relationships. Use it as evidence substrate, not as the compliance program.
+> Yes, with caveats. Consulting and client delivery benefit because the mission, plans, amendments, evidence receipts, and evidence-backed close protocol make it possible to answer "what did you actually do, why, and how do you know it worked?" months later without reconstructing a chat log. Compliance and audit work benefit because every meaningful change traces back to a plan, acceptance criteria, verification commands, and an approval decision — all in version control. **What this is not:** a substitute for SOC 2, ISO 27001, HIPAA, GDPR, or any formal compliance regime. The scaffold gives those processes durable, reviewable repo artifacts to point at; it does not implement controls, encryption, access policy, or auditor relationships. Use it as evidence substrate, not as the compliance program.
 
 ### When is Open Scaffold overkill?
 
@@ -14,7 +14,7 @@ Questions that did not fit in the main README but are still worth answering.
 
 ### Can I run this for 5 hours straight and come back to a finished product?
 
-> No. Anyone who says their framework does that is selling you something. What you *can* do: write a plan, hand it to an orchestrator or runtime harness — for example a private coordinator deployment such as Hermes/Claw, OMC with `/autopilot`/`/ralph` for Claude Code, or OMX with `$team`/`$ralph`/`$ultrawork` for Codex — and come back to mostly-done work that traces back to your acceptance criteria. These are runtime lanes or private deployment examples, not Open Scaffold dependencies; see [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md). The difference the scaffold makes is **recoverability** — because the plan is on disk, you can read what the agent did, compare against the ACs, and know exactly where to resume. Without it, a 5-hour run is a 5-hour black box.
+> No. Anyone who says their framework does that is selling you something. What you *can* do: write a plan, give it to an outside tool or runner, and come back to work that still traces back to your acceptance criteria. Examples include a private coordinator deployment such as Hermes/Claw, OMC with `/autopilot`/`/ralph` for Claude Code, or OMX with `$team`/`$ralph`/`$ultrawork` for Codex. These are runtime lanes or private deployment examples, not Open Scaffold dependencies; see [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md). The difference the scaffold makes is **recoverability** — because the plan is on disk, you can read what the agent did, compare against the ACs, and know exactly where to resume. Without it, a 5-hour run is a 5-hour black box.
 
 ### Does this reduce token usage / cost?
 

--- a/docs/MINIMUM_VIABLE_SCAFFOLD.md
+++ b/docs/MINIMUM_VIABLE_SCAFFOLD.md
@@ -1,6 +1,6 @@
 # Minimum Viable Scaffold
 
-Open Scaffold can look larger than it is because this repository also contains the product's own roadmap, tests, examples, release notes, and dogfood history. A fresh downstream project does not need to understand or keep every product-repo artifact on day one.
+Open Scaffold can look larger than it is because this repository also contains the product's own roadmap, tests, examples, release notes, and dogfood history. A fresh project does not need to understand or keep every artifact from this Open Scaffold repo on day one.
 
 The minimum viable scaffold is the smallest repo state that lets a human and an agent answer:
 
@@ -13,7 +13,7 @@ What evidence proves it closed?
 
 ## The five-step adoption path
 
-Start by generating the tier that fits the repo with npm:
+Start by adding the amount of scaffold your repo needs with npm. Use `--target .` for the current repo, or `--target my-app` for a project folder:
 
 ```bash
 npx open-scaffold init --tier min --target <repo>
@@ -31,19 +31,21 @@ node dist/cli.js init --tier min --target <repo>
 # or: --tier standard / --tier max
 ```
 
-Use `min` for the smallest durable loop, `standard` for the recommended day-one repo, and `max` only when the project already needs GitHub/runtime/glass-cockpit protocol docs. The command writes only local files and refuses to overwrite existing files by default.
+Use `min` for the smallest durable loop, `standard` for the recommended day-one repo, and `max` only when the project already needs GitHub, runtime, or status/control-room protocol docs. The command writes only local files and refuses to overwrite existing files by default.
 
 Then follow the loop:
 
 1. **Define mission** — run `./bootstrap.sh` or edit `MISSION.md` until the project-specific mission is real.
-2. **Create one active plan** — copy `.osc/plans/handoff-template.md` into `.osc/plans/active/<slug>.md` and fill the seven sections.
+2. **Create one active plan** — copy `.osc/plans/handoff-template.md` into `.osc/plans/active/<slug>.md` and fill short bullets for goal, acceptance criteria, and verification.
 3. **Execute and verify** — make the change, run the project test/check, then run `./verify.sh --standard`.
-4. **Record evidence** — add a short `.osc/releases/<date>-<slug>.md` note with summary, traceability, verification, and outcome.
+4. **Record evidence** — add a short `.osc/releases/<date>-<slug>.md` note saying what changed, which plan it closed, what command/test ran, and the result.
 5. **Close the plan** — run `./close.sh <slug> --message "<what shipped>"` so the plan moves to `done/` and `MISSION.md` is stamped.
 
 The payoff appears in the next session. If someone opens the repo later with no chat history, they can read `MISSION.md`, `.osc/plans/active/`, `.osc/plans/done/`, and `.osc/releases/` to see what the project is, whether work is still active, what was verified, and whether the next action is to continue, stop, or write a new plan.
 
 Everything else is optional until the project needs it.
+
+For day one, keep five things in view: `MISSION.md`, one active plan in `.osc/plans/active/`, a verification command, one evidence note in `.osc/releases/`, and `close.sh` to move the plan to `done/`.
 
 ## Core vs optional artifacts
 
@@ -81,14 +83,14 @@ Everything else is optional until the project needs it.
 | `.osc/plans/handoff-template.md` | Required | Seven-section plan template. | Keep. |
 | `.osc/plans/WORKFLOW.md` | Required | Folder state machine. | Keep. |
 | `.osc/releases/` | Required | Evidence/release notes. | Keep `README.md`; add notes when slices close. |
-| `.osc/runs/` | Optional / forensic | Runtime/run packets and logs. | Usually ignored or empty until a run packet is created. Do not treat raw runs as public truth. |
+| `.osc/runs/` | Optional / debug-only until promoted | Runtime logs and `run.json` work packages (run packets). | Usually ignored or empty until a run package is created. Do not treat raw runs as public truth. |
 | `.osc/research/` | Optional / decision support | Research, drafts, issue imports, private-to-public staging. | Not required for first use; promote only curated conclusions. |
 | `.osc/specs/` | Optional | Larger specs before they become plans. | Use only when a plan is too small for the requirement shape. |
 | `.osc/state/` | Optional / local runtime state | Local state for tools. | Keep ignored unless explicitly promoted. |
 
-## Fresh downstream state vs maintainer repo state
+## Fresh project state vs Open Scaffold repo state
 
-A blank downstream project should not inherit Open Scaffold's own product history as if it were the user's project.
+A blank project should not inherit Open Scaffold's own product history as if it were the user's project.
 
 Use this rule:
 
@@ -97,11 +99,11 @@ Template structure can be copied.
 Product history must be reset, removed, or clearly labeled as example material.
 ```
 
-For a fresh downstream repo:
+For a fresh project:
 
-- `MISSION.md` should describe the downstream project.
+- `MISSION.md` should describe your project.
 - `.osc/plans/active/`, `done/`, `backlog/`, and `blocked/` should not contain Open Scaffold product plans unless they are explicitly examples.
-- `.osc/releases/` should not contain Open Scaffold's release history as live downstream truth.
+- `.osc/releases/` should not contain Open Scaffold's release history as live truth for your project.
 - `.osc-dev/` should not exist.
 - `examples/` may contain examples, but example artifacts must be clearly labeled and not confused with active project state.
 
@@ -112,10 +114,10 @@ The lifecycle smoke at `examples/lifecycle-e2e-smoke/` is intentionally an examp
 | Protocol or concept | Status | Use when |
 |---|---:|---|
 | Amendments | Recommended once plans are committed | New information changes scope or acceptance criteria. |
-| Run packets | Optional / advanced | A harness, coordinator, or human lane needs a bounded execution package. |
+| Work packages (run packets) | Optional / advanced | A harness, coordinator, or human lane needs a bounded `run.json` handoff package. |
 | Execution strategy in plans | Optional | Work can be decomposed into dependent/parallel groups. |
-| Glass cockpit events | Optional / integration | Discord/Slack/Telegram/GitHub comments need structured status and approval events. |
-| Runtime binding contract | Optional / adapter-specific | OMC, OMX, Claude Code, Codex, or another runtime consumes run packets. |
+| Status/control-room events (glass cockpit events) | Optional / integration | Discord/Slack/Telegram/GitHub comments need structured status and approval events. |
+| Runtime adapter contract (runtime binding contract) | Optional / adapter-specific | OMC, OMX, Claude Code, Codex, or another runtime consumes `run.json` work packages. |
 | GitHub issue/PR traceability | Recommended for public/versioned work | The work should be reviewed or reconstructed through GitHub. |
 | `osc` CLI | Optional / richer tooling | Node is available and the project wants parsed status/run artifacts or tiered initialization. Shell scripts remain the day-zero floor. |
 | `.osc/research/` | Optional / decision support | Research needs to be saved before a curated decision/release note exists. |

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -26,10 +26,10 @@ Open Scaffold core owns the portable project substrate:
 - `ROADMAP.md` — directional backlog and milestone story.
 - `.osc/plans/` — immutable plans, amendments, stage-folder status.
 - `.osc/specs/` — durable specs and context packs.
-- `.osc/runs/` — generated run packets, prompt bundles, execution evidence.
+- `.osc/runs/` — generated `run.json` work packages (run packets), prompt bundles, execution evidence.
 - `docs/` — decisions, workflow standards, examples, operator guidance.
 - `docs/GLASS_COCKPIT_PROTOCOL.md` — runtime-neutral event vocabulary for status, blockers, questions, approvals, evidence receipts, PR links, and build-in-public streams.
-- `docs/RUNTIME_BINDING_CONTRACT.md` — binding lifecycle and responsibilities for OMC/OMX/plain-agent/human lanes that consume run packets outside core.
+- `docs/RUNTIME_BINDING_CONTRACT.md` — binding lifecycle and responsibilities for OMC/OMX/plain-agent/human lanes that consume `run.json` work packages (run packets) outside core.
 - `docs/SLICE_CLOSE_PROTOCOL.md` — evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance.
 - `verify.sh` / `osc verify` — methodology compliance checks.
 - `.github/` templates — issue and PR traceability for GitHub-centered workflows.
@@ -53,9 +53,9 @@ These tools may read roadmap items, create plans, create/live-update tasks, choo
 
 A coordinator should dispatch **bounded packages** into execution lanes rather than letting multiple systems mutate the same worktree and truth state at once.
 
-### 3. Runtime harnesses
+### 3. Runtime harnesses — workflow wrappers around base agents
 
-Runtime harnesses extend a base agent with workflow modes, teams, persistence, planning, or verification. Bindings that launch those harnesses from Open Scaffold run packets are defined in [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
+Runtime harnesses extend a base agent with workflow modes, teams, persistence, planning, or verification. Bindings that launch those harnesses from Open Scaffold `run.json` work packages (run packets) are defined in [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
 
 They are not the same class as orchestrators like Hermes or Claw/OpenClaw.
 
@@ -90,7 +90,7 @@ It can provide Codex-native capabilities such as:
 
 Use OMX when the execution lane is Codex plus OMX-specific planning/execution workflows.
 
-### 4. Task and state bridges
+### 4. Task and state bridges — work queues/status boards
 
 Task systems hold live operational state: what is ready, running, blocked, under review, or done.
 
@@ -126,9 +126,9 @@ Examples:
 - gateway adapters
 - tmux/session notification hooks
 
-Transport can post active-session updates, blockers, and completion events into a glass cockpit. It should not become canonical task state or perform planning/execution itself.
+Transport can post active-session updates, blockers, and completion events into a glass cockpit — an operator dashboard/control room. It should not become canonical task state or perform planning/execution itself.
 
-### 6. Operator surfaces / glass cockpits
+### 6. Operator surfaces / glass cockpits — human dashboards/control rooms
 
 Operator surfaces let humans and teams see, steer, approve, or unblock work.
 
@@ -148,7 +148,7 @@ The glass cockpit can run in several modes:
 - **Build-in-public room:** public or semi-public devlog channel.
 - **Stakeholder room:** curated client/product updates.
 
-Operator surfaces are **not canonical truth**. They should link back to roadmap items, task IDs, run packets, evidence, issues, branches, and PRs. Their event vocabulary is documented in [`docs/GLASS_COCKPIT_PROTOCOL.md`](GLASS_COCKPIT_PROTOCOL.md).
+Operator surfaces are **not canonical truth**. They should link back to roadmap items, task IDs, `run.json` work packages (run packets), evidence, issues, branches, and PRs. Their event vocabulary is documented in [`docs/GLASS_COCKPIT_PROTOCOL.md`](GLASS_COCKPIT_PROTOCOL.md).
 
 ### 7. GitHub/public versioning layer
 
@@ -207,7 +207,7 @@ A clean coordinator-to-runtime flow looks like this:
 ```text
 User selects runtime
   -> Open Scaffold reads runtime profile
-  -> Open Scaffold creates the run packet
+  -> Open Scaffold creates the run.json work package (run packet)
   -> Adapter/coordinator launches the actual runtime
   -> Runtime does the work
   -> Evidence comes back into Open Scaffold
@@ -242,7 +242,7 @@ ROADMAP.md
   -> GitHub issue or live task
   -> .osc plan / amendment
   -> runtime/harness handoff when needed
-  -> .osc run packet / evidence
+  -> .osc run.json work package / evidence
   -> verification gate
   -> PR / release note
   -> roadmap update

--- a/docs/RUNTIME_BINDING_CONTRACT.md
+++ b/docs/RUNTIME_BINDING_CONTRACT.md
@@ -1,10 +1,10 @@
 # Runtime Binding Contract
 
-This is the execution boundary layer. Runtime selection chooses a lane; runtime profiles describe that lane; the binding contract says what an external adapter/coordinator must do with the run packet.
+This is the execution boundary layer: the rules for what external launchers may do after Open Scaffold creates a package. Runtime selection chooses a lane; runtime profiles describe that lane; the binding contract says what an external adapter/coordinator must do with the `run.json` package (run packet).
 
 Named harnesses in this contract, including OMC and OMX, are runtime lanes or adapter candidates rather than Open Scaffold core dependencies. Use [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md) for public/private/future reference labels.
 
-Open Scaffold core creates bounded run packages. Runtime bindings — execution adapters for a chosen lane — consume those packages and launch outside core. This document defines the contract between the repo-native Open Scaffold package and any coordinator, adapter, harness, agent, or human lane that executes it.
+Open Scaffold core creates bounded run packages. Runtime bindings — external launch glue/adapters for a chosen lane — consume those packages and launch outside core. This document defines the contract between the repo-native Open Scaffold package and any coordinator, adapter, harness, agent, or human lane that executes it.
 
 ## Executive rule
 
@@ -16,11 +16,11 @@ Evidence returns.
 Postflight closes.
 ```
 
-`spawning: false` in `run.json` is not a missing feature. It is the boundary that keeps generic Open Scaffold portable.
+`spawning: false` in `run.json` means core did not launch a real agent/process. It is not a missing feature. It is the boundary that keeps generic Open Scaffold portable.
 
 ## What is a runtime binding?
 
-A runtime binding is the glue that turns a run packet — a repo-written execution package — into a concrete execution attempt.
+A runtime binding is the external launch glue that turns a run packet — a repo-written `run.json` execution package — into a concrete execution attempt.
 
 Examples:
 
@@ -40,7 +40,7 @@ A binding is not the Open Scaffold core. It may be a separate repo, plugin, bot,
 | Coordinator/task bridge | selecting work, choosing lane, assigning owner, retry/block/review state | final evidence by itself |
 | Runtime binding | translating package to a specific launch, attaching runtime metadata, returning artifacts | project truth, merge authority unless granted |
 | Harness/agent/human lane | execution while alive | canonical task database, approval gate |
-| Operator surface | status/questions/approval messages | source of truth |
+| Operator surface — chat/dashboard for status, questions, and approvals | status/questions/approval messages | source of truth |
 | GitHub/evidence | public review, CI, release, proof | runtime session truth |
 
 ## Binding lifecycle
@@ -49,7 +49,7 @@ A binding is not the Open Scaffold core. It may be a separate repo, plugin, bot,
 1. Select task or plan
 2. Create or read .osc/runs/<run_id>/run.json
 3. Validate packageQuality.executable
-4. Validate executor lane and harness skill
+4. Validate executor lane and harness skill — runtime command/mode
 5. Check safety and isolation requirements
 6. Launch or hand off to selected lane outside core
 7. Attach runtime bindings back to run metadata/evidence
@@ -60,9 +60,9 @@ A binding is not the Open Scaffold core. It may be a separate repo, plugin, bot,
 12. Close, retry, amend, block, or create next slice
 ```
 
-## Required input: run packet
+## Required input: `run.json` package (run packet)
 
-A binding should expect a run packet like:
+A binding should expect a `run.json` package (run packet) like:
 
 ```json
 {
@@ -142,11 +142,11 @@ If the package is not executable, do not improvise implementation. Route to clar
 
 ## Binding responsibilities
 
-For the detailed spawning/adapter boundary, dispatch receipt shape, authority vocabulary, and OMX v0.17.0 Hermes MCP bridge evidence, see [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md). This contract remains the lifecycle-level agreement; the boundary document defines the safer next-step vocabulary before any real `osc spawn` implementation.
+For the detailed spawning/adapter boundary, dispatch receipt shape (handoff proof), authority vocabulary (permission words), and OMX v0.17.0 Hermes MCP bridge evidence, see [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md). This contract remains the lifecycle-level agreement; the boundary document defines the safer next-step vocabulary before any real `osc spawn` implementation.
 
 A binding should:
 
-1. Read the run packet and generated prompts.
+1. Read the `run.json` package (run packet) and generated prompts.
 2. Refuse unsupported lanes, unsafe packages, and blocking open questions.
 3. Preserve the commit policy.
 4. Create or select an isolated worktree/session when needed.
@@ -160,14 +160,14 @@ A binding should:
    - log path;
    - operator thread/comment ID;
    - PR number if opened.
-7. Emit glass-cockpit events for status, blockers, questions, approval requests, completion, and evidence receipts when an operator surface is bound.
+7. Emit glass-cockpit events — operator-dashboard/control-room messages — for status, blockers, questions, approval requests, completion, and evidence receipts when an operator surface is bound.
 8. Route human answers by `question_id -> run_id`.
 9. Promote final artifacts and evidence to `.osc/runs`, tracked evidence docs, PRs, issues, or release notes.
 10. Leave approval/merge/release to the configured gate.
 
 ## Audit and evaluation envelope responsibilities
 
-Open Scaffold core defines the audit/evaluation envelope shapes; runtime bindings and adapters fill the execution-specific parts of those envelopes.
+Open Scaffold core defines audit/evaluation envelope shapes — structured records for integrity reconstruction and acceptance-criteria evidence review; runtime bindings and adapters fill the execution-specific parts of those envelopes.
 
 A binding should return enough structured information for postflight to build evaluation and audit records:
 

--- a/docs/RUNTIME_HARNESS_DISPATCH.md
+++ b/docs/RUNTIME_HARNESS_DISPATCH.md
@@ -1,6 +1,6 @@
 # Runtime Harness Dispatch Pattern
 
-Open Scaffold core defines the portable contract for semi-autonomous work. It does **not** own the local control plane that launches agents. A coordinator or runtime-specific binding consumes `.osc/runs/<run_id>/run.json` and dispatches the selected harness.
+Open Scaffold core defines the portable contract for semi-autonomous work. It does **not** own the local launcher/controller that starts agents. A coordinator or runtime-specific binding — external launch glue — consumes `.osc/runs/<run_id>/run.json` and dispatches the selected harness, meaning the workflow wrapper around the chosen agent.
 
 This page captures a **private deployment example**: an owner-local Command Center used Hermes Kanban -> OMX `$ralplan` to prove the dispatch shape. It translates that private dogfood pattern into the public Open Scaffold model; the private deployment is not required to adopt Open Scaffold. The detailed adapter/binding responsibilities live in [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md), and reference labels live in [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md).
 
@@ -8,9 +8,9 @@ This page captures a **private deployment example**: an owner-local Command Cent
 
 ```text
 Open Scaffold packages.
-A task bridge coordinates.
-A harness executes.
-An operator surface observes.
+A task bridge — external work queue/status board — coordinates.
+A harness — workflow wrapper around an agent — executes.
+An operator surface — chat/dashboard for humans — observes.
 GitHub publishes.
 Evidence proves.
 ```
@@ -26,7 +26,7 @@ flowchart TD
     E --> F["6. Evidence + postflight\nlogs, outputs, verification, operator decision"]
     F --> G["7. Publication\nbranch / PR / CI / Codex review / release note"]
 
-    D -. "status/questions only" .-> H["Glass cockpit\nDiscord / Slack / Telegram / GitHub comments"]
+    D -. "status/questions only" .-> H["Glass cockpit / control room\nDiscord / Slack / Telegram / GitHub comments"]
     H -. "question_id -> run_id" .-> D
 
     X["Private deployment example\nowner-local bridge proved:\nKanban -> OMX -> run evidence"] --> Y["You are here in Open Scaffold\nproductizing the public contract/docs"]
@@ -51,10 +51,10 @@ Current state:
 
 | Layer | Owns | Examples | Must not own |
 |---|---|---|---|
-| Open Scaffold core | repo-native contract, run packet, evidence locations, task/run identity | `.osc/plans`, `.osc/runs`, `osc run`, docs, PR templates | live task lifecycle, runtime auth, agent spawning |
+| Open Scaffold core | repo-native contract, `run.json` work package (run packet), evidence locations, task/run identity | `.osc/plans`, `.osc/runs`, `osc run`, docs, PR templates | live task lifecycle, runtime auth, agent spawning |
 | Task bridge / coordinator | operational state and dispatch decision | Hermes Kanban, GitHub Issues bot, Linear/Jira bridge, local queue | final evidence or runtime internals |
 | Runtime harness | actual planning/build/review loop while alive | OMX, OMC, Claude Code, Codex CLI, human lane | canonical task database or commit authority |
-| Operator surface | visibility, questions, approvals | Discord, Slack, Telegram, GitHub comments, CLI dashboard | source of truth |
+| Operator surface — chat/dashboard for humans | visibility, questions, approvals | Discord, Slack, Telegram, GitHub comments, CLI dashboard | source of truth |
 | GitHub/publication | versioned implementation and review | branch, PR, CI, Codex connector review, release | runtime session truth |
 
 ## Canonical public flow
@@ -112,7 +112,7 @@ A coordinator or runtime-specific binding should follow the contract in [`docs/R
 
 1. Read `.osc/runs/<run_id>/run.json`.
 2. Refuse dispatch unless `packageQuality.executable` is true.
-3. Validate executor lane and harness skill.
+3. Validate executor lane and harness skill — runtime command/mode.
 4. Create an isolated runtime session or worktree when needed.
 5. Launch the selected harness with the generated prompt/artifact bundle.
 6. Attach runtime bindings back to the run record:
@@ -154,7 +154,7 @@ Avoid:
 - putting private deployment state, Hermes Kanban state, Discord bot state, or owner-specific auth setup inside Open Scaffold core;
 - making Discord the task database;
 - letting OMX/OMC runtime state replace `.osc/runs` evidence;
-- dispatching a harness from vague prose without a run packet;
+- dispatching a harness from vague prose without a `run.json` work package (run packet);
 - letting a chat reply answer a question without `question_id -> run_id` correlation;
 - treating `spawning: false` as a limitation instead of the core boundary.
 
@@ -166,6 +166,6 @@ Open Scaffold should productize the method, not any private cockpit. The public 
 Open Scaffold core = WHAT/WHERE/PROOF
 Coordinator/adapter = WHEN/WHO/LAUNCH
 Harness = HOW TO EXECUTE
-Operator surface = HUMAN CONTROL GLASS
+Operator surface = HUMAN CONTROL GLASS (chat/dashboard for status and approvals)
 GitHub = PUBLIC VERSIONED REVIEW
 ```

--- a/docs/RUNTIME_PROFILES.md
+++ b/docs/RUNTIME_PROFILES.md
@@ -2,13 +2,13 @@
 
 Runtime profiles are the configuration layer behind `--runtime`. They make runtime selection declarative and extensible without making Open Scaffold core an installer, marketplace, or process supervisor.
 
-A profile is data. It tells Open Scaffold how a selected runtime lane should be recorded in a run packet. A coordinator or adapter may later consume that run packet and launch the real runtime outside core.
+A runtime profile is a data record behind `--runtime`. It tells Open Scaffold how a selected execution target, or lane, should be recorded in a `run.json` package (run packet). A coordinator or adapter may later consume that package and launch the real runtime outside core.
 
 ```text
-User selects runtime
-  -> Open Scaffold reads runtime profile
-  -> Open Scaffold creates the run packet
-  -> Adapter/coordinator launches the actual runtime
+User selects a runtime / outside tool
+  -> Open Scaffold reads its runtime profile
+  -> Open Scaffold creates the run.json work package (run packet)
+  -> Adapter/coordinator launches the actual runtime outside core
   -> Runtime does the work
   -> Evidence comes back into Open Scaffold
 ```
@@ -17,7 +17,7 @@ Layer map:
 
 - [`RUNTIME_SELECTION.md`](RUNTIME_SELECTION.md) — user-facing `--runtime` / `--workflow` choice.
 - `RUNTIME_PROFILES.md` — profile schema, built-ins, and project-local `.osc/runtimes/*.json`.
-- [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) — adapter/coordinator responsibilities after the packet exists.
+- [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) — adapter/coordinator responsibilities after the `run.json` package exists.
 
 ## Commands
 
@@ -99,12 +99,12 @@ Minimal project-local example:
 - `id`: lowercase profile id used by `--runtime <id>`.
 - `displayName`: human-readable name.
 - `lane`: one of `omc-claude`, `omx-codex`, `plain-agent`, `human`, or `custom`.
-- `status`: one of `builtin`, `adapter-candidate`, or `user-defined`.
+- `status`: one of `builtin`, `adapter-candidate` (possible external adapter, not certified core integration), or `user-defined`.
 - `description`: short public-safe description.
 
 ### Workflow mapping
 
-`workflows` maps Open Scaffold workflow names to the runtime/harness command token that an adapter should use.
+`workflows` maps Open Scaffold workflow names to the runtime/harness command token — the runtime command or mode — that an adapter should use.
 
 Supported workflow keys are:
 
@@ -132,13 +132,13 @@ In v0:
 - `launch.spawning` must be `false`.
 - Open Scaffold may display `install.humanHint` or `launch.commandTemplate`, but it does not execute them.
 - Profiles cannot grant commit, push, merge, or publish authority.
-- Runtime-local logs/session state are forensic until promoted into `.osc/runs`, tracked evidence docs, GitHub artifacts, or release notes.
+- Runtime-local logs/session state are forensic — useful for investigation, not durable project truth — until promoted into `.osc/runs`, tracked evidence docs, GitHub artifacts, or release notes.
 
 This is deliberate. Open Scaffold's job is to preserve the source-of-truth chain and package dispatchable intent. Runtime-specific adapters own installation, authentication, session lifecycle, tmux/process management, and provider-specific launch details.
 
 ## OMC, OMX, GSD, and custom runtimes
 
-OMC and OMX are built-in adapter-candidate profiles because Open Scaffold already has a run-packet selection surface and conformance fixture coverage for those lanes.
+OMC and OMX are built-in adapter-candidate profiles — selectable lanes with dry-run/conformance fixture coverage, not certified launch integrations — because Open Scaffold already has a run-packet selection surface and conformance fixture coverage for those lanes.
 
 GSD and other frameworks can be represented as project-local `user-defined` profiles today. They should not be described as certified or built-in integrations until an adapter has passed the conformance expectations and produced public evidence.
 

--- a/docs/RUNTIME_SELECTION.md
+++ b/docs/RUNTIME_SELECTION.md
@@ -1,17 +1,17 @@
 # Runtime selection
 
-Runtime selection is the user-facing layer of Open Scaffold's runtime story. It answers one question: **which lane should this run packet target?**
+Runtime selection is the user-facing layer for choosing an execution target. It answers one question: **which execution target should this `run.json` package — the run packet — be prepared for?**
 
 ```text
-User selects runtime
-  -> Open Scaffold reads runtime profile
-  -> Open Scaffold creates the run packet
-  -> Adapter/coordinator launches the actual runtime
+User selects a runtime / outside tool
+  -> Open Scaffold reads its runtime profile
+  -> Open Scaffold creates the run.json work package (run packet)
+  -> Adapter/coordinator launches the actual runtime outside core
   -> Runtime does the work
   -> Evidence comes back into Open Scaffold
 ```
 
-This page covers the first two Open Scaffold steps: `--runtime`, `--workflow`, and the run-packet fields they create. For profile schema and custom project-local runtimes, read [`RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md). For the external adapter/coordinator contract, read [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
+This page covers the first two Open Scaffold steps: choosing `--runtime` / `--workflow`, then writing those choices into the `run.json` package. For profile schema and custom project-local runtimes, read [`RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md). For the external adapter/coordinator contract, read [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
 
 ## Product intent
 
@@ -29,12 +29,12 @@ and get a concrete `.osc/runs/<run_id>/run.json` package that records:
 
 - selected runtime preset;
 - selected workflow;
-- executor lane;
-- harness skill;
-- repo/worktree/branch binding;
+- executor lane — the execution target;
+- harness skill — the runtime command or mode;
+- repo/worktree/branch binding — the checkout/branch the adapter may use;
 - package quality;
 - evidence/approval expectations;
-- `executor.spawning: false` until an external adapter/coordinator launches it.
+- `executor.spawning: false` — core will not launch the agent/process until an external adapter/coordinator launches it.
 
 The selected runtime is dispatchable by an adapter, but Open Scaffold core still does not launch Claude Code, Codex, OMC, OMX, tmux, or any provider process by itself.
 
@@ -64,13 +64,13 @@ For `omc` and `omx`, `--workflow` defaults to `plan` so `--runtime omx` and `--r
 ## Boundary
 
 ```text
-Open Scaffold core = select + package + prove
+Open Scaffold core = select + package + record evidence expectations
 Runtime adapter     = translate + launch + return receipt/evidence
 Runtime harness     = execute while alive
 Operator            = approve merge/publish gates
 ```
 
-Open Scaffold core owns the run-packet contract. Runtime-specific adapters own process launch, authentication, tmux/session lifecycle, hooks, and runtime logs. Runtime state is forensic until promoted into `.osc/runs`, tracked evidence docs, PRs, issues, or release notes. This boundary is the same one enforced by runtime profiles and the binding contract; this page only describes the selection surface.
+Open Scaffold core owns the run-packet contract. Runtime-specific adapters own process launch, authentication, tmux/session lifecycle, hooks, and runtime logs. Runtime state is forensic — useful for investigation, not durable project truth — until promoted into `.osc/runs`, tracked evidence docs, PRs, issues, or release notes. This boundary is the same one enforced by runtime profiles and the binding contract; this page only describes the selection surface.
 
 ## Adapter checklist
 
@@ -82,7 +82,7 @@ A runtime adapter that consumes Open Scaffold packages should:
 - reject packages where `packageQuality.executable !== true` or blockers are present;
 - preserve `commitPolicy` and human approval gates;
 - keep receipts, artifacts, and evidence repo-local;
-- write an `open-scaffold.dispatch-receipt.v1` dispatch receipt;
+- write an `open-scaffold.dispatch-receipt.v1` dispatch receipt — repo-local proof of handoff/invocation;
 - return completion, blocker, verification, and review evidence into the Open Scaffold/GitHub chain;
 - never claim completion from runtime-local state alone.
 

--- a/docs/SPAWNING_BOUNDARY.md
+++ b/docs/SPAWNING_BOUNDARY.md
@@ -1,18 +1,18 @@
 # Spawning Boundary and Runtime Adapter Contract
 
-Open Scaffold Milestone 16 asks whether core should remain non-spawning, add thin adapter invocation, move execution into adapter packages, or eventually grow a native runtime. This document records the current boundary decision and the contract shape for the next safe step. Public/private tool labels are defined in [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md).
+Open Scaffold Milestone 16 asks whether core should remain non-spawning, add thin adapter invocation, move execution into adapter packages, or eventually grow a native runtime. Here, `spawning` means launching real agent/runtime processes. This document records the current boundary decision and the contract shape for the next safe step. Public/private tool labels are defined in [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md).
 
 ## Current decision
 
 Open Scaffold core should **not** implement real autonomous runtime spawning yet.
 
-Core should first define the adapter/runtime boundary, dispatch receipt, authority vocabulary, and evidence expectations. Real spawning belongs in runtime-specific adapters or a future explicitly governed runtime product.
+Core should first define the adapter/runtime boundary, dispatch receipt (handoff proof), authority vocabulary (permission words), and evidence expectations. Real spawning belongs in runtime-specific adapters or a future explicitly governed runtime product.
 
 ```text
 Open Scaffold core packages work.
 A coordinator chooses the execution lane.
-A bridge/binding translates the package.
-A runtime/harness executes in its own bounded environment.
+A bridge/binding — external translation/launch glue — translates the package.
+A runtime/harness — the agent environment or workflow wrapper — executes in its own bounded environment.
 Evidence returns to the repo/task/PR chain.
 Human approval and merge authority stay explicit.
 ```
@@ -40,11 +40,11 @@ If Open Scaffold core owns those too early, it becomes a runtime by drift. The c
 
 | Layer | Owns | Must not silently own |
 |---|---|---|
-| Open Scaffold core | mission, roadmap, plans, run packets, evidence schema, approval/commit policy, verification expectations | runtime-specific launch mechanics, provider auth, live process control |
+| Open Scaffold core | mission, roadmap, plans, `run.json` work packages (run packets), evidence schema, approval/commit policy, verification expectations | runtime-specific launch mechanics, provider auth, live process control |
 | Coordinator / task bridge | intake, task selection, operator Q&A, lane choice, retry/block/review state | final evidence by itself |
 | Runtime adapter / bridge | translating `.osc` run packets into runtime-specific invocation, returning status/artifacts/evidence | canonical project truth, uncontrolled repo mutation |
 | Runtime / harness | execution, local session state, tool use, local logs, generated artifacts | approval authority or canonical task state unless explicitly granted |
-| Operator surface | visible status, blockers, questions, approvals | source of truth |
+| Operator surface — chat/dashboard for status and approvals | visible status, blockers, questions, approvals | source of truth |
 | GitHub / repo evidence | durable review, CI, release, audit references | raw runtime transcript as canonical truth |
 
 ## Adapter/runtime contract vocabulary
@@ -69,7 +69,7 @@ commit_policy: string
 
 The adapter may attach runtime-specific metadata, but the portable contract should remain small enough that Claude Code, Codex, OpenCode, OMX, OMC, Ouroboros, GSD, human/manual lanes, or future runtimes can implement it without contaminating core.
 
-## Authority and sandbox vocabulary
+## Authority and sandbox vocabulary — permission/isolation words
 
 Open Scaffold should not adopt Claude, Codex, OpenCode, or OMX permission strings as its lingua franca. It should define its own small policy vocabulary and let adapters translate.
 
@@ -101,7 +101,7 @@ human_approval_required for publication
 
 ## Dispatch receipt
 
-A dispatch receipt proves what was invoked, with what authority, from what package.
+A dispatch receipt is repo-local proof of what was invoked, with what authority, from what package.
 
 Minimum receipt fields:
 

--- a/docs/TASK_RUN_MODEL.md
+++ b/docs/TASK_RUN_MODEL.md
@@ -1,6 +1,6 @@
 # Task, Run, and Operator-Surface Model
 
-Open Scaffold separates product intent, operational task state, execution attempts, runtime sessions, and chat/operator surfaces. This prevents a Discord thread, terminal transcript, or runtime state folder from becoming the only place the system remembers what is true.
+Open Scaffold separates product intent, operational task state, execution attempts, runtime sessions, and chat/operator surfaces — the chats, dashboards, comments, or CLIs where humans watch and reply. This prevents a Discord thread, terminal transcript, or runtime state folder from becoming the only place the system remembers what is true.
 
 ## Core rule
 
@@ -8,11 +8,11 @@ Open Scaffold separates product intent, operational task state, execution attemp
 Task owns intent/lifecycle.
 Run owns one execution attempt.
 Harness owns execution while alive.
-Operator surface: visibility/questions/approvals.
+Operator surface: visibility/questions/approvals in a chat, dashboard, comment thread, or CLI.
 Cockpit event: replaceable visible message that references task/run/question/evidence IDs.
 Evidence owns proof.
-Evaluation envelope owns AC-to-evidence judgment and improvement routing.
-Audit envelope owns integrity-oriented reconstruction.
+Evaluation envelope owns AC-to-evidence judgment and improvement routing — a post-run evidence-review record.
+Audit envelope owns integrity-oriented reconstruction — the evidence map needed to reconstruct what happened.
 ```
 
 A chat thread may be extremely useful. It is not the canonical task.
@@ -35,7 +35,7 @@ A task can have many runs.
 
 ### `run_id`
 
-One concrete execution attempt against a task or plan. In Open Scaffold core, a run packet lives under:
+One concrete execution attempt against a task or plan. In Open Scaffold core, a run packet — the `run.json` work package — lives under:
 
 ```text
 .osc/runs/<run_id>/
@@ -75,11 +75,11 @@ A thread can be replaced, deleted, or unavailable without destroying task/run re
 
 ### Runtime binding
 
-A runtime binding consumes `run.json`, validates package quality, launches or hands off to the selected lane outside Open Scaffold core, attaches runtime metadata, and returns evidence. The binding contract is documented in [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
+A runtime binding — external launch glue — consumes `run.json`, validates package quality, launches or hands off to the selected lane outside Open Scaffold core, attaches runtime metadata, and returns evidence. The binding contract is documented in [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
 
 ### Event / cockpit bindings
 
-Cockpit events are status, blocker, question, answer, approval, completion, evidence, PR, release, nudge, or cancellation messages posted to an operator surface. They should carry canonical IDs rather than becoming canonical themselves. See [`docs/GLASS_COCKPIT_PROTOCOL.md`](GLASS_COCKPIT_PROTOCOL.md).
+Cockpit events — operator-dashboard messages — are status, blocker, question, answer, approval, completion, evidence, PR, release, nudge, or cancellation messages posted to an operator surface. They should carry canonical IDs rather than becoming canonical themselves. See [`docs/GLASS_COCKPIT_PROTOCOL.md`](GLASS_COCKPIT_PROTOCOL.md).
 
 ### Runtime bindings
 
@@ -96,7 +96,7 @@ log_paths
 artifact_paths
 ```
 
-Runtime state is live/forensic until promoted into the run packet, evidence, docs, issue, PR, or release note. Bindings that launch OMC, OMX, plain-agent, or human lanes should follow [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
+Runtime state is live/forensic — useful for investigation, not durable project truth — until promoted into the run packet, evidence, docs, issue, PR, or release note. Bindings that launch OMC, OMX, plain-agent, or human lanes should follow [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md).
 
 ## Minimal run record
 
@@ -227,9 +227,9 @@ Kanban/GitHub/CLI/chat creates or selects task_id
 - Roadmap: direction and invariants.
 - Plan/spec/package: executable slice contract.
 - Task system: operational lifecycle.
-- Run packet: exact attempt contract and bindings.
+- Run packet: exact attempt contract and bindings, stored as a `run.json` work package.
 - Runtime harness: execution while alive.
-- Operator surface: visibility/questions/approvals.
+- Operator surface: visibility/questions/approvals in a chat, dashboard, comment thread, or CLI.
 - GitHub PR/release: versioned publication.
 - Evidence receipt / postflight: proof, approval strength, correction routing, and next-slice inheritance.
 - Evaluation envelope: per-acceptance-criterion judgment, feedback capture, confidence, and improvement route.

--- a/docs/WHY_OPEN_SCAFFOLD.md
+++ b/docs/WHY_OPEN_SCAFFOLD.md
@@ -29,7 +29,7 @@ Open Scaffold makes the repository the shared memory. Chat, terminals, agent ses
 ```mermaid
 flowchart LR
     M["MISSION.md\n(what we are building)"] --> P[".osc/plans/...\n(plan: goal, constraints,\nacceptance criteria,\nverification)"]
-    P --> R[".osc/runs/<run_id>/run.json\n(run packet: plan bound to\ntask, branch, surface,\nevidence path)"]
+    P --> R[".osc/runs/<run_id>/run.json\n(run packet: work package bound to\ntask, branch, status channel,\nevidence path)"]
     R --> X["Branch / PR\n(implementation)"]
     X --> V["./verify.sh\n(methodology check)"]
     V --> E[".osc/releases/...\n(release / evidence note)"]
@@ -44,21 +44,21 @@ Each artefact is a small file. Together they form a chain that survives context 
 
 ## Where the scaffold stops
 
-Open Scaffold is the substrate; it is not the runtime. Coordinators, runtimes, operator surfaces, and GitHub all sit around the substrate and read or write to it.
+Open Scaffold is the repo foundation; it is not the runtime. Coordinators, runtimes, status/approval channels, and GitHub all sit around that foundation and read or write to it.
 
 ```mermaid
 flowchart TB
     subgraph CORE["Open Scaffold core (this repo protocol)"]
         M2["mission / roadmap"]
         P2["plans / amendments"]
-        R2["run packets"]
+        R2["run.json work packages\n(run packets)"]
         V2["verification"]
         E2["evidence / releases"]
     end
 
-    COORD["Task bridges / coordinators\n(GitHub Issues, Linear/Jira,\ncustom bots, private examples)"] -. "writes plans, reads evidence" .-> CORE
-    RT["Runtime harnesses\n(Claude Code, Codex, Cursor,\nGemini, OMC, OMX, human)"] -. "executes bounded work" .-> CORE
-    GS["Operator surfaces\n(Discord, Slack, Telegram,\nGitHub comments, CLI)"] -. "shows status, asks questions" .-> CORE
+    COORD["Task trackers/coordinators\n(task bridges: GitHub Issues, Linear/Jira,\ncustom bots, private examples)"] -. "writes plans, reads evidence" .-> CORE
+    RT["Runtime wrappers / runners\n(Claude Code, Codex, Cursor,\nGemini, OMC, OMX, human)"] -. "executes bounded work" .-> CORE
+    GS["Status / approval channels\n(operator surfaces: Discord, Slack, Telegram,\nGitHub comments, CLI)"] -. "shows status, asks questions" .-> CORE
     GH["GitHub\n(issues, PRs, CI, releases)"] -. "publishes implementation" .-> CORE
 
     classDef core fill:#DBEAFE,stroke:#2563EB,color:#0f172a;

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -2,7 +2,7 @@
 
 A phase-to-tool reference for agent-orchestrated development. This file is the operational reference; `README.md` is the landing page. When in doubt about which tool to reach for, start here.
 
-Named coordinators, harnesses, and operator surfaces in this guide are examples. Use [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md) to distinguish public examples, private deployment examples, runtime lanes, adapter candidates, and operator surfaces.
+Named coordinators, harnesses, and status/approval channels (operator surfaces) in this guide are examples. Use [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md) to distinguish public examples, private deployment examples, runtime lanes, adapter candidates, and operator surfaces.
 
 ## Development phases
 
@@ -18,15 +18,15 @@ Ask structured questions until the goal, constraints, and acceptance criteria ar
 >
 > **With OMC harness:** use OMC `/deep-interview` from a Claude Code/OMC session, then promote the clarified result into the Open Scaffold plan/spec chain.
 >
-> **With OMX harness:** use OMX `$deep-interview` from a Codex/OMX session, then promote the clarified result into the Open Scaffold plan/spec chain. Runtime-only question/session state remains forensic until promoted.
+> **With OMX harness:** use OMX `$deep-interview` from a Codex/OMX session, then promote the clarified result into the Open Scaffold plan/spec chain. Runtime-only question/session state remains debug-only until promoted into repo evidence.
 
 ### 2. Plan (when the task is non-trivial)
 
 Write a plan file in `.osc/plans/active/` using the 7-section schema in `.osc/plans/handoff-template.md`. The plan must include acceptance criteria — testable bullets that define success. For risky or multi-file work, get the plan reviewed before executing. See `.osc/plans/WORKFLOW.md` for the stage-folder lifecycle and `.osc/RULES.md` for non-negotiable principles.
 
-> **With OMC harness:** Claude Code/OMC planning flows can use `/ralplan` against an Open Scaffold plan or run packet.
+> **With OMC harness:** Claude Code/OMC planning flows can use `/ralplan` against an Open Scaffold plan or `run.json` work package (run packet).
 >
-> **With OMX harness:** Codex/OMX planning flows can use `$ralplan` against an Open Scaffold plan or run packet.
+> **With OMX harness:** Codex/OMX planning flows can use `$ralplan` against an Open Scaffold plan or `run.json` work package (run packet).
 
 ### 3. Execute (build it)
 
@@ -48,7 +48,7 @@ Run `./verify.sh` for a zero-dependency methodology compliance report (mission d
 
 ### 5. Publish/review (when code or public docs change)
 
-Open a traceable GitHub PR for meaningful changes. The PR should link issue/task, plan/spec, run packet, verification, evidence, and review gates. If the Codex connector is enabled, trigger review by opening the PR for review, marking a draft ready, or commenting `@codex review`. See `docs/GITHUB_WORKFLOW.md`.
+Open a traceable GitHub PR for meaningful changes. The PR should link issue/task, plan/spec, `run.json` work package when delegated, verification, evidence, and review gates. If the Codex connector is enabled, trigger review by opening the PR for review, marking a draft ready, or commenting `@codex review`. See `docs/GITHUB_WORKFLOW.md`.
 
 ### 6. Capture amendments (when you "get smarter")
 
@@ -78,7 +78,7 @@ There is no automatic router between tools. You, the human, decide based on the 
 | Stuck or uncertain | Second opinion | A different model's perspective breaks deadlocks |
 | Public/versioned change | GitHub PR loop | CI, Codex review, and human approval gate merges |
 
-> **Runtime split:** Open Scaffold is the runtime-neutral contract. Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, or custom scripts can act as orchestrators/agents. OMC is a Claude Code harness; OMX is a Codex harness. Operator surfaces such as Discord are glass cockpits, not canonical state.
+> **Runtime split:** Open Scaffold is the runtime-neutral contract. Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, or custom scripts can act as orchestrators/agents. OMC is a Claude Code harness; OMX is a Codex harness. Status/approval channels such as Discord are operator surfaces — visible control rooms, not canonical state.
 
 ### Delegation decision tree
 
@@ -93,8 +93,8 @@ When your plan has multiple tasks, use this decision tree to decide how to execu
    - **No →** Safe to parallelize. Continue to step 3.
 
 3. **Do you have a capable runtime/agent?** (Can it read plan files and use tools?)
-   - **Yes, with OMC harness →** Use Claude Code/OMC-specific workflows such as `/team`, `/ultrawork`, or `/ralph` against the Open Scaffold plan/run packet.
-   - **Yes, with OMX harness →** Use Codex/OMX-specific workflows such as `$team`, `$ralph`, `$ultrawork`, or `$ralplan` against the Open Scaffold plan/run packet.
+   - **Yes, with OMC harness →** Use Claude Code/OMC-specific workflows such as `/team`, `/ultrawork`, or `/ralph` against the Open Scaffold plan or `run.json` work package.
+   - **Yes, with OMX harness →** Use Codex/OMX-specific workflows such as `$team`, `$ralph`, `$ultrawork`, or `$ralplan` against the Open Scaffold plan or `run.json` work package.
    - **Yes, plain Claude Code/Codex or similar →** The agent reads the Execution Strategy section and describes the parallelism opportunity. You decide how to act on it.
    - **No agent, or local LLM →** Run `./delegate.sh <plan-path>` to generate actionable prompts you can paste into separate terminal sessions.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -9,9 +9,9 @@ The four modes:
 3. [GitHub-only workflow](#3-github-only-workflow) — issue → plan → PR → evidence with no chat coordinator.
 4. [Runtime harness handoff](#4-runtime-harness-handoff) — packaging work for an external runtime lane to execute.
 
-If you want one complete non-recursive example first, start with [`downstream-walkthrough.md`](downstream-walkthrough.md). It shows the full mission → plan → run packet → evidence → close loop on a tiny shell CLI that is not Open Scaffold itself, then shows how a second session reconstructs the current state from files alone.
+If you want one complete non-recursive example first, start with [`downstream-walkthrough.md`](downstream-walkthrough.md). It shows the full mission → plan → optional `run.json` work package → evidence → close loop on a tiny shell CLI that is not Open Scaffold itself, then shows how a second session reconstructs the current state from files alone.
 
-Open Scaffold core ships the protocol, the run packet schema, the verification scripts, and dry-run/conformance examples. It does not spawn agents, run a coordinator daemon, or own runtime credentials. Each mode below stays inside that boundary.
+Open Scaffold core ships the protocol, the `run.json` work-package schema (run packet schema), the verification scripts, and dry-run/conformance examples. It does not spawn agents, run a coordinator daemon, or own runtime credentials. Each mode below stays inside that boundary.
 
 For the labels used when these examples mention external coordinators, harnesses, or surfaces, see [`REFERENCE_TRUTH.md`](../REFERENCE_TRUTH.md).
 
@@ -70,8 +70,8 @@ A team or solo operator who wants to keep all coordination on GitHub: Issues for
 
 Reading path:
 
-- [`docs/GITHUB_WORKFLOW.md`](../GITHUB_WORKFLOW.md) — canonical chain from `ROADMAP.md` item or Issue to plan, run packet, branch, PR, CI/review, merge, and release/evidence note.
-- [`docs/SLICE_CLOSE_PROTOCOL.md`](../SLICE_CLOSE_PROTOCOL.md) — evidence-backed slice closure when the only operator surface is a PR thread.
+- [`docs/GITHUB_WORKFLOW.md`](../GITHUB_WORKFLOW.md) — standard chain from `ROADMAP.md` item or Issue to plan, `run.json` work package when delegated, branch, PR, CI/review, merge, and release/evidence note.
+- [`docs/SLICE_CLOSE_PROTOCOL.md`](../SLICE_CLOSE_PROTOCOL.md) — evidence-backed completion / slice closure when the only status channel is a PR thread.
 
 Minimal chain:
 
@@ -86,7 +86,7 @@ GitHub Issue
 
 Acceptance criteria live in the plan; the PR description references the plan and the evidence note. CI runs `./verify.sh` so methodology drift is mechanical, not subjective.
 
-What this mode does **not** require: a chat operator surface, a coordinator service, or a runtime harness. An agent that opens PRs from a branch is one valid executor; a human terminal is another.
+What this mode does **not** require: a chat/status channel (operator surface), a coordinator service, or a runtime harness. An agent that opens PRs from a branch is one valid executor; a human terminal is another.
 
 ---
 
@@ -98,11 +98,11 @@ Reading path:
 
 - [`docs/RUNTIME_SELECTION.md`](../RUNTIME_SELECTION.md) — choosing `--runtime` and `--workflow`.
 - [`docs/RUNTIME_PROFILES.md`](../RUNTIME_PROFILES.md) — built-in and project-local runtime profile metadata.
-- [`docs/RUNTIME_BINDING_CONTRACT.md`](../RUNTIME_BINDING_CONTRACT.md) — lifecycle/responsibilities for any binding that consumes a run packet.
+- [`docs/RUNTIME_BINDING_CONTRACT.md`](../RUNTIME_BINDING_CONTRACT.md) — lifecycle/responsibilities for any binding that consumes a `run.json` work package (run packet).
 - [`runtime-profiles/company-review-bot.json`](runtime-profiles/company-review-bot.json) — example project-local profile.
 - [`runtime-binding-conformance/README.md`](runtime-binding-conformance/README.md) — fake/local adapter conformance fixture.
 
-### Generate a run packet
+### Generate a `run.json` work package (run packet)
 
 From a repository checkout with dependencies installed:
 
@@ -130,7 +130,7 @@ node docs/examples/runtime-binding-dry-run.mjs "$RUN_JSON"
 Expected result:
 
 - exits `0` for an executable package;
-- prints run id, plan path, executor lane, optional harness skill, operator surface, repo/worktree/branch, and commit policy;
+- prints run id, plan path, executor lane, optional runtime command/mode (`harness skill`), status channel (`operator surface`), repo/worktree/branch, and commit policy;
 - states that no runtime was launched;
 - exits nonzero if the packet is not executable, has blockers, requests unsupported lanes, or violates the `spawning: false` boundary.
 
@@ -153,6 +153,6 @@ Expected result:
 
 ### Boundary
 
-These examples are intentionally a **dry-run/conformance consumer**, not a launcher. Real runtime bindings, coordinators, bots, or humans may use the same `run.json` fields to launch work outside Open Scaffold core, attach runtime metadata, return evidence, and request approval.
+These examples are intentionally a **dry-run/conformance consumer**, not a launcher. Real runtime bindings — external launch glue — coordinators, bots, or humans may use the same `run.json` fields to launch work outside Open Scaffold core, attach runtime metadata, return evidence, and request approval.
 
 The fixtures are available from the repository checkout. They are not currently advertised as packaged npm executables or a stable adapter SDK.

--- a/docs/examples/downstream-walkthrough.md
+++ b/docs/examples/downstream-walkthrough.md
@@ -15,7 +15,7 @@ No private credentials, no private coordinator, no chat surface, no runtime harn
 The walkthrough moves through Open Scaffold's canonical identity chain on Tiny Notes:
 
 ```text
-mission -> plan -> implementation -> verification -> run packet -> evidence -> close -> session-2 resume
+mission -> plan -> implementation -> verification -> optional run.json work package -> evidence -> close -> session-2 resume
 ```
 
 Every step has a concrete file, a concrete command, and an expected observable. The artifacts already live under `examples/lifecycle-e2e-smoke/` in this repo — you can read them in place, or copy them into a clean temp directory and run the loop yourself.
@@ -173,9 +173,9 @@ Expected: exit `0`, `0 fail`.
 
 ---
 
-## 5. Run packet — bind the plan to a specific execution attempt
+## 5. Optional `run.json` work package — bind the plan to one execution attempt
 
-A run packet is the optional record that says "this plan, this attempt, this lane." On Tiny Notes, where the work is one human in one terminal, the run packet may feel ceremonial. Generate it once anyway so you can see the shape — the same shape is what an external coordinator, bot, or harness adapter consumes when work spans agents and surfaces.
+A run packet is the optional `run.json` handoff file that says "this plan, this attempt, this lane." On Tiny Notes, where the work is one human in one terminal, the run packet may feel ceremonial. Generate it once anyway so you can see the shape — the same shape is what an external coordinator, bot, or harness adapter consumes when work spans agents and surfaces.
 
 From the Open Scaffold repo root, generate a packet for the in-repo Tiny Notes fixture:
 
@@ -219,7 +219,7 @@ verify the behavior with a local shell test.
 ## Traceability
 - Plan: `.osc/plans/active/001-add-note-command.md` (moves to `done/` on close).
 - Task: `tiny-notes:001-add-note-command`.
-- Run packet: `.osc/runs/<run_id>/run.json` (optional for solo work).
+- `run.json` work package / run packet: `.osc/runs/<run_id>/run.json` (optional for solo work).
 - Branch / PR: <link if applicable>.
 
 ## Verification
@@ -350,7 +350,7 @@ Open Scaffold is genuinely useful when work needs to outlive a single session:
 
 - **Multi-session AI-assisted development.** The plan/evidence trail survives context loss, so the next agent or human can pick up without renegotiating intent.
 - **Small-team or client delivery.** "What was the goal, how was it verified, who approved it?" is answered in files instead of chat history.
-- **Multi-agent handoff.** A plan plus run packet plus evidence note is enough for a second lane to continue work without inheriting hallucinated assumptions.
+- **Multi-agent handoff.** A plan plus optional `run.json` work package plus evidence note is enough for a second lane to continue work without inheriting hallucinated assumptions.
 - **Light audit and compliance contexts.** Mission, plans, amendments, and evidence give an auditor a readable trail without standing up heavier tooling.
 - **AI work that needs "done" to mean something.** Acceptance criteria + verification + evidence is harder to fake than "looks good."
 
@@ -373,4 +373,4 @@ A reasonable rule of thumb: adopt Open Scaffold when at least one of {multi-sess
 - [`docs/E2E_SMOKE.md`](../E2E_SMOKE.md) — the automated smoke that exercises this fixture mechanically.
 - [`docs/RUNTIME_BINDING_CONTRACT.md`](../RUNTIME_BINDING_CONTRACT.md) — the contract any external runtime, coordinator, or harness uses when consuming `.osc/runs/<run_id>/run.json`.
 - [`docs/WORKFLOW.md`](../WORKFLOW.md) — phase-to-tool guide.
-- [`docs/SLICE_CLOSE_PROTOCOL.md`](../SLICE_CLOSE_PROTOCOL.md) — what makes a slice closed instead of merely merged.
+- [`docs/SLICE_CLOSE_PROTOCOL.md`](../SLICE_CLOSE_PROTOCOL.md) — what makes a work slice truly closed instead of merely merged.

--- a/docs/examples/runtime-binding-conformance/README.md
+++ b/docs/examples/runtime-binding-conformance/README.md
@@ -1,12 +1,12 @@
 # Runtime Binding Conformance Fixture
 
-This fixture demonstrates the smallest safe adapter contract: a fake/local adapter consumes a run packet, writes a dispatch receipt and evidence artifact, and exits without launching a real runtime.
+This fixture demonstrates the smallest safe adapter contract: a fake/local adapter consumes a `run.json` work package (run packet), writes an adapter receipt file (`dispatch-receipt.json`) and evidence artifact, and exits without launching a real runtime.
 
 It is not a production adapter SDK. It is a deterministic conformance target for future adapter packages.
 
 ## Run the fixture
 
-Given a run packet at `.osc/runs/<run_id>/run.json`:
+Given a `run.json` work package (run packet) at `.osc/runs/<run_id>/run.json`:
 
 ```bash
 node docs/examples/runtime-binding-conformance/fake-local-adapter.mjs \
@@ -36,8 +36,8 @@ Future adapters can use this fixture as a minimum behavior target before adding 
 
 Supported conformance lanes:
 
-- `plain-agent` with no harness skill;
-- `human` / `manual` with no harness skill;
+- `plain-agent` with no runtime command/mode (`harness skill`);
+- `human` / `manual` with no runtime command/mode (`harness skill`);
 - `omc-claude` with `/deep-interview`, `/ralplan`, `/team`, `/ralph`, or `/ultrawork`;
 - `omx-codex` with `$deep-interview`, `$ralplan`, `$team`, `$ralph`, `$ultrawork`, or `$ultragoal`.
 


### PR DESCRIPTION
## Summary

- compresses first-touch Open Scaffold vocabulary so README/minimum/workflow/example docs lead with plain-language terms before protocol terms
- keeps `run packet` only as an alias for a `run.json` work package in first-touch docs
- preserves runtime/core boundaries: Open Scaffold selects/packages/records expectations; adapters/runtimes launch and execute outside core; humans approve gates
- closes plan `040-vocabulary-compression-v2` and adds release/evidence note with before/after jargon counts

## Traceability

- Plan: `.osc/plans/done/040-vocabulary-compression-v2.md`
- Evidence: `.osc/releases/2026-05-17-vocabulary-compression-v2.md`
- Kanban: `t_323cabd0`
- Branch: `docs/vocabulary-compression-v2`

## Vocabulary audit

First-touch scope: `README.md`, `docs/MINIMUM_VIABLE_SCAFFOLD.md`, `docs/WHY_OPEN_SCAFFOLD.md`, `docs/FAQ.md`, `docs/WORKFLOW.md`, and `docs/examples/**/*.md`.

- `run packet`: 32 -> 16
- `operator surface`: 9 -> 7
- `glass cockpit`: 2 -> 1
- `dispatch receipt`: 1 -> 0
- `slice close`: 1 -> 0
- `runtime binding`: 3 -> 3, now paired with runtime-adapter/external-launch wording
- `harness skill`: 3 -> 3, now paired with runtime command/mode wording
- `task bridge`: 1 -> 1, diagram alias only
- `evaluation envelope`: 0 -> 0
- `audit envelope`: 0 -> 0
- README size: 10448 -> 10360 bytes

Remaining first-touch occurrences are immediate aliases or advanced/example labels with plain-language wording nearby.

## Verification

- `wc -c README.md` -> `10360 README.md`
- Jargon before/after audit -> recorded in release note
- Manual README -> Quickstart read-through -> pass
- `npm run build` -> pass
- `npm test` -> 14 files / 124 tests passed
- `./verify.sh --strict` -> 10 pass / 0 fail / 0 warn
- `npm run osc -- verify` -> pass
- `git diff --check` -> pass

## Out of scope

- no schema field renames
- no runtime/spawn behavior changes
- no historical plan or release-note rewrites
- no compliance/certification claims

Merge remains owner-gated.
