### PR TITLE
Define adapter conformance contract v1

### DIFF
--- a/.osc/plans/done/041-adapter-conformance-contract-v1.md
+++ b/.osc/plans/done/041-adapter-conformance-contract-v1.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+done
 
 ## Context
 

--- a/.osc/releases/2026-05-18-adapter-conformance-contract-v1.md
+++ b/.osc/releases/2026-05-18-adapter-conformance-contract-v1.md
@@ -1,0 +1,36 @@
+# Release / Evidence Note: adapter conformance contract v1
+
+## Summary
+
+Open Scaffold now has a sharper adapter conformance contract for the no-spawn runtime boundary. The fake/local conformance fixture proves the structural path from `run.json` package consumption to dispatch receipt creation and deterministic evidence writing, without launching a runtime or claiming task correctness.
+
+## Traceability
+
+- Plan: `.osc/plans/done/041-adapter-conformance-contract-v1.md`
+- Branch: `runtime/adapter-conformance-contract-v1`
+- PR: `#47` — https://github.com/graphanov/open-scaffold/pull/47
+- Kanban: `t_11706cc9`
+- Primary docs: `docs/RUNTIME_BINDING_CONTRACT.md`, `docs/SPAWNING_BOUNDARY.md`, `docs/RUNTIME_SELECTION.md`, `docs/RUNTIME_PROFILES.md`, `docs/examples/runtime-binding-conformance/README.md`
+- Fixture/test: `docs/examples/runtime-binding-conformance/fake-local-adapter.mjs`, `tests/runtime-binding-conformance.test.ts`
+
+## Outcome
+
+- Canonicalized `open-scaffold.dispatch-receipt.v1` as the dispatch receipt schema and `dispatch-receipt.json` as the default receipt file.
+- Clarified that runtime profiles are declarative data, adapters are external consumers/launch glue, and real runtime launch remains outside Open Scaffold core.
+- Tightened the fake/local fixture to validate runtime selection, workflow/harness matching, required acceptance criteria and verification steps, safe receipt/evidence paths, and no-spawn behavior.
+- Added deterministic evidence content linked to the dispatch receipt and explicit no-runtime/no-network/no-credentials claims.
+- Kept OMC/OMX/Claude/Codex/OpenCode wording at lane/profile/adapter-candidate level, not runtime-support endorsement.
+
+## Verification
+
+- `npm test -- tests/runtime-binding-conformance.test.ts tests/runtime-binding-dry-run.test.ts` → 24 pass.
+- `npm run build` → pass.
+- `npm test` → 14 files / 129 tests passed.
+- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn.
+- `git diff --check` → pass.
+- Boundary scan for new positive `certified integration`, `officially supported`, `spawning: true`, or `spawned: true` claims → pass.
+
+## Follow-up
+
+- `042-reference-adapter-package-no-spawn` can now build against the dispatch receipt/evidence contract without guessing the schema or boundary.
+- `043-one-real-runtime-adapter-spike` remains future work after the no-spawn reference package proves the package boundary.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-18: closed 041-adapter-conformance-contract-v1 — adapter conformance contract v1 shipped
 - 2026-05-17: record full-history checkout for strict CI verification — see .osc/plans/done/045-github-actions-ci-amendment-2.md
 - 2026-05-17: record CI-exposed lifecycle timestamp flake fix — see .osc/plans/done/045-github-actions-ci-amendment-1.md
 - 2026-05-17: closed 045-github-actions-ci — GitHub Actions CI workflow added

--- a/docs/RUNTIME_BINDING_CONTRACT.md
+++ b/docs/RUNTIME_BINDING_CONTRACT.md
@@ -26,9 +26,11 @@ Examples:
 
 - a coordinator script that reads `.osc/runs/<run_id>/run.json` and starts an OMX `$ralplan` session;
 - an OMC-specific command that turns a plan into a Claude Code `/team` handoff;
-- a project-local runtime profile in `.osc/runtimes/<id>.json` that tells an adapter which lane/workflow/evidence contract to use;
+- an adapter that reads a project-local runtime profile in `.osc/runtimes/<id>.json` and translates its lane/workflow/evidence contract;
 - a GitHub bot that assigns a plain agent to a branch and links the PR;
 - a human operator who reads the generated prompt package and performs the work manually.
+
+A project-local runtime profile is not itself a binding. It is declarative data that tells an external adapter which lane, workflow, command token, and evidence expectation to use.
 
 A binding is not the Open Scaffold core. It may be a separate repo, plugin, bot, shell script, GitHub Action, IDE extension, or manual procedure.
 
@@ -140,6 +142,19 @@ open_questions: no blocking questions
 
 If the package is not executable, do not improvise implementation. Route to clarification, deep-interview, plan amendment, blocker, or manual correction.
 
+## Minimum v1 adapter conformance contract
+
+A v1 adapter consumes one `open-scaffold.run.v1` run packet. It either refuses the packet with a clear failure code or writes repo-local handoff proof:
+
+1. an `open-scaffold.dispatch-receipt.v1` dispatch receipt, normally at `.osc/runs/<run_id>/dispatch-receipt.json`;
+2. one or more repo-local evidence artifacts cited by that receipt.
+
+The receipt records which adapter consumed which packet, the selected lane/workflow/profile, what authority was used, whether a real runtime was spawned, and where evidence/logs/artifacts live. The evidence artifact records factual handoff/result proof. Neither artifact proves that the task acceptance criteria passed; postflight/evaluation still decides correctness, approval, merge, and release.
+
+A no-spawn conformance adapter must refuse packets when required fields are missing, blockers/open questions remain, `executor.spawning` is not `false`, the lane/harness does not match the selected workflow, commit policy is absent, or receipt/evidence paths would leave `runtime.repoPath`.
+
+For the fake/local conformance fixture specifically, success means: packet consumed, `spawning: false` enforced, dispatch receipt written, evidence written, and no runtime, network, credentials, commit, push, merge, or publish authority used.
+
 ## Binding responsibilities
 
 For the detailed spawning/adapter boundary, dispatch receipt shape (handoff proof), authority vocabulary (permission words), and OMX v0.17.0 Hermes MCP bridge evidence, see [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md). This contract remains the lifecycle-level agreement; the boundary document defines the safer next-step vocabulary before any real `osc spawn` implementation.
@@ -198,7 +213,9 @@ Generic Open Scaffold core does not own:
 
 Runtime-specific projects or coordinators may own these, but must promote durable outcomes back into the Open Scaffold chain.
 
-## Supported lane examples
+## Example lane packet shapes, not certified launch support
+
+These examples document `run.json` packet shapes and external binding behavior. They do not certify that OMC, OMX, Claude Code, Codex, OpenCode, or any runtime is installed, launched, or endorsed by Open Scaffold core.
 
 ### OMC / Claude Code lane
 
@@ -409,6 +426,6 @@ For concrete, credential-free consumers of this contract, see [`docs/examples/ru
 
 The dry-run example reads a generated `.osc/runs/<run_id>/run.json`, validates the executable-package and `spawning: false` boundary, prints the handoff summary an external binding would use, and exits without launching any runtime.
 
-The fake/local adapter conformance fixture goes one step further: it consumes the same run packet, writes an `open-scaffold.dispatch-receipt.v1` receipt and a deterministic evidence artifact, and still exits without launching any runtime, reading credentials, or requiring network access.
+The fake/local adapter conformance fixture goes one step further: it consumes the same run packet, writes an `open-scaffold.dispatch-receipt.v1` receipt and a deterministic evidence artifact, and still exits without launching any runtime, reading credentials, or requiring network access. This proves structural handoff/evidence behavior only; task correctness, runtime availability, and adapter production support remain separate gates.
 
 These examples are intentionally not a supported adapter SDK and not Open Scaffold launchers. They are reference proofs that run packets are concrete enough for external coordinators, runtime bindings, or humans to consume while core remains runtime-neutral.

--- a/docs/RUNTIME_PROFILES.md
+++ b/docs/RUNTIME_PROFILES.md
@@ -19,6 +19,12 @@ Layer map:
 - `RUNTIME_PROFILES.md` — profile schema, built-ins, and project-local `.osc/runtimes/*.json`.
 - [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) — adapter/coordinator responsibilities after the `run.json` package exists.
 
+Keep the roles separate:
+
+- **Profile** = declarative data that records a lane/workflow in a run packet.
+- **Adapter** = external consumer that may translate or launch that packet.
+- **Launch** = outside Open Scaffold core.
+
 ## Commands
 
 ```bash
@@ -138,7 +144,7 @@ This is deliberate. Open Scaffold's job is to preserve the source-of-truth chain
 
 ## OMC, OMX, GSD, and custom runtimes
 
-OMC and OMX are built-in adapter-candidate profiles — selectable lanes with dry-run/conformance fixture coverage, not certified launch integrations — because Open Scaffold already has a run-packet selection surface and conformance fixture coverage for those lanes.
+OMC and OMX are built-in adapter-candidate profiles — selectable lane metadata with fake/local fixture coverage for their lane tokens, not certified launch integrations and not evidence that OMC/OMX processes were run.
 
 GSD and other frameworks can be represented as project-local `user-defined` profiles today. They should not be described as certified or built-in integrations until an adapter has passed the conformance expectations and produced public evidence.
 

--- a/docs/RUNTIME_SELECTION.md
+++ b/docs/RUNTIME_SELECTION.md
@@ -36,7 +36,7 @@ and get a concrete `.osc/runs/<run_id>/run.json` package that records:
 - evidence/approval expectations;
 - `executor.spawning: false` — core will not launch the agent/process until an external adapter/coordinator launches it.
 
-The selected runtime is dispatchable by an adapter, but Open Scaffold core still does not launch Claude Code, Codex, OMC, OMX, tmux, or any provider process by itself.
+The selected runtime is dispatchable by an adapter, but Open Scaffold core still does not launch Claude Code, Codex, OMC, OMX, tmux, or any provider process by itself. Dispatchable means the `run.json` contains enough structured lane/workflow/profile data for an external adapter to consume if such an adapter exists; it does not mean the adapter is installed or certified.
 
 ## Runtime presets
 
@@ -47,6 +47,8 @@ The selected runtime is dispatchable by an adapter, but Open Scaffold core still
 | `plain` | `plain-agent` | Any capable agent or human-operated CLI | Runtime-neutral prompt package. |
 | `human` | `human` | Human/manual | Manual execution while preserving evidence gates. |
 | `custom` | `custom` | Adapter-defined | Future/private runtime adapter. |
+
+Built-in presets are profile IDs and lane targets, not installed adapters. `--runtime omx` records the OMX/Codex lane in `run.json`; it does not run OMX, Codex, or any provider process from core.
 
 ## Workflow presets
 
@@ -85,6 +87,8 @@ A runtime adapter that consumes Open Scaffold packages should:
 - write an `open-scaffold.dispatch-receipt.v1` dispatch receipt — repo-local proof of handoff/invocation;
 - return completion, blocker, verification, and review evidence into the Open Scaffold/GitHub chain;
 - never claim completion from runtime-local state alone.
+
+Passing this checklist proves structural adapter receipt/evidence conformance only. It does not prove task correctness, runtime quality, production adapter support, or runtime-support endorsement.
 
 ## Non-goals in core
 

--- a/docs/SPAWNING_BOUNDARY.md
+++ b/docs/SPAWNING_BOUNDARY.md
@@ -47,9 +47,9 @@ If Open Scaffold core owns those too early, it becomes a runtime by drift. The c
 | Operator surface — chat/dashboard for status and approvals | visible status, blockers, questions, approvals | source of truth |
 | GitHub / repo evidence | durable review, CI, release, audit references | raw runtime transcript as canonical truth |
 
-## Adapter/runtime contract vocabulary
+## Minimum v1 adapter conformance vocabulary
 
-A future adapter contract should use vendor-neutral fields before any provider-specific implementation exists.
+The adapter contract uses vendor-neutral fields before any provider-specific implementation exists.
 
 Minimum concepts:
 
@@ -101,7 +101,7 @@ human_approval_required for publication
 
 ## Dispatch receipt
 
-A dispatch receipt is repo-local proof of what was invoked, with what authority, from what package.
+A dispatch receipt is repo-local proof of what was invoked, with what authority, from what package. It proves handoff/dispatch facts; it is not approval, not a merge gate, and not proof that acceptance criteria passed.
 
 Minimum receipt fields:
 
@@ -119,6 +119,11 @@ worktree_path: string | null
 branch: string | null
 run_packet_path: string
 prompt_or_package_path: string | null
+runtime_selection:
+  runtime: string | null
+  workflow: string | null
+  profile_id: string | null
+  profile_source: string | null
 authority:
   sandbox_policy: string[]
   commit_policy: string
@@ -163,7 +168,7 @@ Adapters may add runtime-specific codes, but should map back to this portable se
 
 ## OMX v0.17.0 evidence: Hermes MCP bridge
 
-OMX `v0.17.0` is a concrete external validation of this boundary.
+OMX `v0.17.0` is a concrete external example of this boundary pattern. It is not Open Scaffold conformance evidence for an OMX adapter and not a certified launch integration.
 
 The release adds a bounded, opt-in Hermes MCP bridge:
 
@@ -210,9 +215,9 @@ This confirms the adapter/binding thesis: coordinators and project protocols do 
 Near-term:
 
 1. Keep core non-spawning.
-2. Extend `docs/RUNTIME_BINDING_CONTRACT.md` with this adapter/receipt vocabulary.
-3. Treat OMX v0.17.0 Hermes MCP as a reference pattern for coordinator-to-runtime bridges.
-4. Define fake/local `osc spawn` only as a dry-run dispatch receipt if prototyped.
+2. Keep `docs/RUNTIME_BINDING_CONTRACT.md` aligned with this adapter/receipt vocabulary.
+3. Treat OMX v0.17.0 Hermes MCP as a reference pattern for coordinator-to-runtime bridges, not as Open Scaffold adapter certification.
+4. Use the fake/local conformance fixture to prove run-packet consumption, dispatch receipt writing, evidence writing, and no-spawn behavior before any real runtime adapter package.
 5. Keep real Claude/Codex/OpenCode/OMX/Ouroboros spawning in adapter packages or external runtimes.
 
 Longer-term:

--- a/docs/examples/runtime-binding-conformance/README.md
+++ b/docs/examples/runtime-binding-conformance/README.md
@@ -34,11 +34,22 @@ No Claude, Codex, OMC, OMX, GSD, or other runtime is launched.
 
 Future adapters can use this fixture as a minimum behavior target before adding runtime-specific launch mechanics.
 
-Supported conformance lanes:
+## What this proves / does not prove
+
+This fixture proves four structural facts only:
+
+- a valid `open-scaffold.run.v1` packet can be consumed;
+- `executor.spawning: false` is enforced;
+- an `open-scaffold.dispatch-receipt.v1` receipt is written;
+- deterministic evidence is written under the repository root.
+
+It does **not** prove real runtime launch, production adapter support, runtime-support endorsement, or task correctness. Postflight/evaluation still decides whether acceptance criteria passed.
+
+## Accepted fixture lane tokens
 
 - `plain-agent` with no runtime command/mode (`harness skill`);
 - `human` / `manual` with no runtime command/mode (`harness skill`);
 - `omc-claude` with `/deep-interview`, `/ralplan`, `/team`, `/ralph`, or `/ultrawork`;
 - `omx-codex` with `$deep-interview`, `$ralplan`, `$team`, `$ralph`, `$ultrawork`, or `$ultragoal`.
 
-Supporting a lane here means the fake adapter can validate the package and write a receipt/evidence artifact for that lane. It still does not launch Claude Code, Codex, OMC, or OMX.
+Accepted here means the fake/local adapter can validate the package and write receipt/evidence artifacts for that lane token. It does not mean the named runtime is installed, launched, certified, or production-supported.

--- a/docs/examples/runtime-binding-conformance/fake-local-adapter.mjs
+++ b/docs/examples/runtime-binding-conformance/fake-local-adapter.mjs
@@ -9,6 +9,25 @@ const SUPPORTED_LANES = new Map([
   ['omx-codex', { harnessSkills: ['$deep-interview', '$ralplan', '$team', '$ralph', '$ultrawork', '$ultragoal'] }],
 ]);
 
+const WORKFLOW_HARNESS_BY_LANE = {
+  'omc-claude': {
+    interview: '/deep-interview',
+    plan: '/ralplan',
+    team: '/team',
+    loop: '/ralph',
+    execute: '/ultrawork',
+    goal: '/ultrawork',
+  },
+  'omx-codex': {
+    interview: '$deep-interview',
+    plan: '$ralplan',
+    team: '$team',
+    loop: '$ralph',
+    execute: '$ultrawork',
+    goal: '$ultragoal',
+  },
+};
+
 function fail(message) {
   console.error(`Fake/local adapter refused package: ${message}`);
   process.exit(1);
@@ -17,6 +36,13 @@ function fail(message) {
 function requireString(value, label) {
   if (typeof value !== 'string' || value.trim() === '') {
     fail(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireNonEmptyArray(value, label) {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.trim() === '')) {
+    fail(`${label} must be a non-empty array`);
   }
   return value;
 }
@@ -156,6 +182,12 @@ function validateLaneAndHarness(manifest) {
     fail(`executor.harnessSkill ${skill} is not allowed for lane ${lane}`);
   }
 
+  const workflow = manifest?.runtimeSelection?.workflow ?? null;
+  const requiredSkill = WORKFLOW_HARNESS_BY_LANE[lane]?.[workflow];
+  if (requiredSkill && skill !== requiredSkill) {
+    fail(`runtimeSelection.workflow ${workflow} requires executor.harnessSkill ${requiredSkill}`);
+  }
+
   return { lane, skill };
 }
 
@@ -168,6 +200,7 @@ if (manifest.schemaVersion !== 'open-scaffold.run.v1') {
 
 const runId = requireString(manifest.runId, 'runId');
 const planPath = requireString(manifest?.plan?.path, 'plan.path');
+requireString(manifest?.plan?.goal, 'plan.goal');
 const repoPath = requireString(manifest?.runtime?.repoPath, 'runtime.repoPath');
 const commitPolicy = requireString(manifest.commitPolicy, 'commitPolicy');
 const worktreePath = manifest?.runtime?.worktreePath ?? null;
@@ -184,19 +217,25 @@ if (!Array.isArray(manifest?.packageQuality?.blockers) || manifest.packageQualit
 if (hasBlockingOpenQuestions(manifest?.plan?.openQuestions)) {
   fail('plan.openQuestions must not contain blocking questions before dispatch');
 }
+requireNonEmptyArray(manifest?.plan?.acceptanceCriteria, 'plan.acceptanceCriteria');
+requireNonEmptyArray(manifest?.plan?.verificationSteps, 'plan.verificationSteps');
 if (manifest?.executor?.spawning !== false) {
   fail('executor.spawning must be false; Open Scaffold core packages work while adapters own launch behavior');
 }
 
 const defaultReceiptPath = `${dirname(runPacketRelativePath)}/dispatch-receipt.json`;
-const { absolutePath: receiptPath } = prepareSafeArtifactPath(repoPath, outPath ?? defaultReceiptPath);
+const { raw: receiptRelativePath, absolutePath: receiptPath } = prepareSafeArtifactPath(repoPath, outPath ?? defaultReceiptPath);
 const fallbackEvidencePath = `.osc/runs/${runId}/fake-local-evidence.md`;
 const { raw: evidencePath, absolutePath: evidenceAbsolutePath } = prepareSafeArtifactPath(
   repoPath,
   manifest?.artifacts?.evidence?.[0] ?? fallbackEvidencePath,
 );
 
-const evidence = `# Fake/local adapter evidence\n\nRun ID: ${runId}\nTask ID: ${manifest.taskId ?? '(none)'}\nPlan: ${planPath}\nExecutor lane: ${lane}\nHarness skill: ${skill ?? '(none)'}\n\nThis evidence was written by the fake/local adapter conformance fixture.\nNo runtime was launched. No network access or credentials were required.\n`;
+if (resolve(receiptPath) === resolve(evidenceAbsolutePath)) {
+  fail('dispatch receipt and evidence paths must be distinct');
+}
+
+const evidence = `# Fake/local adapter evidence\n\nSchema: open-scaffold.adapter-evidence.v1\nRun ID: ${runId}\nTask ID: ${manifest.taskId ?? '(none)'}\nPlan: ${planPath}\nDispatch receipt: ${receiptRelativePath}\nAdapter ID: fake-local\nRuntime backend: none\nExecutor lane: ${lane}\nHarness skill: ${skill ?? '(none)'}\nSpawned: false\n\nThis evidence was written by the fake/local adapter conformance fixture.\nNo runtime was launched. No network access or credentials were required.\n`;
 writeFileSync(evidenceAbsolutePath, evidence);
 
 const receipt = {
@@ -213,6 +252,12 @@ const receipt = {
   branch,
   run_packet_path: runPacketRelativePath,
   prompt_or_package_path: null,
+  runtime_selection: {
+    runtime: manifest?.runtimeSelection?.runtime ?? null,
+    workflow: manifest?.runtimeSelection?.workflow ?? null,
+    profile_id: manifest?.runtimeSelection?.profileId ?? null,
+    profile_source: manifest?.runtimeSelection?.profileSource ?? null,
+  },
   authority: {
     sandbox_policy: ['write_artifacts_only', 'commit_forbidden', 'push_forbidden', 'merge_forbidden', 'human_approval_required'],
     commit_policy: commitPolicy,

--- a/tests/runtime-binding-conformance.test.ts
+++ b/tests/runtime-binding-conformance.test.ts
@@ -13,9 +13,16 @@ function tempRunPacket(overrides: Record<string, unknown> = {}) {
     schemaVersion: 'open-scaffold.run.v1',
     runId: 'demo-run',
     taskId: 'task:demo',
-    plan: { path: '.osc/plans/active/001-demo.md', goal: 'Prove adapter conformance.' },
+    plan: {
+      path: '.osc/plans/active/001-demo.md',
+      goal: 'Prove adapter conformance.',
+      acceptanceCriteria: ['Dispatch receipt is written.', 'Evidence artifact is written.'],
+      verificationSteps: ['Run fake/local adapter conformance fixture.'],
+      openQuestions: [],
+    },
     packageQuality: { executable: true, blockers: [] },
     executor: { lane: 'plain-agent', harnessSkill: null, spawning: false },
+    runtimeSelection: { runtime: null, workflow: null, profileId: null, profileSource: null },
     runtime: { repoPath: root, worktreePath: root, branch: 'main' },
     bindings: { operatorSurface: 'cli' },
     artifacts: { evidence: ['.osc/runs/demo/evidence.md'] },
@@ -59,7 +66,95 @@ describe('fake/local adapter conformance fixture', () => {
     });
     expect(typeof receipt.receipt_id).toBe('string');
     expect(normalize(receipt.run_packet_path)).toBe(normalize('.osc/runs/demo/run.json'));
+    expect(receipt.authority).toMatchObject({
+      sandbox_policy: ['write_artifacts_only', 'commit_forbidden', 'push_forbidden', 'merge_forbidden', 'human_approval_required'],
+      commit_policy: 'adapter fixture may write receipt only; no commit/push',
+      approval_policy: 'human_approval_required',
+    });
     expect(existsSync(join(root, '.osc/runs/demo/evidence.md'))).toBe(true);
+  });
+
+  it('records runtime selection in the dispatch receipt without launching the selected runtime', () => {
+    const { root, path } = tempRunPacket({
+      runtimeSelection: { runtime: 'omx', workflow: 'plan', profileId: 'omx', profileSource: 'builtin' },
+      executor: { lane: 'omx-codex', harnessSkill: '$ralplan', spawning: false },
+    });
+    const receiptPath = join(root, '.osc/runs/demo/dispatch-receipt.json');
+
+    execFileSync('node', [adapter, path], { encoding: 'utf8' });
+    const receipt = JSON.parse(readFileSync(receiptPath, 'utf8'));
+
+    expect(receipt.runtime_selection).toMatchObject({
+      runtime: 'omx',
+      workflow: 'plan',
+      profile_id: 'omx',
+      profile_source: 'builtin',
+    });
+    expect(receipt.spawned).toBe(false);
+    expect(receipt.runtime_backend).toBe('none');
+  });
+
+  it('refuses packets whose runtime selection workflow conflicts with the executor harness skill', () => {
+    const { path } = tempRunPacket({
+      runtimeSelection: { runtime: 'omx', workflow: 'plan', profileId: 'omx', profileSource: 'builtin' },
+      executor: { lane: 'omx-codex', harnessSkill: '$team', spawning: false },
+    });
+
+    try {
+      execFileSync('node', [adapter, path], { encoding: 'utf8', stdio: 'pipe' });
+      throw new Error('expected fake adapter to fail');
+    } catch (error: any) {
+      expect(error.status).toBe(1);
+      expect(String(error.stderr ?? '')).toContain('runtimeSelection.workflow plan requires executor.harnessSkill $ralplan');
+    }
+  });
+
+  it('refuses executable packets that omit acceptance criteria or verification steps', () => {
+    const { path } = tempRunPacket({
+      plan: {
+        path: '.osc/plans/active/001-demo.md',
+        goal: 'Prove adapter conformance.',
+        acceptanceCriteria: [],
+        verificationSteps: [],
+        openQuestions: [],
+      },
+    });
+
+    try {
+      execFileSync('node', [adapter, path], { encoding: 'utf8', stdio: 'pipe' });
+      throw new Error('expected fake adapter to fail');
+    } catch (error: any) {
+      expect(error.status).toBe(1);
+      expect(String(error.stderr ?? '')).toContain('plan.acceptanceCriteria must be a non-empty array');
+    }
+  });
+
+  it('refuses to write receipt and evidence to the same path', () => {
+    const collisionPath = '.osc/runs/demo/dispatch-receipt.json';
+    const { root, path } = tempRunPacket({ artifacts: { evidence: [collisionPath] } });
+
+    try {
+      execFileSync('node', [adapter, path, '--out', collisionPath], { encoding: 'utf8', stdio: 'pipe' });
+      throw new Error('expected fake adapter to fail');
+    } catch (error: any) {
+      expect(error.status).toBe(1);
+      expect(String(error.stderr ?? '')).toContain('dispatch receipt and evidence paths must be distinct');
+    }
+    expect(existsSync(join(root, collisionPath))).toBe(false);
+  });
+
+  it('writes deterministic evidence content linked to the receipt and no-spawn claim', () => {
+    const { root, path } = tempRunPacket();
+
+    execFileSync('node', [adapter, path], { encoding: 'utf8' });
+    const evidence = readFileSync(join(root, '.osc/runs/demo/evidence.md'), 'utf8');
+
+    expect(evidence).toContain('Schema: open-scaffold.adapter-evidence.v1');
+    expect(evidence).toContain('Dispatch receipt: .osc/runs/demo/dispatch-receipt.json');
+    expect(evidence).toContain('Adapter ID: fake-local');
+    expect(evidence).toContain('Runtime backend: none');
+    expect(evidence).toContain('Spawned: false');
+    expect(evidence).toContain('No runtime was launched.');
   });
 
   it('refuses packets that ask Open Scaffold core to spawn a runtime', () => {


### PR DESCRIPTION
## Summary
- defines the minimum v1 adapter conformance contract around `open-scaffold.dispatch-receipt.v1`
- tightens the fake/local adapter fixture so it validates packet quality, runtime selection, lane/harness matching, safe receipt/evidence paths, and no-spawn behavior
- clarifies runtime docs so profiles stay data-only, adapters remain external consumers/launch glue, and conformance evidence is not task-correctness proof

## Traceability
- Plan: `.osc/plans/done/041-adapter-conformance-contract-v1.md`
- Release/evidence note: `.osc/releases/2026-05-18-adapter-conformance-contract-v1.md`
- Kanban: `t_11706cc9`
- Branch: `runtime/adapter-conformance-contract-v1`
- Roadmap area: runtime harness adapter refresh / adapter evidence chain

## Verification
- `npm test -- tests/runtime-binding-conformance.test.ts tests/runtime-binding-dry-run.test.ts` → 24 pass
- `npm run build` → pass
- `npm test` → 14 files / 129 tests pass
- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn
- `git diff --check` → pass
- Boundary scan for new positive `certified integration`, `officially supported`, `spawning: true`, or `spawned: true` claims → pass

## Boundaries
- No real runtime spawning
- No credential/provider/network/installer behavior
- No runtime-support endorsement claims
- No package publishing
- No merge without owner approval

## Codex review
- Triggered with `@codex review` after the final traceability commit.
