### PR TITLE
Add CLI plan stage movement

### DIFF
--- a/.osc/plans/README.md
+++ b/.osc/plans/README.md
@@ -1,22 +1,26 @@
 # Plans — Amendment Protocol
 
-Plans in this directory and its stage subfolders (`active/`, `backlog/`, `done/`, `blocked/`) are **immutable** once committed. When new information changes a plan's goal, constraints, or acceptance criteria, do NOT edit the plan file in place. Instead, run `osc amend <plan-slug> --message "<what changed>"` (or `npx open-scaffold amend <plan-slug> --message "<what changed>"`) — it handles the common npm/day-two mechanical path so you can focus on the content. To close a completed plan, run `osc close <plan-slug> --message "<what shipped>"` (or `npx open-scaffold close <plan-slug> --message "<what shipped>"`) — it moves the plan and its amendments to `done/` and stamps MISSION.md's changelog. Shell fallbacks remain supported via `./amend.sh <plan-slug>` and `./close.sh <plan-slug>`. See `.osc/plans/WORKFLOW.md` for the full stage-folder workflow.
+Plans in this directory and its stage subfolders (`active/`, `backlog/`, `done/`, `blocked/`) are **immutable** once committed. When new information changes a plan's goal, constraints, or acceptance criteria, do NOT edit the plan file in place. Instead, run `osc amend <plan-slug> --message "<what changed>"` (or `npx open-scaffold amend <plan-slug> --message "<what changed>"`) — it handles the common npm/day-two mechanical path so you can focus on the content. To move non-done work between stages, run `osc plan move <plan-slug> --to active|backlog|blocked`. To close a completed plan, run `osc close <plan-slug> --message "<what shipped>"` (or `npx open-scaffold close <plan-slug> --message "<what shipped>"`) — it moves the plan and its amendments to `done/` and stamps MISSION.md's changelog. Shell fallbacks remain supported via `./amend.sh` and `./close.sh`; manual file movement remains the compatibility floor. See `.osc/plans/WORKFLOW.md` for the full stage-folder workflow.
 
 ## The helpers (recommended path)
 
 ```bash
+osc plan new <plan-slug> --stage active|backlog|blocked
+osc plan move <plan-slug> --to active|backlog|blocked
 osc amend <plan-slug> [--message "<text>"]
 osc close <plan-slug> [--message "<text>"]
 ```
 
 The CLI helpers:
 
-1. Autonumbers the next amendment file as `<plan-slug>-amendment-<n>.md` in the same stage subfolder as the parent plan.
-2. Scaffolds the file with the 5-section schema below (Parent / Date / Learning / New direction / Impact on acceptance criteria), filling Parent and Date automatically and leaving `TODO:` placeholders for the three content sections.
-3. Appends a one-line dated entry to `MISSION.md`'s `## Changelog` section referencing the new amendment filename.
-4. Move a verified plan plus its amendments to `done/` and stamp `MISSION.md` when `osc close` is used.
+1. Create new plan skeletons in `active/`, `backlog/`, or `blocked/` with the standard 7-section schema.
+2. Move non-done plans plus their amendment files between `active/`, `backlog/`, and `blocked/`, while aligning the parent plan's `## Status` body with the destination folder.
+3. Autonumber the next amendment file as `<plan-slug>-amendment-<n>.md` in the same stage subfolder as the parent plan.
+4. Scaffold the amendment file with the 5-section schema below (Parent / Date / Learning / New direction / Impact on acceptance criteria), filling Parent and Date automatically and leaving `TODO:` placeholders for the three content sections.
+5. Append a one-line dated entry to `MISSION.md`'s `## Changelog` section referencing the new amendment filename.
+6. Move a verified plan plus its amendments to `done/` and stamp `MISSION.md` when `osc close` is used.
 
-You then fill in the three `TODO:` sections in the amendment file, review the diff, and commit. The helpers refuse to run if the parent plan is missing or the mission is still unset.
+You then fill in TODO sections, review the diff, and commit. Amendment and close helpers refuse to run if the parent plan is missing or the mission is still unset.
 
 ## Amendment schema
 
@@ -49,7 +53,7 @@ Amendments are for legitimate scope evolution, not silent drift. They exist so t
 
 ## Plan status
 
-Plan status is determined by which stage subfolder the plan lives in — **the folder IS the status**. There is no `## Status` header inside plan files. The four stages are `active/`, `backlog/`, `done/`, and `blocked/`. Use `./close.sh <plan-slug>` to move a plan to `done/` when all acceptance criteria are met. See `.osc/plans/WORKFLOW.md` for movement rules between stages.
+Plan status is determined first by which stage subfolder the plan lives in — **the folder IS the status**. Current plan files also carry a `## Status` section for human readability; keep it aligned with the folder when moving uncommitted or in-flight plans. Use `osc plan move <plan-slug> --to active|backlog|blocked` for non-done movement. Use `osc close <plan-slug>` or `./close.sh <plan-slug>` to move a verified plan to `done/` when all acceptance criteria are met. See `.osc/plans/WORKFLOW.md` for movement rules between stages.
 
 ## The specs/ directory
 

--- a/.osc/plans/WORKFLOW.md
+++ b/.osc/plans/WORKFLOW.md
@@ -13,14 +13,14 @@ Plans move between stage folders. The folder IS the status. File numbering (NNN-
 
 ## Rules
 
-1. **New plans land in `active/`** by default (via `amend.sh` or manual creation).
-2. **Backlog is for future work.** When an agent identifies follow-up tasks or next steps, create a plan in `backlog/`. Do not start work on backlog items without moving them to `active/` first.
+1. **New plans land in `active/` for immediate work or `backlog/` for future work.** Use `osc plan new <slug> --stage active|backlog|blocked` when the CLI is available.
+2. **Backlog is for future work.** When an agent identifies follow-up tasks or next steps, create a plan in `backlog/`. Do not start work on backlog items without moving them to `active/` first. Use `osc plan move <slug> --to active` for that promotion.
 3. **One focus at a time.** Prefer at most 2–3 plans in `active/` simultaneously. If `active/` is full, finish or park existing work before pulling from `backlog/`.
 4. **Moving to `done/`** requires:
    - Acceptance criteria met (from the plan file).
    - `./verify.sh` passes at standard tier or above.
-   - MISSION.md changelog stamped (via `./close.sh <plan-path>` or manually).
-5. **Moving to `blocked/`**: add a comment at the top of the plan file explaining what it's blocked on and the date. Move back to `active/` when unblocked.
+   - MISSION.md changelog stamped (via `osc close <slug> --message "<what shipped>"`, `./close.sh <slug>`, or manually).
+5. **Moving to `blocked/`**: add a comment at the top of the plan file explaining what it's blocked on and the date. Move with `osc plan move <slug> --to blocked`; move back with `osc plan move <slug> --to active` when unblocked.
 6. **Never rename files when moving.** The NNN prefix is the plan's permanent ID. Just `mv` the file between folders.
 7. **Read order**: when starting a session, check `active/` first, then `blocked/`, then `backlog/`. Ignore `done/`.
 8. **Amendments stay with their parent.** If `003-auth.md` is in `active/`, its amendments (`003-auth-amendment-1.md`, etc.) live in `active/` too. They move together.

--- a/.osc/plans/done/049-plan-stage-move.md
+++ b/.osc/plans/done/049-plan-stage-move.md
@@ -1,0 +1,54 @@
+# Plan: 049-plan-stage-move
+
+## Status
+
+done
+
+## Context
+
+After the roadmap open-question reconciliation, Open Scaffold produced and shipped the concrete `048-cli-lifecycle-parity` follow-up. The repo now has first-class CLI helpers for creating plans, creating evidence notes, amending plans, and closing plans, but one common solo-developer action still requires manual file movement: moving a plan between `backlog`, `active`, and `blocked`.
+
+That friction matters because the product promise is repo-native control without needing Hermes Kanban or private operator habits. A fresh user should be able to promote a backlog plan to active or park active work as blocked through the same `npx open-scaffold ...` path as the rest of the lifecycle.
+
+## Goal
+
+Add a small `osc plan move <slug> --to <active|backlog|blocked>` command that moves an existing non-done plan and its amendment files between stage folders, updates the parent plan's internal status to match the destination stage, and keeps `done` movement reserved for `osc close`.
+
+## Constraints / Out of scope
+
+- Do not move plans into `done`; `osc close` remains the done path because it stamps closure evidence.
+- Do not introduce a task database, GitHub issue sync, runtime launch, or Kanban replacement in this slice.
+- Do not edit committed historical done plans.
+- Do not publish npm or bump package version in this slice.
+- Keep shell script fallbacks unchanged.
+
+## Files to touch
+
+- `src/scaffold.ts` — add a safe stage-move helper for non-done plans.
+- `src/cli.ts` — expose `osc plan move <slug> --to <active|backlog|blocked>` and help text.
+- `tests/cli-plan-move.test.ts` — cover moving parent plans/amendments, status updates, missing directories, and refusal cases.
+- `README.md`, `docs/WORKFLOW.md`, `.osc/plans/README.md` — document the common backlog → active / active → blocked CLI path.
+- `.osc/releases/2026-05-18-049-plan-stage-move.md` — record verification evidence after implementation.
+
+## Acceptance criteria
+
+- [x] `osc plan move <slug> --to active` moves a backlog or blocked parent plan into `.osc/plans/active/` and updates its `## Status` body to `active`.
+- [x] The move also carries matching amendment files such as `<slug>-amendment-1.md` to the same destination stage.
+- [x] `osc plan move <slug> --to blocked` and `--to backlog` work for non-done plans.
+- [x] The command refuses unsafe slugs, missing plans, unsupported destinations, and attempts to move into `done` with clear errors.
+- [x] The command creates a missing destination stage folder for older/manual scaffolds.
+- [x] Public docs show the fast solo-dev flow: create a backlog plan, move it to active, amend if needed, close when shipped.
+- [x] Existing lifecycle commands and verification remain green.
+
+## Verification steps
+
+1. `npm test -- tests/cli-plan-move.test.ts` — expected pass after failing first.
+2. `npm run build` — expected pass.
+3. `npm test` — expected pass.
+4. `./verify.sh --strict` — expected pass with 0 warnings.
+5. `npm run osc -- verify` — expected pass.
+6. `git diff --check` — expected no whitespace errors.
+
+## Open questions
+
+- Should a future follow-up add `osc plan list --stage <stage>` ergonomics, or is `osc status` enough for now?

--- a/.osc/releases/2026-05-18-049-plan-stage-move.md
+++ b/.osc/releases/2026-05-18-049-plan-stage-move.md
@@ -25,7 +25,13 @@ Adds `osc plan move <slug> --to active|backlog|blocked` so solo developers can m
 - Post-Codex `npm test` → pass.
 - Post-Codex `./verify.sh --strict` → pass.
 - Post-Codex `npm run osc -- verify` → pass.
-- Post-Codex `git diff --check` → pass.
+- Codex second pass: valid P2 findings on legacy root-level plans and compact `## Status\nactive` formatting; added regression coverage and fixed `movePlan()` to support root plans plus single-newline status headers.
+- Final targeted GREEN: `npm test -- tests/cli-plan-move.test.ts` → 1 file / 4 tests passed.
+- Final `npm run build` → pass.
+- Final `npm test` → pass.
+- Final `./verify.sh --strict` → pass.
+- Final `npm run osc -- verify` → pass.
+- Final `git diff --check` → pass.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-18-049-plan-stage-move.md
+++ b/.osc/releases/2026-05-18-049-plan-stage-move.md
@@ -19,7 +19,13 @@ Adds `osc plan move <slug> --to active|backlog|blocked` so solo developers can m
 - `npm test` → 22 files / 186 tests passed.
 - `./verify.sh --strict` → 10 pass / 0 fail / 0 warn; 59 plan files before closure.
 - `npm run osc -- verify` → pass; 59 plan file(s), 0 warning(s).
-- `git diff --check` → pass.
+- Codex follow-up: first review artifact reported a subprocess-heavy Vitest timeout risk in `tests/cli-plan-move.test.ts`; the three new tests now carry explicit `20_000` ms per-test timeouts without changing assertions or CLI behavior.
+- Post-Codex targeted GREEN: `npm test -- tests/cli-plan-move.test.ts` → pass.
+- Post-Codex `npm run build` → pass.
+- Post-Codex `npm test` → pass.
+- Post-Codex `./verify.sh --strict` → pass.
+- Post-Codex `npm run osc -- verify` → pass.
+- Post-Codex `git diff --check` → pass.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-18-049-plan-stage-move.md
+++ b/.osc/releases/2026-05-18-049-plan-stage-move.md
@@ -9,7 +9,7 @@ Adds `osc plan move <slug> --to active|backlog|blocked` so solo developers can m
 - Roadmap / issue / task: Kanban `t_c6641254`.
 - Plan: `.osc/plans/done/049-plan-stage-move.md`.
 - Run ID / run packet: `N/A` — local CLI/product slice, no runtime run packet needed.
-- Branch: `cli/plan-stage-move`; PR pending owner review.
+- Branch / PR: `cli/plan-stage-move`; PR #55 — https://github.com/graphanov/open-scaffold/pull/55.
 
 ## Verification
 

--- a/.osc/releases/2026-05-18-049-plan-stage-move.md
+++ b/.osc/releases/2026-05-18-049-plan-stage-move.md
@@ -1,0 +1,33 @@
+# Release / Evidence Note: 049-plan-stage-move
+
+## Summary
+
+Adds `osc plan move <slug> --to active|backlog|blocked` so solo developers can move non-done plans through the stage folders without manual file moves. The command carries amendment files with the parent plan, updates the parent `## Status` body, and keeps movement into `done/` reserved for `osc close`.
+
+## Traceability
+
+- Roadmap / issue / task: Kanban `t_c6641254`.
+- Plan: `.osc/plans/done/049-plan-stage-move.md`.
+- Run ID / run packet: `N/A` — local CLI/product slice, no runtime run packet needed.
+- Branch: `cli/plan-stage-move`; PR pending owner review.
+
+## Verification
+
+- RED check: `npm test -- tests/cli-plan-move.test.ts` initially failed because `osc plan move` did not exist and `osc plan` tried to parse `move` as a file path.
+- Targeted GREEN: `npm test -- tests/cli-plan-move.test.ts` → 1 file / 3 tests passed.
+- `npm run build` → pass.
+- `npm test` → 22 files / 186 tests passed.
+- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn; 59 plan files before closure.
+- `npm run osc -- verify` → pass; 59 plan file(s), 0 warning(s).
+- `git diff --check` → pass.
+
+## Outcome
+
+The plan movement gap is closed for the normal npm/day-two path. Users can now create a backlog plan, promote it to active, park it as blocked, move it back, amend it, create evidence, and close it without private Hermes/Kanban habits or manual filesystem moves.
+
+Out of scope: moving plans into `done` outside `osc close`, task database behavior, GitHub issue sync, runtime launch, npm publish, package version bump, and broad runtime/model-lab hypothesis work.
+
+## Follow-up
+
+- Consider a later `osc plan list --stage <stage>` / `osc plan show <slug>` ergonomics slice if `osc status` feels too coarse.
+- Publish remains a separate owner-gated release action after enough product slices accumulate.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-18: closed 049-plan-stage-move — added plan stage movement CLI
 - 2026-05-18: closed 048-cli-lifecycle-parity — CLI lifecycle parity helpers shipped
 - 2026-05-18: closed 047-roadmap-open-question-reconciliation — roadmap open-question reconciliation shipped
 - 2026-05-18: closed 044-cli-friction-reduction — CLI plan and evidence helpers shipped

--- a/README.md
+++ b/README.md
@@ -121,12 +121,17 @@ If the goal is clear, tell your agent:
 Write a plan in .osc/plans/active/ for <task> using .osc/plans/handoff-template.md.
 ```
 
-If the goal is fuzzy, ask the agent to interview you first, then write the plan. Fill the template with short bullets; the important parts are goal, acceptance criteria, and verification. The helper creates the file and TODO prompts; it does **not** invent acceptance criteria for you:
+If the goal is fuzzy, park the plan in backlog first, then move it to active when it becomes the work you are actually doing. Fill the template with short bullets; the important parts are goal, acceptance criteria, and verification. The helpers create files and TODO prompts; they do **not** invent acceptance criteria for you:
 
 ```bash
-osc plan new my-first-task --stage active
-# or, without local install: npx open-scaffold plan new my-first-task --stage active
+osc plan new my-first-task --stage backlog
+osc plan move my-first-task --to active
+# or, without local install:
+npx open-scaffold plan new my-first-task --stage backlog
+npx open-scaffold plan move my-first-task --to active
 ```
+
+Use `--to blocked` when a plan needs to wait for input, credentials, or a product decision.
 
 Shell fallback remains supported:
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -27,10 +27,18 @@ Write a plan file in `.osc/plans/active/` using the 7-section schema in `.osc/pl
 Use the helper when the repo has the `osc` CLI available:
 
 ```bash
-osc plan new <slug> --stage active
+osc plan new <slug> --stage backlog
+osc plan move <slug> --to active
 ```
 
-Then fill every TODO before implementation. The helper creates structure only; it does not invent acceptance criteria. Shell fallback remains the day-zero floor: copy `.osc/plans/handoff-template.md` into `.osc/plans/active/<slug>.md` and fill it manually.
+Use `active` directly when execution is immediate. Use `blocked` or `backlog` when you need to park work without deleting the plan:
+
+```bash
+osc plan move <slug> --to blocked
+osc plan move <slug> --to backlog
+```
+
+Then fill every TODO before implementation. The helpers create and move structure only; they do not invent acceptance criteria. Shell fallback remains the day-zero floor: copy `.osc/plans/handoff-template.md` into the right stage folder and move files manually when needed.
 
 > **With OMC harness:** Claude Code/OMC planning flows can use `/ralplan` against an Open Scaffold plan or `run.json` work package (run packet).
 >

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { createRunArtifacts, type ArtifactMode, type ExecutorLane, type Operator
 import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
-import { closePlan, createEvidenceNoteSkeleton, createPlanAmendment, createPlanSkeleton, inspectScaffold, parsePlanFile, planToJson, PLAN_CREATION_STAGES, type PlanCreationStage } from './scaffold.js';
+import { closePlan, createEvidenceNoteSkeleton, createPlanAmendment, createPlanSkeleton, inspectScaffold, movePlan, parsePlanFile, planToJson, PLAN_CREATION_STAGES, type PlanCreationStage } from './scaffold.js';
 import { validateScaffold } from './validation.js';
 
 function printHelp(): void {
@@ -18,6 +18,7 @@ Usage:
   osc status [--json]
   osc plan <plan-path>
   osc plan new <slug> --stage <active|backlog|blocked>
+  osc plan move <slug> --to <active|backlog|blocked>
   osc amend <plan-slug> [--message <text>]
   osc evidence new <slug>
   osc close <plan-slug> [--message <text>]
@@ -333,6 +334,39 @@ function parsePlanStage(args: string[]): PlanCreationStage {
   return stage;
 }
 
+function parsePlanMoveDestination(args: string[]): PlanCreationStage {
+  let toStage: PlanCreationStage | undefined;
+  for (let i = 0; i < args.length; i += 1) {
+    const flag = args[i];
+    if (flag === '--to') {
+      const value = args[i + 1];
+      if (!value || value.startsWith('--')) {
+        console.error('Missing value for --to');
+        process.exit(2);
+      }
+      if (value === 'done') {
+        console.error('Use osc close <plan-slug> [--message <text>] to move a plan to done.');
+        process.exit(2);
+      }
+      if (!(PLAN_CREATION_STAGES as readonly string[]).includes(value)) {
+        console.error(`Invalid value for --to: ${value}. Expected one of: ${PLAN_CREATION_STAGES.join(', ')}`);
+        process.exit(2);
+      }
+      toStage = value as PlanCreationStage;
+      i += 1;
+    } else {
+      console.error(`Unknown option for plan move: ${flag}`);
+      console.error('Usage: osc plan move <slug> --to <active|backlog|blocked>');
+      process.exit(2);
+    }
+  }
+  if (!toStage) {
+    console.error('Missing required option: --to <active|backlog|blocked>');
+    process.exit(2);
+  }
+  return toStage;
+}
+
 function planCommand(args: string[]): void {
   if (args[0] === 'new') {
     const slug = requireArg(args.slice(1), 'slug');
@@ -341,6 +375,24 @@ function planCommand(args: string[]): void {
       const result = createPlanSkeleton(slug, stage, process.cwd());
       console.log(`Created plan: ${result.relativePath}`);
       console.log('Next: fill the TODO prompts before implementation; do not treat the skeleton as acceptance criteria.');
+      return;
+    } catch (error) {
+      exitForScaffoldHelperError(error);
+    }
+  }
+  if (args[0] === 'move') {
+    const slug = requireArg(args.slice(1), 'slug');
+    const toStage = parsePlanMoveDestination(args.slice(2));
+    try {
+      const result = movePlan(slug, toStage, process.cwd());
+      if (result.alreadyInStage) {
+        console.log(`Plan ${result.slug}.md is already in ${result.toStage}/; status aligned.`);
+        return;
+      }
+      console.log(`Moved plan: ${result.slug}`);
+      console.log(`From: ${result.fromStage}`);
+      console.log(`To: ${result.toStage}`);
+      console.log(`Moved files: ${result.movedFiles.join(', ')}`);
       return;
     } catch (error) {
       exitForScaffoldHelperError(error);

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -352,11 +352,11 @@ export function createEvidenceNoteSkeleton(slug: string, start = process.cwd(), 
 }
 
 function updatePlanStatus(markdown: string, stage: PlanCreationStage): string {
-  const statusPattern = /(## Status\r?\n\r?\n)([\s\S]*?)(?=\r?\n##\s+|$)/;
+  const statusPattern = /(^## Status[^\S\r\n]*\r?\n)(?:[^\S\r\n]*\r?\n)?([\s\S]*?)(?=\r?\n##\s+|$)/m;
   if (!statusPattern.test(markdown)) {
     throw new Error('Plan is missing a ## Status section. Refusing to move without a status to update.');
   }
-  return markdown.replace(statusPattern, `$1${stage}\n`);
+  return markdown.replace(statusPattern, `$1\n${stage}\n`);
 }
 
 export function movePlan(slug: string, toStage: PlanCreationStage, start = process.cwd()): MovedPlanResult {
@@ -365,7 +365,7 @@ export function movePlan(slug: string, toStage: PlanCreationStage, start = proce
   }
   const safeSlug = normalizeLifecyclePlanSlug(slug);
   const root = requireScaffoldRoot(start);
-  const parent = findPlanBySlug(root, safeSlug, ['active', 'backlog', 'blocked']);
+  const parent = findPlanBySlug(root, safeSlug, ['active', 'backlog', 'blocked', 'root']);
   if (!parent) {
     const donePlan = findPlanBySlug(root, safeSlug, ['done']);
     if (donePlan) {

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -52,6 +52,15 @@ export interface ClosedPlanResult {
   alreadyDone: boolean;
 }
 
+export interface MovedPlanResult {
+  root: string;
+  slug: string;
+  fromStage: PlanStage | 'root';
+  toStage: PlanCreationStage;
+  movedFiles: string[];
+  alreadyInStage: boolean;
+}
+
 export interface ExecutionGroup {
   name: string;
   rationale: string;
@@ -340,6 +349,56 @@ export function createEvidenceNoteSkeleton(slug: string, start = process.cwd(), 
   mkdirSync(releasesDir, { recursive: true });
   writeFileSync(path, renderEvidenceSkeleton(safeSlug), 'utf8');
   return { root, path, relativePath, slug: safeSlug };
+}
+
+function updatePlanStatus(markdown: string, stage: PlanCreationStage): string {
+  const statusPattern = /(## Status\r?\n\r?\n)([\s\S]*?)(?=\r?\n##\s+|$)/;
+  if (!statusPattern.test(markdown)) {
+    throw new Error('Plan is missing a ## Status section. Refusing to move without a status to update.');
+  }
+  return markdown.replace(statusPattern, `$1${stage}\n`);
+}
+
+export function movePlan(slug: string, toStage: PlanCreationStage, start = process.cwd()): MovedPlanResult {
+  if (!PLAN_CREATION_STAGES.includes(toStage)) {
+    throw new Error(`Invalid plan stage: ${toStage}. Expected one of: ${PLAN_CREATION_STAGES.join(', ')}`);
+  }
+  const safeSlug = normalizeLifecyclePlanSlug(slug);
+  const root = requireScaffoldRoot(start);
+  const parent = findPlanBySlug(root, safeSlug, ['active', 'backlog', 'blocked']);
+  if (!parent) {
+    const donePlan = findPlanBySlug(root, safeSlug, ['done']);
+    if (donePlan) {
+      throw new Error(`Plan is already done: ${safeSlug}.md. Done plans are immutable; create a follow-up plan instead.`);
+    }
+    throw new Error(`Plan not found: ${safeSlug}.md in .osc/plans/{active,backlog,blocked}.`);
+  }
+
+  const parentPath = join(parent.dir, `${safeSlug}.md`);
+  const updatedParentText = updatePlanStatus(readText(parentPath), toStage);
+  if (parent.stage === toStage) {
+    writeFileSync(parentPath, updatedParentText, 'utf8');
+    return { root, slug: safeSlug, fromStage: parent.stage, toStage, movedFiles: [], alreadyInStage: true };
+  }
+
+  const targetDir = join(root, OSC_NAMESPACE, 'plans', toStage);
+  mkdirSync(targetDir, { recursive: true });
+  const amendmentPattern = new RegExp(`^${escapeRegex(safeSlug)}-amendment-\\d+\\.md$`);
+  const filesToMove = [
+    `${safeSlug}.md`,
+    ...readdirSync(parent.dir).filter((file) => amendmentPattern.test(file)).sort(),
+  ];
+  for (const file of filesToMove) {
+    const destination = join(targetDir, file);
+    if (existsSync(destination)) {
+      throw new Error(`Refusing to overwrite existing plan file: ${relative(root, destination)}`);
+    }
+  }
+  for (const file of filesToMove) {
+    renameSync(join(parent.dir, file), join(targetDir, file));
+  }
+  writeFileSync(join(targetDir, `${safeSlug}.md`), updatedParentText, 'utf8');
+  return { root, slug: safeSlug, fromStage: parent.stage, toStage, movedFiles: filesToMove, alreadyInStage: false };
 }
 
 export function createPlanAmendment(slug: string, start = process.cwd(), message = '', date = new Date()): CreatedPlanAmendment {

--- a/tests/cli-plan-move.test.ts
+++ b/tests/cli-plan-move.test.ts
@@ -76,6 +76,56 @@ describe('osc plan move CLI', () => {
     expect(existsSync(blockedPlan)).toBe(false);
   }, 20_000);
 
+  it('moves legacy root plans with compact status formatting into a stage folder', () => {
+    const target = initializedScaffold();
+    const rootPlanPath = join(target, '.osc/plans/004-root-task.md');
+    writeFileSync(rootPlanPath, [
+      '# Plan: 004-root-task',
+      '',
+      '## Status',
+      'backlog',
+      '',
+      '## Context',
+      '',
+      'Legacy root-level plan.',
+      '',
+      '## Goal',
+      '',
+      'Move it into staged workflow.',
+      '',
+      '## Constraints / Out of scope',
+      '',
+      '- Do not close it.',
+      '',
+      '## Files to touch',
+      '',
+      '- `.osc/plans/004-root-task.md` — legacy source.',
+      '',
+      '## Acceptance criteria',
+      '',
+      '- [ ] Plan moves to active.',
+      '',
+      '## Verification steps',
+      '',
+      '1. Run the move command.',
+      '',
+      '## Open questions',
+      '',
+      '- None.',
+      '',
+    ].join('\n'));
+    writeFileSync(join(target, '.osc/plans/004-root-task-amendment-1.md'), '# Amendment 1: 004-root-task\n');
+
+    const output = execFileSync(tsx, [cli, 'plan', 'move', '004-root-task', '--to', 'active'], { cwd: target, encoding: 'utf8' });
+
+    expect(output).toContain('From: root');
+    const activePlan = join(target, '.osc/plans/active/004-root-task.md');
+    expect(existsSync(activePlan)).toBe(true);
+    expect(existsSync(join(target, '.osc/plans/active/004-root-task-amendment-1.md'))).toBe(true);
+    expect(existsSync(rootPlanPath)).toBe(false);
+    expect(readFileSync(activePlan, 'utf8')).toContain('## Status\n\nactive\n');
+  }, 20_000);
+
   it('refuses unsafe slugs, missing plans, done destinations, and unsupported options', () => {
     const target = initializedScaffold();
     execFileSync(tsx, [cli, 'plan', 'new', '003-third-task', '--stage', 'active'], { cwd: target, encoding: 'utf8' });

--- a/tests/cli-plan-move.test.ts
+++ b/tests/cli-plan-move.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempDir(prefix = 'osc-cli-plan-move-') {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function initializedScaffold() {
+  const target = tempDir();
+  execFileSync(tsx, [cli, 'init', '--tier', 'min', '--target', target], { encoding: 'utf8' });
+  defineMission(target);
+  return target;
+}
+
+function defineMission(target: string) {
+  writeFileSync(join(target, 'MISSION.md'), [
+    '# Mission',
+    '',
+    'Test project mission.',
+    '',
+    '## Goals',
+    '',
+    '- Test plan movement.',
+    '',
+    '## Non-Goals',
+    '',
+    '- Do not execute runtime work.',
+    '',
+    '## Changelog',
+    '',
+    '<!-- append YYYY-MM-DD entries below this line -->',
+    '',
+  ].join('\n'));
+}
+
+describe('osc plan move CLI', () => {
+  it('moves a backlog plan and its amendments to active while updating the parent status', () => {
+    const target = initializedScaffold();
+    execFileSync(tsx, [cli, 'plan', 'new', '001-first-task', '--stage', 'backlog'], { cwd: target, encoding: 'utf8' });
+    execFileSync(tsx, [cli, 'amend', '001-first-task', '--message', 'Scope changed'], { cwd: target, encoding: 'utf8' });
+
+    const output = execFileSync(tsx, [cli, 'plan', 'move', '001-first-task', '--to', 'active'], { cwd: target, encoding: 'utf8' });
+
+    expect(output).toContain('Moved plan: 001-first-task');
+    expect(output).toContain('From: backlog');
+    expect(output).toContain('To: active');
+    const activePlan = join(target, '.osc/plans/active/001-first-task.md');
+    expect(existsSync(activePlan)).toBe(true);
+    expect(existsSync(join(target, '.osc/plans/active/001-first-task-amendment-1.md'))).toBe(true);
+    expect(existsSync(join(target, '.osc/plans/backlog/001-first-task.md'))).toBe(false);
+    expect(existsSync(join(target, '.osc/plans/backlog/001-first-task-amendment-1.md'))).toBe(false);
+    expect(readFileSync(activePlan, 'utf8')).toContain('## Status\n\nactive');
+  });
+
+  it('moves active plans to blocked or backlog and creates missing destination folders', () => {
+    const target = initializedScaffold();
+    execFileSync(tsx, [cli, 'plan', 'new', '002-second-task', '--stage', 'active'], { cwd: target, encoding: 'utf8' });
+    rmSync(join(target, '.osc/plans/blocked'), { recursive: true, force: true });
+
+    execFileSync(tsx, [cli, 'plan', 'move', '002-second-task', '--to', 'blocked'], { cwd: target, encoding: 'utf8' });
+    const blockedPlan = join(target, '.osc/plans/blocked/002-second-task.md');
+    expect(existsSync(blockedPlan)).toBe(true);
+    expect(readFileSync(blockedPlan, 'utf8')).toContain('## Status\n\nblocked');
+
+    execFileSync(tsx, [cli, 'plan', 'move', '002-second-task', '--to', 'backlog'], { cwd: target, encoding: 'utf8' });
+    const backlogPlan = join(target, '.osc/plans/backlog/002-second-task.md');
+    expect(existsSync(backlogPlan)).toBe(true);
+    expect(readFileSync(backlogPlan, 'utf8')).toContain('## Status\n\nbacklog');
+    expect(existsSync(blockedPlan)).toBe(false);
+  });
+
+  it('refuses unsafe slugs, missing plans, done destinations, and unsupported options', () => {
+    const target = initializedScaffold();
+    execFileSync(tsx, [cli, 'plan', 'new', '003-third-task', '--stage', 'active'], { cwd: target, encoding: 'utf8' });
+
+    const doneTarget = spawnSync(tsx, [cli, 'plan', 'move', '003-third-task', '--to', 'done'], { cwd: target, encoding: 'utf8' });
+    expect(doneTarget.status).toBe(2);
+    expect(doneTarget.stderr).toContain('Use osc close');
+
+    const invalidTarget = spawnSync(tsx, [cli, 'plan', 'move', '003-third-task', '--to', 'later'], { cwd: target, encoding: 'utf8' });
+    expect(invalidTarget.status).toBe(2);
+    expect(invalidTarget.stderr).toContain('Invalid value for --to');
+
+    const unsafe = spawnSync(tsx, [cli, 'plan', 'move', '../outside', '--to', 'active'], { cwd: target, encoding: 'utf8' });
+    expect(unsafe.status).toBe(2);
+    expect(unsafe.stderr).toContain('Unsafe slug');
+
+    const missing = spawnSync(tsx, [cli, 'plan', 'move', '999-missing', '--to', 'active'], { cwd: target, encoding: 'utf8' });
+    expect(missing.status).toBe(1);
+    expect(missing.stderr).toContain('Plan not found');
+
+    const extra = spawnSync(tsx, [cli, 'plan', 'move', '003-third-task', '--to', 'active', '--force'], { cwd: target, encoding: 'utf8' });
+    expect(extra.status).toBe(2);
+    expect(extra.stderr).toContain('Unknown option for plan move');
+  });
+});

--- a/tests/cli-plan-move.test.ts
+++ b/tests/cli-plan-move.test.ts
@@ -57,7 +57,7 @@ describe('osc plan move CLI', () => {
     expect(existsSync(join(target, '.osc/plans/backlog/001-first-task.md'))).toBe(false);
     expect(existsSync(join(target, '.osc/plans/backlog/001-first-task-amendment-1.md'))).toBe(false);
     expect(readFileSync(activePlan, 'utf8')).toContain('## Status\n\nactive');
-  });
+  }, 20_000);
 
   it('moves active plans to blocked or backlog and creates missing destination folders', () => {
     const target = initializedScaffold();
@@ -74,7 +74,7 @@ describe('osc plan move CLI', () => {
     expect(existsSync(backlogPlan)).toBe(true);
     expect(readFileSync(backlogPlan, 'utf8')).toContain('## Status\n\nbacklog');
     expect(existsSync(blockedPlan)).toBe(false);
-  });
+  }, 20_000);
 
   it('refuses unsafe slugs, missing plans, done destinations, and unsupported options', () => {
     const target = initializedScaffold();
@@ -99,5 +99,5 @@ describe('osc plan move CLI', () => {
     const extra = spawnSync(tsx, [cli, 'plan', 'move', '003-third-task', '--to', 'active', '--force'], { cwd: target, encoding: 'utf8' });
     expect(extra.status).toBe(2);
     expect(extra.stderr).toContain('Unknown option for plan move');
-  });
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary

Adds `osc plan move <slug> --to active|backlog|blocked` for the common solo-dev lifecycle path.

This lets a user:

- create a backlog plan,
- promote it to active,
- park it as blocked,
- move it back to backlog/active,
- keep amendment files beside the parent plan,
- and keep `done/` reserved for `osc close`.

## Traceability

- Plan: `.osc/plans/done/049-plan-stage-move.md`
- Evidence: `.osc/releases/2026-05-18-049-plan-stage-move.md`
- Kanban: `t_c6641254`
- Branch: `cli/plan-stage-move`

## What changed

- Added a safe `movePlan()` helper in `src/scaffold.ts`.
- Added `osc plan move <slug> --to <active|backlog|blocked>` in `src/cli.ts`.
- Added tests for:
  - backlog → active movement,
  - amendment movement with parent plans,
  - active → blocked → backlog movement,
  - missing destination folder creation,
  - legacy root-level plan movement,
  - compact `## Status\nactive` formatting,
  - unsafe slug / missing plan / invalid destination / `done` refusal.
- Added per-test timeouts for the subprocess-heavy new CLI tests after Codex flagged timeout risk.
- Updated README and workflow docs to show the backlog → active flow.

## Verification

- RED check: `npm test -- tests/cli-plan-move.test.ts` initially failed because `osc plan move` did not exist.
- `npm test -- tests/cli-plan-move.test.ts` → 1 file / 4 tests passed
- `npm run build` → pass
- `npm test` → 22 files / 187 tests passed
- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn
- `npm run osc -- verify` → pass; 0 warnings
- `git diff --check` → pass

## Scope boundaries

- No movement into `done` outside `osc close`.
- No task database.
- No GitHub issue sync.
- No runtime launch.
- No npm publish or version bump.

## Codex review

Re-triggered after fixing the two valid P2 findings on latest head `34ab8e5`.
