### PR TITLE
Add 24 detailed v2 backlog plans (050-073) — full product roadmap

### DIFF
--- a/.osc/plans/backlog/050-npm-publish-and-npx-init.md
+++ b/.osc/plans/backlog/050-npm-publish-and-npx-init.md
@@ -1,0 +1,57 @@
+# Plan: 050-npm-publish-and-npx-init
+
+## Status
+
+backlog — high-priority adoption blocker. The package is not on the public npm registry; `npx open-scaffold init` returns `npm ERR! 404` for every prospective user. This is the single largest obstacle to public adoption. Self-dogfooded planning, verification, and scaffolding infrastructure exists in-repo but has zero external reach until publish.
+
+## Context
+
+The README instructs users to run `npx open-scaffold init --tier min --target <dir>` as the first onboarding command. As of 2026-05-18, `npm view open-scaffold version` returns nothing — the package has never been published. The repo contains a complete `package.json`, a `src/` tree with a working CLI, bootstrap scripts, and verification tooling, but none of it is reachable from npm. This plan follows the completion of the v1 scaffolding core (plans 001–049 covering init, plan lifecycle, amendments, verify.sh, and run packets) and is the necessary final step to make those features externally consumable. It is blocked only on owner approval of npm publish.
+
+## Goal
+
+Publish open-scaffold to the public npm registry so that `npx open-scaffold init --tier min --target <dir>` succeeds for any user with Node.js ≥18, producing a valid scaffold that passes `./verify.sh --standard`.
+
+## Constraints / Out of scope
+
+- Do not ship `.osc/plans/done/`, `.osc-dev/`, or private owner data in the npm package. The payload must be tight and public-safe.
+- Do not modify the scaffold protocol — whatever ships in the npm package must be identical to what lives in-repo, minus gitignored private directories.
+- Do not automate publish on every push; npm publish requires explicit owner approval (2FA token or OTP).
+- Do not claim published status until `npm view open-scaffold version` returns the actual version string.
+- Keep the package footprint small — `npm pack --dry-run` gzipped size should stay under 100KB.
+
+## Files to touch
+
+- `package.json` — version bump to 0.1.0 or 1.0.0, audit `"files"` field to include `src/`, `docs/`, `AGENTS.md`, `CLAUDE.md`, `MISSION.md`, `.osc/` (core scaffold dirs only, not dogfood plans), `bootstrap.sh`, `verify.sh`, `amend.sh`, `close.sh`, and template files; verify `"bin"` entry maps to compiled or source entry point.
+- `.npmignore` — create if absent; explicitly exclude `.osc/plans/done/`, `.osc/plans/backlog/0*` (dogfood plans), `.osc-dev/`, `.osc/runs/`, `node_modules/`, `.git/`, test fixtures with private data, and CI artifacts.
+- `docs/` — ensure all docs referenced from README are included in the files list; check for broken cross-document links.
+- `src/` — verify build output (`dist/`) is correct and entry point resolves; run `npm run build` and confirm no TypeScript errors.
+- `.github/workflows/` — add a `publish.yml` CI workflow that runs `npm test`, `npm run build`, and `npm publish --dry-run` on version-tagged commits, with a manual `workflow_dispatch` trigger for actual publish.
+- `README.md` — add a "published version" badge and confirm the `npx` invocation example matches the actual binary name.
+
+## Acceptance criteria
+
+- [ ] `npm pack --dry-run --json` output lists only public-safe files; no `.osc-dev/`, no `.osc/plans/done/`, no gitignored directories.
+- [ ] `npm view open-scaffold version` returns the published version (e.g., `0.1.0`).
+- [ ] `npx open-scaffold init --tier min --target /tmp/test-smoke` succeeds, creates `.osc/`, `MISSION.md`, `AGENTS.md`, `CLAUDE.md`, `verify.sh`, and the shell scripts.
+- [ ] `cd /tmp/test-smoke && ./verify.sh --standard` exits 0.
+- [ ] The published package does not contain `.osc/plans/done/` or `.osc-dev/` (verify with `npm pack --dry-run | grep`).
+- [ ] `.github/workflows/publish.yml` exists with a `workflow_dispatch` publish trigger and a dry-run verification on tag push.
+- [ ] `npm run build` exits 0 and `npm test` passes with no failures before publish.
+- [ ] npm registry page shows correct description, license (MIT), repository link, and keywords.
+
+## Verification steps
+
+1. Run `npm pack --dry-run --json 2>&1 | jq '.[].name' | sort` and inspect the file list. Confirm no `.osc-dev/`, `.osc/plans/done/`, `.osc/plans/backlog/0*` (dogfood plans), `.osc/runs/`, or `node_modules/` entries.
+2. Run `npm publish --dry-run` and confirm it would publish without errors.
+3. After actual publish (owner-gated), run `npm view open-scaffold version` and confirm it returns the published semver.
+4. Run `npx open-scaffold@latest init --tier min --target /tmp/test-smoke && cd /tmp/test-smoke && ./verify.sh --standard`. Expected exit 0.
+5. Check the npm registry page at `https://www.npmjs.com/package/open-scaffold` for correct metadata (description, license, repository, README rendering).
+6. Run `npm pack` locally, extract the tarball, and `grep -r "TODO" .` inside the extracted dir — confirm no TODO markers ship in the published package.
+
+## Open questions
+
+- Should the initial publish be version `0.1.0` (pre-stable semver signaling) or `1.0.0` (signaling v1 readiness)? The scaffold core is stable enough for v1, but the ecosystem of adapter evidence and runtime bindings is nascent.
+- Who holds the npm 2FA token for publish? Does the owner use `npm token create` with CI secrets, or publish manually from their local machine?
+- Should `npx open-scaffold init` default to `--tier standard` and require `--tier min` for minimal, or default to `--tier min` and require `--tier standard` for full? Current CLI behavior needs confirmation.
+- Should the npm package include `.osc/plans/` template files (handoff template, workflow docs) or only the scaffold generator that produces them? Including them lets `osc plan new` work from template, but risks confusion if users edit the shipped templates.

--- a/.osc/plans/backlog/051-brownfield-init-from-existing.md
+++ b/.osc/plans/backlog/051-brownfield-init-from-existing.md
@@ -1,0 +1,57 @@
+# Plan: 051-brownfield-init-from-existing
+
+## Status
+
+backlog — blocked on 050 (npm publish) for baseline `osc init` availability. This extends the greenfield-only `osc init` to support existing project directories, which is the majority real-world adoption path. No work begins until `osc init --tier min` is stable and published.
+
+## Context
+
+`osc init` in its shipped form assumes greenfield: it creates a fresh scaffold in an empty or scaffold-absent directory, generating `MISSION.md`, `.osc/plans/`, `AGENTS.md`, `CLAUDE.md`, and shell scripts from scratch. Most real projects already exist — they have `package.json`, source trees in `src/` or `lib/`, existing `README.md`, CI configs, and established conventions. Users should not have to restructure their entire project to adopt Open Scaffold. The `--from-existing` flag bridges this gap by detecting the existing project structure and placing Open Scaffold protocol files alongside it without disruption. This plan was prompted by early adopter feedback that "start from scratch" is a non-starter for projects with history.
+
+## Goal
+
+Add `osc init --from-existing` that detects an existing project's language, package manager, and structure, then scaffolds the Open Scaffold protocol (`.osc/`, `MISSION.md`, `AGENTS.md`, `CLAUDE.md`, shell scripts) alongside existing files without overwriting or moving anything.
+
+## Constraints / Out of scope
+
+- Must NOT overwrite existing files unless `--force` is explicitly passed. If `MISSION.md`, `.osc/`, `AGENTS.md`, or `CLAUDE.md` already exist, refuse with a clear message listing each conflict.
+- Must NOT move or rename existing project files. The scaffold is additive only.
+- Detection covers common project types (Node.js via `package.json`, Python via `pyproject.toml` or `setup.py`, Go via `go.mod`, Rust via `Cargo.toml`, monorepo via workspace config) and falls back to a generic scaffold for unrecognized structures.
+- Does NOT auto-detect existing task systems (Jira, Linear, GitHub Issues) or CI pipelines — those remain manual integrations.
+- Does NOT modify the user's existing `package.json`, build scripts, or lockfiles.
+- Does NOT generate a full `MISSION.md` from project analysis — it writes a reasonable first draft with the detected project type and a `<!-- mission:unset -->` marker so the user fills in specifics.
+
+## Files to touch
+
+- `src/init.ts` — add `--from-existing` flag parsing, detection logic (`detectProjectType()`, `detectPackageManager()`), conflict check (`checkExistingConflicts()`), and template selection based on detected type.
+- `src/cli.ts` — wire `--from-existing` and `--force` flags into the `init` subcommand. Update help text to describe brownfield behavior.
+- `docs/MINIMUM_VIABLE_SCAFFOLD.md` — add a "Brownfield adoption" section explaining the flag, detection capabilities, and what users should expect.
+- `tests/init.test.ts` — add test cases for Node.js project fixture, Python project fixture, empty directory (greenfield fallback), conflict detection, `--force` override, and monorepo detection.
+- Test fixtures: create `tests/fixtures/brownfield-node/` (with `package.json`, `src/index.js`), `tests/fixtures/brownfield-python/` (with `pyproject.toml`, `src/__init__.py`), `tests/fixtures/brownfield-empty/` (empty dir).
+
+## Acceptance criteria
+
+- [ ] `osc init --from-existing --tier min` in a directory containing `package.json` creates `.osc/`, `MISSION.md`, `AGENTS.md`, `CLAUDE.md`, and shell scripts alongside the existing `package.json`.
+- [ ] Existing files (`package.json`, `src/`, `README.md`) are untouched — verified by `git diff` showing zero changes to pre-existing content.
+- [ ] Generated `MISSION.md` contains a reasonable first draft mentioning "Node.js" (or detected language) and the `<!-- mission:unset -->` marker.
+- [ ] Works for directories with no package manager files (generic scaffold, no language-specific snippet).
+- [ ] Refuses to overwrite existing `MISSION.md` or `.osc/` without `--force`; error message lists each conflicting path.
+- [ ] `--force` flag overwrites existing scaffold files but still leaves user project files untouched.
+- [ ] `./verify.sh --quick --quiet` exits 0 after init in each test fixture.
+- [ ] Detects and tailors scaffold for Node.js, Python, Go, and Rust projects (at minimum).
+
+## Verification steps
+
+1. Create test fixture: `mkdir -p /tmp/brownfield-node && cd /tmp/brownfield-node && echo '{"name":"test"}' > package.json && mkdir src && echo 'console.log("hi")' > src/index.js`.
+2. Run `osc init --from-existing --tier min` in `/tmp/brownfield-node`. Verify `package.json` and `src/index.js` are untouched (md5sum unchanged). Verify `.osc/`, `MISSION.md`, `AGENTS.md`, `CLAUDE.md`, `verify.sh` exist.
+3. Run `./verify.sh --quick --quiet` — expected exit 0.
+4. Run `osc init --from-existing --tier min` a second time (no `--force`). Expected: error message listing `MISSION.md` and `.osc/` as conflicts, exit code non-zero.
+5. Run `osc init --from-existing --tier min --force`. Expected: succeeds, overwrites scaffold files, user files untouched.
+6. Create Python fixture (`pyproject.toml`), Go fixture (`go.mod`), Rust fixture (`Cargo.toml`), and empty dir. Repeat init in each. Verify detection and tailored `MISSION.md` snippets.
+
+## Open questions
+
+- Should `--from-existing` become the default behavior when `osc init` detects existing project files, or remain an explicit opt-in flag? Opt-in is safer for v1 to avoid surprise scaffold placement.
+- How deeply should detection go — read `package.json` scripts for test/lint/build commands and suggest them in the generated scaffold? That crosses into CI config generation, which is out of scope for this slice.
+- Should `osc init --from-existing` also generate a `ROADMAP.md` with a first item derived from the existing project's git history or README? No — roadmap generation is a separate feature requiring semantic understanding.
+- What happens when a directory has multiple package manager files (e.g., both `package.json` and `pyproject.toml`)? The detector should pick the primary one based on a priority heuristic (Node.js first, then Python, then Go, then Rust) and note the others in a comment.

--- a/.osc/plans/backlog/052-interactive-plan-wizard.md
+++ b/.osc/plans/backlog/052-interactive-plan-wizard.md
@@ -1,0 +1,57 @@
+# Plan: 052-interactive-plan-wizard
+
+## Status
+
+backlog — depends on 050 (npm publish) for baseline `osc plan new` availability. Addresses the blank-page paralysis problem where new users see a 7-section template full of `TODO:` markers and don't know where to start. The wizard is a UX layer over the existing plan scaffolding; it does not change the plan format or lifecycle.
+
+## Context
+
+`osc plan new <slug>` creates a skeleton plan file with all seven sections labeled `TODO:`. This is correct from a protocol perspective — plans must be filled by humans — but new users face blank-page paralysis. They don't know what a good goal looks like, what constraints are reasonable, or how to write testable acceptance criteria. The handoff template comments provide guidance, but passive documentation is not the same as an active interview. An interactive wizard that asks structured questions in plain terminal and fills the plan template would dramatically lower the barrier to writing actionable plans. This is the plan-creation equivalent of `npm init` (which interviews for `package.json` fields) or `git commit` without `-m` (which opens an editor for the message).
+
+## Goal
+
+Add `osc plan wizard [slug]` that interactively interviews the user with 5–8 structured questions and produces a filled plan file in `.osc/plans/active/<slug>.md` with real content in every section — no `TODO:` markers remain.
+
+## Constraints / Out of scope
+
+- The wizard asks questions; it does NOT invent acceptance criteria, goals, or implementation details on behalf of the user. Every answer comes from the user.
+- Must work in a plain terminal with readline-style input — no TUI framework dependency (no `inquirer`, `blessed`, or similar heavyweight libraries). Use Node.js built-in `readline` module.
+- Must accept `--non-interactive` mode with `--answers answers.json` for agent-to-agent or script use, producing identical output from a JSON input.
+- Output is a standard plan file in `.osc/plans/active/<slug>.md` following the 7-section handoff template — no special format, no metadata injection beyond what the template supports.
+- Does NOT validate the semantic quality of answers (e.g., whether AC is actually testable) — that's the plan linter's job (plan 055).
+- Refuses to proceed if `MISSION.md` contains `<!-- mission:unset -->` — redirect user to define their mission first.
+
+## Files to touch
+
+- `src/cli.ts` — add `wizard` subcommand under `osc plan` with `--non-interactive` and `--answers` flags; update help text.
+- `src/wizard.ts` — new file: question bank, readline-based interview loop, answer-to-template mapping, file output. Question flow: (1) goal, (2) what triggered this work, (3) constraints / what NOT to do, (4) files likely to change, (5) acceptance criteria (prompt for multiple, accept blank line to finish), (6) verification commands, (7) open questions or dependencies.
+- `tests/wizard.test.ts` — unit tests for `mapAnswersToTemplate()`, `validateAnswers()`, empty answer handling, special characters in answers, `--non-interactive` path.
+- `tests/fixtures/wizard-answers.json` — sample answers file for non-interactive test.
+- `docs/WORKFLOW.md` — mention `osc plan wizard` as the recommended first step for new plan creation; add quick example.
+
+## Acceptance criteria
+
+- [ ] `osc plan wizard my-feature` asks 5–8 questions interactively (goal description, context/trigger, constraints, files to touch, acceptance criteria with multi-line input, verification method, open questions/dependencies).
+- [ ] Produces a plan file at `.osc/plans/active/my-feature.md` with all 7 sections filled with user-provided content.
+- [ ] No `TODO:` markers remain in the generated plan.
+- [ ] User can skip any question by entering an empty line (section is left blank or marked "not specified").
+- [ ] `--non-interactive --answers answers.json` reads from file and produces identical output to what interactive input would generate for the same answers.
+- [ ] Generated plan passes `./verify.sh --strict` schema checks (correct headings, required sections present).
+- [ ] Wizard refuses to continue if `MISSION.md` is unset (contains `<!-- mission:unset -->`), printing a clear message.
+- [ ] `--stage` flag allows targeting `backlog/`, `blocked/`, or `active/` (default `active/`).
+
+## Verification steps
+
+1. Run interactive test: `echo -e "Build a CLI cache\nCache misses were slow\nDo not change API\nsrc/cache.ts, tests/cache.test.ts\nCache hit rate above 90%\nResponse under 10ms\n\nRun npm test\ndepends on PR #42\n" | osc plan wizard test-wizard`. Verify output plan at `.osc/plans/active/test-wizard.md` has all sections with provided content.
+2. Run `grep -c "TODO:" .osc/plans/active/test-wizard.md` — expected: 0.
+3. Run `./verify.sh --strict` — expected exit 0.
+4. Run `osc plan wizard --non-interactive --answers tests/fixtures/wizard-answers.json test-json`. Verify output matches interactive equivalent.
+5. Run `osc plan wizard test-skip` and press Enter (empty) for every question. Verify all sections are present but contain only `_not specified_` or blank.
+6. In a repo with `<!-- mission:unset -->` in `MISSION.md`, run `osc plan wizard test-blocked`. Expected: refusal with message about undefined mission.
+
+## Open questions
+
+- Should the wizard support an `--editor` mode that opens `$EDITOR` with the pre-filled template instead of inline Q&A? This could serve users who prefer writing in their editor but want the template pre-populated with prompts.
+- Should answers be cached so the wizard can resume an interrupted session? The `readline` approach loses state on Ctrl+C — a `.osc/.wizard-cache.json` temp file could enable resume with `osc plan wizard --resume`.
+- Should the wizard auto-detect the stage folder based on answers (e.g., if user mentions "blocked on X" in open questions, suggest `--stage blocked`)? That's heuristic and fragile; explicit `--stage` is clearer.
+- How many AC prompts should the wizard offer before timing out? The current design loops until empty line; a max of 10 AC items with a "continue? (y/n)" prompt after 5 could prevent accidental infinite loops.

--- a/.osc/plans/backlog/053-plan-template-library.md
+++ b/.osc/plans/backlog/053-plan-template-library.md
@@ -1,0 +1,65 @@
+# Plan: 053-plan-template-library
+
+## Status
+
+backlog — depends on 050 (npm publish) so that shipped templates are reachable. Complements 052 (interactive wizard) as an alternative plan-creation acceleration path: rather than answering questions, users copy a domain-specific template and fill in placeholders. Both wizard and templates ship together so users can choose their preferred workflow.
+
+## Context
+
+The generic handoff template in `.osc/plans/handoff-template.md` is flexible but blank — every section is a `TODO:` or empty prompt. Domain-specific plans have naturally different shapes: a bug fix plan emphasizes reproduction steps and verification commands, a new feature plan emphasizes design decisions and acceptance criteria, a refactor plan emphasizes before/after behavior and risk mitigation, and a dependency upgrade plan emphasizes compatibility checks and rollback procedures. Pre-filled templates with realistic example content and clearly labeled replaceable sections would accelerate plan creation by giving users a concrete starting point. This is the template equivalent of GitHub Issue templates or `dependabot` PR descriptions — structured starting points that encode domain knowledge.
+
+## Goal
+
+Ship 6 domain-specific plan templates under `.osc/plans/templates/` that users can copy manually or reference with `osc plan new <slug> --from-template <name>`, each with all 7 sections filled with realistic example content and clearly marked replaceable parts.
+
+## Constraints / Out of scope
+
+- Templates are starting points, not mandatory shapes. The generic handoff template remains the default — `osc plan new <slug>` without `--from-template` still produces the blank skeleton.
+- Templates MUST NOT contain `TODO:` markers. Instead, they use `REPLACE_ME:` prefix or `<placeholder description>` angle-bracket markers that are clearly distinguishable from real content.
+- The template library is extensible: users can add their own `.osc/plans/templates/custom-<name>.md` files, and `osc plan new --from-template custom-<name>` will find them.
+- Does NOT include AI-generated template suggestions based on project context — that crosses into semantic analysis territory.
+- Templates are shipped with the npm package; they are part of the scaffold, not generated at init time.
+
+## Files to touch
+
+- `.osc/plans/templates/` — new directory for template files.
+- `.osc/plans/templates/bug-fix.md` — reproduction steps, expected vs actual behavior, affected versions, verification commands, regression test requirement.
+- `.osc/plans/templates/new-feature.md` — feature description, user story, design decisions, API surface changes, acceptance criteria, rollout plan.
+- `.osc/plans/templates/refactor.md` — motivation, before/after behavior, risk assessment, affected callers, performance impact, migration path.
+- `.osc/plans/templates/docs-update.md` — which docs, what changed, review checklist, broken link check, translation impact.
+- `.osc/plans/templates/dependency-upgrade.md` — package name, from/to version, changelog link, breaking changes, compatibility test plan, rollback procedure.
+- `.osc/plans/templates/arch-decision.md` — decision title, context, alternatives considered, tradeoffs, consequences, validation criteria.
+- `.osc/plans/templates/README.md` — explains how to use templates, how `--from-template` works, how to create custom templates, and naming conventions.
+- `src/scaffold.ts` — modify `createPlanSkeleton()` to accept an optional template name; if provided, copy the template content and replace `REPLACE_ME:` markers with blank prompts.
+- `src/cli.ts` — wire `--from-template <name>` flag on `osc plan new` subcommand. List available templates on `--from-template list`.
+- `tests/plan.test.ts` — add test cases for template-based plan creation, missing template error, custom template discovery, and template content validation.
+- `docs/WORKFLOW.md` — mention `--from-template` flag and template library.
+
+## Acceptance criteria
+
+- [ ] At least 6 templates exist under `.osc/plans/templates/` (bug-fix, new-feature, refactor, docs-update, dependency-upgrade, arch-decision).
+- [ ] Each template has all 7 required sections (Status, Context, Goal, Constraints/Out of scope, Files to touch, Acceptance criteria, Verification steps) plus Open questions.
+- [ ] Each template has realistic example content — a bug-fix template might mention "NullPointerException in UserService.createUser()" and " reproduce with empty email field" rather than generic placeholder text.
+- [ ] `osc plan new my-bug --from-template bug-fix --stage backlog` copies the bug-fix template to `.osc/plans/backlog/my-bug.md`, replacing `REPLACE_ME:` markers with blank prompts.
+- [ ] `osc plan new my-thing --from-template list` prints available template names.
+- [ ] `.osc/plans/templates/README.md` explains usage, extension, and naming conventions.
+- [ ] All templates pass `./verify.sh --strict` schema checks (headings match, sections present).
+- [ ] No `TODO:` markers in any template; all placeholder content uses `REPLACE_ME:` prefix.
+
+## Verification steps
+
+1. Run `ls .osc/plans/templates/` and confirm at least 6 `.md` files plus `README.md`.
+2. Run `grep -r "TODO:" .osc/plans/templates/` — expected: no matches.
+3. Run `grep -r "REPLACE_ME:" .osc/plans/templates/` — expected: at least one per template in sections where user input is required.
+4. Run `osc plan new test-bug --from-template bug-fix --stage backlog`. Verify output file at `.osc/plans/backlog/test-bug.md` has all sections with content, `REPLACE_ME:` markers replaced by blank prompts.
+5. Run `./verify.sh --strict` — expected exit 0.
+6. Run `osc plan new test-custom --from-template custom-acme --stage backlog`. Expected: error "template 'custom-acme' not found in .osc/plans/templates/".
+7. Create `.osc/plans/templates/custom-acme.md` with valid plan content. Run `osc plan new test-custom --from-template custom-acme --stage backlog`. Expected: succeeds, uses custom template.
+8. Run `osc plan new --from-template list` — expected: prints available template names.
+
+## Open questions
+
+- Should templates be versioned (e.g., `bug-fix-v1.md`) to allow template evolution without breaking existing plans that reference old template names? Simple approach: version the directory (`templates/v1/`) and symlink or alias the latest.
+- Should the template system support includes or inheritance (e.g., a "performance" template that extends "refactor")? That adds complexity; flat templates with clear naming are sufficient for v1.
+- Should the npm package ship only the 6 core templates, or also include the `custom-` namespace for user templates? Only core templates ship; user templates live in the scaffold directory and are gitignored from npm pack.
+- Should `osc plan new --from-template` validate that the template is a valid plan before copying? Yes — validate template structure at copy time and reject malformed templates with a clear error.

--- a/.osc/plans/backlog/054-multi-language-agent-entry-points.md
+++ b/.osc/plans/backlog/054-multi-language-agent-entry-points.md
@@ -1,0 +1,69 @@
+# Plan: 054-multi-language-agent-entry-points
+
+## Status
+
+backlog — depends on 050 (npm publish) so translated files ship in the npm package. This is an adoption-expansion slice: AGENTS.md and CLAUDE.md are the two primary entry-point files that coding agents read to understand the project, and they are currently available only in English. Global developer communities in China, Japan, Korea, Brazil, and Spanish-speaking countries benefit from native-language entry points.
+
+## Context
+
+AGENTS.md and CLAUDE.md serve as the paired-view instruction files that agentic coding tools (Claude Code, Codex, Cursor, Copilot, Gemini CLI, and others) read on project load. They carry project facts, operating rules, and workflow conventions. For non-English-speaking developers and coding agents, these files are opaque until translated. The paired-view constraint — that both files carry the same project facts in formats each tool reads natively — applies across languages too: a Japanese AGENTS.md must mirror the English AGENTS.md structure and factual claims, just as it mirrors CLAUDE.md. This plan adds translations in 5 major languages plus a contribution guide so the community can add more. The English originals remain canonical; translations carry a header noting that.
+
+## Goal
+
+Ship AGENTS.md and CLAUDE.md translations in 5 languages (Chinese/zh, Japanese/ja, Korean/ko, Spanish/es, Portuguese/pt) plus a contributor translation guide, with structural parity to the English originals verified by heading-count diff.
+
+## Constraints / Out of scope
+
+- Translated files MUST mirror the English source exactly in structure: same heading hierarchy, same section order, same factual claims. The paired-view constraint applies across languages.
+- Translations are best-effort: machine translation is acceptable for initial ship with a disclaimer header, but human review is preferred. The disclaimer must state "This is a machine-assisted translation. The English AGENTS.md is canonical. Report discrepancies as issues."
+- Each language gets two files: `AGENTS-<lang>.md` and `CLAUDE-<lang>.md`. The English originals (`AGENTS.md`, `CLAUDE.md`) remain unchanged and canonical.
+- Does NOT translate `MISSION.md`, `ROADMAP.md`, plan files, docs, or shell scripts — those are project-specific and change frequently; translation maintenance cost would be too high.
+- Does NOT add i18n infrastructure, locale detection, or automatic language switching for agent tools — agents read whichever file the user or tooling points them to.
+- Translated files must NOT contain `TODO:` markers or untranslated English sections.
+
+## Files to touch
+
+- `AGENTS-zh.md` — Chinese translation of AGENTS.md, with canonical-source header.
+- `CLAUDE-zh.md` — Chinese translation of CLAUDE.md, with canonical-source header.
+- `AGENTS-ja.md` — Japanese translation, canonical-source header.
+- `CLAUDE-ja.md` — Japanese translation, canonical-source header.
+- `AGENTS-ko.md` — Korean translation, canonical-source header.
+- `CLAUDE-ko.md` — Korean translation, canonical-source header.
+- `AGENTS-es.md` — Spanish translation, canonical-source header.
+- `CLAUDE-es.md` — Spanish translation, canonical-source header.
+- `AGENTS-pt.md` — Portuguese translation, canonical-source header.
+- `CLAUDE-pt.md` — Portuguese translation, canonical-source header.
+- `docs/TRANSLATIONS.md` — contributor guide: how to add a new language, heading parity check script, machine translation workflow, review checklist, and maintenance policy (English source changes trigger a translation update issue).
+- `docs/decisions/README.md` — add a decision note about the translation policy: "AGENTS.md and CLAUDE.md are translated into 5 languages with machine-assisted best-effort quality. English is canonical. Translation discrepancies are bugs to be reported."
+- `README.md` — add a "Languages" section or badge listing available translations with links.
+
+## Acceptance criteria
+
+- [ ] 10 translated files exist (5 language pairs: zh, ja, ko, es, pt), each with the canonical-source header.
+- [ ] Each translated file has identical heading structure to its English source, verified by `diff <(grep '^##' AGENTS.md | sort) <(grep '^##' AGENTS-<lang>.md | sort)` returning no output (empty diff).
+- [ ] `docs/TRANSLATIONS.md` exists with contribution guide: file naming convention (`AGENTS-<ISO 639-1>.md`), heading parity check command, machine translation tool recommendation (DeepL or Google Translate), human review checklist, and maintenance policy.
+- [ ] `./verify.sh --strict` passes — translated files are additive and do not modify originals.
+- [ ] Each translated file has a header block: `<!-- TRANSLATION: This is a machine-assisted <language> translation. The canonical source is the English AGENTS.md. Report discrepancies at <repo>/issues. Last synced: <date>. -->`
+- [ ] `README.md` mentions available translations, either in a "Languages" section or as badges.
+- [ ] No `TODO:` markers or untranslated English sections in any translated file.
+
+## Verification steps
+
+1. For each language (`zh`, `ja`, `ko`, `es`, `pt`), run:
+   ```
+   diff <(grep '^##' AGENTS.md | sort) <(grep '^##' AGENTS-<lang>.md | sort)
+   diff <(grep '^##' CLAUDE.md | sort) <(grep '^##' CLAUDE-<lang>.md | sort)
+   ```
+   Expected: no output (empty diff = structural parity).
+2. Run `grep -r "TODO:" AGENTS-*.md CLAUDE-*.md` — expected: no matches.
+3. Run `grep -L "canonical source" AGENTS-*.md CLAUDE-*.md` — expected: no output (all files have the header).
+4. Run `./verify.sh --strict` — expected exit 0.
+5. Manually open one translated file per language and spot-check at least 3 sections for translation quality and factual accuracy against the English source.
+6. Confirm `docs/TRANSLATIONS.md` header parity check command works by running it against an existing language pair.
+
+## Open questions
+
+- Should translated files live at repo root (alongside AGENTS.md) or in a `i18n/` or `translations/` subdirectory? Root keeps them visible to agent tools that scan the root for entry-point files; a subdirectory hides them from automatic detection.
+- What is the maintenance contract when English AGENTS.md changes? Option A: a CI check that fails if translated files have diverged heading structure, flagging them for manual update. Option B: an automated translation update workflow using a translation API. Option A is simpler and more trustworthy for v1.
+- Should we include French, German, Russian, or Arabic? The 5 languages were chosen for coverage of large developer populations (China, Japan, Korea, Latin America, Brazil). Additional languages can follow the contributor guide.
+- Should `AGENTS-<lang>.md` files include a `lang` attribute in their frontmatter or header for machine detection? The ISO 639-1 code in the filename is sufficient for now; YAML frontmatter would add parsing complexity without clear benefit.

--- a/.osc/plans/backlog/055-plan-linter.md
+++ b/.osc/plans/backlog/055-plan-linter.md
@@ -1,0 +1,59 @@
+# Plan: 055-plan-linter
+
+## Status
+
+backlog — depends on 050 (npm publish) for `osc plan` subcommand availability. Complements 052 (wizard) and 053 (templates) by providing post-creation quality feedback. The linter catches structural and heuristic issues at plan creation time rather than waiting for verification at PR time.
+
+## Context
+
+`verify.sh --strict` checks plan structure at the verification gate — typically when a PR is opened or a slice is being closed. By then, the plan has already been used for implementation. A dedicated `osc plan validate <slug>` that runs at plan creation time catches problems early: missing sections, empty acceptance criteria, vague goals that can't be verified, status/stage mismatches, and `TODO:` markers that should have been filled. This is the plan-level equivalent of ESLint for JavaScript or ruff for Python — mechanical checks that give instant feedback with line numbers and fix suggestions. The linter is mechanical and heuristic, not semantic: it can tell you a section is empty, but it cannot tell you whether the acceptance criteria are correct for the goal.
+
+## Goal
+
+Add `osc plan validate <slug-or-path>` that performs mechanical and heuristic checks on a plan file, reports actionable issues with severity (error/warning/note), line number, and fix suggestion, and supports machine-parseable JSON output for CI integration.
+
+## Constraints / Out of scope
+
+- Checks are mechanical and heuristic, not semantic — the linter detects missing sections, empty AC, `TODO:` markers, and vague goals (heuristic word matching), but cannot judge whether the AC is correct or the goal is achievable.
+- Must work for plans in any stage folder (`active/`, `backlog/`, `blocked/`, `done/`).
+- Must output machine-parseable JSON with `--json` flag for CI/tool integration.
+- Must NOT require network access — all checks run locally against the file.
+- Does NOT validate that referenced files in `## Files to touch` actually exist — that's a separate `--check-files` flag (future enhancement).
+- Does NOT auto-fix issues — the linter reports problems; the user fixes them. Auto-fix for simple issues (e.g., adding missing sections) is a future enhancement.
+
+## Files to touch
+
+- `src/validate-plan.ts` — new file: linter engine with rule registry, file parser, issue reporter. Rules: `required-sections` (all 7 sections present), `no-todos` (no `TODO:` markers), `non-empty-ac` (at least one non-empty acceptance criterion), `no-vague-goal` (heuristic: flags goals containing only "improve", "fix", "update" without specifics), `blocking-questions-tagged` (open questions about blockers should have `BLOCKING:` prefix), `status-stage-consistency` (plan's `## Status` must match the folder it's in — e.g., `## Status: active` in `backlog/` is an error), `heading-order` (headings must be in the canonical order), `no-empty-sections` (sections other than Open questions must not be empty).
+- `src/cli.ts` — wire `validate` subcommand under `osc plan` with `--json`, `--strict` flags.
+- `tests/plan-validate.test.ts` — test cases: perfect plan (0 issues), missing section (1 error), multiple TODOs (1 error per TODO), empty AC (1 warning), vague goal (1 warning), status/folder mismatch (1 error), edge cases (empty file, binary file, non-existent file).
+- `tests/fixtures/` — create test plan fixtures: `plan-valid.md`, `plan-missing-section.md`, `plan-with-todos.md`, `plan-empty-ac.md`, `plan-vague-goal.md`, `plan-status-mismatch.md`.
+- `docs/WORKFLOW.md` — mention `osc plan validate` as recommended step after `osc plan new` or `osc plan wizard`.
+
+## Acceptance criteria
+
+- [ ] `osc plan validate my-feature` checks: all 7 required sections present, no `TODO:` markers, acceptance criteria section not empty, goal section not consisting solely of vague words ("improve", "fix", "update" without specifics), open questions about blockers use `BLOCKING:` prefix, plan status matches stage folder.
+- [ ] Output includes severity level (`error`, `warning`, `note`), line number, and a fix suggestion for each issue.
+- [ ] `--json` outputs a JSON array of issue objects: `[{severity, line, rule, message, suggestion}]`.
+- [ ] Exit code is 0 for clean, 1 for any error-level issues, 0 for warnings-only when `--strict` is NOT set. With `--strict`, exit code 1 for any warning or error.
+- [ ] Works for plans in `active/`, `backlog/`, `blocked/`, and `done/` — resolves the slug to the appropriate stage folder.
+- [ ] Detects plan status/folder mismatch: if `## Status` says `active` but the file is in `backlog/`, reports an error.
+- [ ] `osc plan validate nonexistent-plan` prints clear error and exits non-zero.
+
+## Verification steps
+
+1. Create a perfect plan fixture and run `osc plan validate tests/fixtures/plan-valid.md`. Expected: exit 0, no output (or "0 issues found").
+2. Run `osc plan validate tests/fixtures/plan-valid.md --json | jq '. | length'`. Expected: 0.
+3. Create a plan with missing `## Acceptance criteria` section. Run `osc plan validate tests/fixtures/plan-missing-section.md`. Expected: exit 1, output includes error about missing section with line number hint.
+4. Create a plan with `TODO: write AC`. Run `osc plan validate tests/fixtures/plan-with-todos.md`. Expected: error about TODO marker at the relevant line.
+5. Create a plan with `## Goal: Improve the system`. Run `osc plan validate tests/fixtures/plan-vague-goal.md`. Expected: warning about vague goal.
+6. Create a plan with `## Status: active` but placed in `backlog/`. Run `osc plan validate tests/fixtures/plan-status-mismatch.md`. Expected: error about status/stage mismatch.
+7. Run `osc plan validate --json tests/fixtures/plan-with-todos.md | jq '.'
+   `. Confirm valid JSON with `severity`, `line`, `rule`, `message`, `suggestion` fields.
+8. Run `osc plan validate nonexistent.md`. Expected: non-zero exit, "file not found" message.
+
+## Open questions
+
+- Should the linter also check that `MISSION.md` is defined before validating a plan? The verify.sh chain already enforces this; duplicating it in the linter adds coupling. Keep it in verify.sh for now.
+- What heuristic threshold qualifies a goal as "vague"? Current plan: flag goals that are fewer than 5 words OR consist entirely of stopwords and generic verbs ("improve", "fix", "update", "change", "make better", "refactor"). This will have false positives for genuinely concise goals — the severity should be `warning` not `error`.
+- Should the linter check for MISSION.md alignment (e.g., plan goal contradicts a MISSION.md non-goal)? That crosses into semantic analysis and is out of scope for a mechanical linter.
+- Should `osc plan validate` be run automatically as a git pre-commit hook? A `.husky/pre-commit` hook that runs `osc plan validate` on staged plan files would be ideal but requires opt-in setup (Husky dependency). Document the hook in `docs/WORKFLOW.md` and leave it as a user opt-in.

--- a/.osc/plans/backlog/056-run-dry-run-preview.md
+++ b/.osc/plans/backlog/056-run-dry-run-preview.md
@@ -1,0 +1,56 @@
+# Plan: 056-run-dry-run-preview
+
+## Status
+
+backlog — depends on 050 (npm publish) for baseline `osc run` availability. This adds a preview mode to the run command that lets users and reviewers inspect what would happen before committing to a real run. Complements 055 (linter) as part of the pre-execution quality gate.
+
+## Context
+
+`osc run <plan>` creates a real run packet under `.osc/runs/<run_id>/` containing `run.json` (metadata, executor lane, harness skill, workflow), `package.md` (the prompt/instruction text for the executor), and associated files. Once created, the run is part of the project's evidence trail — it has a `run_id`, it appears in status dashboards, and downstream tools may act on it. Users and reviewers need a way to see exactly what would be generated without creating anything: a dry run that validates the plan, generates the full package in-memory, prints it to stdout, and reports what an executor would do. This is the `terraform plan` or `kubectl apply --dry-run=client` equivalent for Open Scaffold runs — a preview that builds confidence before execution.
+
+## Goal
+
+Add `osc run <plan> --dry-run` that validates the plan, generates the complete `run.json` and `package.md` in memory, prints them to stdout with a human-readable summary, and exits without creating any files in `.osc/runs/`.
+
+## Constraints / Out of scope
+
+- Must NOT create `.osc/runs/` directories, `run.json`, `package.md`, or any other files. The dry run is read-only.
+- Must validate the plan and report blockers as if creating a real run — if `packageQuality.executable` would be `false`, the dry run must report the blocking issues and exit non-zero.
+- Must show which files would be touched (from the plan's `## Files to touch` section) and the executor lane, harness skill, and workflow that would be used.
+- Does NOT validate that files listed in `## Files to touch` actually exist — that is the linter's domain or a future `--check-files` flag.
+- Does NOT invoke the executor or simulate execution — it shows the packet that would be sent, not the result of sending it.
+- The output format (`--json` for programmatic consumers, human-readable summary for terminal) must be stable and documented.
+
+## Files to touch
+
+- `src/artifacts.ts` — add `dryRun: boolean` mode to the run artifact generation pipeline. In dry-run mode, build `run.json` and `package.md` in memory, then return them instead of writing to disk. The `generateRunArtifacts()` function gains a `mode: 'write' | 'dry-run'` parameter.
+- `src/cli.ts` — wire `--dry-run` flag on `osc run` subcommand with optional `--json` flag for machine-parseable output. Update help text.
+- `tests/artifacts.test.ts` — add test cases: dry-run on valid plan (verify JSON output, no files created), dry-run on plan with missing AC (verify exit 1, blocking issues reported), dry-run on non-existent plan (verify error), dry-run output schema validation.
+- `docs/WORKFLOW.md` — mention `osc run --dry-run` as the recommended pre-execution check, before `osc run` without the flag.
+
+## Acceptance criteria
+
+- [ ] `osc run .osc/plans/active/my-feature.md --dry-run` prints the complete `run.json` that would be generated to stdout, followed by a human-readable summary.
+- [ ] The summary includes: "Would create run <run_id> in .osc/runs/... with executor <executor>, workflow <workflow>, harness skill <skill>".
+- [ ] The summary lists files that would be touched, extracted from the plan's `## Files to touch` section.
+- [ ] Does NOT create any files or directories under `.osc/runs/` — verified by `ls .osc/runs/` before and after.
+- [ ] Reports blockers if `packageQuality.executable` would be `false` (missing acceptance criteria, blocking open questions, undefined mission).
+- [ ] Exit code 1 if the plan is not executable; exit code 0 if the dry run would succeed.
+- [ ] `--json` flag outputs only the JSON (no summary), suitable for piping to `jq` or other tools.
+- [ ] Works with `--runtime <name>` and `--workflow <name>` overrides, reflected in the generated `run.json`.
+
+## Verification steps
+
+1. Create a valid plan with acceptance criteria. Run `osc run .osc/plans/active/test-plan.md --dry-run --runtime omx --workflow plan`. Verify stdout contains valid `run.json` with `executor: "omx-codex"`, `workflow: "plan"`, and a `harnessSkill` field.
+2. Verify no files created: `ls .osc/runs/` before and after the command — list must be identical.
+3. Run `osc run .osc/plans/active/test-plan.md --dry-run --json | jq '.'` — verify valid JSON with expected fields (`runId`, `planSlug`, `executor`, `workflow`, `harnessSkill`, `packageMarkdown`, `filesToTouch`, `packageQuality`).
+4. Create a plan with empty acceptance criteria. Run `osc run .osc/plans/active/bad-plan.md --dry-run`. Expected: exit 1, message about `packageQuality.executable: false`, details on missing AC.
+5. Run `osc run nonexistent-plan.md --dry-run`. Expected: non-zero exit, "plan not found" message.
+6. Run `osc run .osc/plans/active/test-plan.md --dry-run --runtime omc --workflow code-review`. Verify `run.json` reflects `executor: "omc-claude"` and `workflow: "code-review"`.
+
+## Open questions
+
+- Should the dry-run output include an estimated token count or cost estimate for the executor? That would require model-specific pricing data and is out of scope, but a character count of the generated `package.md` would be a cheap proxy.
+- Should `osc run --dry-run` be the default behavior, requiring `--execute` or `--write` to actually create the run? Changing defaults would break existing workflows; keep `--dry-run` as an opt-in flag and document it as the recommended first step.
+- Should the dry-run also validate that the executor/harness skill is available? Currently the run packet just names the executor; validation would require checking that the named harness is installed, which crosses into environment dependency checking.
+- Should `--dry-run` be available on `osc amend` and `osc close` as well? Those commands are simpler and less destructive, but dry-run consistency across all lifecycle commands is desirable. Defer to future plans.

--- a/.osc/plans/backlog/057-automated-evidence-collection.md
+++ b/.osc/plans/backlog/057-automated-evidence-collection.md
@@ -1,0 +1,60 @@
+# Plan: 057-automated-evidence-collection
+
+## Status
+
+backlog — depends on 050 (npm publish) for baseline `osc evidence` availability. This is the final slice in the 050–057 backlog batch, closing the loop from plan creation (050–055) through execution preview (056) to evidence collection (057). It makes the evidence loop feel lightweight by automating the gathering of verification results, git context, and CI status.
+
+## Context
+
+`osc evidence new <slug>` creates a TODO skeleton that users must fill manually: verification command output, git branch, PR links, CI status, changed files, and outcomes. This manual step is friction — after running `./verify.sh`, checking CI, and opening a PR, the user has to copy-paste results back into the evidence note. Automated collection reads these facts from the local environment (git, shell commands, and optionally the GitHub CLI) and populates the evidence skeleton, turning evidence creation from a form-filling exercise into a single command that captures the current state. This is the evidence equivalent of `osc plan wizard` (plan 052) — it makes a structured artifact feel responsive rather than burdensome.
+
+## Goal
+
+Add `osc evidence collect <slug>` that automatically gathers verification output (`./verify.sh`), git context (branch, recent commits, changed files), PR and CI status (via `gh` CLI when available), and populates the evidence note skeleton with collected data, preserving any existing content.
+
+## Constraints / Out of scope
+
+- Collects local, non-network evidence only by default: file stats, git log, shell command output. No outbound API calls unless the user explicitly opts in.
+- `--ci` flag enables CI environment variable checking (`GITHUB_ACTIONS`, `GITHUB_RUN_ID`, etc.) and `gh pr checks` calls. Without `--ci`, these checks are skipped.
+- Does NOT judge evidence quality or approve the slice — it gathers facts, not opinions. The evidence note still requires human review.
+- Must handle missing data gracefully: if `gh` CLI is not installed, skip PR/CI checks and note "gh CLI not available" in the collected output rather than erroring.
+- Must NOT overwrite existing evidence content that the user has manually filled in. New collection appends a timestamped block below existing content, preserving the user's narrative.
+- Does NOT upload evidence anywhere — the evidence note stays in `.osc/evidence/` as a local markdown file.
+
+## Files to touch
+
+- `src/evidence.ts` — new file: collection engine with pluggable collectors (`verifyOutputCollector`, `gitContextCollector`, `changedFilesCollector`, `prStatusCollector`, `ciStatusCollector`), evidence note reader/writer with append-preserving merge logic, and `--dry-run` mode.
+- `src/cli.ts` — wire `collect` subcommand under `osc evidence` with `--ci`, `--dry-run`, and `--verbose` flags. Update help text.
+- `tests/evidence.test.ts` — test cases: full collection on a repo with git and verify.sh, collection without gh CLI (graceful degradation), dry-run output format, append-preserving merge (existing content survives), empty repo (no git history — graceful skip), verify.sh failure capture (non-zero exit still captured).
+- `tests/fixtures/` — create test evidence note files: `evidence-empty.md` (skeleton), `evidence-partial.md` (some sections filled), `evidence-complete.md` (all sections filled).
+- `docs/WORKFLOW.md` — mention `osc evidence collect` as the recommended workflow after `./verify.sh` and before slice close.
+
+## Acceptance criteria
+
+- [ ] `osc evidence collect my-feature` runs `./verify.sh --standard` and captures its stdout and exit code in the evidence note.
+- [ ] Detects current git branch (via `git branch --show-current`) and includes it in the evidence note.
+- [ ] Lists changed files from `git diff --name-status HEAD~1..HEAD` (or `git diff --cached` if no commits) and includes them.
+- [ ] Checks for open PRs via `gh pr list --head <branch>` when available; captures PR number, title, and URL if found.
+- [ ] Checks CI status via `gh pr checks` when `--ci` flag is set; captures check names and conclusions (success/failure/pending).
+- [ ] Populates the evidence note skeleton with collected data as a new timestamped block (e.g., `### Collected 2026-05-18T14:30:00Z`), preserving any existing content above it.
+- [ ] Reports what it could NOT collect (e.g., "gh CLI not available — PR and CI checks skipped", "no git repository detected — git context skipped") in the evidence note.
+- [ ] `--dry-run` prints what would be collected to stdout without writing the evidence file.
+- [ ] Works without `gh` CLI installed (skips PR/CI data gracefully, includes note about missing tool).
+- [ ] Works in a non-git directory (skips git context gracefully).
+
+## Verification steps
+
+1. In a repo with a plan, git history, and `verify.sh`: run `osc evidence collect my-feature`. Verify the evidence note at `.osc/evidence/my-feature.md` contains a new timestamped block with verify.sh output, branch name, and changed files.
+2. Open the evidence note and confirm any pre-existing content (above the new block) is preserved unchanged.
+3. Run `osc evidence collect my-feature --dry-run`. Verify stdout shows the collected data block but `.osc/evidence/my-feature.md` is unchanged (mtime same as before).
+4. In an environment without `gh` CLI: run `osc evidence collect my-feature`. Verify the evidence note includes "gh CLI not available — PR and CI checks skipped" and continues without error.
+5. In a non-git directory: run `osc evidence collect my-feature`. Verify the evidence note includes "no git repository detected — git context skipped" and continues with only verify.sh output.
+6. Run `osc evidence collect my-feature --ci` in a repo with an open PR and GitHub Actions running. Verify the evidence note includes PR number, URL, and CI check names with conclusions.
+7. Run `osc evidence collect nonexistent-plan`. Expected: non-zero exit, "plan not found" or "evidence note skeleton not found — run `osc evidence new <slug>` first" message.
+
+## Open questions
+
+- Should `osc evidence collect` also capture environment context (OS, Node version, shell) for reproducibility? Including `uname -a` and `node --version` output would help debug environment-specific issues but could leak private machine details. Make it opt-in with `--env` flag.
+- Should collected evidence include a diff of the changed files, or just the file list? Full diffs could be large and clutter the evidence note. File list with `git diff --stat` is a good middle ground; full diffs can be requested with `--full-diff`.
+- Should `osc evidence collect` be run automatically by `osc close <slug>` before closing the slice? Yes — `osc close` should offer to run `osc evidence collect` if the evidence note is a skeleton (unfilled), then proceed with close. This integrates 057 with the existing close workflow.
+- Should evidence collection support custom collector plugins (e.g., a `custom-collector.sh` that the user drops in `.osc/evidence/collectors/`)? Plugin architecture is future work; the 5 built-in collectors cover the most common evidence needs.

--- a/.osc/plans/backlog/058-doctor-auto-fix.md
+++ b/.osc/plans/backlog/058-doctor-auto-fix.md
@@ -1,0 +1,63 @@
+# Plan: 058-doctor-auto-fix
+
+## Status
+
+backlog — depends on 055 (plan-linter) for the diagnostic framework that doctor extends into repair, and 057 (automated-evidence-collection) for evidence gathering that doctor can verify. This is the first slice in the 058–064 batch, building on the diagnostic foundation from 050–057 to add repair capability. The jump from diagnosis to repair is the natural next step after linter and evidence collection have proven the system can see its own state clearly.
+
+## Context
+
+`osc doctor` currently diagnoses scaffold health issues — stale plans sitting in active/ while marked backlog, broken paired views where CLAUDE.md and AGENTS.md have drifted apart, missing changelog entries in MISSION.md for existing amendment files, and missing .osc/releases/README.md — but it only reports problems. The user must manually open each file and fix the alignment, which is tedious and error-prone. Many of these issues are mechanical: a plan's `## Status` line says "backlog" but the file lives in `active/`; an amendment file exists at `.osc/plans/active/050-npm-publish-amendment-1.md` but MISSION.md's `## Changelog` has no entry for it; CLAUDE.md has a `## Project facts` section that AGENTS.md lacks. These are deterministic repair operations — the system can fix them faster and more reliably than a human. Auto-fix reduces the maintenance burden of scaffold hygiene and makes `osc doctor` feel like a tool rather than a nag.
+
+## Goal
+
+Add `osc doctor [--fix] [--dry-run]` that can automatically repair common scaffold issues: misaligned plan status, missing changelog entries for existing amendment files, broken paired-view drift between CLAUDE.md and AGENTS.md, stale active plans (move to blocked/ with annotation), and missing `.osc/releases/README.md` — without ever modifying plan goals, acceptance criteria, or constraints.
+
+## Constraints / Out of scope
+
+- Auto-fix only for mechanically-detectable issues. Ambiguous problems (e.g., "should this plan be in done/ or superseded/?") are reported but never auto-resolved.
+- Never modifies plan content beyond `## Status` alignment and stage folder movement. Plan goals, acceptance criteria, constraints, and verification steps are read-only.
+- Never edits MISSION.md's `## Goals` or `## Non-Goals` sections — only the `## Changelog` section is eligible for auto-repair (backfilling missing amendment entries).
+- `--fix` requires an explicit flag; the default mode (no flags) is diagnostic-only — reports issues with severity and fixability.
+- `--dry-run` prints what would change without mutating any file on disk. Can be combined with `--fix` to preview repairs.
+- Does NOT create new plans, close plans, or make judgment calls about plan correctness. Does NOT modify `.osc-dev/` contents.
+- Must exit with code 0 when no unfixable issues remain after `--fix`. Non-zero exit indicates issues exist that require human attention.
+
+## Files to touch
+
+- `src/doctor.ts` — new file: diagnostic engine with pluggable checkers (`statusAlignmentChecker`, `changelogGapChecker`, `pairedViewDriftChecker`, `stalePlanChecker`, `releaseReadmeChecker`), each producing a `Diagnosis` with `severity` (info/warn/error), `fixable` (boolean), and `repair()` function. The `runDiagnostics()` function returns all diagnoses; `applyFixes()` runs repairs for all fixable issues. Dry-run mode calls `describeFix()` instead of `repair()`.
+- `src/cli.ts` — update `doctor` command to accept `--fix`, `--dry-run`, `--severity <level>` (only report issues at or above this severity), and `--check <name>` (run only a named checker). Update help text to describe auto-fix capability. Wire the exit-code contract: 0 = clean or all fixable issues repaired, 1 = unfixable issues remain.
+- `tests/doctor.test.ts` — test cases: diagnostic-only output format, `--fix` repairs misaligned plan status (file in active/ with `## Status: backlog` → updated to `## Status: active`), `--fix --dry-run` prints planned changes without mutating, changelog backfill (amendment file exists but no MISSION.md entry → entry appended to `## Changelog`), paired-view drift correction (CLAUDE.md has a section missing from AGENTS.md → section added), stale plan movement (plan in active/ with no commits touching it in >30 days → moved to blocked/ with annotation amendment), graceful handling of edge cases (corrupt markdown, missing files, permission errors), exit code contract (0 when clean or all fixable issues repaired, 1 when unfixable issues remain).
+- `tests/fixtures/` — create deliberately broken scaffold states: `broken-status-alignment/` (plan in active/ with `## Status: backlog`), `broken-changelog-gap/` (amendment file present but no MISSION.md changelog entry), `broken-paired-view/` (AGENTS.md missing a section that CLAUDE.md has), `broken-stale-active/` (plan in active/ last touched 45 days ago), `broken-multiple/` (all of the above combined).
+- `docs/WORKFLOW.md` — mention `osc doctor --fix` as the recommended maintenance command, note that it's safe to run in CI, and document the dry-run workflow.
+
+## Acceptance criteria
+
+- [ ] `osc doctor` (no flags) reports issues with severity (info/warn/error) and fixability (fixable/unfixable), with a human-readable description of each issue and what `--fix` would do.
+- [ ] `osc doctor --fix` repairs all fixable issues: plan `## Status` aligned to actual folder, changelog entries backfilled for amendment files, paired-view drift corrected, stale active plans moved to blocked/ with annotation, missing `.osc/releases/README.md` created.
+- [ ] `osc doctor --fix --dry-run` prints every planned change with before/after file paths and the exact mutation that would occur, without touching any file on disk.
+- [ ] Does NOT modify plan goals, acceptance criteria, constraints, or verification steps under any circumstances.
+- [ ] Does NOT edit MISSION.md sections other than `## Changelog`.
+- [ ] Exit code 0 when no unfixable issues remain after `--fix`; exit code 1 when unfixable issues remain (with a summary of what needs human attention).
+- [ ] Reports what it CANNOT fix and why: ambiguous plan status (plan in done/ but content suggests in-progress), paired-view content conflicts (same section in both files but content differs meaningfully), and permission errors.
+- [ ] `osc doctor --check stale-plan` runs only the stale-plan checker, skipping all other diagnostics.
+- [ ] `osc doctor --severity error` reports only error-severity issues, suppressing info and warn.
+- [ ] Works in CI: no interactive prompts, clear exit codes, dry-run output is parseable.
+
+## Verification steps
+
+1. Create a deliberately broken state: create a plan file `broken-plan.md` in `.osc/plans/active/` with `## Status: backlog`. Create an amendment file `.osc/plans/active/050-npm-publish-amendment-1.md` but ensure MISSION.md's `## Changelog` has no entry for it. Delete a section from AGENTS.md that exists in CLAUDE.md. Create a plan in `active/` with mtime >45 days ago.
+2. Run `osc doctor --fix --dry-run`. Verify output lists exactly the expected repairs: "would update broken-plan.md ## Status from 'backlog' to 'active'", "would add changelog entry for amendment 050-npm-publish-amendment-1", "would restore missing section to AGENTS.md", "would move stale-plan.md to blocked/". Verify no files were actually changed (check mtimes).
+3. Run `osc doctor --fix`. Verify all fixable issues are repaired: broken-plan.md now says `## Status: active`, MISSION.md's changelog has the backfilled entry, AGENTS.md has the restored section, stale plan moved to blocked/.
+4. Run `osc doctor` again. Expected: exit code 0, output reports "no issues found" or equivalent clean-state message.
+5. Run `./verify.sh --strict` after repairs. Verify the scaffold passes all compliance checks.
+6. Create an unfixable issue: a plan in `done/` with ambiguous content (says "almost done, pending review" in the goal). Run `osc doctor --fix`. Verify the issue is reported as "unfixable" with explanation, and exit code is 1.
+7. Run `osc doctor --check stale-plan`. Verify only stale-plan diagnostics appear in output.
+8. Run `osc doctor --help`. Verify `--fix`, `--dry-run`, `--severity`, and `--check` flags are documented.
+
+## Open questions
+
+- Should `osc doctor --fix` create a backup of modified files before repairing (e.g., `.osc/doctor-backups/`)? Git already provides rollback for committed files, but uncommitted plan drafts could be lost. A `--backup` flag that saves pre-repair copies to `.osc/doctor-backups/` would add safety without being default behavior. Start without backups; add if user feedback demands it.
+- Should stale-plan detection use file mtime, git log, or both? File mtime works on any filesystem but is unreliable (touched by `git checkout`, backup tools, etc.). Git log (`git log --follow --format=%ci <file>`) is more accurate but requires git. Use git log when available, fall back to mtime with a warning.
+- What threshold defines "stale"? 30 days is the default, but teams on different cadences may want 14 days or 90 days. Make stale threshold configurable via `.osc/config.json` with key `doctor.staleThresholdDays`, defaulting to 30.
+- Should `osc doctor --fix` be run automatically by `osc verify` or `osc status`? No — auto-fix should always require explicit intent. But `osc verify` could suggest running `osc doctor --fix` when it detects fixable issues.
+- Should doctor auto-fix be able to split a paired view section that has drifted in content (not just in presence/absence)? Content-level drift (same section heading in both files but different body text) indicates a real divergence that needs human judgment. Doctor should report it as unfixable and suggest a manual review, not attempt to merge the differing content.

--- a/.osc/plans/backlog/059-adoption-metrics.md
+++ b/.osc/plans/backlog/059-adoption-metrics.md
@@ -1,0 +1,64 @@
+# Plan: 059-adoption-metrics
+
+## Status
+
+backlog — depends on 058 (doctor-auto-fix) for clean scaffold state that metrics can read reliably, and 050 (npm-publish) for baseline `osc` availability. This is the second slice in the 058–064 batch, providing the aggregation layer that turns raw scaffold data into actionable numbers. After doctor keeps the scaffold healthy and evidence collection captures verification data, metrics answer the natural next question: "how are we doing?" — cycle time, close velocity, stale plan count, evidence completeness, and approval distribution.
+
+## Context
+
+The scaffold system collects evidence across `.osc/releases/`, plan creation timestamps in `.osc/plans/`, plan movement through stage folders (active → done/blocked), amendment files, and evidence note verification data — but there is no aggregation layer to turn this raw data into answers. A user or team lead who wants to know "how long do our slices typically take?" or "how many plans are sitting stale?" has to manually grep and count across the filesystem. This is fragile, slow, and inconsistent. An `osc metrics` command that reads scaffold state from disk and computes standard engineering metrics — cycle time, stale plan count, close velocity, evidence completeness, approval distribution — would give teams real visibility into their development cadence without requiring an external analytics service, database, or dashboard. It keeps Open Scaffold self-contained while providing the kind of data-driven feedback that teams expect from modern project management tools.
+
+## Goal
+
+Add `osc metrics` that computes cycle time, stale plan count, close velocity, evidence completeness, and approval distribution from local scaffold state, with `--json` output for CI/dashboard consumption and `--since` for date-range filtering.
+
+## Constraints / Out of scope
+
+- Local-only: reads scaffold state exclusively from the filesystem — `.osc/plans/`, `.osc/releases/`, `.osc/evidence/`, and file timestamps. No network calls, no analytics service, no database.
+- Metrics are calculated from file timestamps and plan content, not from an external database or event log. This means metrics are a snapshot of current file state, not a time-series.
+- Output supports `--json` for machine consumption (CI pipelines, dashboards, monitoring tools) and human-readable table output by default.
+- Does NOT benchmark, rank, or judge team performance. Reports facts only — no "your team is slow" commentary. The user interprets the numbers.
+- Does NOT generate charts, graphs, or visualizations. The output is text (terminal table or JSON). Charting is future work.
+- Does NOT require git history (works with file mtimes), though git-aware cycle time (using commit dates) is more accurate and preferred when available.
+- Cycle time is measured from plan file creation timestamp to plan movement into `done/`. If a plan was created before the scaffold was initialized, its creation time is unknown — report as "insufficient data" rather than guessing.
+
+## Files to touch
+
+- `src/metrics.ts` — new file: metrics engine with `computeMetrics(opts?: { since?: Date; json?: boolean })` that returns a `ScaffoldMetrics` object. Sub-computations: `cycleTimeMetrics()` (mean/median/p90/p99 days from creation to close), `stalePlanMetrics()` (count of active plans >30 days since last file modification), `closeVelocity()` (plans closed per week over the lookback window), `evidenceCompleteness()` (percentage of done plans with non-empty evidence notes), `approvalDistribution()` (counts by approval strength: approved/weak_approved/rejected/blocked), `planDistribution()` (counts by stage: active/backlog/done/blocked). Date filtering via `--since` cuts off plans created before the given date.
+- `src/cli.ts` — wire `metrics` command with `--json`, `--since <date>`, `--lookback <weeks>` (default 12 weeks for velocity calculation), `--table` (force human-readable table even when stdout is not a TTY), and `--verbose` (include per-plan breakdown). Update help text.
+- `tests/metrics.test.ts` — test cases: metrics on the open-scaffold repo itself (50+ done plans — verify reasonable numbers), empty scaffold (all zeros, no crash), date filtering (`--since 2026-01-01` only includes plans created after that date), JSON output parseable by `jq`, evidence completeness calculation (8 plans closed, 3 have evidence notes → 37.5%), approval distribution counting, cycle time with git commit dates vs file mtime, stale plan detection boundary (plan at exactly 30 days is not stale; plan at 31 days is), zero-plan scaffold (reports zeros gracefully), lookback window effect on velocity.
+- `tests/fixtures/` — create test scaffold states: `healthy-scaffold/` (10 plans at various stages with realistic timestamps), `empty-scaffold/` (no plans), `partial-evidence/` (7 of 10 done plans have evidence notes), `stale-mix/` (3 active plans, 2 stale). Include a `timestamps.json` manifest that `touch`-based test setup reads to set realistic file mtimes without requiring git.
+- `docs/WORKFLOW.md` — mention `osc metrics` as the go-to command for understanding scaffold health numerically, and `osc metrics --json` for CI dashboards.
+
+## Acceptance criteria
+
+- [ ] `osc metrics` prints a table with: total plans by stage (active/backlog/done/blocked counts), average days from plan creation to close, median cycle time, p90 cycle time, stale active plans (>30 days since last modification), close velocity (plans closed per week over the lookback window), evidence completeness (percentage of done plans with evidence notes), and approval distribution (approved/weak_approved/rejected/blocked counts).
+- [ ] `osc metrics --json` outputs a single JSON object with keys `summary` (top-level counts), `cycle_time` (mean/median/p90/p99 in days), `stale` (count and list of slugs), `velocity` (plans/week), `evidence` (completeness percentage and per-plan detail), `approval` (distribution object). Output is valid JSON parseable by `jq`.
+- [ ] `osc metrics --since 2026-01-01` filters all calculations to only include plans created on or after the given date.
+- [ ] `osc metrics --lookback 4` calculates close velocity over the most recent 4 weeks instead of the default 12.
+- [ ] Works with zero plans: reports all zeros, no crash, exit code 0. Output says "No plans found in scaffold — run `osc plan new` to create your first plan."
+- [ ] All data sourced from local filesystem only — no network activity during `osc metrics` execution (verify with network monitoring or by running offline).
+- [ ] Reports when data is incomplete: "8 plans closed but only 3 have evidence notes (37.5%)" — clearly indicates data gaps without penalizing.
+- [ ] `osc metrics --verbose` includes per-plan breakdown: each plan's slug, stage, age in days, evidence status, and approval strength.
+- [ ] Cycle time uses git commit dates when available (more accurate); falls back to file mtime with a warning "git not available — using file modification times for cycle time calculation".
+- [ ] Date parsing for `--since` handles ISO 8601 dates (`2026-01-01`), relative dates (`30 days ago`, `last month`), and rejects ambiguous formats with a clear error message.
+
+## Verification steps
+
+1. Run `osc metrics` on the open-scaffold repository (which has 50+ done plans). Verify output shows reasonable numbers: total plans >50, non-zero cycle time, some done plans with evidence, approval distribution entries.
+2. Run `osc metrics --json | jq .summary.total_plans`. Verify jq parses successfully and returns a number.
+3. Run `osc metrics --json | jq .cycle_time.mean_days`. Verify a reasonable positive number.
+4. Create an empty scaffold directory with `.osc/plans/` and no plan files. Run `osc metrics`. Verify output says "No plans found" and all numbers are zero. Exit code is 0.
+5. Create a scaffold with 10 plans: 5 done (3 with evidence notes, 2 without), 3 active (1 stale with mtime 45 days ago), 2 backlog. Run `osc metrics`. Verify evidence completeness is 60% (3/5), stale count is 1, total plans is 10, done count is 5.
+6. Run `osc metrics --since 2026-06-01` on the test scaffold. If all plans were created before June 2026, verify output reports zero plans in range.
+7. Run `osc metrics --lookback 2` to test lookback window. Verify velocity calculation only considers plans closed in the last 2 weeks.
+8. Run `osc metrics --verbose`. Verify per-plan breakdown lists each plan slug with stage, age, evidence status, and approval.
+9. Run `osc metrics --help`. Verify all flags are documented with usage examples.
+
+## Open questions
+
+- Should `osc metrics` also report amendment frequency (plans with 0/1/2+ amendments)? Plans with many amendments indicate scope volatility and could be a useful signal. Add as `--include-amendments` flag initially; promote to default if useful.
+- Should metrics track "time in each stage" (backlog → active → done) rather than just creation → close? Multi-stage timing requires tracking folder-move events, which we don't currently log. This would require a state-change log (`.osc/metrics-log.jsonl`) that records when a plan moves between folders. Future work.
+- Should `osc metrics` be runnable as a git hook or scheduled task that writes a metrics snapshot to `.osc/metrics/` for historical comparison? A `--snapshot` flag that writes the current metrics to `.osc/metrics/YYYY-MM-DD.json` would enable trend analysis over time without a database. Defer to future slice.
+- What's the right default lookback window for close velocity? 12 weeks (one quarter) provides enough data for meaningful velocity without being skewed by ancient history. Teams on 1-week sprint cycles may prefer 4 weeks; teams on monthly cycles may prefer 26 weeks. The 12-week default with `--lookback` override handles both.
+- Should metrics distinguish between "plan created" and "plan activated" (moved from backlog to active)? Currently the scaffold doesn't track activation time separately from creation time. If activation tracking is added later, metrics should update to use activation time as the start of the cycle time clock.

--- a/.osc/plans/backlog/060-mcp-server.md
+++ b/.osc/plans/backlog/060-mcp-server.md
@@ -1,0 +1,68 @@
+# Plan: 060-mcp-server
+
+## Status
+
+backlog
+
+## Context
+
+MCP (Model Context Protocol) has become the ecosystem standard for AI agent tool integration. Claude Desktop, Claude Code, Hermes, Continue, Cursor, and other tools now speak MCP natively. Open Scaffold currently requires agents to parse markdown files directly — every agent reinvents plan parsing. An MCP server exposing plan/run/evidence state as queryable tools and resources would make Open Scaffold immediately useful to the entire MCP ecosystem without requiring any agent to adopt the full scaffold protocol. This is the highest-leverage integration surface available today: one server, every MCP-compatible agent benefits. Follows the protocol infrastructure established by M0-M17 and the runtime binding contract.
+
+## Goal
+
+Ship an MCP server that exposes Open Scaffold repository state as standard MCP tools and resources, so any MCP-compatible AI agent can list plans, read acceptance criteria, check verification status, navigate evidence, and query scaffold health without parsing markdown directly.
+
+## Constraints / Out of scope
+
+- The MCP server is an optional add-on (`osc mcp serve`), not a core requirement for scaffold use.
+- Uses stdio transport exclusively in v1 (the MCP standard for local tools).
+- Read-only by default. Write operations (plan create, amend, close, evidence new) require explicit `--allow-write` flag.
+- Must NOT require network access. All data comes from local filesystem.
+- Does NOT implement streaming, SSE transport, or HTTP transport in v1 (those are extensions).
+- Does NOT spawn agents, launch runtimes, or execute code — query-only.
+- Does NOT replace the CLI — it's an alternative interface for agents, not humans.
+- The MCP server binary is `osc-mcp` (separate package.json bin entry) or `osc mcp serve`.
+
+## Files to touch
+
+- `src/mcp-server.ts` — new file: MCP server implementation (tool handlers, resource handlers, stdio transport, JSON-RPC message loop)
+- `src/mcp-tools.ts` — new file: tool definitions with JSON Schema input/output shapes, separated from transport logic
+- `src/mcp-resources.ts` — new file: resource URI definitions and content resolvers
+- `src/cli.ts` — wire `osc mcp serve [--allow-write] [--validate]` command and `osc-mcp` bin alias
+- `package.json` — add `"osc-mcp": "dist/mcp-cli.js"` bin entry (or share CLI entry point with argv[1] dispatch)
+- `tests/mcp-server.test.ts` — test tool handlers, resource resolution, read-only enforcement, JSON-RPC message parsing
+- `docs/MCP.md` — new file: integration guide with config examples for Claude Desktop, Hermes, Claude Code, Continue, Cursor
+- `docs/OPEN_SCAFFOLD_SYSTEM.md` — add MCP server to the integration layers section
+- `.osc/releases/README.md` — no changes needed (MCP is additive, not structural)
+
+## Acceptance criteria
+
+- [ ] `osc mcp serve` starts a stdio MCP server that responds to `initialize`, `tools/list`, `resources/list`, and `tools/call` JSON-RPC methods
+- [ ] Tools exposed: `list_plans` (filters by stage: active|backlog|blocked|done), `get_plan` (returns all sections as structured JSON), `get_mission` (returns goals, non-goals, recent changelog), `list_evidence` (filters by slug), `get_evidence` (full content), `get_status` (scaffold health: mission defined, plan counts, stale warnings, verify result), `search_plans` (full-text search across plan goals and AC), `list_amendments` (amendments for a given plan slug)
+- [ ] Resources exposed: `osc://plans/active` (list of active plan slugs), `osc://plans/backlog`, `osc://plans/done`, `osc://plans/blocked`, `osc://releases/latest` (most recent evidence note), `osc://mission/goals`, `osc://mission/changelog`, `osc://rules` (.osc/RULES.md content), `osc://roadmap` (ROADMAP.md content)
+- [ ] All read operations work without `--allow-write`
+- [ ] Write operations (`create_plan`, `amend_plan`, `close_plan`, `create_evidence`) return error JSON-RPC error code -32000 with message "Write operations require --allow-write flag" when flag is absent
+- [ ] `osc mcp serve --validate` starts, validates scaffold state, outputs JSON status to stdout, and exits — useful for CI health checks and connection testing
+- [ ] Server handles malformed JSON-RPC gracefully (returns parse error, does not crash)
+- [ ] Server handles requests for nonexistent plans/evidence with structured error (not crash)
+- [ ] Documentation explains registration config for at least 3 MCP clients with copy-pasteable JSON config blocks
+- [ ] All existing tests pass (`npm test`), new MCP tests cover tool dispatch, resource resolution, read-only gate, and error handling
+- [ ] `npm run build` succeeds with new files
+- [ ] `./verify.sh --standard` passes (MCP files are additive, no plan/schema violations)
+
+## Verification steps
+
+1. **Unit tests:** Run `npm test -- --reporter=verbose` and verify all MCP test cases pass.
+2. **Manual stdio test:** Start server with `echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' | npx tsx src/cli.ts mcp serve --validate 2>/dev/null`. Verify JSON-RPC response includes server info and capabilities.
+3. **Tool list test:** Pipe `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}` into server, verify response lists all tools with correct input schemas.
+4. **Read enforcement test:** Pipe a `tools/call` for `create_plan` without `--allow-write`, verify response is error code -32000.
+5. **Real data test:** Run `osc mcp serve --validate` in the open-scaffold repo, verify output includes plan counts matching `osc status --json`.
+6. **Build check:** Run `npm run build`, verify `dist/mcp-server.js` and related files exist.
+7. **Schema check:** Run `./verify.sh --strict`, verify plan schema checks pass (new MCP files are docs/code, not plans, so no plan violations).
+
+## Open questions
+
+- Should the MCP server use a separate npm package (`@graphanov/open-scaffold-mcp`) or ship inside the main `open-scaffold` package? Preference: ship inside main package for lower adoption friction; users shouldn't need two packages. Downside: main package gains a dependency on MCP SDK types.
+- Which MCP SDK to use? The official `@modelcontextprotocol/sdk` is the obvious choice but adds a dependency. Alternative: implement the JSON-RPC stdio loop directly (it's ~200 lines) to stay zero-dependency. Trade-off: zero-deps is cleaner but misses ecosystem compatibility testing and future protocol upgrades. Recommendation: zero-dependency implementation for v1 since MCP stdio transport is simple and stable enough.
+- Should resources use `osc://` URI scheme or `open-scaffold://`? `osc://` is shorter and matches the CLI brand. Confirm with owner.
+- Should `get_plan` return raw markdown or parsed JSON? Both: parsed JSON as the primary output (sections, AC, files, etc.) with a `raw_markdown` field for tools that want the original text.

--- a/.osc/plans/backlog/061-local-task-database.md
+++ b/.osc/plans/backlog/061-local-task-database.md
@@ -1,0 +1,73 @@
+# Plan: 061-local-task-database
+
+## Status
+
+backlog
+
+## Context
+
+Open Scaffold's system ontology describes Kanban, GitHub Issues, Linear, and Jira as task bridges — the operational layer that tracks what's ready, running, blocked, or done. But the scaffold itself ships with zero task tracking. A solo developer adopting Open Scaffold today has nowhere to put "things I need to do" inside the scaffold. They must bring their own GitHub Issues project, set up a Kanban board, or keep a mental list. This is the #1 "now what?" gap after `osc init`. A lightweight local task database — not a Kanban replacement, not a project management tool, just durable task tracking that lives in the repo — closes this gap. Follows the task/run identity model in `docs/TASK_RUN_MODEL.md` and the folder-as-state-machine pattern.
+
+## Goal
+
+Ship a lightweight, SQLite-backed local task database with `osc task` subcommands (new, list, claim, start, complete, comment, link) that gives solo developers and small teams basic durable task tracking without requiring any external system.
+
+## Constraints / Out of scope
+
+- The task DB is local and optional — `osc task` commands fail gracefully if no tasks.db exists (no crash, just report zero tasks).
+- Task DB file lives at `.osc/tasks.db` (gitignored — added to `.osc/.gitignore`).
+- NOT a Kanban replacement — no swimlanes, no WIP limits, no multi-assignee, no due dates in v1.
+- NOT multi-user — SQLite is local. For team use, recommend GitHub Issues or a shared coordinator.
+- Tasks can optionally link to a plan (`--plan <slug>`), but tasks and plans are independent — a task can exist without a plan and vice versa.
+- Task IDs are auto-generated short codes (e.g., `T-001`, `T-002`) for easy human reference.
+- NO network access, NO daemon, NO background sync. Pure file-backed SQLite.
+- Statuses: `todo`, `in-progress`, `done`, `blocked`, `cancelled` — simple and sufficient.
+- Priority: `high`, `medium`, `low` — optional, defaults to medium.
+
+## Files to touch
+
+- `src/tasks.ts` — new file: SQLite schema creation, CRUD operations, list with filters, status transitions
+- `src/cli.ts` — wire `osc task new|list|claim|start|complete|comment|link|show` subcommands
+- `tests/tasks.test.ts` — test task creation, listing, filtering, status transitions, plan linking, persistence across CLI invocations
+- `.osc/.gitignore` — add `tasks.db` line (or `tasks.db*` if WAL/SHM files are generated)
+- `docs/TASKS.md` — new file: task system guide, relationship to plans, when to use tasks vs plans vs GitHub Issues
+- `docs/OPEN_SCAFFOLD_SYSTEM.md` — add local task database to the task bridges section as an optional local option
+- `docs/WORKFLOW.md` — mention `osc task` commands in the Execute phase section
+
+## Acceptance criteria
+
+- [ ] `osc task new "Fix login redirect bug" --priority high --plan 050-npm-publish` creates a task with auto-generated ID (T-001), sets status to `todo`, stores timestamp, and prints the task ID
+- [ ] `osc task list` shows all tasks with ID, status, priority, title, and linked plan (if any) in a readable table
+- [ ] `osc task list --status todo` filters to tasks with that status
+- [ ] `osc task list --priority high` filters by priority
+- [ ] `osc task list --plan 050-npm-publish` filters by linked plan
+- [ ] `osc task show T-001` displays full task details including all comments with timestamps
+- [ ] `osc task claim T-001` transitions task from `todo` to `in-progress` and records the transition timestamp
+- [ ] `osc task start T-001` is an alias for `claim` (ergonomic — matches common mental model of "starting" work)
+- [ ] `osc task complete T-001` transitions to `done` with completion timestamp
+- [ ] `osc task block T-001 --reason "Waiting for npm access token"` transitions to `blocked` with a reason stored in the task
+- [ ] `osc task cancel T-001` transitions to `cancelled`
+- [ ] `osc task comment T-001 "Investigated: the redirect uses window.location not router.push"` adds a timestamped comment to the task
+- [ ] `osc task link T-001 --plan 060-mcp-server` adds or changes the linked plan
+- [ ] Tasks survive between CLI invocations — close terminal, reopen, `osc task list` shows same tasks (SQLite persistence verified)
+- [ ] `osc status` includes task summary counts when `.osc/tasks.db` exists (e.g., "Tasks: 3 todo, 2 in-progress, 12 done")
+- [ ] Commands fail gracefully when no tasks.db exists: `osc task list` outputs "No tasks yet. Create one with `osc task new <title>`"
+- [ ] `osc task list --json` outputs machine-parseable JSON array for CI/scripting
+- [ ] Existing tests pass, new task tests cover all CRUD operations and edge cases
+
+## Verification steps
+
+1. **CRUD cycle:** Run `osc task new "Test task 1" --priority high`. Note the ID. Run `osc task list --json | jq '.[] | select(.id=="T-001")'`. Verify title, priority, status=todo.
+2. **Status transitions:** Run `osc task claim T-001`, then `osc task show T-001`, verify status=in-progress. Run `osc task complete T-001`, verify status=done.
+3. **Comments:** Run `osc task comment T-001 "Found the issue"` then `osc task show T-001`, verify comment appears with timestamp.
+4. **Persistence:** After closing terminal, run `osc task list` again. Verify T-001 still exists.
+5. **Plan linking:** Run `osc task new "Test with plan" --plan 060-mcp-server`. Verify `osc task list --plan 060-mcp-server` shows it.
+6. **Graceful degradation:** Delete `.osc/tasks.db`. Run `osc task list`. Verify friendly "no tasks" message, not error.
+7. **Status integration:** Run `osc status`. Verify task counts appear when tasks.db exists. Delete tasks.db, run `osc status`, verify no crash.
+
+## Open questions
+
+- Should `osc task` use a separate WAL-mode SQLite file or a simpler JSON file? SQLite is preferred for durability and query flexibility (filtering by status/priority/plan is trivial with SQL, painful with grep on JSON). Trade-off: adds a native dependency or uses better-sqlite3 (native addon) or sql.js (WASM). Recommendation: use `better-sqlite3` for performance, with graceful fallback message if native build fails ("Install with npm install --build-from-source or use GitHub Issues for task tracking").
+- Should task IDs be globally unique or per-project? Auto-increment simple integers (T-001, T-002) are local to the DB file. This is sufficient for local use. If multiple repos share tasks, they'd use GitHub Issues.
+- Should completed tasks be archived or kept in the active DB? Keep all tasks in the DB; filtering by status handles the UX. Archival could be a future `osc task archive` command.
+- Should `osc task` support tags/labels in v1? Defer — add after priority proves useful. Tags add schema complexity (many-to-many) without clear demand signal.

--- a/.osc/plans/backlog/062-glass-cockpit-webhooks.md
+++ b/.osc/plans/backlog/062-glass-cockpit-webhooks.md
@@ -1,0 +1,68 @@
+# Plan: 062-glass-cockpit-webhooks
+
+## Status
+
+backlog
+
+## Context
+
+The glass cockpit protocol (`docs/GLASS_COCKPIT_PROTOCOL.md`) defines a rich event vocabulary — session_start, status, blocker, question, completion_report, evidence_receipt, approval_request, cancellation, pr_link, release_note — but none of it is implemented. The protocol document is well-designed but until a single message actually posts to a real channel, the glass cockpit is a specification, not a feature. This plan proves the protocol with working code: webhook-based posting to Discord and Slack. It is intentionally minimal — one command, one event type at a time, push-only — to establish the implementation pattern that richer cockpit UIs can build on later.
+
+## Goal
+
+Ship `osc cockpit post` and `osc cockpit test` commands that send structured glass-cockpit events to configured Discord and Slack webhooks, proving the protocol with working, credential-safe implementation.
+
+## Constraints / Out of scope
+
+- Push-only: sends messages to webhooks. Does NOT receive messages, handle slash commands, or implement two-way interaction.
+- Webhook URLs are stored in `.osc/cockpit.json` (gitignored). A documented example at `.osc/cockpit.example.json` shows the format.
+- Does NOT implement a daemon, real-time listener, or background process — each `osc cockpit post` is a one-shot HTTP POST.
+- Does NOT handle incoming webhooks, interactive buttons, or threaded replies in v1.
+- Discord and Slack only in v1. Telegram, Matrix, and custom webhooks are deferred.
+- Event format follows the glass cockpit protocol event vocabulary exactly.
+- Messages include `task_id`, `run_id`, `plan_slug`, and repo links when available.
+- Must work without any runtime or agent dependency — just Node.js built-in `fetch` (Node 20+) or `https` module.
+
+## Files to touch
+
+- `src/cockpit.ts` — new file: webhook message formatting (Discord embed, Slack block kit), HTTP POST, config loading and validation
+- `src/cli.ts` — wire `osc cockpit post --event <event> --message <text> [--run-id <id>] [--plan <slug>] [--task-id <id>] [--pr <url>] [--evidence-path <path>] [--dry-run]` and `osc cockpit test [--dry-run]` and `osc cockpit config` (show config)
+- `.osc/cockpit.example.json` — new file: example config with placeholder webhook URLs, comments explaining each platform's format, and the event-to-channel mapping
+- `tests/cockpit.test.ts` — test message formatting, config parsing, Discord embed structure validation, Slack block structure validation, dry-run output, graceful missing-config handling
+- `docs/GLASS_COCKPIT_PROTOCOL.md` — add "Implementation" section with `osc cockpit` usage examples, webhook setup instructions for Discord and Slack, and message format examples
+- `docs/WORKFLOW.md` — mention `osc cockpit` in the Publish/review phase
+
+## Acceptance criteria
+
+- [ ] `.osc/cockpit.example.json` exists with documented format: `{"targets":[{"platform":"discord","webhookUrl":"https://discord.com/api/webhooks/...","events":["status","completion_report"]},{"platform":"slack","webhookUrl":"https://hooks.slack.com/services/...","events":["blocker","approval_request"]}]}`
+- [ ] `osc cockpit config` prints the configured targets with masked webhook URLs (show first 20 chars + "..."), and warns if no config exists
+- [ ] `osc cockpit test --dry-run` prints the test message that would be sent without sending (validates config format, message structure)
+- [ ] `osc cockpit test` sends a test message to all configured targets, reports success/failure per target
+- [ ] `osc cockpit post --event status --message "Plan 062 in progress: implementing webhook dispatch"` posts to all targets whose `events` list includes `status`
+- [ ] `osc cockpit post --event completion_report --run-id 20260518T120000Z-062 --plan 062-glass-cockpit-webhooks --pr "https://github.com/graphanov/open-scaffold/pull/56"` posts structured completion report with run ID, plan slug, and PR link
+- [ ] `osc cockpit post --event evidence_receipt --evidence-path ".osc/releases/2026-05-18-062-glass-cockpit-webhooks.md"` posts evidence receipt linking the evidence file
+- [ ] `osc cockpit post --event blocker --message "Blocked: waiting for webhook URL approval"` posts blocker event
+- [ ] `osc cockpit post --event approval_request --message "Please review PR #56: 20 backlog items"` posts approval request
+- [ ] `osc cockpit post --dry-run` prints exactly what would be sent (platform, URL masked, message body) without sending
+- [ ] When no `.osc/cockpit.json` exists, all commands gracefully report "No cockpit targets configured. See .osc/cockpit.example.json" (exit 0, not error)
+- [ ] When a webhook POST fails (4xx/5xx), error message includes the platform name, HTTP status, and response body snippet (not the full webhook URL)
+- [ ] Messages include a footer with `osc cockpit` version and repo path
+- [ ] Discord messages use embed format (title, description, fields for structured data like run_id/plan/task, color-coded by event type: green=completion, red=blocker, yellow=approval_request, blue=status)
+- [ ] Slack messages use Block Kit format for structured, readable messages
+- [ ] All existing tests pass, new cockpit tests cover formatting, config handling, dry-run, and error cases
+- [ ] `npm run build` succeeds
+
+## Verification steps
+
+1. **Config format:** Copy `.osc/cockpit.example.json` to `.osc/cockpit.json`. Replace webhook URLs with a test webhook (or leave placeholders). Run `osc cockpit config`, verify targets are listed with masked URLs.
+2. **Dry-run:** Run `osc cockpit test --dry-run`. Verify output shows the exact message that would be sent, with masked URL.
+3. **Format validation:** Run `osc cockpit post --event status --message "Test message" --dry-run`. Manually inspect output for correct Discord embed structure (title, description, color, footer) or Slack block structure.
+4. **Real send:** With a real Discord webhook URL configured, run `osc cockpit test`. Verify message appears in the Discord channel with correct formatting.
+5. **Event routing:** Configure one target with `events: ["blocker"]` only. Run `osc cockpit post --event status --message "should not send" --dry-run`. Verify message is skipped for that target (event not in list). Run `osc cockpit post --event blocker --message "should send" --dry-run`. Verify message is included.
+6. **Missing config:** Rename `.osc/cockpit.json` to `.osc/cockpit.json.bak`. Run `osc cockpit test`. Verify graceful message, exit 0.
+7. **Build:** Run `npm run build`, verify no TypeScript errors.
+
+## Open questions
+
+- Should cockpit events auto-post during `osc close` and `osc evidence new`? That is, should the lifecycle commands automatically post to configured cockpits? This would be a natural next step but adds complexity to commands that are currently filesystem-only. Defer to a follow-up plan — keep v1 as explicit `osc cockpit post` only.
+- Should `osc cockpit post` infer event type from the command context? E.g., `osc cockpit post --run-id X --status completed` auto-sets event to `completion_report`. This is a nice-to-have but adds ambiguity. Keep explicit `--event` flag for clarity in v1.

--- a/.osc/plans/backlog/063-github-actions-ci-templates.md
+++ b/.osc/plans/backlog/063-github-actions-ci-templates.md
@@ -1,0 +1,59 @@
+# Plan: 063-github-actions-ci-templates
+
+## Status
+
+backlog
+
+## Context
+
+The repo ships one CI workflow (`.github/workflows/ci.yml` — build and test). Scaffold users get zero automated guardrails beyond that single check. The scaffold's own design emphasizes mechanical verification, but the verification isn't running automatically. Four specialized CI workflows would turn the scaffold's verification principles into always-on automated gates: plan validation on every PR, stale plan detection on a schedule, evidence note validation on release changes, and npm publish on version tags. These templates serve dual purpose: they dogfood the scaffold on itself (proving the system works) and they serve as copy-paste templates for any downstream scaffold project.
+
+## Goal
+
+Ship 4 production-grade GitHub Actions workflow templates plus a CI strategy guide, so scaffold projects get automated plan validation, stale plan detection, evidence verification, and npm publishing from day one.
+
+## Constraints / Out of scope
+
+- Workflows use only built-in GitHub Actions (`actions/checkout`, `actions/setup-node`) plus the project's own `osc` CLI (via `npx open-scaffold` or local build).
+- No unpublished third-party actions. No Docker container actions in v1.
+- Workflows target `ubuntu-latest` only in v1. macOS/Windows runners are deferred.
+- Workflows must function with full git history available (`fetch-depth: 0` for plan immutability checks).
+- Stale plan workflow opens a GitHub Issue, not just logs — issues are the task bridge for most scaffold users.
+- NPM publish workflow only triggers on version tags (`v*`), not on every merge to main.
+- CI strategy doc (`docs/CI.md`) explains what each workflow does, when to use it, and how to customize it for private repos or different package registries.
+
+## Files to touch
+
+- `.github/workflows/plan-validate.yml` — new: on PR, runs `osc plan validate` on changed plans, fails if issues found
+- `.github/workflows/stale-plans.yml` — new: on schedule (weekly), detects plans in `active/` older than 30 days, opens GitHub Issue listing stale plans
+- `.github/workflows/evidence-validate.yml` — new: on PR touching `.osc/releases/`, runs `osc verify --strict` evidence checks
+- `.github/workflows/npm-publish.yml` — new: on tag push matching `v*`, runs build+test, publishes to npm
+- `docs/CI.md` — new file: CI strategy guide explaining each workflow, configuration, customization for private registries, and local testing with `act`
+- `docs/GITHUB_WORKFLOW.md` — add CI section referencing the new templates
+
+## Acceptance criteria
+
+- [ ] `plan-validate.yml`: triggers on PRs that touch `.osc/plans/**/*.md` files. Checks out full history. Runs `osc plan validate <each-changed-plan>`. Fails PR if any plan has errors (missing sections, TODOs, empty AC). Passes if only warnings.
+- [ ] `stale-plans.yml`: triggers on `schedule: cron(0 9 * * 1)` (Monday 9am UTC) and `workflow_dispatch` (manual trigger). Scans `.osc/plans/active/` for plans with mtime >30 days. If stale plans found, opens a GitHub Issue titled "Stale active plans — week of YYYY-MM-DD" with plan names, last modified dates, and suggestion to move to `blocked/` or `done/`. If no stale plans, workflow passes silently (no issue).
+- [ ] `evidence-validate.yml`: triggers on PRs touching `.osc/releases/**/*.md`. Runs `./verify.sh --strict`. Validates that evidence notes have all required sections (Summary, Traceability, Verification, Outcome). Fails if evidence note says "pending" while citing merged PR or closed issue (stale evidence detection).
+- [ ] `npm-publish.yml`: triggers on tag push matching `v*`. Runs `npm ci && npm run build && npm test`. If all pass, runs `npm publish`. Uses `NPM_TOKEN` secret. Does NOT run on regular pushes or PRs.
+- [ ] All workflows are valid YAML (pass `actionlint` or manual syntax check).
+- [ ] `docs/CI.md` explains: what each workflow does, how to enable/disable, how to customize stale days threshold, how to test locally with `act`, and how to adapt for private npm registries.
+- [ ] Existing `.github/workflows/ci.yml` continues to work alongside new workflows (no conflicts).
+- [ ] Workflows are tested: at minimum, dry-run validation via `act` or manual YAML schema check. Ideally, push a test branch and verify at least `plan-validate.yml` runs in CI.
+
+## Verification steps
+
+1. **YAML validity:** Run each workflow through a YAML linter or `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/plan-validate.yml'))"` for each file.
+2. **Plan validate test:** Create a branch with a deliberately broken plan (missing ## Goal section). Push a PR. Verify CI fails with specific error message pointing to the plan and missing section.
+3. **Plan validate good test:** Create a branch with a valid plan. Push PR. Verify CI passes.
+4. **Stale plans test:** Temporarily set stale threshold to 1 day. Create an active plan and `touch -t 202601010000` to make it appear old. Run the workflow (via `workflow_dispatch` or `act`). Verify issue is created with the plan name and age.
+5. **Evidence validate test:** Create a branch touching `.osc/releases/` with an evidence note that says "pending" but also "PR #10 merged". Push PR. Verify CI warns about stale evidence.
+6. **NPM publish test:** Create a test tag (`v0.0.0-test`). Push. Verify workflow triggers, runs build/test, and attempts publish (will fail on auth if NPM_TOKEN not set, but verify it reaches that step).
+7. **Integration:** Run `./verify.sh --standard` after adding workflows. Verify passes (workflows are .github/, not plans).
+
+## Open questions
+
+- Should `stale-plans.yml` automatically move stale plans to `blocked/` instead of just opening an issue? Decision: no — auto-mutation of plan state from CI is too aggressive. Opening an issue is the right level of automation; the human decides.
+- Should the npm publish workflow also create a GitHub Release with auto-generated release notes? This would be a natural enhancement. Keep v1 minimal (publish only) and add release creation in a follow-up.
+- Should workflows be opt-in (in a `templates/` directory) or active by default (in `.github/workflows/`)? Active by default — they're harmless if the repo doesn't have plans/evidence yet (they'll just pass with zero findings), and they provide immediate value when plans are created.

--- a/.osc/plans/backlog/064-devcontainer-profile.md
+++ b/.osc/plans/backlog/064-devcontainer-profile.md
@@ -1,0 +1,63 @@
+# Plan: 064-devcontainer-profile
+
+## Status
+
+backlog
+
+## Context
+
+Container-based development is now standard for team onboarding — VS Code Dev Containers, GitHub Codespaces, Gitpod, and JetBrains all support `.devcontainer/` configurations. A new team member should be able to clone an Open Scaffold project, reopen it in a container, and have `osc` working immediately without installing Node.js, npm, or any global tools. Currently, every new contributor must manually install Node.js and run `npm install && npm run build` before they can use `osc`. A pre-built devcontainer profile eliminates this friction and signals that Open Scaffold takes team workflows seriously.
+
+## Goal
+
+Ship a `.devcontainer/devcontainer.json` and `Dockerfile` that pre-installs the `osc` CLI, Node.js, and git, so any developer can clone and start working in a fully-configured environment within seconds.
+
+## Constraints / Out of scope
+
+- Uses the official Node.js LTS Docker image matching `package.json` engines (`node:22`).
+- Must pre-install `osc` globally so the command works immediately after container start.
+- Must NOT include project-specific secrets, credentials, tokens, or `.env` files.
+- Must NOT require VS Code — the Dockerfile should be independently buildable with `docker build`.
+- The devcontainer is an optional profile, not a requirement — `osc init` should mention it but not force it.
+- Does NOT configure VS Code extensions beyond the essentials (TypeScript support) in v1.
+- Does NOT pre-install Claude Code, Codex, or any AI agent runtime — those are user-choice add-ons.
+
+## Files to touch
+
+- `.devcontainer/devcontainer.json` — new: VS Code devcontainer config referencing the Dockerfile, setting up post-create commands, and mounting the workspace
+- `.devcontainer/Dockerfile` — new: extends `node:22`, installs git (if not present), builds and installs `open-scaffold` globally
+- `.devcontainer/README.md` — new file: brief setup guide, how to use with VS Code and Codespaces, how to customize
+- `README.md` — add a "Dev Container" section or badge mentioning container support
+- `docs/DEV_CONTAINER.md` — new file: detailed dev container guide with troubleshooting and customization options
+- `.osc/plans/backlog/064-devcontainer-profile.md` — this plan
+
+## Acceptance criteria
+
+- [ ] `.devcontainer/devcontainer.json` is valid JSONC and references the Dockerfile correctly
+- [ ] `Dockerfile` builds successfully with `docker build -t osc-devcontainer -f .devcontainer/Dockerfile .devcontainer/`
+- [ ] Container starts with `osc` available in PATH — `docker run --rm osc-devcontainer osc --version` prints version
+- [ ] Container has Node.js and npm available — `docker run --rm osc-devcontainer node --version` prints v22.x
+- [ ] Container has git available — `docker run --rm osc-devcontainer git --version` prints version
+- [ ] `devcontainer.json` includes `postCreateCommand` that runs `npm install` (so dependencies are ready after container creation)
+- [ ] VS Code devcontainer flow works end-to-end: clone repo, "Reopen in Container", wait for build, open terminal, run `osc status` — works
+- [ ] GitHub Codespaces: if the repo is opened in Codespaces, it detects `.devcontainer/` and builds the environment automatically
+- [ ] `.devcontainer/README.md` explains the setup in 3 sentences, with links to VS Code and Codespaces docs
+- [ ] `docs/DEV_CONTAINER.md` covers: prerequisites (Docker, VS Code), first launch walkthrough, customization (adding extensions, changing Node version), troubleshooting (port conflicts, rebuild), and how to use without VS Code (plain Docker)
+- [ ] `README.md` mentions dev container support alongside the npm init path
+- [ ] `osc init --tier standard --target <dir>` generates a `.devcontainer/` in the target project (so downstream projects inherit container support)
+- [ ] `npm test` and `./verify.sh --standard` pass (devcontainer files are additive, no plan/schema impact)
+
+## Verification steps
+
+1. **Dockerfile build:** Run `docker build -t osc-test -f .devcontainer/Dockerfile .devcontainer/`. Verify build succeeds with no errors.
+2. **CLI presence:** Run `docker run --rm osc-test osc --version`. Verify version string matches package.json version.
+3. **Node and git:** Run `docker run --rm osc-test node --version` and `docker run --rm osc-test git --version`. Verify both print versions.
+4. **VS Code test:** Open the repo in VS Code. When prompted "Reopen in Container", accept. Wait for build. Open integrated terminal. Run `osc status`. Verify output shows scaffold state. Run `osc --help`. Verify help text.
+5. **Codespaces test (if available):** Push the branch to GitHub. Open in Codespaces. Verify auto-build triggers and terminal has `osc`.
+6. **Init generation test:** Run `osc init --tier standard --target /tmp/test-devcontainer`. Verify `/tmp/test-devcontainer/.devcontainer/` exists with devcontainer.json, Dockerfile, and README.md.
+
+## Open questions
+
+- Should the Dockerfile install `osc` globally via `npm install -g open-scaffold` (requires npm publish, plan 050) or build from local source? Decision: build from local source in the Dockerfile for self-containment (doesn't depend on npm registry). After plan 050 ships npm publish, add the `npm install -g` path as an alternative documented in `docs/DEV_CONTAINER.md`.
+- Should `.devcontainer/` be generated by `osc init --tier standard` or only `--tier max`? `standard` is the recommended starter — it should include devcontainer support. `min` should not (keep it as small as possible).
+- Post-create command: `npm install` is the obvious choice, but should it also run `npm run build`? Yes — the user should be able to run `osc` commands immediately without manual build step.

--- a/.osc/plans/backlog/065-tui-dashboard.md
+++ b/.osc/plans/backlog/065-tui-dashboard.md
@@ -1,0 +1,61 @@
+# Plan: 065-tui-dashboard
+
+## Status
+
+backlog
+
+## Context
+
+`osc status` is the only command that shows scaffold state, and it prints a flat list of plan counts by stage. For a project with 50+ done plans, 10 active plans, and multiple evidence notes, the flat list is inadequate. Users need a rich terminal dashboard that shows the full picture at a glance: active plans with staleness indicators, recent evidence activity, pending reviews, verification status, and the identity chain from roadmap to release. A TUI (terminal UI) dashboard makes the scaffold feel alive — it turns "what's going on?" from a grep exercise into a single command. This is the glass cockpit made real for the terminal.
+
+## Goal
+
+Ship `osc dashboard` (or `osc status --dashboard`) — an interactive terminal dashboard that displays active plans with status, recent evidence, stale warnings, verification health, and the identity chain in a single refreshing view.
+
+## Constraints / Out of scope
+
+- Pure terminal UI — no browser, no Electron, no web server.
+- Must use a lightweight TUI library compatible with Node.js (blessed, ink, or similar). Prefer `ink` (React-based, widely used in CLI tools) or a zero-dependency approach using ANSI escape codes and raw terminal I/O.
+- Must work in standard terminal dimensions (80x24 minimum). Graceful degradation on smaller terminals.
+- Must NOT require a daemon or background process — runs once (like `htop`) or with optional `--watch` flag for live refresh.
+- Read-only — no editing plans from the dashboard in v1.
+- Keyboard-navigable: arrow keys to scroll plan list, Enter to expand plan details, `q` to quit, `r` to refresh.
+- Color-coded: green for clean/done, yellow for stale/warning, red for broken/blocked, blue for active/in-progress.
+
+## Files to touch
+
+- `src/dashboard.ts` — new file: TUI implementation (layout, data fetching, keyboard handling, refresh loop)
+- `src/cli.ts` — wire `osc dashboard` and `osc status --dashboard` commands
+- `tests/dashboard.test.ts` — test data fetching logic and output formatting (TUI rendering is hard to unit test; focus on data layer)
+- `docs/GLASS_COCKPIT_PROTOCOL.md` — add "Terminal Dashboard" section as the simplest glass cockpit implementation
+
+## Acceptance criteria
+
+- [ ] `osc dashboard` starts a full-screen terminal UI showing at minimum: header with project name and mission status, active plans pane (plan name, last modified, staleness indicator), backlog count, done count, blocked count, recent evidence (last 3 evidence notes), and a footer with keyboard shortcuts
+- [ ] Active plans are color-coded: green (modified <7 days ago), yellow (7-30 days), red (>30 days)
+- [ ] Arrow keys move selection between plans in the active pane
+- [ ] Pressing Enter on a selected plan expands it inline to show full goal, AC summary, and last verification status
+- [ ] Pressing `q` or `Esc` quits the dashboard and restores the terminal
+- [ ] Pressing `r` refreshes all data from disk
+- [ ] `osc dashboard --watch` automatically refreshes every 30 seconds (configurable with `--interval <seconds>`)
+- [ ] `osc status --dashboard` is an alias for `osc dashboard`
+- [ ] Dashboard gracefully handles empty scaffold (zero plans): shows "No active plans. Create one with `osc plan new <slug> --stage active`"
+- [ ] Dashboard shows verify status indicator: green if `./verify.sh --standard` passes, yellow if warnings only, red if failures
+- [ ] Dashboard works in terminals as small as 80x24 — content is scrollable if it exceeds viewport
+- [ ] All existing tests pass; new dashboard tests cover data fetching and state formatting
+
+## Verification steps
+
+1. **Launch:** Run `osc dashboard` in the open-scaffold repo. Verify full-screen TUI appears with plan data.
+2. **Navigation:** Press arrow keys. Verify selection moves. Press Enter. Verify plan detail expands.
+3. **Color coding:** Check that active plans show appropriate colors based on age.
+4. **Quit:** Press `q`. Verify terminal is restored to pre-dashboard state (no leftover ANSI codes).
+5. **Empty state:** Run `osc dashboard` in an empty scaffold directory. Verify friendly empty-state message.
+6. **Watch mode:** Run `osc dashboard --watch --interval 5`. In another terminal, create a plan with `osc plan new test-dash --stage active`. Verify the new plan appears in the dashboard within 10 seconds.
+7. **Small terminal:** Resize terminal to 80x24. Run `osc dashboard`. Verify no overflow/crash.
+
+## Open questions
+
+- Which TUI library? `ink` uses React, which is heavy for a CLI tool but provides excellent component model. `blessed` is more traditional and lighter. A zero-dependency implementation with raw ANSI codes is the most portable but most labor-intensive. Recommendation: use `ink` — it's the modern standard for Node.js TUI apps (used by Stripe, Shopify, Vercel CLIs) and its React model makes the dashboard composable. Accept the dependency weight.
+- Should `osc dashboard` replace `osc status` over time? Not initially — `osc status` is quick, scriptable, and JSON-output-capable. The dashboard is for human consumption. Both should coexist.
+- Should the dashboard show `osc task` data when task DB exists? Yes — add a task summary pane (counts by status) when `.osc/tasks.db` is detected. This makes the dashboard a unified cockpit.

--- a/.osc/plans/backlog/066-web-dashboard.md
+++ b/.osc/plans/backlog/066-web-dashboard.md
@@ -1,0 +1,60 @@
+# Plan: 066-web-dashboard
+
+## Status
+
+backlog
+
+## Context
+
+The TUI dashboard (plan 065) serves terminal-native users, but many developers and stakeholders want a visual dashboard in the browser. A static HTML dashboard — no backend, no server, no database — generated from repo state and viewable by opening a single file or serving via `osc dashboard --serve` — makes the scaffold's state accessible to non-terminal users, project managers, and public build-in-public streams. This is the glass cockpit protocol rendered as a web page, with the same data sources as the TUI but a richer visual presentation.
+
+## Goal
+
+Ship `osc dashboard --web` that generates a single self-contained HTML page from scaffold state, and `osc dashboard --serve` that serves it locally, providing a browser-based glass cockpit for Open Scaffold projects.
+
+## Constraints / Out of scope
+
+- The HTML page is fully self-contained — no external CSS, no CDN fonts, no JavaScript framework CDN. All styles and scripts are inline or generated.
+- Read-only — displays state, does not mutate plans or evidence.
+- No backend process required for the static file. `--serve` mode spins up a temporary HTTP server (Node.js built-in `http` module) for local viewing; it is NOT a production server.
+- Must NOT require network access to render (self-contained). `--serve` mode is localhost-only.
+- Dark theme by default (matches the product's premium brutalism aesthetic), with a system-theme toggle.
+- Data refreshes on page reload. No WebSocket, no live updates in v1 (the TUI covers live refresh).
+- Must work when opened as `file://` (CSP-friendly, no fetch requests to external origins).
+- Does NOT embed git history, runtime logs, or any data beyond what `osc status --json` + plan file content provides.
+
+## Files to touch
+
+- `src/dashboard-web.ts` — new file: HTML generation from scaffold state (inline CSS, inline JS for interactivity, data embedded as JSON in a `<script>` tag)
+- `src/cli.ts` — wire `osc dashboard --web [--out <path>]` and `osc dashboard --serve [--port <port>]`
+- `tests/dashboard-web.test.ts` — test HTML generation, data embedding, self-contained property (no external refs), serve mode
+- `docs/GLASS_COCKPIT_PROTOCOL.md` — add "Web Dashboard" section as a cockpit mode
+
+## Acceptance criteria
+
+- [ ] `osc dashboard --web` generates a self-contained `.osc/dashboard.html` file (or outputs to `--out <path>`)
+- [ ] `osc dashboard --serve` starts a local HTTP server, prints the URL, and serves the dashboard
+- [ ] The HTML page displays: mission summary (goals excerpt), plan kanban columns (active, backlog, blocked, done) with plan names and status, recent evidence notes with links, verification status indicator, identity chain visualization (roadmap → plan → run → PR → evidence), and task summary if `.osc/tasks.db` exists
+- [ ] Clicking a plan name expands it inline to show goal, acceptance criteria (with check marks for completed), and open questions
+- [ ] The page uses a dark theme with clean typography, subtle borders, and color-coded status indicators (green=done, yellow=stale, red=blocked, blue=active)
+- [ ] The page is responsive — works on desktop and mobile viewports
+- [ ] The page has zero external dependencies: no `<link>` tags to external CSS, no `<script src="...">` to external JS, no CDN fonts, no analytics
+- [ ] Opening the generated `.osc/dashboard.html` as a `file://` URL works without errors (no CORS issues, no blocked fetches)
+- [ ] `osc dashboard --serve --port 9999` serves on that port and prints `http://localhost:9999`
+- [ ] `osc dashboard --serve` exits cleanly on Ctrl+C (SIGINT handled)
+- [ ] Generated HTML is committed to `.osc/dashboard.html` so it can be viewed directly on GitHub Pages or raw git hosting
+- [ ] All existing tests pass; new web dashboard tests cover HTML generation and serve mode
+
+## Verification steps
+
+1. **Generate:** Run `osc dashboard --web --out /tmp/test-dashboard.html`. Open `/tmp/test-dashboard.html` in a browser. Verify all sections render with correct data.
+2. **Self-contained check:** Run `grep -E '(href=|src=)' /tmp/test-dashboard.html`. Verify no external URLs (only inline `#` anchors and data URIs).
+3. **Serve mode:** Run `osc dashboard --serve --port 9876`. In another terminal, run `curl -s http://localhost:9876 | head -20`. Verify HTML response. Press Ctrl+C, verify server stops.
+4. **Empty state:** Run `osc dashboard --web` in an empty scaffold dir. Verify generated HTML shows "No plans yet" message, not a crash.
+5. **Verification:** Run `./verify.sh --standard`. Verify passes (web dashboard is additive).
+
+## Open questions
+
+- Should the dashboard include a Mermaid.js diagram of the identity chain (roadmap → plan → run → PR → evidence)? Mermaid is an external CDN dependency — violates the self-contained constraint. Alternative: render an ASCII art diagram or simple CSS-only flowchart. Decision: simple CSS flowchart for v1. Mermaid can be added as an optional `--with-mermaid` flag that acknowledges the CDN dependency.
+- Should `osc dashboard --serve` support `--open` to auto-open the browser? Yes — a common UX expectation. Add `--open` flag that uses `open` (macOS), `xdg-open` (Linux), or `start` (Windows).
+- Should `.osc/dashboard.html` be gitignored or tracked? Track it — it's a generated artifact that represents repo state at a point in time. Similar to `.osc/releases/` evidence notes. Users can regenerate it anytime.

--- a/.osc/plans/backlog/067-plan-dependency-graph.md
+++ b/.osc/plans/backlog/067-plan-dependency-graph.md
@@ -1,0 +1,61 @@
+# Plan: 067-plan-dependency-graph
+
+## Status
+
+backlog
+
+## Context
+
+Plans in `.osc/plans/` can reference each other — a feature plan may depend on a refactor plan, an architecture decision may block three implementation plans, a follow-up plan inherits from a prior slice. But there is no way to visualize these relationships. A developer looking at 20 active and backlog plans has no answer to "what should I work on first?" or "what's blocking what?" A dependency graph — even a simple ASCII or Mermaid rendering — turns a flat list of files into a navigable work map.
+
+## Goal
+
+Ship `osc plan graph [--format ascii|mermaid|json]` that reads plan cross-references and renders a dependency DAG showing which plans depend on which, which are blocking others, and the critical path.
+
+## Constraints / Out of scope
+
+- Parse dependencies from plan content: look for explicit references like `depends on: 050-npm-publish`, `blocks: 052-interactive-plan-wizard`, `follows: 001-generic-osc-core`, or `--plan <slug>` style references in the Context and Open Questions sections.
+- Does NOT infer dependencies from file timestamps or git history — dependencies must be explicitly declared in plan text.
+- Output formats: `ascii` (terminal-friendly tree), `mermaid` (copy-pasteable Mermaid flowchart for docs/PRs), `json` (machine-parseable for tooling and CI).
+- Does NOT detect circular dependencies in v1 (warns but doesn't block).
+- Does NOT validate that dependency targets actually exist in v1 (reports "unresolved dependency" as warning).
+- Does NOT modify plans to add dependency metadata — parsing only.
+
+## Files to touch
+
+- `src/plan-graph.ts` — new file: dependency extraction (regex patterns), DAG construction, cycle detection, format renderers
+- `src/cli.ts` — wire `osc plan graph [--format ascii|mermaid|json] [--stage active|backlog|all] [--direction downstream|upstream|both]`
+- `tests/plan-graph.test.ts` — test dependency extraction from various plan formats, DAG construction, cycle detection, renderer output
+- `docs/WORKFLOW.md` — mention `osc plan graph` in the Plan phase
+
+## Acceptance criteria
+
+- [ ] `osc plan graph` prints an ASCII tree showing all plans in active/ and backlog/ with their declared dependencies as indented children
+- [ ] `osc plan graph --format mermaid` outputs a valid Mermaid flowchart that can be pasted into GitHub markdown and renders correctly
+- [ ] `osc plan graph --format json` outputs a JSON DAG with nodes (plan slug, stage, goal summary) and edges (from, to, relationship type: depends_on|blocks|follows)
+- [ ] Dependency patterns detected: `depends on: <slug>`, `blocks: <slug>`, `follows: <slug>`, `--plan <slug>`, `see plan <slug>`, `blocked by: <slug>`, `inherits from: <slug>`
+- [ ] `--stage active` filters to only active plans and their dependencies
+- [ ] `--stage all` includes all stages (active, backlog, blocked, done)
+- [ ] `--direction downstream` shows only what this plan depends on
+- [ ] `--direction upstream` shows only what depends on this plan (reverse dependency — "what's blocked on this?")
+- [ ] `--direction both` (default) shows the full neighborhood
+- [ ] Warnings printed to stderr for: unresolved dependencies (target plan not found), circular dependencies detected
+- [ ] Plans with zero declared dependencies show as standalone nodes (not an error)
+- [ ] Exit code 0 even with warnings (warnings are informational, not blocking)
+- [ ] All existing tests pass; new graph tests cover dependency extraction and rendering
+
+## Verification steps
+
+1. **Basic graph:** Create three plans: A depends on B, B depends on C. Run `osc plan graph`. Verify A → B → C chain rendered correctly.
+2. **Blocks relationship:** Create plan X that says "blocks: Y". Run `osc plan graph --direction upstream` and verify Y shows X as upstream dependent.
+3. **Mermaid output:** Run `osc plan graph --format mermaid`. Copy output to a GitHub issue or Mermaid live editor. Verify it renders as a flowchart.
+4. **JSON output:** Run `osc plan graph --format json | jq .edges`. Verify correct from/to/relationship structure.
+5. **Unresolved dependency:** Create a plan that says "depends on: nonexistent-plan". Run `osc plan graph`. Verify warning on stderr about unresolved dependency.
+6. **Circular dependency:** Create A depends on B, B depends on A. Run `osc plan graph`. Verify circular dependency warning on stderr, graph still renders (with cycle indicated).
+7. **Empty state:** Run `osc plan graph` in empty scaffold. Verify output is "No plans found" or empty graph.
+
+## Open questions
+
+- Should `osc plan graph` also read dependency data from a machine-readable field in the plan YAML frontmatter (if we add frontmatter support)? This would be more reliable than regex parsing. Decision: regex parsing for v1 (works with existing plans). If frontmatter is added in a future plan, add a `dependencies:` field that the graph command reads preferentially.
+- Should the graph show done plans by default? No — done plans clutter the graph. But `--stage all` includes them for historical context.
+- Should `osc plan graph --critical-path` compute the longest dependency chain (critical path for project completion)? This is a natural analytics feature. Defer to v2 — requires proper DAG topological sort, which is straightforward but adds scope.

--- a/.osc/plans/backlog/068-python-reference-parser.md
+++ b/.osc/plans/backlog/068-python-reference-parser.md
@@ -1,0 +1,62 @@
+# Plan: 068-python-reference-parser
+
+## Status
+
+backlog
+
+## Context
+
+Open Scaffold is currently TypeScript-only for programmatic access to plan state. The CLI (`osc`) and its underlying libraries (`src/scaffold.ts`, `src/validation.ts`) parse plans, validate schemas, and query scaffold state — but only from Node.js. Python-centric projects cannot programmatically read plans, validate acceptance criteria, or integrate scaffold state into Python tooling without shelling out to `osc --json`. A Python reference parser — a single-file, zero-dependency implementation — would make Open Scaffold queryable from Python scripts, CI pipelines, data science notebooks, and any Python-based AI agent.
+
+## Goal
+
+Ship a single-file Python reference parser (`open_scaffold/parser.py`) that reads plan files, extracts sections and acceptance criteria, and exposes scaffold state — matching the TypeScript implementation's semantics — with zero dependencies beyond Python 3.10+ stdlib.
+
+## Constraints / Out of scope
+
+- Single-file implementation: one `.py` file that can be vendored (copied into any project without `pip install`).
+- Zero dependencies beyond Python 3.10+ standard library.
+- Read-only in v1 — parses and exposes state, does not create, amend, or close plans.
+- Must match the TypeScript parser's behavior for: section extraction, AC parsing, file-to-touch list, open question detection, status extraction, execution strategy parsing.
+- Plan file format is Markdown with `## Heading` sections — no custom format, no YAML frontmatter requirement.
+- Does NOT reimplement the full CLI. Does NOT implement verify.sh logic. Does NOT implement run packet generation. Parsing only.
+- Must ship with a `pyproject.toml` so it can be optionally `pip install`-ed for projects that want it as a proper package.
+
+## Files to touch
+
+- `python/open_scaffold/__init__.py` — new: package init, version
+- `python/open_scaffold/parser.py` — new: plan parser (section extraction, AC parsing, file list, status, execution strategy), scaffold inspector (find .osc root, list plans by stage, read mission)
+- `python/open_scaffold/cli.py` — new: minimal CLI (`python -m open_scaffold status|plan <path>|verify`) for parity testing
+- `python/pyproject.toml` — new: package metadata, optional `pip install` support
+- `python/tests/test_parser.py` — new: tests using sample plan files matching TypeScript test fixtures
+- `python/README.md` — new: usage guide, vendoring instructions, TypeScript parity table
+- `docs/REFERENCE_TRUTH.md` — add Python parser to the tool references section
+
+## Acceptance criteria
+
+- [ ] `open_scaffold/parser.py` contains a `parse_plan(path: str) -> dict` function that returns: slug, status, goal, sections (dict of heading → content), files_to_touch (list), acceptance_criteria (list), verification_steps (list), open_questions (list), execution_strategy (optional dict with groups/dependencies/delegation_notes)
+- [ ] `open_scaffold/parser.py` contains an `inspect_scaffold(root: str = ".") -> dict` function that returns: root, namespace, mission (defined, reason), plans (dict of stage → list of {slug, path})
+- [ ] Output of `parse_plan()` matches the TypeScript `parsePlanFile()` output for the same plan file (verified by comparing JSON outputs)
+- [ ] Output of `inspect_scaffold()` matches the TypeScript `inspectScaffold()` output for the same repo
+- [ ] `python -m open_scaffold status` prints plan counts by stage (matching `osc status` text output shape)
+- [ ] `python -m open_scaffold plan .osc/plans/backlog/050-npm-publish-and-npx-init.md` prints parsed plan as JSON
+- [ ] `python -m open_scaffold verify` runs mission-defined and plan-presence checks (matching `osc verify --quick` semantics)
+- [ ] The parser correctly handles: plans with amendments in the same folder (ignores amendment files when listing plans), plans in root `.osc/plans/` (not in a stage folder), plans with empty sections, plans with `## Status` mismatch (reports actual folder location vs declared status)
+- [ ] All parser tests pass with `python -m pytest python/tests/` (or `python -m unittest` if no pytest dependency)
+- [ ] `python/README.md` includes: 3-line vendoring example (copy parser.py, import, use), pip install instructions, parity table showing TypeScript function → Python function mapping
+- [ ] `npm test` and `./verify.sh --standard` pass (Python files are additive, no impact on Node.js code)
+
+## Verification steps
+
+1. **Parse existing plans:** Run `python -m open_scaffold plan .osc/plans/backlog/050-npm-publish-and-npx-init.md`. Compare JSON output to `osc plan .osc/plans/backlog/050-npm-publish-and-npx-init.md` (TypeScript). Verify all fields match.
+2. **Inspect scaffold:** Run `python -m open_scaffold status` in the open-scaffold repo. Compare output to `osc status`. Verify plan counts match.
+3. **Verify:** Run `python -m open_scaffold verify`. Compare exit code to `osc verify --quick`. Verify both pass.
+4. **Parse all plans:** Loop over all `.osc/plans/backlog/*.md` and `.osc/plans/done/*.md`, run the Python parser on each. Verify no crashes, all return valid dicts.
+5. **Vendoring test:** Copy `parser.py` to `/tmp/test-vendor/`. Create a simple Python script that imports and parses a plan. Verify works with only stdlib.
+6. **Edge cases:** Create a plan with empty AC section. Verify parser returns empty list, not error. Create a plan with `## Execution strategy` present. Verify execution_strategy dict is populated.
+
+## Open questions
+
+- Should the Python parser be a separate PyPI package (`pip install open-scaffold-parser`) or only vendorable? Vendoring-first: the single-file copy approach supports the widest range of use cases (air-gapped, no pip, embedded in larger projects). PyPI publication can follow as a convenience.
+- Should the Python parser support plan creation/amendment in v1? No — read-only parsing is the 80/20 use case. Python-based plan mutation would require reimplementing amend.sh logic (autonumbering, changelog stamping), which is significantly more code.
+- Should there be parity tests that run both TypeScript and Python parsers on the same plan files and diff the output? Yes — this is the gold standard for reference implementation correctness. Add a CI step or test script that generates JSON from both parsers and asserts structural equivalence.

--- a/.osc/plans/backlog/069-v1-launch.md
+++ b/.osc/plans/backlog/069-v1-launch.md
@@ -1,0 +1,68 @@
+# Plan: 069-v1-launch
+
+## Status
+
+backlog
+
+## Context
+
+Open Scaffold has been under active self-dogfood development since May 2026. The repo has 50+ closed plans, a stable CLI at v0.4.1, comprehensive protocol documentation, self-dogfood proof through PRs and Codex reviews, a project wiki, and now a v2 backlog of 20+ detailed plans. But the project has no public release on npm, no launch announcement, no "why now" story, and no clear signal of what's stable vs experimental. A v1.0.0 launch turns the project from "promising protocol in development" to "stable product you can adopt." It is a marketing and trust milestone, not a feature milestone.
+
+## Goal
+
+Ship Open Scaffold v1.0.0: npm published, README crisp, documentation compressed, at least 3 downstream use cases cited, website or landing page live, and a clear public statement of what is stable (the protocol and CLI) versus what is experimental (runtime adapters, MCP, glass cockpit).
+
+## Constraints / Out of scope
+
+- v1.0.0 is a trust and adoption milestone, not a feature completion milestone. The backlog contains 20+ v2 plans; v1.0.0 does NOT mean all those are done.
+- npm publish is mandatory for v1.0.0. The `npx open-scaffold init` path must work.
+- Downstream use cases may be anonymized or described in general terms if users haven't given explicit permission to be named.
+- The launch does NOT include a marketing site with a custom domain unless the owner explicitly commissions it. A `docs/` page or GitHub Pages site is sufficient.
+- v1.0.0 does NOT mean the protocol is frozen — the amendment protocol means scope can always evolve cleanly.
+- Semantic versioning: v1.0.0 signals that the public API (CLI commands, plan schema, verify.sh checks) is stable and will not break without a major version bump.
+
+## Files to touch
+
+- `package.json` — bump version to `1.0.0`
+- `README.md` — add "v1.0.0 Stable" section, clarify what's stable vs experimental, add adoption examples
+- `MISSION.md` — add v1.0.0 changelog entry, review goals/non-goals for accuracy
+- `ROADMAP.md` — add v1.0.0 milestone entry summarizing what shipped, mark v0.x milestones as completed
+- `docs/STABILITY.md` — new file: stability guarantees, what's covered by semver, what's experimental
+- `docs/CHANGELOG.md` — new file: curated changelog from MISSION.md changelog entries, organized by version
+- `docs/` or GitHub Pages — landing page content or a `docs/index.html` for presentation
+- `.osc/releases/2026-05-XX-v1.0.0.md` — v1.0.0 release evidence note
+- `AGENTS.md` and `CLAUDE.md` — ensure both reflect v1.0.0 state
+
+## Acceptance criteria
+
+- [ ] `npm view open-scaffold version` returns `1.0.0`
+- [ ] `npx open-scaffold@1.0.0 init --tier min --target /tmp/test-v1` succeeds and creates a valid scaffold
+- [ ] `npx open-scaffold@1.0.0 init --tier standard --target /tmp/test-v1-std` succeeds with all standard files
+- [ ] `README.md` contains a "Stability" section that lists: stable (CLI commands plan/new/amend/close/evidence/verify/status, plan schema, folder state machine, verify.sh), experimental (runtime profiles, MCP, glass cockpit webhooks, task database, TUI dashboard), and future (native spawning, compliance certification, model benchmarking)
+- [ ] `docs/STABILITY.md` exists with detailed semver guarantees and migration guidance for future breaking changes
+- [ ] `docs/CHANGELOG.md` exists with curated, human-readable changelog grouped by version (v0.1 through v1.0.0)
+- [ ] At least one public landing page or presentation exists: either `docs/index.html`, a GitHub Pages site, or a dedicated website page explaining what Open Scaffold is, who it's for, and how to start
+- [ ] The landing page answers in 30 seconds: what problem does this solve, who is it for, what's the first command to run
+- [ ] `ROADMAP.md` shows v1.0.0 as a completed milestone with links to release evidence and key PRs
+- [ ] `MISSION.md` changelog has a v1.0.0 entry summarizing the launch
+- [ ] `AGENTS.md` and `CLAUDE.md` paired views are in sync for v1.0.0
+- [ ] `./verify.sh --strict` passes
+- [ ] `npm test` passes
+- [ ] `npm run build` succeeds
+- [ ] GitHub Release exists at https://github.com/graphanov/open-scaffold/releases/tag/v1.0.0 with release notes citing key milestones and the identity chain
+
+## Verification steps
+
+1. **npm publish test:** Run `npm publish --dry-run`. Verify package contents, version 1.0.0, no private files.
+2. **Fresh install test:** In a clean directory: `npx open-scaffold@1.0.0 init --tier standard --target /tmp/v1-smoke && cd /tmp/v1-smoke && ./verify.sh --standard`. Verify all checks pass.
+3. **Stability doc:** Read `docs/STABILITY.md`. Verify it clearly separates stable from experimental.
+4. **Landing page:** Open the landing page or `docs/index.html` in a browser. Verify it answers the three questions in under 30 seconds of reading.
+5. **GitHub Release:** Visit the release URL. Verify release notes are comprehensive, link to key PRs and evidence.
+6. **Verify:** Run `./verify.sh --strict` and `npm test` in the repo. Both must pass.
+
+## Open questions
+
+- Should v1.0.0 coincide with a formal launch post (blog, social media, Hacker News, Reddit)? This is a marketing decision for the owner. The plan should prepare the technical artifacts; the owner decides when and where to announce.
+- Should there be a v1.0.0 video demo or only text/image? A video demo would dramatically improve first-impression conversion. If the owner is willing, a 2-minute screen recording of `npx open-scaffold init` → create plan → verify → evidence → close would be the single most effective adoption artifact.
+- Should the landing page use `graphanov.com/open-scaffold` or a separate domain? The owner's current strategy routes Open Scaffold as proof through graphanov.com. Use `graphanov.com/open-scaffold` as the canonical URL, with a GitHub Pages fallback at `graphanov.github.io/open-scaffold`.
+- What v0.x features should be declared experimental vs stable for v1.0.0? The guiding principle: if it has automated tests and has been used in the self-dogfood loop, it's stable. CLI commands with test coverage (plan, amend, close, evidence, verify, status, init) = stable. CLI commands without full E2E test coverage (run, review, ultrareview, eval, audit, runtimes, doctor, delegate) = experimental. Shell scripts = stable (they're the zero-dep floor).

--- a/.osc/plans/backlog/070-runtime-adapter-registry.md
+++ b/.osc/plans/backlog/070-runtime-adapter-registry.md
@@ -1,0 +1,63 @@
+# Plan: 070-runtime-adapter-registry
+
+## Status
+
+backlog
+
+## Context
+
+Open Scaffold ships with built-in runtime profiles (omc, omx, plain, human) and one in-repo agentic runtime package (`packages/runtime-omx/`). But there is no discoverability mechanism — a user running `osc runtimes list` sees built-in profiles but has no way to know what third-party adapters exist, what workflows they support, or how to install them. A runtime adapter registry — even a simple JSON file in the repo — would make the runtime ecosystem feel real and give adapter authors a canonical place to register their work. This is infrastructure for the multi-runtime vision without committing core to any specific runtime.
+
+## Goal
+
+Ship a runtime adapter registry: a JSON file in the Open Scaffold repo listing known adapter packages, plus `osc runtimes search|install|info` commands to discover and set up adapters, establishing the marketplace pattern without building a marketplace backend.
+
+## Constraints / Out of scope
+
+- The registry is a single `registry.json` file tracked in the Open Scaffold repo. No server, no API, no dynamic resolution.
+- Registry entries are curated by PR — adapter authors submit a PR adding their entry. The Open Scaffold maintainer reviews and merges.
+- `osc runtimes install <id>` runs the adapter's documented install command (typically `npm install`). It does NOT execute arbitrary code from the registry — it prints the install command for the user to run manually if the command looks unsafe.
+- Does NOT implement automatic runtime discovery, version compatibility checking, or dependency resolution.
+- Does NOT validate that adapter packages actually work — the registry is a directory, not a certification.
+- Does NOT implement a marketplace with ratings, downloads, or popularity metrics.
+- Adapter entries must include: name, description, repo URL, install command, supported workflows, minimum Open Scaffold version, and a conformance badge (self-declared).
+
+## Files to touch
+
+- `registry.json` — new file: array of adapter entries with standardized schema
+- `src/registry.ts` — new file: registry loading, searching, display formatting, install command generation
+- `src/cli.ts` — wire `osc runtimes search <query>`, `osc runtimes info <id>`, `osc runtimes install <id> [--yes]`, `osc runtimes registry`
+- `tests/registry.test.ts` — test registry loading, search, info display, install command output
+- `docs/RUNTIME_PROFILES.md` — add "Adapter Registry" section
+- `docs/ADAPTER_REGISTRY.md` — new file: registry schema, submission guide, review criteria
+
+## Acceptance criteria
+
+- [ ] `registry.json` exists with a `$schema` field, a `version` field, and an `adapters` array
+- [ ] `registry.json` includes at minimum: the built-in OMX adapter (`packages/runtime-omx/`), plus documentation for how to submit new entries
+- [ ] Each adapter entry has: `id` (unique slug), `name` (human-readable), `description`, `repo` (URL), `install` (command or object with platform variants), `workflows` (list of supported workflow names), `runtime` (omc|omx|plain-agent|human|custom), `minOpenScaffoldVersion`, `conformance` (self-declared conformance level and date), `status` (stable|beta|experimental)
+- [ ] `osc runtimes search "omx"` returns entries matching the query in name, description, or id
+- [ ] `osc runtimes search` (no query) lists all registry entries
+- [ ] `osc runtimes info omx` displays the full entry for the OMX adapter: name, description, repo, install command, supported workflows, conformance status
+- [ ] `osc runtimes install omx` prints the install command (e.g., `cd packages/runtime-omx && npm install && npm run build`) and asks for confirmation before executing
+- [ ] `osc runtimes install omx --yes` skips confirmation and runs the install command
+- [ ] `osc runtimes registry` shows registry metadata: number of adapters, last updated, schema version
+- [ ] The `registry.json` schema is documented in `docs/ADAPTER_REGISTRY.md` with a JSON Schema definition
+- [ ] `docs/ADAPTER_REGISTRY.md` includes submission instructions: fork, add entry, open PR, what the maintainer checks before merge
+- [ ] All existing tests pass; new registry tests cover search, info display, and install command generation
+
+## Verification steps
+
+1. **Registry validity:** Run `python3 -c "import json; json.load(open('registry.json'))"` to validate JSON. Verify required fields present on all entries.
+2. **Search:** Run `osc runtimes search omx`. Verify output includes the OMX adapter entry.
+3. **Info:** Run `osc runtimes info omx`. Verify all fields (name, description, repo, install, workflows) are displayed.
+4. **Install dry-run:** Run `osc runtimes install omx` (without --yes). Verify it prints the command and asks for confirmation. Answer "no". Verify nothing is installed.
+5. **Empty search:** Run `osc runtimes search "nonexistent"`. Verify output is "No adapters found matching 'nonexistent'."
+6. **Schema doc:** Run `osc runtimes registry`. Verify metadata output. Read `docs/ADAPTER_REGISTRY.md`. Verify submission guide is clear.
+
+## Open questions
+
+- Should the registry support version ranges (e.g., adapter v1.2.0 requires Open Scaffold >=1.0.0)? Yes — `minOpenScaffoldVersion` is a simple floor. Semantic version range support (e.g., `^1.0.0`) would be more precise but adds complexity. Start with minimum version only.
+- Should `osc runtimes install` ever install packages globally (npm install -g)? No — adapters should be project-local (npm install in the repo or in a packages/ directory). Global installs create version conflicts across projects.
+- Should the registry be automatically tested in CI? A CI step that validates `registry.json` schema and checks that all listed repos are accessible (HTTP 200) would catch stale entries. Add this as a stretch goal if the registry grows beyond 10 entries.
+- Should the registry be in the core repo or a separate `open-scaffold-registry` repo? In the core repo for v1 — it's a single file and the submission flow (PR to core) is simple. A separate repo would be warranted if the registry grows to 50+ entries with automated validation.

--- a/.osc/plans/backlog/071-evidence-chain-verifier.md
+++ b/.osc/plans/backlog/071-evidence-chain-verifier.md
@@ -1,0 +1,56 @@
+# Plan: 071-evidence-chain-verifier
+
+## Status
+
+backlog
+
+## Context
+
+`osc verify` and `verify.sh` check structural compliance — mission defined, plans present, amendments sequential, evidence notes have sections. But they don't verify the evidentiary chain: does every closed plan have evidence? Does every acceptance criterion have a pass/fail verdict? Does every run reference actually point to an existing run packet? Does every evidence note link back to a plan? A chain verifier walks the identity chain from plan to run to evidence to release, verifying that every link is intact and every claim is backed by an artifact that actually exists on disk. This turns Open Scaffold from "files exist" to "the story checks out."
+
+## Goal
+
+Ship `osc verify --evidence-chain` that walks the full identity chain for a plan or the entire project, verifying that every acceptance criterion has evidence, every run reference is valid, every evidence note links back to a plan, and the close decision has a rationale.
+
+## Constraints / Out of scope
+
+- Verifies evidence existence and structural linkage, NOT evidence quality or correctness. "AC1 has evidence at path X" is a valid link even if the evidence is weak.
+- Local filesystem only — does not check that GitHub PRs are merged, CI passed, or Codex reviewed.
+- Links are detected from: plan acceptance criteria checkboxes, evidence note traceability section, run packet references, MISSION.md changelog entries.
+- Does NOT modify any files — read-only verification.
+- Reports are structured: each link is either `intact`, `broken` (reference points to nonexistent file), `missing` (no evidence found for a criterion), or `unverifiable` (link points to a URL or external system, can't check locally).
+- Does NOT require git history (works on filesystem state alone).
+
+## Files to touch
+
+- `src/evidence-chain.ts` — new file: chain walker (plan → run → evidence → release traversal), link extraction, existence verification
+- `src/cli.ts` — wire `osc verify --evidence-chain [--plan <slug>] [--json]`
+- `tests/evidence-chain.test.ts` — test chain walking on fixtures: intact chain, broken chain, missing evidence, external links
+- `docs/SLICE_CLOSE_PROTOCOL.md` — add "Evidence Chain Verification" section
+
+## Acceptance criteria
+
+- [ ] `osc verify --evidence-chain` walks all done plans in the project and reports: total plans checked, total evidence links found, intact/broken/missing/unverifiable counts, and a per-plan breakdown
+- [ ] `osc verify --evidence-chain --plan 050-npm-publish` verifies the chain for a single plan: plan exists → acceptance criteria have evidence references → evidence note exists → evidence note links back to plan → close decision has rationale
+- [ ] For each done plan, the verifier checks: (1) plan file exists in `done/`, (2) plan has acceptance criteria, (3) each AC checkbox is marked `[x]` with an evidence reference (or explicitly marked `N/A`), (4) if plan references a run ID, `.osc/runs/<run_id>/` exists, (5) if plan references a PR, the PR reference is syntactically valid (URL or `#NN`), (6) if an evidence note exists for the plan, it cites the plan slug, (7) the close decision in the evidence note or plan is one of: approved, weak_approved, rejected, blocked
+- [ ] `--json` outputs a JSON array of findings with: plan_slug, links (array of {type, reference, status, detail})
+- [ ] `--strict` mode: exit code 1 if any link is `broken` or `missing` (not just `unverifiable`)
+- [ ] Default mode: exit code 1 only for `broken` links; `missing` and `unverifiable` produce warnings but exit 0
+- [ ] Verifier handles plans with no evidence (reports "no evidence links found" for that plan, not an error)
+- [ ] Verifier handles plans with no run ID (skips run packet check, reports "no run reference" as informational)
+- [ ] All existing tests pass; new chain verifier tests cover all link statuses
+
+## Verification steps
+
+1. **Intact chain:** Pick a done plan with full evidence (e.g., 050-npm-publish). Run `osc verify --evidence-chain --plan 050-npm-publish`. Verify all links intact.
+2. **Broken chain:** Manually create a plan that references a nonexistent evidence note. Run `osc verify --evidence-chain --strict`. Verify exit code 1, broken link reported.
+3. **Missing evidence:** Create a plan with unchecked AC checkboxes (`[ ]`). Run `osc verify --evidence-chain`. Verify "missing evidence" reported for those ACs.
+4. **External link:** Create a plan with a PR reference like `https://github.com/owner/repo/pull/99` (URL, not local file). Run `osc verify --evidence-chain`. Verify link is `unverifiable`, not `broken`.
+5. **JSON output:** Run `osc verify --evidence-chain --json | jq '.links | group_by(.status)'`. Verify correct status distribution.
+6. **Full project:** Run `osc verify --evidence-chain` on the entire open-scaffold repo. Verify reasonable counts (50+ done plans, hundreds of links, mostly intact).
+
+## Open questions
+
+- Should `osc verify --evidence-chain` also validate that evidence notes aren't stale (e.g., saying "pending" while citing a merged PR)? This is partially covered by `verify.sh --strict` Check 9 (release note stale-state detection). The chain verifier could deepen this: check that the evidence note's Outcome section doesn't contradict its Traceability section. Defer to a follow-up — keep v1 focused on chain integrity.
+- Should the chain verifier be integrated into `verify.sh` as a new tier (`--evidence-chain`) or stay as a separate `osc` command? Stay as `osc verify --evidence-chain` — the shell script is already long and complex. The chain verifier requires plan parsing logic that's impractical in bash.
+- Should links to GitHub PRs and issues be verified via API? This would require network access and a GitHub token, violating the local-only constraint. The `unverifiable` status is the correct handling — it tells the user "this link exists but I can't check it from here."

--- a/.osc/plans/backlog/072-cross-platform-workflow-docs.md
+++ b/.osc/plans/backlog/072-cross-platform-workflow-docs.md
@@ -1,0 +1,56 @@
+# Plan: 072-cross-platform-workflow-docs
+
+## Status
+
+backlog
+
+## Context
+
+The GitHub Workflow document (`docs/GITHUB_WORKFLOW.md`) and the broader identity chain (issue → plan → run → PR → evidence → release) are described exclusively in GitHub terms: Issues, Pull Requests, `gh` CLI, Codex connector. But many teams use GitLab, Bitbucket, Gitea, or Azure DevOps. The protocol itself is platform-agnostic — plans, runs, and evidence are just files — but the workflow documentation makes it seem GitHub-only. Cross-platform workflow documentation would make Open Scaffold adoptable by teams on any git forge without them having to translate the GitHub-specific instructions themselves.
+
+## Goal
+
+Ship cross-platform workflow documentation covering GitLab, Bitbucket, and Gitea, mapping the GitHub identity chain to each platform's equivalent primitives (Issues → merge requests → CI → releases), with platform-specific command examples.
+
+## Constraints / Out of scope
+
+- Documentation only — no code changes to the scaffold itself. The scaffold is already platform-agnostic; the docs just need to reflect that.
+- Covers GitLab (Self-Managed and SaaS), Bitbucket Cloud, and Gitea as the three most common non-GitHub forges.
+- Does NOT implement platform-specific CLI commands or adapters — documents how to use existing `osc` commands with each platform.
+- Does NOT test or certify the workflows on each platform (that would require platform accounts and CI setup beyond the scope of a docs plan).
+- Codex connector is GitHub-only; document alternatives for each platform (GitLab CI review jobs, Bitbucket Pipeline review steps, manual review).
+
+## Files to touch
+
+- `docs/GITLAB_WORKFLOW.md` — new file: GitLab workflow mapping (Issues → Merge Requests → CI → Releases), command examples using `glab` CLI, MR template
+- `docs/BITBUCKET_WORKFLOW.md` — new file: Bitbucket workflow mapping (Issues → Pull Requests → Pipelines → Downloads/Releases), command examples
+- `docs/GITEA_WORKFLOW.md` — new file: Gitea workflow mapping (Issues → Pull Requests → Actions → Releases), command examples using `tea` CLI
+- `docs/GITHUB_WORKFLOW.md` — add a "Cross-Platform" section at the top linking to the other platform docs
+- `docs/OPEN_SCAFFOLD_SYSTEM.md` — update the GitHub/public versioning layer section to mention platform agnosticism
+- `docs/COMPARISON.md` — add note about platform flexibility as a differentiator
+
+## Acceptance criteria
+
+- [ ] `docs/GITLAB_WORKFLOW.md` exists with: platform overview, identity chain mapping (GitHub Issue → GitLab Issue, PR → Merge Request, Codex review → GitLab CI review job, GitHub Release → GitLab Release), `glab` CLI examples for issue creation, MR creation, and CI status checking, MR template with scaffold traceability fields
+- [ ] `docs/BITBUCKET_WORKFLOW.md` exists with: platform overview, identity chain mapping (GitHub Issue → Bitbucket Issue, PR → Pull Request, Codex review → Pipeline review step, GitHub Release → Bitbucket Download/Release), `curl`/API examples for issue and PR management (Bitbucket has no official CLI), PR template
+- [ ] `docs/GITEA_WORKFLOW.md` exists with: platform overview, identity chain mapping (GitHub Issue → Gitea Issue, PR → Pull Request, Codex review → Gitea Actions review job, GitHub Release → Gitea Release), `tea` CLI examples
+- [ ] Each platform doc follows the same structure: (1) Platform overview, (2) Identity chain mapping table, (3) Setup: creating the first issue from a roadmap item, (4) Branching and PR/MR workflow, (5) CI integration, (6) Release and evidence, (7) Platform-specific limitations (e.g., no Codex connector, different CI syntax)
+- [ ] Each platform doc includes a copy-pasteable PR/MR template body with scaffold traceability fields (plan slug, run ID, task ID, verification, evidence path)
+- [ ] `docs/GITHUB_WORKFLOW.md` has a prominent "Other Platforms" section at the top linking to the three new docs
+- [ ] `docs/OPEN_SCAFFOLD_SYSTEM.md` section 7 ("GitHub/public versioning layer") is renamed to "Public versioning layer" and states that the protocol works with any git forge, with GitHub as the documented reference implementation
+- [ ] All docs use neutral language: "merge request" for GitLab, "pull request" for Bitbucket/Gitea, not assuming GitHub terminology
+- [ ] `./verify.sh --standard` passes (new docs are additive, no plan/schema violations)
+
+## Verification steps
+
+1. **Structure parity:** For each platform doc, verify it has all 7 sections listed in AC #4. Check heading counts match across docs.
+2. **Platform accuracy:** For each doc, verify that the CLI commands and API examples use the correct platform tool: `glab` for GitLab, `tea` for Gitea, `curl` with correct Bitbucket API endpoints.
+3. **Terminology audit:** Search each doc for "GitHub" outside of comparison tables. Verify GitHub is only used in cross-reference contexts, not as default terminology.
+4. **Links:** Verify all cross-document links are valid (relative paths between docs/ files).
+5. **Verify:** Run `./verify.sh --standard`. Verify passes.
+
+## Open questions
+
+- Should the scaffold generate platform-specific CI templates (`.gitlab-ci.yml`, `bitbucket-pipelines.yml`) like it does `.github/workflows/`? Defer to a follow-up plan — the docs are the first step. CI templates require testing on each platform, which is significantly more effort.
+- Azure DevOps support? Deferred — Azure DevOps has a different enough model (work items, boards, pipelines as separate products) that a proper mapping requires more research. Add if there's demand.
+- Should the platform docs be in a `docs/platforms/` subdirectory? Yes — as the number of platform docs grows, they should be grouped. Do this as part of this plan: `docs/platforms/github.md` (move and rename existing), `docs/platforms/gitlab.md`, `docs/platforms/bitbucket.md`, `docs/platforms/gitea.md`, with `docs/GITHUB_WORKFLOW.md` becoming a redirect/symlink for backward compatibility.

--- a/.osc/plans/backlog/073-glass-cockpit-event-persistence.md
+++ b/.osc/plans/backlog/073-glass-cockpit-event-persistence.md
@@ -1,0 +1,66 @@
+# Plan: 073-glass-cockpit-event-persistence
+
+## Status
+
+backlog
+
+## Context
+
+The glass cockpit protocol defines events (status, blocker, completion_report, evidence_receipt, etc.) and plan 062 implements webhook posting, but events are fire-and-forget — once posted, they disappear into chat scrollback. For compliance, audit, and team handoff, cockpit events should be persisted locally as a durable log. An event log — a simple append-only JSON Lines file — would give cockpit events the same durability as plans and evidence. The log serves as both a recovery mechanism (what was communicated and when) and an audit trail (who approved what, when was a blocker raised, when was evidence published). Together with plan 062 (webhook posting) and plan 071 (evidence chain verifier), this completes the cockpit protocol from "specification" to "fully implemented with durable state."
+
+## Goal
+
+Add `osc cockpit log` — an append-only JSON Lines event log at `.osc/cockpit.log` that persists every cockpit event with timestamp, event type, content, and correlation IDs — and `osc cockpit history` to query and replay the log.
+
+## Constraints / Out of scope
+
+- The event log is a local JSON Lines file (`.osc/cockpit.log`), one JSON object per line. Append-only — events are never modified or deleted.
+- Events are written automatically by `osc cockpit post` (plan 062) and can also be written manually via `osc cockpit log-event`.
+- The log is gitignored (similar to `.osc/tasks.db` and `.osc/runs/`). It's forensic/operational data, not canonical truth.
+- Does NOT implement log rotation, compression, or archiving in v1 — the file grows indefinitely. For projects generating thousands of events, log rotation can be added later.
+- Does NOT sync to a remote service or implement distributed event logs.
+- Querying supports: time range filtering, event type filtering, plan/task/run ID filtering, and full-text search over message content.
+
+## Files to touch
+
+- `src/cockpit-log.ts` — new file: event log writer (append JSON Lines), reader (parse and filter), query functions
+- `src/cockpit.ts` — modify cockpit.ts to call log writer automatically on every `osc cockpit post`
+- `src/cli.ts` — wire `osc cockpit log-event --event <type> --message <text> [correlation IDs]`, `osc cockpit history [--since <ISO>] [--until <ISO>] [--event <type>] [--plan <slug>] [--task-id <id>] [--run-id <id>] [--search <query>] [--limit <n>] [--json]`, `osc cockpit stats`
+- `tests/cockpit-log.test.ts` — test event writing, log parsing, filtering, querying
+- `docs/GLASS_COCKPIT_PROTOCOL.md` — add "Event Persistence" section
+
+## Acceptance criteria
+
+- [ ] `osc cockpit log-event --event status --message "Sprint review started" --plan 050-npm-publish` appends a JSON line to `.osc/cockpit.log` with: timestamp (ISO 8601), event_type, message, plan_slug, and an auto-generated event_id (UUID or timestamp-nanoid)
+- [ ] `osc cockpit post --event completion_report --message "..." --plan 050-npm-publish` (plan 062) automatically writes the same event to the log after posting to webhooks (no double command needed)
+- [ ] `osc cockpit post --dry-run` does NOT write to the log (dry-run means no side effects)
+- [ ] `.osc/cockpit.log` is valid JSON Lines: every line is a parseable JSON object, no trailing commas, no multi-line objects
+- [ ] `osc cockpit history` displays recent events in reverse chronological order (newest first) with timestamp, event type, and message summary
+- [ ] `osc cockpit history --since 2026-05-01 --until 2026-05-18` filters by time range
+- [ ] `osc cockpit history --event blocker` filters to only blocker events
+- [ ] `osc cockpit history --plan 050-npm-publish` filters to events correlated with that plan
+- [ ] `osc cockpit history --search "deploy"` full-text searches event messages
+- [ ] `osc cockpit history --limit 10` returns at most 10 events
+- [ ] `osc cockpit history --json` outputs machine-parseable JSON array
+- [ ] `osc cockpit stats` prints: total events, events by type (count per event_type), events by plan (count per plan), date range (first event to last event), most recent event timestamp
+- [ ] When `.osc/cockpit.log` does not exist, all commands gracefully report "No cockpit events logged yet" (exit 0)
+- [ ] Events logged include all correlation IDs from the post command: task_id, run_id, plan_slug, pr_url, evidence_path
+- [ ] All existing tests pass; new cockpit log tests cover writing, reading, filtering, querying, and empty-state handling
+
+## Verification steps
+
+1. **Write event:** Run `osc cockpit log-event --event status --message "Test event" --plan 050-npm-publish`. Verify `.osc/cockpit.log` exists with one JSON line containing correct fields.
+2. **Read history:** Run `osc cockpit history`. Verify the test event appears.
+3. **Filter by plan:** Run `osc cockpit history --plan 050-npm-publish`. Verify only events with that plan appear.
+4. **Filter by type:** Run `osc cockpit history --event status`. Verify only status events.
+5. **Stats:** Run `osc cockpit stats`. Verify correct counts and date range.
+6. **Automatic logging (integration with plan 062):** Run `osc cockpit post --event status --message "Integration test" --dry-run`. Verify no event logged. Run without `--dry-run` (may fail if no webhook configured). Verify event logged even if webhook posting fails (logging should succeed independently).
+7. **Empty state:** Delete `.osc/cockpit.log`. Run `osc cockpit history`. Verify friendly "no events" message.
+8. **JSON validity:** Run `python3 -c "import json; [json.loads(line) for line in open('.osc/cockpit.log')]"`. Verify no parse errors.
+9. **Build:** Run `npm run build`. Verify no TypeScript errors.
+
+## Open questions
+
+- Should cockpit events be automatically logged during `osc close` and `osc evidence new` lifecycle commands? Plan 062 left this as an open question. This plan should answer it: yes, lifecycle commands should emit cockpit events that are both posted (if webhooks are configured) and logged. The event types map naturally: `osc close` → `completion_report`, `osc evidence new` → `evidence_receipt`, `osc amend` → `status` (scope change). Implementation should be in the lifecycle commands themselves, not the cockpit module — each command calls `cockpit.emit(event)` after its main operation succeeds.
+- Should `.osc/cockpit.log` be human-readable in a text editor? JSON Lines is semi-human-readable (one JSON object per line). It's not pretty-printed but `jq` can format it. This is the right trade-off: machine-parseable and append-efficient, with human readability via tooling.
+- Should the log support structured event schemas beyond the current flat JSON? Each event type could have a specific schema (e.g., `completion_report` must include `verification_status`, `approval_decision`). Defer to v2 — v1 uses a common base schema for all events with optional type-specific fields. This keeps the implementation simple while allowing richer data on a per-event basis.


### PR DESCRIPTION
## Summary

Adds 24 detailed backlog plans covering the complete v2 product roadmap. Each plan follows the 7-section handoff template with concrete acceptance criteria, specific verification steps, and explicit constraints. All sections fully filled — no TODOs, no placeholders.

**24 plans, 1,491 lines, ~167KB of detailed specification.**

## Plan index

### Adoption & Onboarding (050-054)
- **050:** npm publish and npx init — unblock the first-instruction adoption path
- **051:** `osc init --from-existing` — brownfield project support
- **052:** Interactive plan wizard — guided plan creation for new users
- **053:** Plan template library — 6 domain-specific templates (bug-fix, feature, refactor, docs, deps, arch-decision)
- **054:** Multi-language AGENTS.md/CLAUDE.md — 5 languages (zh, ja, ko, es, pt)

### CLI & Developer Experience (055-059)
- **055:** `osc plan validate` — dedicated plan linter with severity levels
- **056:** `osc run --dry-run` — execution preview without file creation
- **057:** `osc evidence collect` — automated verification/git/PR/CI data gathering
- **058:** `osc doctor --fix` — auto-repair common scaffold issues
- **059:** `osc metrics` — cycle time, stale plans, close velocity, evidence completeness

### Integrations & Ecosystem (060-064)
- **060:** MCP server — expose plan/run/evidence state to any MCP-compatible agent
- **061:** Local SQLite task database — `osc task` commands for solo devs
- **062:** Glass cockpit webhooks — Discord and Slack integration with structured events
- **063:** GitHub Actions CI templates — 4 workflows (plan-validate, stale-plans, evidence-validate, npm-publish)
- **064:** Devcontainer profile — instant container-based onboarding

### Visualization & UX (065-067)
- **065:** `osc dashboard` TUI — interactive terminal cockpit
- **066:** Web dashboard — self-contained HTML glass cockpit
- **067:** `osc plan graph` — dependency DAG visualization (ASCII/Mermaid/JSON)

### Platform & Ecosystem (068-070)
- **068:** Python reference parser — zero-dependency, vendorable plan parser
- **069:** Open Scaffold v1.0.0 launch — npm publish, stability guarantees, landing page
- **070:** Runtime adapter registry — discoverable adapter ecosystem with `osc runtimes search/install`

### Quality & Trust (071-073)
- **071:** `osc verify --evidence-chain` — identity chain integrity verification
- **072:** Cross-platform workflow docs — GitLab, Bitbucket, Gitea workflow mappings
- **073:** Glass cockpit event persistence — durable append-only event log with query/replay

## Verification

```
./verify.sh --strict
  10 pass, 0 fail, 0 warn
```

All 24 plans pass schema validation — every plan has all 7 required sections.