### PR TITLE
Add brownfield init for existing repositories

### DIFF
--- a/.osc/plans/done/051-brownfield-init-from-existing.md
+++ b/.osc/plans/done/051-brownfield-init-from-existing.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog — blocked on 050 (npm publish) for baseline `osc init` availability. This extends the greenfield-only `osc init` to support existing project directories, which is the majority real-world adoption path. No work begins until `osc init --tier min` is stable and published.
+done
 
 ## Context
 

--- a/.osc/releases/2026-05-19-051-brownfield-init-from-existing.md
+++ b/.osc/releases/2026-05-19-051-brownfield-init-from-existing.md
@@ -14,10 +14,10 @@ Adds explicit brownfield initialization with `osc init --from-existing` so Open 
 
 ## Verification
 
-- RED check: `npm test -- --run tests/init.test.ts tests/cli-init.test.ts` initially failed because `fromExisting` behavior did not exist and the CLI rejected `--from-existing`; a later independent review also exposed unsafe standard/max brownfield force semantics and incomplete monorepo detection before the final fix.
-- Targeted GREEN: `npm test -- --run tests/init.test.ts tests/cli-init.test.ts` → 2 files / 40 tests passed.
+- RED check: `npm test -- --run tests/init.test.ts tests/cli-init.test.ts` initially failed because `fromExisting` behavior did not exist and the CLI rejected `--from-existing`; independent review/Codex also exposed unsafe standard/max force semantics, incomplete monorepo detection, and root shell-script overwrite risk before the final fixes.
+- Targeted GREEN: `npm test -- --run tests/init.test.ts tests/cli-init.test.ts` → 2 files / 41 tests passed.
 - `npm run build` → pass.
-- Full test suite: `npm test -- --run` → 22 files / 195 tests passed.
+- Full test suite: `npm test -- --run` → 22 files / 196 tests passed.
 - Manual brownfield smoke: `node dist/cli.js init --from-existing --tier min --target <tmp>` against an existing Node.js repo preserved `package.json` and `src/index.js` hashes, generated `MISSION.md`, `.osc/`, `AGENTS.md`, and `CLAUDE.md`, and refused a second run with scaffold-owned conflicts listed.
 - `git diff --check` → pass.
 - `./verify.sh --strict` before closure → 10 pass / 0 fail / 0 warn.

--- a/.osc/releases/2026-05-19-051-brownfield-init-from-existing.md
+++ b/.osc/releases/2026-05-19-051-brownfield-init-from-existing.md
@@ -1,0 +1,34 @@
+# Release / Evidence Note: 051-brownfield-init-from-existing
+
+## Summary
+
+Adds explicit brownfield initialization with `osc init --from-existing` so Open Scaffold can be adopted inside existing repositories without moving or overwriting user project files. Brownfield init detects common project markers, writes a mission draft that names the detected project type, includes agent instruction files even for the min tier, and keeps scaffold-owned conflict handling explicit.
+
+## Traceability
+
+- Roadmap / issue / task: Kanban `t_7c4a64fb`.
+- Plan: `.osc/plans/done/051-brownfield-init-from-existing.md`.
+- Run ID / run packet: `N/A` — local CLI/product slice, no runtime run packet needed.
+- Branch: `cli/brownfield-init-from-existing`.
+- PR: pending owner review; not opened in this local execution gate.
+
+## Verification
+
+- RED check: `npm test -- --run tests/init.test.ts tests/cli-init.test.ts` initially failed because `fromExisting` behavior did not exist and the CLI rejected `--from-existing`; a later independent review also exposed unsafe standard/max brownfield force semantics and incomplete monorepo detection before the final fix.
+- Targeted GREEN: `npm test -- --run tests/init.test.ts tests/cli-init.test.ts` → 2 files / 40 tests passed.
+- `npm run build` → pass.
+- Full test suite: `npm test -- --run` → 22 files / 195 tests passed.
+- Manual brownfield smoke: `node dist/cli.js init --from-existing --tier min --target <tmp>` against an existing Node.js repo preserved `package.json` and `src/index.js` hashes, generated `MISSION.md`, `.osc/`, `AGENTS.md`, and `CLAUDE.md`, and refused a second run with scaffold-owned conflicts listed.
+- `git diff --check` → pass.
+- `./verify.sh --strict` before closure → 10 pass / 0 fail / 0 warn.
+
+## Outcome
+
+`osc init --from-existing` is now the safe min-tier adoption path for real existing repositories. It is additive by default, refuses existing scaffold-owned paths unless `--force` is explicit, rejects standard/max brownfield tiers before they can overwrite user-owned docs, detects Node.js, Python, Go, Rust, monorepo, and generic existing projects, and documents the brownfield command in the first-use docs.
+
+Out of scope: task-system autodetection, CI autodetection, semantic mission generation, runtime spawning, runtime registry, MCP server, dashboards, package publish, and mutations to user project files.
+
+## Follow-up
+
+- If users want deeper project analysis later, make that a separate semantic/wizard slice rather than expanding brownfield init.
+- If PR is opened, patch this note or the PR body with the final PR URL and Codex review status.

--- a/.osc/releases/2026-05-19-051-brownfield-init-from-existing.md
+++ b/.osc/releases/2026-05-19-051-brownfield-init-from-existing.md
@@ -10,7 +10,7 @@ Adds explicit brownfield initialization with `osc init --from-existing` so Open 
 - Plan: `.osc/plans/done/051-brownfield-init-from-existing.md`.
 - Run ID / run packet: `N/A` — local CLI/product slice, no runtime run packet needed.
 - Branch: `cli/brownfield-init-from-existing`.
-- PR: pending owner review; not opened in this local execution gate.
+- PR: #60 — https://github.com/graphanov/open-scaffold/pull/60.
 
 ## Verification
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-19: closed 051-brownfield-init-from-existing — brownfield init from existing repos shipped
 - 2026-05-19: closed 074-package-public-surface-sync — published 0.4.2 and aligned package public surfaces
 - 2026-05-18: closed 050-npm-publish-and-npx-init — reconciled live npm/npx package truth and created package public-surface follow-up
 - 2026-05-18: reconcile stale npm publish blocker with live 0.4.1 package evidence — see .osc/plans/done/050-npm-publish-and-npx-init-amendment-1.md

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Use npm for the normal first run. Use `--target .` to add scaffold files to the 
 
 ```bash
 npx open-scaffold init --tier min --target <your-project>
+# existing repo: npx open-scaffold init --from-existing --tier min --target .
 cd <your-project>
 ```
 

--- a/docs/MINIMUM_VIABLE_SCAFFOLD.md
+++ b/docs/MINIMUM_VIABLE_SCAFFOLD.md
@@ -31,7 +31,20 @@ node dist/cli.js init --tier min --target <repo>
 # or: --tier standard / --tier max
 ```
 
-Use `min` for the smallest durable loop, `standard` for the recommended day-one repo, and `max` only when the project already needs GitHub, runtime, or status/control-room protocol docs. The command writes only local files and refuses to overwrite existing files by default.
+Use `min` for the smallest durable loop, `standard` for the recommended day-one repo, and `max` only when the project already needs GitHub, runtime, or status/control-room protocol docs. The command writes only local files and refuses to overwrite existing files unless `--force` is supplied.
+
+## Brownfield adoption
+
+Most useful projects already have source files, package manifests, README content, and CI conventions. Use the explicit brownfield flag when adding Open Scaffold to an existing repo:
+
+```bash
+npx open-scaffold init --from-existing --tier min --target .
+# source checkout fallback: node dist/cli.js init --from-existing --tier min --target .
+```
+
+Brownfield init currently supports the `min` tier only. That keeps adoption safe and additive: advanced standard/max docs can be added manually later, but the first brownfield command will not replace user-owned README, roadmap, or docs content.
+
+It detects common project markers (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, and workspace files), writes a mission draft that names the detected project type, and adds scaffold files around the existing project. It does not edit package manifests, source trees, lockfiles, README content, or CI files. If scaffold-owned paths such as `MISSION.md`, `.osc/`, `AGENTS.md`, or `CLAUDE.md` already exist, it refuses and lists the conflicts; use `--force` only when you intend to replace those scaffold-owned files.
 
 Then follow the loop:
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -8,7 +8,7 @@ Named coordinators, harnesses, and status/approval channels (operator surfaces) 
 
 Every task moves through a natural progression. You do not need to use every phase — small fixes skip straight to Execute. The phases exist so you know where you are and what to reach for.
 
-For first-use setup, start with the [Minimum Viable Scaffold](MINIMUM_VIABLE_SCAFFOLD.md): choose a scaffold tier with `osc init --tier min|standard|max --target <repo>`, define the mission, add one active plan, verify, record evidence, and close.
+For first-use setup, start with the [Minimum Viable Scaffold](MINIMUM_VIABLE_SCAFFOLD.md): choose a scaffold tier with `osc init --tier min|standard|max --target <repo>` for greenfield setup or `osc init --from-existing --tier min --target .` for an existing repo, define the mission, add one active plan, verify, record evidence, and close.
 
 ### 1. Clarify (when the goal is fuzzy)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ function printHelp(): void {
 
 Usage:
   osc init --tier <min|standard|max> --target <dir> [--force]
+  osc init --from-existing --tier min --target <dir> [--force]
   osc init --min|--standard|--max --target <dir> [--force]
   osc status [--json]
   osc plan <plan-path>
@@ -216,10 +217,11 @@ function parseRunOptions(args: string[]): { planPathArg: string; options: RunArt
   return { planPathArg, options };
 }
 
-function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string; force: boolean } {
+function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string; force: boolean; fromExisting: boolean } {
   let tier: ScaffoldTier | undefined;
   let target: string | undefined;
   let force = false;
+  let fromExisting = false;
 
   function takeValue(index: number, flag: string): string {
     const value = args[index + 1];
@@ -253,6 +255,9 @@ function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string;
       case '--force':
         force = true;
         break;
+      case '--from-existing':
+        fromExisting = true;
+        break;
       default:
         console.error(`Unknown option for init: ${flag}`);
         printHelp();
@@ -268,7 +273,7 @@ function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string;
     console.error('Missing required option: --target <dir>');
     process.exit(2);
   }
-  return { tier, target, force };
+  return { tier, target, force, fromExisting };
 }
 
 function init(args: string[]): void {

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,4 @@
-import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import type { Stats } from 'node:fs';
 import { dirname, join, relative as relativePath, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -55,6 +55,13 @@ export interface InitializeScaffoldOptions {
   tier: ScaffoldTier;
   target: string;
   force?: boolean;
+  fromExisting?: boolean;
+}
+
+interface ExistingProjectDetection {
+  label: string;
+  marker: string | null;
+  packageManager?: string;
 }
 
 export interface InitializeScaffoldResult {
@@ -78,8 +85,96 @@ function sourcePathFor(file: string): string | null {
   return join(packageRoot(), file);
 }
 
-function missionTemplate(): string {
-  return `# Mission\n\n<!-- mission:unset -->\n\nTODO: define mission.\n\nDescribe what this repository is trying to accomplish, the non-goals, and the owner-visible definition of done before starting substantial work.\n`;
+function missionTemplate(project?: ExistingProjectDetection): string {
+  if (!project) {
+    return `# Mission\n\n<!-- mission:unset -->\n\nTODO: define mission.\n\nDescribe what this repository is trying to accomplish, the non-goals, and the owner-visible definition of done before starting substantial work.\n`;
+  }
+
+  const marker = project.marker ? ` Detected marker: \`${project.marker}\`.` : '';
+  const packageManager = project.packageManager ? ` Package manager: ${project.packageManager}.` : '';
+  return [
+    '# Mission',
+    '',
+    '<!-- mission:unset -->',
+    '',
+    `TODO: define the mission for this ${project.label}.`,
+    '',
+    `This repository appears to be an existing ${project.label}. Open Scaffold was added in brownfield mode so existing project files stay owned by the project.${marker}${packageManager}`,
+    '',
+    '## Goals',
+    '',
+    `- TODO: describe what this ${project.label} should achieve first.`,
+    '',
+    '## Non-Goals',
+    '',
+    '- TODO: describe what this project should not do yet.',
+    '',
+    '## Changelog',
+    '',
+    'One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.',
+    '',
+    '<!-- append YYYY-MM-DD entries below this line -->',
+  ].join('\n') + '\n';
+}
+
+function detectPackageManager(target: string): string | undefined {
+  if (existsSync(join(target, 'pnpm-lock.yaml')) || existsSync(join(target, 'pnpm-workspace.yaml'))) return 'pnpm';
+  if (existsSync(join(target, 'yarn.lock'))) return 'Yarn';
+  if (existsSync(join(target, 'package-lock.json'))) return 'npm';
+  if (existsSync(join(target, 'bun.lockb')) || existsSync(join(target, 'bun.lock'))) return 'Bun';
+  return undefined;
+}
+
+function packageJsonDeclaresWorkspaces(target: string): boolean {
+  try {
+    const parsed = JSON.parse(readFileSync(join(target, 'package.json'), 'utf8')) as { workspaces?: unknown };
+    return Array.isArray(parsed.workspaces) || (typeof parsed.workspaces === 'object' && parsed.workspaces !== null);
+  } catch {
+    return false;
+  }
+}
+
+function detectExistingProject(target: string): ExistingProjectDetection {
+  if (existsSync(join(target, 'package.json'))) {
+    return {
+      label: packageJsonDeclaresWorkspaces(target) || existsSync(join(target, 'pnpm-workspace.yaml')) || existsSync(join(target, 'lerna.json')) || existsSync(join(target, 'nx.json')) ? 'Node.js monorepo' : 'Node.js project',
+      marker: 'package.json',
+      packageManager: detectPackageManager(target),
+    };
+  }
+  if (existsSync(join(target, 'pyproject.toml')) || existsSync(join(target, 'setup.py')) || existsSync(join(target, 'requirements.txt'))) {
+    return { label: 'Python project', marker: existsSync(join(target, 'pyproject.toml')) ? 'pyproject.toml' : existsSync(join(target, 'setup.py')) ? 'setup.py' : 'requirements.txt' };
+  }
+  if (existsSync(join(target, 'go.mod'))) return { label: 'Go project', marker: 'go.mod' };
+  if (existsSync(join(target, 'Cargo.toml'))) return { label: 'Rust project', marker: 'Cargo.toml' };
+  if (existsSync(join(target, 'pnpm-workspace.yaml')) || existsSync(join(target, 'lerna.json')) || existsSync(join(target, 'nx.json'))) {
+    return { label: 'monorepo', marker: existsSync(join(target, 'pnpm-workspace.yaml')) ? 'pnpm-workspace.yaml' : existsSync(join(target, 'lerna.json')) ? 'lerna.json' : 'nx.json' };
+  }
+  return { label: 'existing project', marker: null };
+}
+
+function filesForInitialization(tier: ScaffoldTier, fromExisting: boolean): string[] {
+  const files = [...tierFiles[tier]];
+  if (fromExisting) {
+    for (const file of ['AGENTS.md', 'CLAUDE.md']) {
+      if (!files.includes(file)) files.push(file);
+    }
+  }
+  return files;
+}
+
+function scaffoldConflicts(target: string, files: readonly string[], fromExisting: boolean): string[] {
+  if (!fromExisting) return files.filter((file) => existsSync(join(target, file)));
+
+  const conflicts: string[] = [];
+  const oscExists = existsSync(join(target, '.osc'));
+
+  for (const file of files) {
+    if (file.startsWith('.osc/')) continue;
+    if (existsSync(join(target, file))) conflicts.push(file);
+  }
+  if (oscExists) conflicts.push('.osc');
+  return conflicts;
 }
 
 function downstreamReadmeTemplate(): string {
@@ -347,10 +442,10 @@ printf '\\nBootstrap complete.\\nRead: %s\\n' "$NEXT_READ"
 
 function downstreamTemplateFor(file: string, tier: ScaffoldTier): string | null {
   if (file === 'bootstrap.sh') return downstreamBootstrapTemplate();
+  if (file === 'AGENTS.md' || file === 'CLAUDE.md') return downstreamAgentInstructionsTemplate(file);
   if (tier === 'min') return null;
   if (file === 'README.md') return downstreamReadmeTemplate();
   if (file === 'ROADMAP.md') return downstreamRoadmapTemplate();
-  if (file === 'AGENTS.md' || file === 'CLAUDE.md') return downstreamAgentInstructionsTemplate(file);
   if (file === 'docs/MINIMUM_VIABLE_SCAFFOLD.md') return downstreamMinimumScaffoldDocTemplate();
   return null;
 }
@@ -494,9 +589,13 @@ function assertTemplateExists(file: string, source: string): void {
   }
 }
 
-function formatSummary(tier: ScaffoldTier, target: string, files: string[]): string {
+function formatSummary(tier: ScaffoldTier, target: string, files: string[], project?: ExistingProjectDetection): string {
+  const detection = project
+    ? [`Detected existing ${project.label}${project.marker ? ` via ${project.marker}` : ''}${project.packageManager ? ` (${project.packageManager})` : ''}.`]
+    : [];
   return [
     `Generated ${tier} Open Scaffold in ${target}`,
+    ...detection,
     `Files created (${files.length}):`,
     ...files.map((file) => `  - ${file}`),
     '',
@@ -551,8 +650,13 @@ function rejectSymlinkedDestination(target: string, destination: string): void {
 
 export function initializeScaffold(options: InitializeScaffoldOptions): InitializeScaffoldResult {
   ensureKnownTier(options.tier);
+  if (options.fromExisting && options.tier !== 'min') {
+    throw new Error('Brownfield init currently supports --tier min only. Use greenfield init for standard/max docs, or add advanced docs manually after preserving existing project files.');
+  }
   const target = resolve(options.target);
-  const files = [...tierFiles[options.tier]];
+  const fromExisting = Boolean(options.fromExisting);
+  const project = fromExisting ? detectExistingProject(target) : undefined;
+  const files = filesForInitialization(options.tier, fromExisting);
 
   rejectSymlinkedExistingPath(target);
   mkdirSync(target, { recursive: true });
@@ -561,10 +665,11 @@ export function initializeScaffold(options: InitializeScaffoldOptions): Initiali
     rejectSymlinkedDestination(target, join(target, file));
   }
 
-  const existing = files.filter((file) => existsSync(join(target, file)));
+  const existing = scaffoldConflicts(target, files, fromExisting);
 
   if (existing.length > 0 && !options.force) {
-    throw new Error(`Refusing to overwrite existing files: ${existing.join(', ')}. Re-run with --force only if you intend to replace them.`);
+    const noun = fromExisting ? 'existing scaffold files' : 'existing files';
+    throw new Error(`Refusing to overwrite ${noun}: ${existing.join(', ')}. Re-run with --force only if you intend to replace them.`);
   }
 
   for (const file of files) {
@@ -576,7 +681,7 @@ export function initializeScaffold(options: InitializeScaffoldOptions): Initiali
     if (generatedTemplate !== null) {
       writeFileSync(destination, generatedTemplate);
     } else if (source === null) {
-      writeFileSync(destination, file === 'MISSION.md' ? missionTemplate() : '');
+      writeFileSync(destination, file === 'MISSION.md' ? missionTemplate(project) : '');
     } else if (file === '.osc/RULES.md' && options.tier === 'min') {
       writeFileSync(destination, minRulesTemplate());
     } else if (file === '.osc/plans/README.md' && options.tier === 'min') {
@@ -595,7 +700,7 @@ export function initializeScaffold(options: InitializeScaffoldOptions): Initiali
     tier: options.tier,
     target,
     filesCreated: files,
-    summary: formatSummary(options.tier, target, files),
+    summary: formatSummary(options.tier, target, files, project),
   };
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -655,6 +655,12 @@ export function initializeScaffold(options: InitializeScaffoldOptions): Initiali
   }
   const target = resolve(options.target);
   const fromExisting = Boolean(options.fromExisting);
+  const protectedExistingProjectFiles = fromExisting && options.force
+    ? ['verify.sh', 'close.sh', 'bootstrap.sh'].filter((file) => existsSync(join(target, file)))
+    : [];
+  if (protectedExistingProjectFiles.length > 0) {
+    throw new Error(`Refusing to overwrite existing project files in brownfield mode: ${protectedExistingProjectFiles.join(', ')}. Rename or move them before re-running with --force.`);
+  }
   const project = fromExisting ? detectExistingProject(target) : undefined;
   const files = filesForInitialization(options.tier, fromExisting);
 

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -154,6 +154,27 @@ describe('osc init CLI', () => {
     expect(output).not.toContain(join(target, 'docs/WORKFLOW.md'));
   });
 
+  it('creates a brownfield scaffold from the CLI without replacing existing project files', () => {
+    const target = tempTarget();
+    const packageJson = '{"name":"cli-brownfield"}\n';
+    writeFileSync(join(target, 'package.json'), packageJson);
+
+    const output = execFileSync(tsx, [cli, 'init', '--from-existing', '--tier', 'min', '--target', target], { encoding: 'utf8' });
+
+    expect(output).toContain('Detected existing Node.js project');
+    expect(readFileSync(join(target, 'package.json'), 'utf8')).toBe(packageJson);
+    expect(readFileSync(join(target, 'MISSION.md'), 'utf8')).toContain('Node.js');
+    expect(existsSync(join(target, 'AGENTS.md'))).toBe(true);
+    expect(existsSync(join(target, 'CLAUDE.md'))).toBe(true);
+  });
+
+  it('mentions the brownfield init flag in CLI help', () => {
+    const result = spawnSync(tsx, [cli, '--help'], { encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('osc init --from-existing --tier min --target <dir> [--force]');
+  });
+
   it('maps runtime and workflow presets into a run packet without spawning', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -101,4 +101,101 @@ describe('tiered scaffold initialization', () => {
     expect(() => initializeScaffold({ tier: 'standard', target, force: true })).toThrow(/Refusing to write through symlinked path: README\.md/);
     expect(readFileSync(join(outside, 'README.md'), 'utf8')).toBe('outside');
   });
+
+  it('adds a min brownfield scaffold to an existing Node.js repo without touching project files', () => {
+    const target = tempTarget();
+    const packageJson = '{"name":"brownfield-node","scripts":{"test":"node src/index.js"}}\n';
+    const source = 'console.log("hi")\n';
+    writeFileSync(join(target, 'package.json'), packageJson);
+    mkdirSync(join(target, 'src'));
+    writeFileSync(join(target, 'src/index.js'), source);
+
+    const result = initializeScaffold({ tier: 'min', target, fromExisting: true });
+
+    expect(result.summary).toContain('Detected existing Node.js project');
+    expect(result.filesCreated).toContain('AGENTS.md');
+    expect(result.filesCreated).toContain('CLAUDE.md');
+    expect(existsSync(join(target, '.osc/plans/active/.gitkeep'))).toBe(true);
+    expect(existsSync(join(target, 'AGENTS.md'))).toBe(true);
+    expect(existsSync(join(target, 'CLAUDE.md'))).toBe(true);
+    expect(readFileSync(join(target, 'MISSION.md'), 'utf8')).toContain('Node.js');
+    expect(readFileSync(join(target, 'MISSION.md'), 'utf8')).toContain('<!-- mission:unset -->');
+    expect(readFileSync(join(target, 'package.json'), 'utf8')).toBe(packageJson);
+    expect(readFileSync(join(target, 'src/index.js'), 'utf8')).toBe(source);
+  });
+
+  it('refuses brownfield scaffold conflicts without force and lists scaffold-owned conflicts', () => {
+    const target = tempTarget();
+    writeFileSync(join(target, 'package.json'), '{"name":"conflict"}\n');
+    writeFileSync(join(target, 'MISSION.md'), 'keep mission');
+    mkdirSync(join(target, '.osc'));
+
+    expect(() => initializeScaffold({ tier: 'min', target, fromExisting: true })).toThrow(/Refusing to overwrite existing scaffold files: MISSION\.md, \.osc/);
+    expect(readFileSync(join(target, 'MISSION.md'), 'utf8')).toBe('keep mission');
+    expect(readFileSync(join(target, 'package.json'), 'utf8')).toBe('{"name":"conflict"}\n');
+  });
+
+  it('allows forced brownfield scaffold refresh while preserving user project files', () => {
+    const target = tempTarget();
+    const packageJson = '{"name":"force-node"}\n';
+    writeFileSync(join(target, 'package.json'), packageJson);
+    writeFileSync(join(target, 'MISSION.md'), 'old mission');
+    writeFileSync(join(target, 'README.md'), 'user readme');
+
+    initializeScaffold({ tier: 'min', target, fromExisting: true, force: true });
+
+    expect(readFileSync(join(target, 'package.json'), 'utf8')).toBe(packageJson);
+    expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('user readme');
+    expect(readFileSync(join(target, 'MISSION.md'), 'utf8')).toContain('Node.js');
+    expect(readFileSync(join(target, 'AGENTS.md'), 'utf8')).toContain('This repository uses Open Scaffold');
+  });
+
+  it('tailors brownfield mission drafts for Python, Go, Rust, and generic projects', () => {
+    const cases = [
+      { marker: 'pyproject.toml', contents: '[project]\nname="demo"\n', expected: 'Python' },
+      { marker: 'go.mod', contents: 'module example.com/demo\n', expected: 'Go' },
+      { marker: 'Cargo.toml', contents: '[package]\nname="demo"\n', expected: 'Rust' },
+      { marker: 'README.md', contents: '# Existing project\n', expected: 'existing project' },
+    ];
+
+    for (const entry of cases) {
+      const target = tempTarget();
+      writeFileSync(join(target, entry.marker), entry.contents);
+
+      initializeScaffold({ tier: 'min', target, fromExisting: true });
+
+      expect(readFileSync(join(target, 'MISSION.md'), 'utf8'), entry.marker).toContain(entry.expected);
+      expect(readFileSync(join(target, entry.marker), 'utf8'), entry.marker).toBe(entry.contents);
+    }
+  });
+
+  it('detects common Node.js monorepo markers before falling back to a plain Node.js project', () => {
+    const cases = [
+      { file: 'package.json', contents: '{"name":"mono","workspaces":["packages/*"]}\n' },
+      { file: 'pnpm-workspace.yaml', contents: 'packages:\n  - packages/*\n' },
+      { file: 'lerna.json', contents: '{"packages":["packages/*"]}\n' },
+      { file: 'nx.json', contents: '{"npmScope":"demo"}\n' },
+    ];
+
+    for (const entry of cases) {
+      const target = tempTarget();
+      writeFileSync(join(target, 'package.json'), '{"name":"mono"}\n');
+      writeFileSync(join(target, entry.file), entry.contents);
+
+      initializeScaffold({ tier: 'min', target, fromExisting: true });
+
+      expect(readFileSync(join(target, 'MISSION.md'), 'utf8'), entry.file).toContain('Node.js monorepo');
+      expect(readFileSync(join(target, entry.file), 'utf8'), entry.file).toBe(entry.contents);
+    }
+  });
+
+  it('rejects standard and max brownfield tiers so force cannot overwrite user-owned docs', () => {
+    const target = tempTarget();
+    writeFileSync(join(target, 'package.json'), '{"name":"safe"}\n');
+    writeFileSync(join(target, 'README.md'), 'user readme');
+
+    expect(() => initializeScaffold({ tier: 'standard', target, fromExisting: true, force: true })).toThrow(/supports --tier min only/);
+    expect(() => initializeScaffold({ tier: 'max', target, fromExisting: true })).toThrow(/supports --tier min only/);
+    expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('user readme');
+  });
 });

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -198,4 +198,14 @@ describe('tiered scaffold initialization', () => {
     expect(() => initializeScaffold({ tier: 'max', target, fromExisting: true })).toThrow(/supports --tier min only/);
     expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('user readme');
   });
+
+  it('refuses to force-overwrite existing project root shell scripts in brownfield mode', () => {
+    const target = tempTarget();
+    writeFileSync(join(target, 'package.json'), '{"name":"script-safe"}\n');
+    writeFileSync(join(target, 'verify.sh'), '#!/usr/bin/env bash\necho project verify\n');
+
+    expect(() => initializeScaffold({ tier: 'min', target, fromExisting: true, force: true })).toThrow(/Refusing to overwrite existing project files in brownfield mode: verify\.sh/);
+    expect(readFileSync(join(target, 'verify.sh'), 'utf8')).toBe('#!/usr/bin/env bash\necho project verify\n');
+    expect(existsSync(join(target, 'MISSION.md'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds explicit `osc init --from-existing` for safe brownfield adoption in existing repositories.
- Detects Node.js, Python, Go, Rust, Node monorepo, and generic existing projects for mission draft context.
- Preserves user-owned files, refuses scaffold-owned conflicts unless `--force`, and rejects standard/max brownfield tiers to avoid overwriting existing docs.
- Protects pre-existing root project scripts (`verify.sh`, `close.sh`, `bootstrap.sh`) from brownfield `--force` overwrites.
- Updates first-use docs, closes plan 051, and records release/evidence.

## Traceability
- Plan: `.osc/plans/done/051-brownfield-init-from-existing.md`
- Evidence: `.osc/releases/2026-05-19-051-brownfield-init-from-existing.md`
- Kanban: `t_7c4a64fb`
- Branch: `cli/brownfield-init-from-existing`

## Verification
- RED observed: targeted init/CLI tests failed before implementation because `fromExisting` / `--from-existing` did not exist.
- Independent pre-commit review: first pass found unsafe standard/max force behavior and incomplete monorepo detection; fixes added and second review passed.
- Codex first pass found root shell-script overwrite risk under brownfield `--force`; fixed in `4c64bd4` and replied inline.
- `npm test -- --run tests/init.test.ts tests/cli-init.test.ts` — 2 files / 41 tests passed.
- `git diff --check` — pass.
- `npm run build` — pass.
- `npm test -- --run` — 22 files / 196 tests passed.
- `./verify.sh --strict` — 10 pass / 0 fail / 0 warn.
- `npm run osc -- verify` — exits 0; one pre-existing backlog warning for plan 062 run-id summary.
- Manual dist smoke: brownfield Node.js repo preserved `package.json` and `src/index.js` hashes and refused a second run with scaffold-owned conflicts listed.

## Codex review
- Initial review on `585e107983` found root shell-script overwrite risk; fixed in `4c64bd4`.
- Latest-head re-review on `4c64bd4d03da7c02810f29abac52669629e89111`: “Didn't find any major issues. Breezy!”
- No inline comments after the latest trigger.

## Out of scope
- Package publish / version bump.
- Runtime spawning, runtime registry, MCP server, dashboards, task-system autodetection, CI autodetection, or semantic mission generation.
- Mutating existing user project files.

## Merge gate
- Do not merge without owner approval.
