### PR TITLE
Prepare brownfield init package release

### DIFF
--- a/.osc/plans/done/075-brownfield-package-release-sync.md
+++ b/.osc/plans/done/075-brownfield-package-release-sync.md
@@ -1,0 +1,57 @@
+# Plan: 075-brownfield-package-release-sync
+
+## Status
+
+done
+
+## Context
+
+PR #60 shipped `osc init --from-existing` on `main`, including safety tests for brownfield repositories and root project script preservation. GitHub truth now says brownfield init exists, and README/main can mention it.
+
+The public package truth has not caught up yet: npm `latest` is still `open-scaffold@0.4.2`, and `npx --yes open-scaffold@latest --help` does not show `--from-existing`. A fresh user following the brownfield README path would hit `Unknown option for init: --from-existing`. That makes the just-shipped adoption path false until a package/release sync happens.
+
+## Goal
+
+Prepare the smallest package/public-surface sync needed for brownfield init: bump the package release candidate, verify the tarball and command surface, record evidence, and leave npm publish / GitHub Release as explicit owner gates.
+
+## Constraints / Out of scope
+
+- Do not run `npm publish` without explicit owner approval.
+- Do not create or mark a GitHub Release without explicit owner approval.
+- Do not implement plan wizard/templates/linter work from plans 052/053/055.
+- Do not change runtime package distribution, runtime spawning, MCP, dashboards, task DB, or evidence-chain verifier behavior.
+- Do not broaden this into a mission/roadmap wording pass.
+- Keep the release sync limited to package version, public install truth, release evidence, and documentation needed to avoid stale package claims.
+
+## Files to touch
+
+- `package.json` — bump the release candidate version so the brownfield command can be published as a patch/minor release.
+- `package-lock.json` — keep lock metadata aligned if the version changes.
+- `.osc/releases/2026-05-19-075-brownfield-package-release-sync.md` — record package/public-surface evidence and gates.
+- `MISSION.md` — close stamp after the package sync slice is locally verified.
+- `.osc/plans/active/075-brownfield-package-release-sync.md` — this plan, moved to `done/` at slice close.
+
+## Acceptance criteria
+
+- [ ] Local `node dist/cli.js --help` exposes `osc init --from-existing --tier min --target <dir> [--force]`.
+- [ ] `npm view open-scaffold version time dist-tags --json` is captured and shows npm latest still behind the brownfield command before publish.
+- [ ] `npx --yes open-scaffold@latest --help` is captured and either lacks `--from-existing` before publish or shows it after owner-approved publish.
+- [ ] `npm pack --dry-run --json` succeeds and confirms the package payload remains public-safe: no `.osc/research/`, `.osc/runs/`, `.osc/plans/done/`, or `.osc/plans/backlog/` payload.
+- [ ] `npm publish --dry-run` succeeds for the release candidate.
+- [ ] Build, tests, strict scaffold verification, and whitespace checks pass.
+- [ ] Evidence states the exact owner gate for `npm publish` and GitHub Release creation.
+
+## Verification steps
+
+1. `npm view open-scaffold version time dist-tags --json` — capture current registry truth.
+2. `npx --yes open-scaffold@latest --help` — capture current public command surface.
+3. `npm run build` — local package builds.
+4. `node dist/cli.js --help` — local command surface includes brownfield init.
+5. `npm pack --dry-run --json` — package payload is public-safe and records file count/size.
+6. `npm publish --dry-run` — publish candidate validates without performing a real publish.
+7. `npm test -- --run`, `git diff --check`, and `./verify.sh --strict` — repo gates pass.
+
+## Open questions
+
+- Patch or minor version: default assumption is patch (`0.4.3`) because this exposes an already-merged CLI adoption feature without changing runtime boundaries.
+- Publish gate: owner approval is required before running real `npm publish` or creating/updating the GitHub Release marked Latest.

--- a/.osc/releases/2026-05-19-075-brownfield-package-release-sync.md
+++ b/.osc/releases/2026-05-19-075-brownfield-package-release-sync.md
@@ -1,0 +1,60 @@
+# Release / Evidence Note: 075-brownfield-package-release-sync
+
+## Summary
+
+Prepared the package/public-surface sync needed after PR #60 added brownfield init. Local `main` now exposes `osc init --from-existing`, but npm `latest` remains `open-scaffold@0.4.2` and rejects the new flag. This slice bumps the release candidate to `0.4.3`, verifies the package payload, and records the explicit owner gates for real npm publish and GitHub Release creation.
+
+## Traceability
+
+- Preceding feature: PR #60 — https://github.com/graphanov/open-scaffold/pull/60.
+- Preceding evidence: `.osc/releases/2026-05-19-051-brownfield-init-from-existing.md`.
+- Plan: `.osc/plans/done/075-brownfield-package-release-sync.md`.
+- Branch: `release/brownfield-init-package-sync`.
+- Kanban: `t_16140b93`.
+- Release candidate: `open-scaffold@0.4.3`.
+- PR: pending owner review; not opened in this local execution gate.
+
+## Registry and command-surface evidence
+
+Before publish:
+
+- `npm view open-scaffold version time dist-tags --json` reports `version: 0.4.2` and `dist-tags.latest: 0.4.2`.
+- `npx --yes open-scaffold@latest --help` does not include `osc init --from-existing --tier min --target <dir> [--force]`.
+- `npx --yes open-scaffold@latest init --from-existing --tier min --target <tmp>` exits `2` with `Unknown option for init: --from-existing`.
+- Local build help includes `osc init --from-existing --tier min --target <dir> [--force]`.
+
+## Package payload evidence
+
+`npm pack --dry-run --json` for the local release candidate reports:
+
+- package name: `open-scaffold`.
+- version: `0.4.3`.
+- filename: `open-scaffold-0.4.3.tgz`.
+- package size: `164190` bytes.
+- unpacked size: `559055` bytes.
+- file count: `84`.
+- forbidden private/dogfood prefixes: none found for `.osc/research/`, `.osc/runs/`, `.osc/plans/done/`, `.osc/plans/backlog/`, `.git/`, or `node_modules/`.
+- `dist/cli.js` is present.
+- plan/evidence history for `051` or `075` is not shipped in the root npm payload.
+
+`npm publish --dry-run` succeeds for `open-scaffold@0.4.3` and reports a dry-run publish to the npm registry with tag `latest`.
+
+## Verification
+
+- `npm view open-scaffold version time dist-tags --json` — captured current registry truth (`0.4.2` latest).
+- `npx --yes open-scaffold@latest --help` — captured missing brownfield command.
+- `npx --yes open-scaffold@latest init --from-existing --tier min --target <tmp>` — fails before publish with `Unknown option for init: --from-existing`, confirming drift.
+- `npm run build` — pass.
+- `node dist/cli.js --help` — local brownfield command present.
+- `npm pack --dry-run --json` — pass; public-safe payload, 84 files.
+- `npm publish --dry-run` — pass.
+
+## Gates
+
+- Real `npm publish` is not performed in this branch. It requires explicit owner approval after review/merge.
+- GitHub Release creation or marking `v0.4.3` as Latest is not performed in this branch. It requires explicit owner approval after publish.
+- Merge remains an owner gate.
+
+## Outcome
+
+`open-scaffold@0.4.3` is prepared as the smallest package release candidate for brownfield init. Public npm truth is still intentionally unchanged until the owner approves real publish and GitHub Release creation.

--- a/.osc/releases/2026-05-19-075-brownfield-package-release-sync.md
+++ b/.osc/releases/2026-05-19-075-brownfield-package-release-sync.md
@@ -12,7 +12,7 @@ Prepared the package/public-surface sync needed after PR #60 added brownfield in
 - Branch: `release/brownfield-init-package-sync`.
 - Kanban: `t_16140b93`.
 - Release candidate: `open-scaffold@0.4.3`.
-- PR: pending owner review; not opened in this local execution gate.
+- PR: #61 — https://github.com/graphanov/open-scaffold/pull/61.
 
 ## Registry and command-surface evidence
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-19: closed 075-brownfield-package-release-sync — prepared brownfield init package release candidate
 - 2026-05-19: closed 051-brownfield-init-from-existing — brownfield init from existing repos shipped
 - 2026-05-19: closed 074-package-public-surface-sync — published 0.4.2 and aligned package public surfaces
 - 2026-05-18: closed 050-npm-publish-and-npx-init — reconciled live npm/npx package truth and created package public-surface follow-up

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Prepares the package release candidate that makes PR #60's brownfield init available through npm/npx.
- Bumps `open-scaffold` from `0.4.2` to `0.4.3` in package metadata.
- Adds plan/evidence traceability for the package sync and keeps real publish / GitHub Release as owner gates.

## Traceability
- Plan: `.osc/plans/done/075-brownfield-package-release-sync.md`
- Evidence: `.osc/releases/2026-05-19-075-brownfield-package-release-sync.md`
- Prior feature: PR #60 — `osc init --from-existing`
- Kanban: `t_16140b93`
- Release candidate: `open-scaffold@0.4.3`

## Verification
- `npm view open-scaffold version time dist-tags --json` — npm latest is still `0.4.2`.
- `npx --yes open-scaffold@latest --help` — current public package lacks `--from-existing`.
- `npx --yes open-scaffold@latest init --from-existing --tier min --target <tmp>` — fails with `Unknown option for init: --from-existing`, confirming drift.
- `npm run build` — pass.
- `node dist/cli.js --help` — local help includes `osc init --from-existing --tier min --target <dir> [--force]`.
- `npm test -- --run` — 22 files / 196 tests passed.
- `npm pack --dry-run --json` — pass; 84 files; no forbidden private/dogfood payload prefixes.
- `npm publish --dry-run` — pass for `open-scaffold@0.4.3`.
- `git diff --check` — pass.
- `./verify.sh --strict` — 10 pass / 0 fail / 0 warn.
- `npm run osc -- verify` — exits 0; only pre-existing plan 062 warning remains.
- GitHub CI — pass.
- Codex latest-head review on `8927f9159a63081d324825fd9c194edbbed0b5cf` — “Didn't find any major issues. Hooray!”

## Gates
- Do not merge without owner approval.
- Do not run real `npm publish` without owner approval.
- Do not create or mark GitHub Release `v0.4.3` as Latest without owner approval.

## Out of scope
- Plan wizard/templates/linter work from 052/053/055.
- Runtime package distribution changes.
- Runtime spawning, MCP, dashboards, task DB, evidence-chain verifier, or broad docs/mission rewrite.
