### PR TITLE
Add interactive plan wizard

### DIFF
--- a/.osc/plans/done/052-interactive-plan-wizard.md
+++ b/.osc/plans/done/052-interactive-plan-wizard.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog — depends on 050 (npm publish) for baseline `osc plan new` availability. Addresses the blank-page paralysis problem where new users see a 7-section template full of `TODO:` markers and don't know where to start. The wizard is a UX layer over the existing plan scaffolding; it does not change the plan format or lifecycle.
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-19-052-interactive-plan-wizard.md
+++ b/.osc/releases/2026-05-19-052-interactive-plan-wizard.md
@@ -1,0 +1,33 @@
+# Release / Evidence Note: 052-interactive-plan-wizard
+
+## Summary
+
+Added `osc plan wizard`, a plain-terminal plan-creation interview that turns user-provided answers into a filled Open Scaffold plan without `TODO:` markers. The feature supports both interactive stdin/TTY use and deterministic `--non-interactive --answers <json>` mode for scripts and agents.
+
+## Traceability
+
+- Roadmap / issue / task: V2 adoption friction backlog; `.osc/plans/done/052-interactive-plan-wizard.md`.
+- Plan: `.osc/plans/done/052-interactive-plan-wizard.md`.
+- Run ID / run packet: N/A — OSC Shipwright executed directly in the repo under the accepted roadmap plan.
+- Branch / PR: `cli/interactive-plan-wizard`; PR pending at initial evidence capture.
+
+## Verification
+
+- `npm test -- tests/wizard.test.ts --run` — pass; 6 wizard tests cover template rendering, JSON normalization, non-interactive creation, stdin-driven interactive creation, and unset-mission refusal.
+- `npm run build` — pass; core and runtime package TypeScript builds succeeded.
+- `npm test -- --run` — pass; 23 test files / 202 tests passed.
+- Built CLI smoke: `node dist/cli.js plan wizard test-json --stage backlog --non-interactive --answers tests/fixtures/wizard-answers.json` in a temporary initialized scaffold — pass; created `.osc/plans/backlog/test-json.md`, no `TODO:` markers, cache acceptance criteria present.
+- Built CLI stdin smoke: `node dist/cli.js plan wizard test-interactive` with piped answers in a temporary initialized scaffold — pass; created `.osc/plans/active/test-interactive.md`, no `TODO:` markers, two acceptance criteria present.
+- Built CLI unset-mission smoke: `node dist/cli.js plan wizard blocked-plan --non-interactive --answers tests/fixtures/wizard-answers.json` in a fresh scaffold with the default unset mission — pass; exited 1, printed `Mission is not yet defined...`, and created no plan.
+- `git diff --check` — pass.
+- `./verify.sh --strict` — pass; 10 pass, 0 fail, 0 warn.
+- `npm pack --dry-run --json` — pass; package candidate `open-scaffold@0.4.3`, 86 files, includes `dist/wizard.js`/`dist/wizard.d.ts`, and keeps dogfood plan/release history out of the npm payload.
+
+## Outcome
+
+The plan wizard is implemented as a local helper over the existing plan lifecycle. It does not invent scope, run agents, validate semantic quality, or replace plan review; it only captures user-provided answers into the standard seven-section plan shape.
+
+## Follow-up
+
+- PR review and Codex latest-head review remain pending until the branch is pushed and the PR is opened.
+- Plan `055-plan-linter` remains the later mechanical quality feedback layer for judging generated or hand-written plans.

--- a/.osc/releases/2026-05-19-052-interactive-plan-wizard.md
+++ b/.osc/releases/2026-05-19-052-interactive-plan-wizard.md
@@ -9,7 +9,7 @@ Added `osc plan wizard`, a plain-terminal plan-creation interview that turns use
 - Roadmap / issue / task: V2 adoption friction backlog; `.osc/plans/done/052-interactive-plan-wizard.md`.
 - Plan: `.osc/plans/done/052-interactive-plan-wizard.md`.
 - Run ID / run packet: N/A — OSC Shipwright executed directly in the repo under the accepted roadmap plan.
-- Branch / PR: `cli/interactive-plan-wizard`; PR pending at initial evidence capture.
+- Branch / PR: `cli/interactive-plan-wizard`; PR #62 — https://github.com/graphanov/open-scaffold/pull/62.
 
 ## Verification
 

--- a/.osc/releases/2026-05-19-052-interactive-plan-wizard.md
+++ b/.osc/releases/2026-05-19-052-interactive-plan-wizard.md
@@ -15,10 +15,11 @@ Added `osc plan wizard`, a plain-terminal plan-creation interview that turns use
 
 - `npm test -- tests/wizard.test.ts --run` — pass; 6 wizard tests cover template rendering, JSON normalization, non-interactive creation, stdin-driven interactive creation, and unset-mission refusal.
 - `npm run build` — pass; core and runtime package TypeScript builds succeeded.
-- `npm test -- --run` — pass; 23 test files / 202 tests passed.
+- `npm test -- --run` — pass; 23 test files / 203 tests passed after the Codex preflight regression test was added.
 - Built CLI smoke: `node dist/cli.js plan wizard test-json --stage backlog --non-interactive --answers tests/fixtures/wizard-answers.json` in a temporary initialized scaffold — pass; created `.osc/plans/backlog/test-json.md`, no `TODO:` markers, cache acceptance criteria present.
 - Built CLI stdin smoke: `node dist/cli.js plan wizard test-interactive` with piped answers in a temporary initialized scaffold — pass; created `.osc/plans/active/test-interactive.md`, no `TODO:` markers, two acceptance criteria present.
 - Built CLI unset-mission smoke: `node dist/cli.js plan wizard blocked-plan --non-interactive --answers tests/fixtures/wizard-answers.json` in a fresh scaffold with the default unset mission — pass; exited 1, printed `Mission is not yet defined...`, and created no plan.
+- Codex preflight regression smoke: `node dist/cli.js plan wizard blocked-plan` with piped answers in a fresh unset-mission scaffold — pass; exited 1 before collecting answers, wrote no stdout prompts, printed `Mission is not yet defined...`, and created no plan.
 - `git diff --check` — pass.
 - `./verify.sh --strict` — pass; 10 pass, 0 fail, 0 warn.
 - `npm pack --dry-run --json` — pass; package candidate `open-scaffold@0.4.3`, 86 files, includes `dist/wizard.js`/`dist/wizard.d.ts`, and keeps dogfood plan/release history out of the npm payload.

--- a/.osc/releases/2026-05-19-052-interactive-plan-wizard.md
+++ b/.osc/releases/2026-05-19-052-interactive-plan-wizard.md
@@ -13,9 +13,9 @@ Added `osc plan wizard`, a plain-terminal plan-creation interview that turns use
 
 ## Verification
 
-- `npm test -- tests/wizard.test.ts --run` — pass; 6 wizard tests cover template rendering, JSON normalization, non-interactive creation, stdin-driven interactive creation, and unset-mission refusal.
+- `npm test -- tests/wizard.test.ts --run` — pass; 8 wizard tests cover template rendering, JSON normalization, non-interactive creation, stdin-driven interactive creation, unset-mission refusal, and a Codex P2 regression that proves mission readiness is checked before waiting for interactive stdin.
 - `npm run build` — pass; core and runtime package TypeScript builds succeeded.
-- `npm test -- --run` — pass; 23 test files / 203 tests passed after the Codex preflight regression test was added.
+- `npm test -- --run` — pass; 23 test files / 204 tests passed.
 - Built CLI smoke: `node dist/cli.js plan wizard test-json --stage backlog --non-interactive --answers tests/fixtures/wizard-answers.json` in a temporary initialized scaffold — pass; created `.osc/plans/backlog/test-json.md`, no `TODO:` markers, cache acceptance criteria present.
 - Built CLI stdin smoke: `node dist/cli.js plan wizard test-interactive` with piped answers in a temporary initialized scaffold — pass; created `.osc/plans/active/test-interactive.md`, no `TODO:` markers, two acceptance criteria present.
 - Built CLI unset-mission smoke: `node dist/cli.js plan wizard blocked-plan --non-interactive --answers tests/fixtures/wizard-answers.json` in a fresh scaffold with the default unset mission — pass; exited 1, printed `Mission is not yet defined...`, and created no plan.
@@ -30,5 +30,5 @@ The plan wizard is implemented as a local helper over the existing plan lifecycl
 
 ## Follow-up
 
-- PR review and Codex latest-head review remain pending until the branch is pushed and the PR is opened.
+- PR #62 is open; Codex P2 feedback is addressed with the mission-preflight regression test and the latest-head recheck is handled in PR review comments.
 - Plan `055-plan-linter` remains the later mechanical quality feedback layer for judging generated or hand-written plans.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-19: closed 052-interactive-plan-wizard — added interactive plan wizard
 - 2026-05-19: closed 075-brownfield-package-release-sync — prepared brownfield init package release candidate
 - 2026-05-19: closed 051-brownfield-init-from-existing — brownfield init from existing repos shipped
 - 2026-05-19: closed 074-package-public-surface-sync — published 0.4.2 and aligned package public surfaces

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -31,6 +31,15 @@ osc plan new <slug> --stage backlog
 osc plan move <slug> --to active
 ```
 
+For a first filled draft instead of a blank skeleton, use the terminal interview wizard:
+
+```bash
+osc plan wizard <slug> --stage active
+osc plan wizard <slug> --stage backlog --non-interactive --answers answers.json
+```
+
+The wizard asks for goal, context, constraints, likely files, acceptance criteria, verification, and open questions. It still records your answers only — it does not invent scope or judge whether the plan is good.
+
 Use `active` directly when execution is immediate. Use `blocked` or `backlog` when you need to park work without deleting the plan:
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js'
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
 import { closePlan, createEvidenceNoteSkeleton, createPlanAmendment, createPlanSkeleton, inspectScaffold, movePlan, parsePlanFile, planToJson, PLAN_CREATION_STAGES, type PlanCreationStage } from './scaffold.js';
 import { validateScaffold } from './validation.js';
+import { askInteractiveAnswers, createWizardPlan, loadAnswersFile, type PlanWizardAnswers } from './wizard.js';
 
 function printHelp(): void {
   console.log(`osc — Open Scaffold CLI
@@ -19,6 +20,7 @@ Usage:
   osc status [--json]
   osc plan <plan-path>
   osc plan new <slug> --stage <active|backlog|blocked>
+  osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]
   osc plan move <slug> --to <active|backlog|blocked>
   osc amend <plan-slug> [--message <text>]
   osc evidence new <slug>
@@ -372,7 +374,64 @@ function parsePlanMoveDestination(args: string[]): PlanCreationStage {
   return toStage;
 }
 
-function planCommand(args: string[]): void {
+function printPlanWizardUsage(): void {
+  console.error('Usage: osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]');
+}
+
+function parsePlanWizardOptions(args: string[]): { slug: string; stage: PlanCreationStage; nonInteractive: boolean; answersPath?: string } {
+  const slug = requireArg(args, 'slug');
+  const rest = args.slice(1);
+  let stage: PlanCreationStage = 'active';
+  let nonInteractive = false;
+  let answersPath: string | undefined;
+  for (let i = 0; i < rest.length; i += 1) {
+    const flag = rest[i];
+    switch (flag) {
+      case '--stage': {
+        const value = rest[i + 1];
+        if (!value || value.startsWith('--')) {
+          console.error('Missing value for --stage');
+          process.exit(2);
+        }
+        if (!(PLAN_CREATION_STAGES as readonly string[]).includes(value)) {
+          console.error(`Invalid value for --stage: ${value}. Expected one of: ${PLAN_CREATION_STAGES.join(', ')}`);
+          process.exit(2);
+        }
+        stage = value as PlanCreationStage;
+        i += 1;
+        break;
+      }
+      case '--non-interactive':
+        nonInteractive = true;
+        break;
+      case '--answers': {
+        const value = rest[i + 1];
+        if (!value || value.startsWith('--')) {
+          console.error('Missing value for --answers');
+          process.exit(2);
+        }
+        answersPath = value;
+        i += 1;
+        break;
+      }
+      default:
+        console.error(`Unknown option for plan wizard: ${flag}`);
+        printPlanWizardUsage();
+        process.exit(2);
+    }
+  }
+  if (nonInteractive && !answersPath) {
+    console.error('Missing required option for --non-interactive: --answers <answers.json>');
+    process.exit(2);
+  }
+  if (answersPath && !nonInteractive) {
+    console.error('--answers is only supported with --non-interactive');
+    process.exit(2);
+  }
+  return { slug, stage, nonInteractive, answersPath };
+}
+
+async function planCommand(args: string[]): Promise<void> {
   if (args[0] === 'new') {
     const slug = requireArg(args.slice(1), 'slug');
     const stage = parsePlanStage(args.slice(2));
@@ -380,6 +439,23 @@ function planCommand(args: string[]): void {
       const result = createPlanSkeleton(slug, stage, process.cwd());
       console.log(`Created plan: ${result.relativePath}`);
       console.log('Next: fill the TODO prompts before implementation; do not treat the skeleton as acceptance criteria.');
+      return;
+    } catch (error) {
+      exitForScaffoldHelperError(error);
+    }
+  }
+  if (args[0] === 'wizard') {
+    const options = parsePlanWizardOptions(args.slice(1));
+    try {
+      let answers: PlanWizardAnswers;
+      if (options.nonInteractive) {
+        answers = loadAnswersFile(resolve(options.answersPath as string));
+      } else {
+        answers = await askInteractiveAnswers();
+      }
+      const result = createWizardPlan(options.slug, options.stage, answers, process.cwd());
+      console.log(`Created plan: ${result.relativePath}`);
+      console.log('Next: review the generated plan, adjust any _not specified_ sections, then verify before implementation.');
       return;
     } catch (error) {
       exitForScaffoldHelperError(error);
@@ -771,7 +847,7 @@ function runtimes(args: string[]): void {
   process.exit(2);
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const [command, ...args] = process.argv.slice(2);
   switch (command) {
     case undefined:
@@ -787,7 +863,7 @@ function main(): void {
       status(args.includes('--json'));
       return;
     case 'plan':
-      planCommand(args);
+      await planCommand(args);
       return;
     case 'amend':
       amendCommand(args);
@@ -838,4 +914,7 @@ function main(): void {
   }
 }
 
-main();
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js'
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
 import { closePlan, createEvidenceNoteSkeleton, createPlanAmendment, createPlanSkeleton, inspectScaffold, movePlan, parsePlanFile, planToJson, PLAN_CREATION_STAGES, type PlanCreationStage } from './scaffold.js';
 import { validateScaffold } from './validation.js';
-import { askInteractiveAnswers, createWizardPlan, loadAnswersFile, type PlanWizardAnswers } from './wizard.js';
+import { askInteractiveAnswers, assertWizardReady, createWizardPlan, loadAnswersFile, type PlanWizardAnswers } from './wizard.js';
 
 function printHelp(): void {
   console.log(`osc — Open Scaffold CLI
@@ -447,6 +447,7 @@ async function planCommand(args: string[]): Promise<void> {
   if (args[0] === 'wizard') {
     const options = parsePlanWizardOptions(args.slice(1));
     try {
+      assertWizardReady(process.cwd());
       let answers: PlanWizardAnswers;
       if (options.nonInteractive) {
         answers = loadAnswersFile(resolve(options.answersPath as string));

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -143,6 +143,14 @@ export function loadAnswersFile(path: string): PlanWizardAnswers {
   return validateAnswers(parsed);
 }
 
+export function assertWizardReady(start = process.cwd()): string {
+  const root = findScaffoldRoot(start);
+  if (!root) throw new Error(`No Open Scaffold root found from ${start}. Run this inside a repo with .osc/plans and .osc/releases.`);
+  const mission = inspectMission(root);
+  if (!mission.defined) throw new Error('Mission is not yet defined. Run ./bootstrap.sh or edit MISSION.md first.');
+  return root;
+}
+
 function answersFromLines(text: string): PlanWizardAnswers {
   const lines = text.split(/\r?\n/);
   const next = () => lines.shift() ?? '';
@@ -203,10 +211,7 @@ export async function askInteractiveAnswers(): Promise<PlanWizardAnswers> {
 
 export function createWizardPlan(slug: string, stage: PlanCreationStage, answers: PlanWizardAnswers, start = process.cwd()): CreatedWizardPlan {
   const safeSlug = assertSafeWizardSlug(slug);
-  const root = findScaffoldRoot(start);
-  if (!root) throw new Error(`No Open Scaffold root found from ${start}. Run this inside a repo with .osc/plans and .osc/releases.`);
-  const mission = inspectMission(root);
-  if (!mission.defined) throw new Error('Mission is not yet defined. Run ./bootstrap.sh or edit MISSION.md first.');
+  const root = assertWizardReady(start);
   const stageDir = join(root, '.osc', 'plans', stage);
   if (!existsSync(stageDir)) throw new Error(`Open Scaffold stage folder missing: ${relative(root, stageDir)}`);
   const path = join(stageDir, `${safeSlug}.md`);

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -1,0 +1,218 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { findScaffoldRoot, inspectMission, PLAN_CREATION_STAGES, type PlanCreationStage } from './scaffold.js';
+
+export interface PlanWizardAnswers {
+  goal?: string;
+  context?: string;
+  trigger?: string;
+  constraints?: string | string[];
+  filesToTouch?: string | string[];
+  acceptanceCriteria?: string | string[];
+  verificationSteps?: string | string[];
+  openQuestions?: string | string[];
+}
+
+export interface CreatedWizardPlan {
+  root: string;
+  path: string;
+  relativePath: string;
+  slug: string;
+  stage: PlanCreationStage;
+}
+
+type NormalizedAnswers = Required<Omit<PlanWizardAnswers, 'trigger' | 'constraints' | 'filesToTouch' | 'acceptanceCriteria' | 'verificationSteps' | 'openQuestions'>> & {
+  constraints: string[];
+  filesToTouch: string[];
+  acceptanceCriteria: string[];
+  verificationSteps: string[];
+  openQuestions: string[];
+};
+
+function assertSafeWizardSlug(slug: string): string {
+  const trimmed = slug.trim();
+  if (!trimmed || trimmed.endsWith('.md') || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed) || trimmed.includes('..')) {
+    throw new Error(`Unsafe slug: ${slug}. Use letters, numbers, dots, underscores, and hyphens only; omit .md and path separators.`);
+  }
+  return trimmed;
+}
+
+function splitList(value: string | string[] | undefined, splitCommas = false): string[] {
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry).trim()).filter(Boolean);
+  }
+  if (typeof value !== 'string') return [];
+  const separator = splitCommas ? /[\n,]+/ : /\n+/;
+  return value.split(separator).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function scalar(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function validateAnswers(raw: unknown): NormalizedAnswers {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('Wizard answers must be a JSON object.');
+  }
+  const value = raw as PlanWizardAnswers;
+  return {
+    goal: scalar(value.goal),
+    context: scalar(value.context) || scalar(value.trigger),
+    constraints: splitList(value.constraints),
+    filesToTouch: splitList(value.filesToTouch, true),
+    acceptanceCriteria: splitList(value.acceptanceCriteria),
+    verificationSteps: splitList(value.verificationSteps),
+    openQuestions: splitList(value.openQuestions),
+  };
+}
+
+function paragraph(value: string): string {
+  return value.trim() || '_not specified_.';
+}
+
+function bullets(items: string[], fallback = '_not specified_.'): string {
+  const clean = items.map((item) => item.trim()).filter(Boolean);
+  if (clean.length === 0) return `- ${fallback}`;
+  return clean.map((item) => `- ${item}`).join('\n');
+}
+
+function fileBullets(items: string[]): string {
+  const clean = items.map((item) => item.trim()).filter(Boolean);
+  if (clean.length === 0) return '- _not specified_.';
+  return clean.map((item) => `- \`${item}\``).join('\n');
+}
+
+function acceptanceBullets(items: string[]): string {
+  const clean = items.map((item) => item.trim()).filter(Boolean);
+  if (clean.length === 0) return '- [ ] _not specified_.';
+  return clean.map((item) => `- [ ] ${item}`).join('\n');
+}
+
+function numbered(items: string[]): string {
+  const clean = items.map((item) => item.trim()).filter(Boolean);
+  if (clean.length === 0) return '1. _not specified_.';
+  return clean.map((item, index) => `${index + 1}. ${item}`).join('\n');
+}
+
+export function mapAnswersToTemplate(slug: string, stage: PlanCreationStage, rawAnswers: PlanWizardAnswers): string {
+  if (!(PLAN_CREATION_STAGES as readonly string[]).includes(stage)) {
+    throw new Error(`Invalid plan stage: ${stage}. Expected one of: ${PLAN_CREATION_STAGES.join(', ')}`);
+  }
+  const safeSlug = assertSafeWizardSlug(slug);
+  const answers = validateAnswers(rawAnswers);
+  return `# Plan: ${safeSlug}
+
+## Status
+
+${stage}
+
+## Context
+
+${paragraph(answers.context)}
+
+## Goal
+
+${paragraph(answers.goal)}
+
+## Constraints / Out of scope
+
+${bullets(answers.constraints)}
+
+## Files to touch
+
+${fileBullets(answers.filesToTouch)}
+
+## Acceptance criteria
+
+${acceptanceBullets(answers.acceptanceCriteria)}
+
+## Verification steps
+
+${numbered(answers.verificationSteps)}
+
+## Open questions
+
+${bullets(answers.openQuestions)}
+`;
+}
+
+export function loadAnswersFile(path: string): PlanWizardAnswers {
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+  return validateAnswers(parsed);
+}
+
+function answersFromLines(text: string): PlanWizardAnswers {
+  const lines = text.split(/\r?\n/);
+  const next = () => lines.shift() ?? '';
+  const goal = next();
+  const context = next();
+  const constraints = next();
+  const files = next();
+  const acceptanceCriteria: string[] = [];
+  while (lines.length > 0) {
+    const answer = next();
+    if (!answer.trim()) break;
+    acceptanceCriteria.push(answer.trim());
+  }
+  const verification = next();
+  const openQuestions = next();
+  return {
+    goal,
+    context,
+    constraints,
+    filesToTouch: files,
+    acceptanceCriteria,
+    verificationSteps: verification,
+    openQuestions,
+  };
+}
+
+export async function askInteractiveAnswers(): Promise<PlanWizardAnswers> {
+  if (!input.isTTY) {
+    return answersFromLines(readFileSync(0, 'utf8'));
+  }
+  const rl = createInterface({ input, output });
+  try {
+    const goal = await rl.question('Goal / done outcome: ');
+    const context = await rl.question('What triggered this work? ');
+    const constraints = await rl.question('Constraints / what NOT to do: ');
+    const files = await rl.question('Files likely to change (comma-separated): ');
+    const acceptanceCriteria: string[] = [];
+    while (true) {
+      const answer = await rl.question('Acceptance criterion (blank to finish): ');
+      if (!answer.trim()) break;
+      acceptanceCriteria.push(answer.trim());
+    }
+    const verification = await rl.question('Verification command or method: ');
+    const openQuestions = await rl.question('Open questions or dependencies: ');
+    return {
+      goal,
+      context,
+      constraints,
+      filesToTouch: files,
+      acceptanceCriteria,
+      verificationSteps: verification,
+      openQuestions,
+    };
+  } finally {
+    rl.close();
+  }
+}
+
+export function createWizardPlan(slug: string, stage: PlanCreationStage, answers: PlanWizardAnswers, start = process.cwd()): CreatedWizardPlan {
+  const safeSlug = assertSafeWizardSlug(slug);
+  const root = findScaffoldRoot(start);
+  if (!root) throw new Error(`No Open Scaffold root found from ${start}. Run this inside a repo with .osc/plans and .osc/releases.`);
+  const mission = inspectMission(root);
+  if (!mission.defined) throw new Error('Mission is not yet defined. Run ./bootstrap.sh or edit MISSION.md first.');
+  const stageDir = join(root, '.osc', 'plans', stage);
+  if (!existsSync(stageDir)) throw new Error(`Open Scaffold stage folder missing: ${relative(root, stageDir)}`);
+  const path = join(stageDir, `${safeSlug}.md`);
+  const relativePath = relative(root, path);
+  if (existsSync(path)) throw new Error(`Refusing to overwrite existing plan: ${relativePath}`);
+  mkdirSync(stageDir, { recursive: true });
+  writeFileSync(path, mapAnswersToTemplate(safeSlug, stage, answers), 'utf8');
+  return { root, path, relativePath, slug: basename(path, '.md'), stage };
+}

--- a/tests/fixtures/wizard-answers.json
+++ b/tests/fixtures/wizard-answers.json
@@ -1,0 +1,9 @@
+{
+  "goal": "Build a CLI cache",
+  "context": "Cache misses were slow",
+  "constraints": ["Do not change API"],
+  "filesToTouch": ["src/cache.ts", "tests/cache.test.ts"],
+  "acceptanceCriteria": ["Cache hit rate above 90%", "Response under 10ms"],
+  "verificationSteps": ["Run npm test"],
+  "openQuestions": ["Depends on PR #42"]
+}

--- a/tests/wizard.test.ts
+++ b/tests/wizard.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { mapAnswersToTemplate, validateAnswers, type PlanWizardAnswers } from '../src/wizard.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempDir(prefix = 'osc-wizard-') {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function initializedScaffold(options: { defineMission?: boolean } = { defineMission: true }) {
+  const target = tempDir();
+  execFileSync(tsx, [cli, 'init', '--tier', 'min', '--target', target], { encoding: 'utf8' });
+  if (options.defineMission !== false) {
+    writeFileSync(join(target, 'MISSION.md'), [
+      '# Mission',
+      '',
+      'Test project mission.',
+      '',
+      '## Goals',
+      '',
+      '- Exercise the plan wizard.',
+      '',
+      '## Non-Goals',
+      '',
+      '- Do not spawn agents.',
+      '',
+      '## Changelog',
+      '',
+      '<!-- append YYYY-MM-DD entries below this line -->',
+      '',
+    ].join('\n'));
+  }
+  return target;
+}
+
+const completeAnswers: PlanWizardAnswers = {
+  goal: 'Build a CLI cache',
+  context: 'Cache misses were slow',
+  constraints: ['Do not change API'],
+  filesToTouch: ['src/cache.ts', 'tests/cache.test.ts'],
+  acceptanceCriteria: ['Cache hit rate above 90%', 'Response under 10ms'],
+  verificationSteps: ['Run npm test'],
+  openQuestions: ['Depends on PR #42'],
+};
+
+describe('plan wizard template rendering', () => {
+  it('maps answers to a complete seven-section plan without TODO markers', () => {
+    const text = mapAnswersToTemplate('test-wizard', 'active', completeAnswers);
+
+    expect(text).toContain('# Plan: test-wizard');
+    expect(text).toContain('## Status\n\nactive');
+    expect(text).toContain('Build a CLI cache');
+    expect(text).toContain('Cache misses were slow');
+    expect(text).toContain('- Do not change API');
+    expect(text).toContain('- `src/cache.ts`');
+    expect(text).toContain('- [ ] Cache hit rate above 90%');
+    expect(text).toContain('1. Run npm test');
+    expect(text).toContain('- Depends on PR #42');
+    expect(text).not.toContain('TODO:');
+  });
+
+  it('keeps skipped answers explicit without breaking plan structure', () => {
+    const text = mapAnswersToTemplate('test-skip', 'backlog', {});
+
+    for (const heading of ['Context', 'Goal', 'Constraints / Out of scope', 'Files to touch', 'Acceptance criteria', 'Verification steps', 'Open questions']) {
+      expect(text).toContain(`## ${heading}`);
+    }
+    expect(text).toContain('## Status\n\nbacklog');
+    expect(text).toContain('_not specified_');
+    expect(text).not.toContain('TODO:');
+  });
+
+  it('normalizes scalar and array values from JSON answers', () => {
+    const validated = validateAnswers({
+      goal: 'Ship a thing',
+      constraints: 'Do not touch secrets',
+      filesToTouch: 'src/index.ts, tests/index.test.ts',
+      acceptanceCriteria: ['First criterion', '', 'Second criterion'],
+    });
+
+    expect(validated.goal).toBe('Ship a thing');
+    expect(validated.constraints).toEqual(['Do not touch secrets']);
+    expect(validated.filesToTouch).toEqual(['src/index.ts', 'tests/index.test.ts']);
+    expect(validated.acceptanceCriteria).toEqual(['First criterion', 'Second criterion']);
+  });
+});
+
+describe('osc plan wizard CLI', () => {
+  it('creates a non-interactive plan from JSON answers in the requested stage', () => {
+    const target = initializedScaffold();
+    const answersPath = join(repoRoot, 'tests/fixtures/wizard-answers.json');
+
+    const output = execFileSync(tsx, [cli, 'plan', 'wizard', 'test-json', '--stage', 'backlog', '--non-interactive', '--answers', answersPath], { cwd: target, encoding: 'utf8' });
+
+    const planPath = join(target, '.osc/plans/backlog/test-json.md');
+    const text = readFileSync(planPath, 'utf8');
+    expect(output).toContain('Created plan: .osc/plans/backlog/test-json.md');
+    expect(text).toContain('## Status\n\nbacklog');
+    expect(text).toContain('Build a CLI cache');
+    expect(text).not.toContain('TODO:');
+  }, 20_000);
+
+  it('asks interactive questions and writes provided answers', () => {
+    const target = initializedScaffold();
+    const input = [
+      'Build a CLI cache',
+      'Cache misses were slow',
+      'Do not change API',
+      'src/cache.ts, tests/cache.test.ts',
+      'Cache hit rate above 90%',
+      'Response under 10ms',
+      '',
+      'Run npm test',
+      'Depends on PR #42',
+      '',
+    ].join('\n');
+
+    const result = spawnSync(tsx, [cli, 'plan', 'wizard', 'test-interactive'], { cwd: target, input, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    const planPath = join(target, '.osc/plans/active/test-interactive.md');
+    const text = readFileSync(planPath, 'utf8');
+    expect(text).toContain('- [ ] Cache hit rate above 90%');
+    expect(text).toContain('- [ ] Response under 10ms');
+    expect(text).toContain('1. Run npm test');
+    expect(text).not.toContain('TODO:');
+  }, 20_000);
+
+  it('refuses to run when the mission is unset', () => {
+    const target = initializedScaffold({ defineMission: false });
+    const answersPath = join(repoRoot, 'tests/fixtures/wizard-answers.json');
+
+    const result = spawnSync(tsx, [cli, 'plan', 'wizard', 'blocked-plan', '--non-interactive', '--answers', answersPath], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Mission is not yet defined');
+    expect(existsSync(join(target, '.osc/plans/active/blocked-plan.md'))).toBe(false);
+  }, 20_000);
+});

--- a/tests/wizard.test.ts
+++ b/tests/wizard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -147,5 +147,43 @@ describe('osc plan wizard CLI', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('Mission is not yet defined');
     expect(existsSync(join(target, '.osc/plans/active/blocked-plan.md'))).toBe(false);
+  }, 20_000);
+
+  it('checks mission readiness before waiting for interactive stdin', async () => {
+    const target = initializedScaffold({ defineMission: false });
+    const child = spawn(tsx, [cli, 'plan', 'wizard', 'blocked-interactive'], {
+      cwd: target,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    const result = await new Promise<{ status: number | null }>((resolvePromise, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error('wizard waited for stdin instead of failing mission preflight'));
+      }, 1_500);
+      child.once('error', (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.once('exit', (status) => {
+        clearTimeout(timeout);
+        resolvePromise({ status });
+      });
+    });
+
+    expect(result.status).toBe(1);
+    expect(stderr).toContain('Mission is not yet defined');
+    expect(stdout).not.toContain('Goal / done outcome');
+    expect(existsSync(join(target, '.osc/plans/active/blocked-interactive.md'))).toBe(false);
   }, 20_000);
 });

--- a/tests/wizard.test.ts
+++ b/tests/wizard.test.ts
@@ -3,7 +3,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { mapAnswersToTemplate, validateAnswers, type PlanWizardAnswers } from '../src/wizard.js';
+import { assertWizardReady, mapAnswersToTemplate, validateAnswers, type PlanWizardAnswers } from '../src/wizard.js';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const tsx = join(repoRoot, 'node_modules/.bin/tsx');
@@ -50,6 +50,12 @@ const completeAnswers: PlanWizardAnswers = {
 };
 
 describe('plan wizard template rendering', () => {
+  it('exposes a mission preflight so callers can refuse before collecting answers', () => {
+    const target = initializedScaffold({ defineMission: false });
+
+    expect(() => assertWizardReady(target)).toThrow('Mission is not yet defined');
+  });
+
   it('maps answers to a complete seven-section plan without TODO markers', () => {
     const text = mapAnswersToTemplate('test-wizard', 'active', completeAnswers);
 


### PR DESCRIPTION
## Summary
- Adds `osc plan wizard <slug>` with plain-terminal interactive prompts for goal, context, constraints, likely files, acceptance criteria, verification, and open questions.
- Adds deterministic `--non-interactive --answers <answers.json>` support for scripts/agents.
- Documents the wizard in `docs/WORKFLOW.md` and closes plan `052-interactive-plan-wizard` with release/evidence notes.
- Addresses Codex P2 feedback by preflighting mission readiness before answer collection and adding a regression test that fails if the wizard waits on interactive stdin before refusing an unset mission.

## Traceability
- Plan: `.osc/plans/done/052-interactive-plan-wizard.md`
- Evidence: `.osc/releases/2026-05-19-052-interactive-plan-wizard.md`
- Branch: `cli/interactive-plan-wizard`
- Issue/task: accepted V2 backlog plan; no GitHub issue open.

## Verification
- [x] `npm test -- tests/wizard.test.ts --run` — 8 tests passed
- [x] Built CLI non-interactive wizard smoke in a temp scaffold
- [x] Built CLI stdin/interactive wizard smoke in a temp scaffold
- [x] Built CLI unset-mission refusal smoke in a temp scaffold
- [x] Codex P2 regression: unset-mission wizard exits before waiting for interactive stdin
- [x] `npm run build`
- [x] `npm test -- --run` — 23 files / 204 tests passed
- [x] `git diff --check`
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- [x] `npm pack --dry-run --json`
- [x] CI passed on latest head `43508c8`

## Codex review
- Initial review raised one P2: mission readiness needed to happen before answer collection.
- Fixed in `d0b3b0d`; regression/evidence commit `43508c8` covers the edge case.
- Latest-head Codex recheck after `43508c8`: clean — “Didn't find any major issues. Bravo.”

## Out of scope
- No semantic plan-quality judgment; plan `055-plan-linter` remains the later mechanical feedback layer.
- No AI-generated scope, no runtime spawning, no npm publish, and no GitHub Release update.
