### PR TITLE
Prepare plan wizard package release

### DIFF
--- a/.osc/plans/done/076-plan-wizard-package-release-sync.md
+++ b/.osc/plans/done/076-plan-wizard-package-release-sync.md
@@ -1,0 +1,56 @@
+# Plan: 076-plan-wizard-package-release-sync
+
+## Status
+
+done
+
+## Context
+
+PR #62 shipped `osc plan wizard` on `main`, including interactive and non-interactive plan creation plus a Codex-hardening regression for unset missions. GitHub truth now says the wizard exists, but public package truth has not caught up: npm `latest` is still `open-scaffold@0.4.3` and `npx --yes open-scaffold@latest --help` does not show `osc plan wizard`.
+
+This slice exists to prevent the first-run adoption path from becoming false after a merged CLI feature. It follows the same narrow package/public-surface sync pattern used for plans 074 and 075.
+
+## Goal
+
+Prepare the smallest package/public-surface sync needed for the plan wizard: bump the package release candidate, verify npm/tarball/command-surface truth, record evidence, and leave real npm publish plus GitHub Release creation behind explicit owner gates.
+
+## Constraints / Out of scope
+
+- Do not run `npm publish` without explicit owner approval.
+- Do not create or mark a GitHub Release without explicit owner approval.
+- Do not implement plan templates, plan linter, run preview, evidence collection, dashboards, MCP, task database, or runtime work.
+- Do not broaden this into mission/roadmap wording, runtime package distribution, or public positioning changes.
+- Keep this release sync limited to package version, npm/latest command-surface truth, release evidence, and any minimal docs needed to avoid stale package claims.
+
+## Files to touch
+
+- `package.json` — bump the release candidate version so the merged wizard command can be published.
+- `package-lock.json` — keep lock metadata aligned if the version changes.
+- `.osc/releases/2026-05-19-076-plan-wizard-package-release-sync.md` — record package/public-surface evidence and owner gates.
+- `MISSION.md` — close stamp after the package sync slice is locally verified.
+- `.osc/plans/active/076-plan-wizard-package-release-sync.md` — this plan, moved to `done/` at slice close.
+
+## Acceptance criteria
+
+- [ ] Local `node dist/cli.js --help` exposes `osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]`.
+- [ ] `npm view open-scaffold version time dist-tags --json` is captured and shows npm latest before publish.
+- [ ] `npx --yes open-scaffold@latest --help` is captured and either lacks `osc plan wizard` before publish or shows it after owner-approved publish.
+- [ ] `npm pack --dry-run --json` succeeds and confirms the package payload remains public-safe: no `.osc/research/`, `.osc/runs/`, `.osc/plans/done/`, or `.osc/plans/backlog/` payload.
+- [ ] `npm publish --dry-run` succeeds for the release candidate.
+- [ ] Build, tests, strict scaffold verification, and whitespace checks pass.
+- [ ] Evidence states the exact owner gate for real `npm publish` and GitHub Release creation.
+
+## Verification steps
+
+1. `npm view open-scaffold version time dist-tags --json` — capture current registry truth.
+2. `npx --yes open-scaffold@latest --help` — capture current public command surface.
+3. `npm run build` — local package builds.
+4. `node dist/cli.js --help` — local command surface includes `osc plan wizard`.
+5. `npm pack --dry-run --json` — package payload is public-safe and records file count/size.
+6. `npm publish --dry-run` — publish candidate validates without performing a real publish.
+7. `npm test -- --run`, `git diff --check`, and `./verify.sh --strict` — repo gates pass.
+
+## Open questions
+
+- Patch or minor version: default assumption is patch (`0.4.4`) because this exposes an already-merged CLI adoption helper without changing runtime boundaries.
+- Publish gate: owner approval is required before running real `npm publish` or creating/updating the GitHub Release marked Latest.

--- a/.osc/releases/2026-05-19-076-plan-wizard-package-release-sync.md
+++ b/.osc/releases/2026-05-19-076-plan-wizard-package-release-sync.md
@@ -1,0 +1,34 @@
+# Release / Evidence Note: 076-plan-wizard-package-release-sync
+
+## Summary
+
+Prepared `open-scaffold@0.4.4` as the package release candidate for the already-merged `osc plan wizard` command. This is a narrow public-surface sync: repo `main` has the plan wizard, while npm `latest` is still `open-scaffold@0.4.3` and the public `npx` help does not yet expose `osc plan wizard`.
+
+## Traceability
+
+- Roadmap / issue / task: V2 adoption friction backlog; follows `.osc/plans/done/052-interactive-plan-wizard.md` and PR #62.
+- Plan: `.osc/plans/done/076-plan-wizard-package-release-sync.md`.
+- Run ID / run packet: N/A — OSC Shipwright executed directly in the repo under the accepted release-sync plan.
+- Branch / PR: `release/plan-wizard-package-sync`; PR pending until this branch is pushed.
+- Package candidate: `open-scaffold@0.4.4`.
+
+## Verification
+
+- `npm view open-scaffold version time dist-tags --json` — pass; registry `latest` is `0.4.3` before owner-approved publish.
+- `npx --yes open-scaffold@latest --help` — pass; public `latest` help exposes `osc init --from-existing` but does not expose `osc plan wizard`, proving package/public-surface drift.
+- `npm run build` — pass; core and `packages/runtime-omx` TypeScript builds succeeded for `open-scaffold@0.4.4`.
+- `node dist/cli.js --help` — pass; local built help exposes `osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]`.
+- `npm pack --dry-run --json` — pass; candidate `open-scaffold-0.4.4.tgz`, 86 files, unpacked size 570,913 bytes, includes `dist/wizard.js` and `dist/wizard.d.ts`, and includes no `.osc/research/`, `.osc/runs/`, `.osc/plans/done/`, or `.osc/plans/backlog/` payload.
+- `npm publish --dry-run` — pass; dry-run produced `+ open-scaffold@0.4.4` and did not publish.
+- `npm test -- --run` — pass; 23 test files / 204 tests passed.
+- `git diff --check` — pass.
+- `./verify.sh --strict` — pass; 10 pass, 0 fail, 0 warn.
+
+## Outcome
+
+The repository is prepared for a patch package sync that makes `osc plan wizard` available through `npx open-scaffold@latest` after the owner-approved publish step. No real npm publish, GitHub Release creation, runtime work, dashboard work, MCP work, template/linter work, or broader public-positioning change was performed.
+
+## Follow-up
+
+- Owner gate: run real `npm publish` for `open-scaffold@0.4.4` only after explicit approval.
+- Owner gate: create or update the GitHub Release for `v0.4.4` and mark it Latest only after explicit approval.

--- a/.osc/releases/2026-05-19-076-plan-wizard-package-release-sync.md
+++ b/.osc/releases/2026-05-19-076-plan-wizard-package-release-sync.md
@@ -9,7 +9,7 @@ Prepared `open-scaffold@0.4.4` as the package release candidate for the already-
 - Roadmap / issue / task: V2 adoption friction backlog; follows `.osc/plans/done/052-interactive-plan-wizard.md` and PR #62.
 - Plan: `.osc/plans/done/076-plan-wizard-package-release-sync.md`.
 - Run ID / run packet: N/A — OSC Shipwright executed directly in the repo under the accepted release-sync plan.
-- Branch / PR: `release/plan-wizard-package-sync`; PR pending until this branch is pushed.
+- Branch / PR: `release/plan-wizard-package-sync`; PR #63 — https://github.com/graphanov/open-scaffold/pull/63.
 - Package candidate: `open-scaffold@0.4.4`.
 
 ## Verification

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-19: closed 076-plan-wizard-package-release-sync — prepared plan wizard package release candidate
 - 2026-05-19: closed 052-interactive-plan-wizard — added interactive plan wizard
 - 2026-05-19: closed 075-brownfield-package-release-sync — prepared brownfield init package release candidate
 - 2026-05-19: closed 051-brownfield-init-from-existing — brownfield init from existing repos shipped

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Prepares `open-scaffold@0.4.4` as the package release candidate after PR #62 added `osc plan wizard` on `main`.
- Closes plan `076-plan-wizard-package-release-sync` with a release/evidence note.
- Captures the current public drift: npm `latest` is still `0.4.3`, and `npx open-scaffold@latest --help` does not expose `osc plan wizard` yet.
- Latest head: `3fa56bfe4448975c5894deedb311caae6efaa9e8`.

## Traceability
- Preceding feature: PR #62 — https://github.com/graphanov/open-scaffold/pull/62
- Plan: `.osc/plans/done/076-plan-wizard-package-release-sync.md`
- Evidence: `.osc/releases/2026-05-19-076-plan-wizard-package-release-sync.md`
- Branch: `release/plan-wizard-package-sync`

## Verification
- [x] `npm view open-scaffold version time dist-tags --json` — latest is `0.4.3`
- [x] `npx --yes open-scaffold@latest --help` — lacks `osc plan wizard`, confirming drift
- [x] `npm run build`
- [x] `node dist/cli.js --help` — includes `osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]`
- [x] `npm test -- --run` — 23 files / 204 tests passed
- [x] `git diff --check`
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- [x] `npm pack --dry-run --json --silent` — `open-scaffold-0.4.4.tgz`, 86 files, includes `dist/wizard.js` and `dist/wizard.d.ts`, no private/dogfood plan payload
- [x] `npm publish --dry-run` — dry-run only, produced `+ open-scaffold@0.4.4`
- [x] Post-PR traceability follow-up: `git diff --check && ./verify.sh --strict`
- [x] GitHub CI — pass on latest head
- [x] Codex latest-head review — clean after explicit retrigger; no formal review or inline findings after final trigger

## Gates
- Real `npm publish` remains owner-gated.
- GitHub Release `v0.4.4` creation / Latest marking remains owner-gated.
- Merge remains owner-gated.

## Out of scope
- No real npm publish.
- No GitHub Release mutation.
- No plan templates, plan linter, runtime, dashboard, MCP, task database, or public positioning work.
