### PR TITLE
Add npm trusted publishing workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,66 @@
+name: Publish npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected-version:
+        description: "Version in package.json that should be published"
+        required: true
+        type: string
+      npm-tag:
+        description: "npm dist-tag to publish"
+        required: true
+        default: latest
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test -- --run
+
+      - name: Verify scaffold
+        run: ./verify.sh --strict
+
+      - name: Validate requested version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          if [[ "$version" != "${{ inputs.expected-version }}" ]]; then
+            echo "package.json version $version does not match expected version ${{ inputs.expected-version }}" >&2
+            exit 1
+          fi
+          if npm view "open-scaffold@$version" version >/dev/null 2>&1; then
+            echo "open-scaffold@$version is already published" >&2
+            exit 1
+          fi
+
+      - name: Publish to npm with trusted publishing
+        run: npm publish --tag "${{ inputs.npm-tag }}" --provenance

--- a/.osc/plans/done/077-npm-trusted-publishing-workflow.md
+++ b/.osc/plans/done/077-npm-trusted-publishing-workflow.md
@@ -1,0 +1,54 @@
+# Plan: 077-npm-trusted-publishing-workflow
+
+## Status
+
+done
+
+## Context
+
+`open-scaffold@0.4.4` is prepared on `main`, but manual `npm publish` is blocked by npm write-time two-factor authentication. npm trusted publishing is the correct release path because it publishes from a specific GitHub Actions workflow through OIDC instead of relying on long-lived write tokens or browser/OTP prompts.
+
+## Goal
+
+Add the repo-side trusted publishing workflow and evidence needed for the owner to bind npm package `open-scaffold` to GitHub Actions and publish `0.4.4` through a manually dispatched workflow.
+
+## Constraints / Out of scope
+
+- Do not commit npm auth tokens, OTPs, browser auth URLs, or secrets.
+- Do not publish from this feature branch; trusted publishing must run from the configured workflow after the workflow exists on the default branch.
+- Do not change package version, package payload, CLI behavior, runtime boundaries, docs positioning, templates, linter, dashboard, MCP, or task database work.
+- Keep the npm-side trusted publisher configuration as an owner/manual setup step because it lives in npm package settings.
+
+## Files to touch
+
+- `.github/workflows/publish-npm.yml` — manual GitHub Actions workflow with OIDC permission, pre-publish verification, version guard, and `npm publish --provenance`.
+- `.osc/releases/2026-05-19-077-npm-trusted-publishing-workflow.md` — evidence note with exact npm UI trusted-publisher fields and post-merge publish sequence.
+- `MISSION.md` — close stamp after local verification if the setup slice is accepted.
+- `.osc/plans/active/077-npm-trusted-publishing-workflow.md` — this plan, moved to `done/` when the workflow setup slice is locally verified.
+
+## Implementation Architecture Coverage
+
+- Strengthens: authority, audit trails, and package release recovery.
+- Audit envelope: PR, workflow filename, npm trusted publisher fields, local verification commands, and eventual GitHub Actions run URL reconstruct the release path.
+- Evaluation envelope: workflow syntax parses, local build/tests/strict verification pass, and release evidence states exact npm and GitHub owner gates.
+- Feedback routing: if the workflow fails after npm trusted publisher setup, fix through a follow-up PR or amendment rather than editing this closed plan in place.
+- Boundary: npm package settings, actual npm publish execution, and GitHub Release creation remain gated by owner action after the workflow is merged.
+
+## Acceptance criteria
+
+- [ ] `.github/workflows/publish-npm.yml` exists and uses `workflow_dispatch` with explicit `expected-version` and `npm-tag` inputs.
+- [ ] The workflow grants `id-token: write` and `contents: read`, uses a GitHub-hosted Ubuntu runner, installs a current npm CLI, runs build/tests/strict scaffold verification, checks that the requested version matches `package.json`, refuses already-published versions, and runs `npm publish --provenance` without an npm token.
+- [ ] The release/evidence note records exact npm trusted publisher UI fields: GitHub Actions, owner `graphanov`, repository `open-scaffold`, workflow filename `publish-npm.yml`, and no environment name unless a protected environment is later added.
+- [ ] No npm token, OTP, browser auth URL, or secret appears in tracked files.
+- [ ] Local workflow YAML parsing, build, tests, strict scaffold verification, and whitespace checks pass.
+
+## Verification steps
+
+1. `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-npm.yml"); puts "yaml ok"'` — workflow YAML parses.
+2. `grep -n "id-token: write\|npm publish --tag\|--provenance" .github/workflows/publish-npm.yml` — OIDC and publish command are present.
+3. `git grep -nE 'npm_[A-Za-z0-9]{20,}|https://www[.]npmjs[.]com/auth/cli/' -- . ':!package-lock.json'` — expected: no tracked npm token or browser-auth URL leakage from this slice.
+4. `npm run build`, `npm test -- --run`, `./verify.sh --strict`, and `git diff --check` — repo gates pass.
+
+## Open questions
+
+- The npm package settings step cannot be done from the repo. After merge, configure npm package `open-scaffold` trusted publisher with workflow filename `publish-npm.yml`, then manually run the workflow from `main` with `expected-version=0.4.4` and `npm-tag=latest`.

--- a/.osc/releases/2026-05-19-077-npm-trusted-publishing-workflow.md
+++ b/.osc/releases/2026-05-19-077-npm-trusted-publishing-workflow.md
@@ -1,0 +1,58 @@
+# Release / Evidence Note: 077-npm-trusted-publishing-workflow
+
+## Summary
+
+Added a manually dispatched GitHub Actions workflow for npm trusted publishing. The workflow is the repo-side setup needed to publish `open-scaffold@0.4.4` through npm OIDC instead of local browser/OTP publishing.
+
+## Traceability
+
+- Roadmap / issue / task: package release reliability follow-up after `.osc/plans/done/076-plan-wizard-package-release-sync.md` and PR #63.
+- Plan: `.osc/plans/done/077-npm-trusted-publishing-workflow.md`.
+- Branch / PR: `ci/npm-trusted-publishing`; PR URL to be added after PR creation.
+- Workflow: `.github/workflows/publish-npm.yml`.
+- Package target: `open-scaffold@0.4.4`.
+
+## Trusted publisher setup fields
+
+Configure this in npm after the workflow file is merged to the default branch:
+
+- npm package: `open-scaffold`
+- npm page: `https://www.npmjs.com/package/open-scaffold/access`
+- Trusted Publisher provider: GitHub Actions
+- Organization or user: `graphanov`
+- Repository: `open-scaffold`
+- Workflow filename: `publish-npm.yml`
+- Environment name: leave blank for this workflow unless a protected GitHub environment is added in a later slice.
+
+## Publish sequence after merge
+
+1. Merge the trusted publishing workflow PR to `main`.
+2. In npm package settings, add the trusted publisher using the fields above.
+3. In GitHub Actions, open `Publish npm package`.
+4. Run workflow on `main` with:
+   - `expected-version`: `0.4.4`
+   - `npm-tag`: `latest`
+5. After the workflow succeeds, verify:
+   - `npm view open-scaffold version dist-tags --json` shows `0.4.4` as `latest`.
+   - `npx --yes open-scaffold@latest --help` includes `osc plan wizard`.
+6. Then create/mark GitHub Release `v0.4.4` as Latest, targeting the merged `main` commit.
+
+## Verification
+
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-npm.yml"); puts "yaml ok"'` — pass.
+- `grep -n "id-token: write\|npm publish --tag\|--provenance" .github/workflows/publish-npm.yml` — pass; OIDC permission and provenance publish command are present.
+- `git grep -nE 'npm_[A-Za-z0-9]{20,}|https://www[.]npmjs[.]com/auth/cli/' -- . ':!package-lock.json'` — pass; no tracked npm token or browser-auth URL leakage found.
+- `npm run build` — pass.
+- `npm test -- --run` — pass; 23 test files / 204 tests.
+- `./verify.sh --strict` — pass; 10 pass, 0 fail, 0 warn.
+- `git diff --check` — pass.
+
+## Outcome
+
+Repo-side trusted publishing setup is locally verified and ready for PR review. No npm publish or GitHub Release creation is performed by this setup slice.
+
+## Follow-up
+
+- Owner gate: npm trusted publisher settings must be configured on npmjs.com after the workflow lands on `main`.
+- Owner gate: the GitHub Actions publish run should be manually dispatched after npm trusted publisher setup.
+- Owner gate: GitHub Release `v0.4.4` should be created or marked Latest only after npm confirms `open-scaffold@0.4.4` is published.

--- a/.osc/releases/2026-05-19-077-npm-trusted-publishing-workflow.md
+++ b/.osc/releases/2026-05-19-077-npm-trusted-publishing-workflow.md
@@ -8,7 +8,7 @@ Added a manually dispatched GitHub Actions workflow for npm trusted publishing. 
 
 - Roadmap / issue / task: package release reliability follow-up after `.osc/plans/done/076-plan-wizard-package-release-sync.md` and PR #63.
 - Plan: `.osc/plans/done/077-npm-trusted-publishing-workflow.md`.
-- Branch / PR: `ci/npm-trusted-publishing`; PR URL to be added after PR creation.
+- Branch / PR: `ci/npm-trusted-publishing`; PR #64 — https://github.com/graphanov/open-scaffold/pull/64.
 - Workflow: `.github/workflows/publish-npm.yml`.
 - Package target: `open-scaffold@0.4.4`.
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-19: closed 077-npm-trusted-publishing-workflow — added npm trusted publishing workflow setup
 - 2026-05-19: closed 076-plan-wizard-package-release-sync — prepared plan wizard package release candidate
 - 2026-05-19: closed 052-interactive-plan-wizard — added interactive plan wizard
 - 2026-05-19: closed 075-brownfield-package-release-sync — prepared brownfield init package release candidate


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish-npm.yml` for manually dispatched npm trusted publishing via GitHub Actions OIDC.
- Close plan `077-npm-trusted-publishing-workflow` and record release/evidence with exact npm trusted publisher setup fields.
- Keep real npm publish and GitHub Release creation gated until the workflow is merged and npm package settings trust this workflow.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-npm.yml"); puts "yaml ok"'`
- `grep -n "id-token: write\|npm publish --tag\|--provenance" .github/workflows/publish-npm.yml`
- `git grep -nE 'npm_[A-Za-z0-9]{20,}|https://www[.]npmjs[.]com/auth/cli/' -- . ':!package-lock.json'`
- `npm run build`
- `npm test -- --run` — 23 test files / 204 tests
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- `git diff --check`

## npm trusted publisher setup after merge
Configure npm package `open-scaffold` at https://www.npmjs.com/package/open-scaffold/access:
- Provider: GitHub Actions
- Organization or user: `graphanov`
- Repository: `open-scaffold`
- Workflow filename: `publish-npm.yml`
- Environment name: blank for this workflow

Then run GitHub Actions → `Publish npm package` on `main` with:
- `expected-version`: `0.4.4`
- `npm-tag`: `latest`

## Gates / out of scope
- Does not run npm publish from this PR.
- Does not create/mark GitHub Release `v0.4.4`.
- Does not change package version, CLI behavior, runtime boundaries, templates, linter, dashboard, MCP, or task DB work.
