### PR TITLE
Refresh GitHub Actions runtime pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.12.0
           cache: npm

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"

--- a/.osc/plans/done/078-github-actions-node24-runtime-refresh.md
+++ b/.osc/plans/done/078-github-actions-node24-runtime-refresh.md
@@ -1,0 +1,54 @@
+# Plan: 078-github-actions-node24-runtime-refresh
+
+## Status
+
+done
+
+## Context
+
+After `open-scaffold@0.4.4` was published through GitHub Actions trusted publishing, the workflow run showed a Node.js 20 deprecation annotation for GitHub Actions dependencies. The repo still pins `actions/checkout@v4` and `actions/setup-node@v4` in CI and publish workflows, which are the likely source of the annotation.
+
+## Goal
+
+Refresh the GitHub Actions workflow action pins so CI and trusted publishing use Node 24-compatible first-party actions without changing package behavior or release authority.
+
+## Constraints / Out of scope
+
+- Do not change the package version, package payload, CLI behavior, npm trusted publisher settings, or release contents.
+- Do not run npm publish from this branch.
+- Do not create or update GitHub Releases in this workflow-maintenance PR.
+- Keep the change limited to first-party GitHub Actions version pins and evidence.
+
+## Files to touch
+
+- `.github/workflows/ci.yml` — bump first-party action pins used by CI.
+- `.github/workflows/publish-npm.yml` — bump first-party action pins used by trusted publishing.
+- `.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md` — record the annotation cause, fix, and verification.
+- `MISSION.md` — close stamp for this workflow-maintenance slice.
+
+## Implementation Architecture Coverage
+
+- Strengthens: package release reliability and audit trails for trusted publishing.
+- Audit envelope: workflow pins, PR, CI result, and release/evidence note reconstruct why the maintenance slice happened.
+- Evaluation envelope: local YAML parsing, workflow grep, build/tests/strict verification, and PR CI confirm the maintenance change.
+- Feedback routing: any remaining GitHub annotation after merge should become a follow-up CI maintenance slice, not runtime/product scope.
+- Boundary: npm publish, GitHub Release creation, package behavior, and trusted publisher settings remain outside this slice.
+
+## Acceptance criteria
+
+- [ ] `.github/workflows/ci.yml` uses Node 24-compatible first-party GitHub Actions pins for checkout and setup-node.
+- [ ] `.github/workflows/publish-npm.yml` uses Node 24-compatible first-party GitHub Actions pins for checkout and setup-node.
+- [ ] Workflow YAML parses locally.
+- [ ] Build, tests, strict scaffold verification, and whitespace checks pass.
+- [ ] No package version, package payload, CLI behavior, npm trusted publisher field, or release state changes are included.
+
+## Verification steps
+
+1. `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'` — workflow YAML parses.
+2. `grep -RInE 'uses: actions/(checkout|setup-node)@' .github/workflows` — checkout/setup-node pins show the refreshed versions.
+3. `npm run build`, `npm test -- --run`, `./verify.sh --strict`, and `git diff --check` — repo gates pass.
+4. `gh pr checks` after opening the PR — GitHub CI passes.
+
+## Open questions
+
+- If GitHub still shows a deprecation annotation after this change, inspect the workflow run annotations and patch the specific remaining action in a follow-up slice.

--- a/.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md
+++ b/.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md
@@ -8,7 +8,7 @@ Refreshed first-party GitHub Actions pins in CI and trusted publishing workflows
 
 - Roadmap / issue / task: workflow maintenance follow-up after trusted publishing setup and `open-scaffold@0.4.4` publish.
 - Plan: `.osc/plans/done/078-github-actions-node24-runtime-refresh.md`.
-- Branch / PR: `ci/update-actions-node24`; PR URL to be added after PR creation.
+- Branch / PR: `ci/update-actions-node24`; PR #65 — https://github.com/graphanov/open-scaffold/pull/65.
 - Package/release target: none; no npm publish or GitHub Release mutation in this slice.
 
 ## Verification

--- a/.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md
+++ b/.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md
@@ -1,0 +1,32 @@
+# Release / Evidence Note: 078-github-actions-node24-runtime-refresh
+
+## Summary
+
+Refreshed first-party GitHub Actions pins in CI and trusted publishing workflows after the `open-scaffold@0.4.4` publish run surfaced a Node.js 20 actions deprecation annotation.
+
+## Traceability
+
+- Roadmap / issue / task: workflow maintenance follow-up after trusted publishing setup and `open-scaffold@0.4.4` publish.
+- Plan: `.osc/plans/done/078-github-actions-node24-runtime-refresh.md`.
+- Branch / PR: `ci/update-actions-node24`; PR URL to be added after PR creation.
+- Package/release target: none; no npm publish or GitHub Release mutation in this slice.
+
+## Verification
+
+- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'` — pass.
+- `grep -RInE 'uses: actions/(checkout|setup-node)@' .github/workflows` — pass; CI and publish workflows now use `actions/checkout@v6` and `actions/setup-node@v6`.
+- GitHub tag checks for `actions/checkout@v6` and `actions/setup-node@v6` — pass.
+- `npm run build` — pass.
+- `npm test -- --run` — pass; 23 test files / 204 tests.
+- `./verify.sh --strict` — pass; 10 pass, 0 fail, 0 warn.
+- `git diff --check` — pass.
+- PR CI — pending.
+
+## Outcome
+
+Pending PR creation and CI verification. This slice updates workflow action pins only; it does not publish npm, change package version, change CLI behavior, or create/update GitHub Releases.
+
+## Follow-up
+
+- After merge, inspect the next CI/publish run annotations. If GitHub still reports Node.js runtime deprecation, patch the specific remaining action in a new maintenance slice.
+- Separately, GitHub Release `v0.4.4` still needs to be created/marked Latest after `open-scaffold@0.4.4` was published.

--- a/.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md
+++ b/.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md
@@ -22,7 +22,7 @@ Refreshed first-party GitHub Actions pins in CI and trusted publishing workflows
 - `git diff --check` — pass.
 - PR CI — pass; https://github.com/graphanov/open-scaffold/actions/runs/26109263576.
 - PR CI annotations — pass; `gh run view 26109263576 --json jobs` reported `annotationsCount: 0` for the `ci` job.
-- Codex latest-head review — pass; PR #65 head `488f9ff110778e24ac3dda0d6823a75377cdebd2` returned “Didn't find any major issues.”
+- Codex review loop — PR #65 review artifacts inspected. The release note does not freeze a “latest head” hash because evidence-only commits can change the head and make the note recursively stale; final latest-head readiness is determined from the PR conversation after the last push.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md
+++ b/.osc/releases/2026-05-19-078-github-actions-node24-runtime-refresh.md
@@ -20,11 +20,13 @@ Refreshed first-party GitHub Actions pins in CI and trusted publishing workflows
 - `npm test -- --run` — pass; 23 test files / 204 tests.
 - `./verify.sh --strict` — pass; 10 pass, 0 fail, 0 warn.
 - `git diff --check` — pass.
-- PR CI — pending.
+- PR CI — pass; https://github.com/graphanov/open-scaffold/actions/runs/26109263576.
+- PR CI annotations — pass; `gh run view 26109263576 --json jobs` reported `annotationsCount: 0` for the `ci` job.
+- Codex latest-head review — pass; PR #65 head `488f9ff110778e24ac3dda0d6823a75377cdebd2` returned “Didn't find any major issues.”
 
 ## Outcome
 
-Pending PR creation and CI verification. This slice updates workflow action pins only; it does not publish npm, change package version, change CLI behavior, or create/update GitHub Releases.
+Repo-side workflow annotation fix is verified and ready for merge. This slice updates workflow action pins only; it does not publish npm, change package version, change CLI behavior, or create/update GitHub Releases.
 
 ## Follow-up
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-19: closed 078-github-actions-node24-runtime-refresh — refreshed GitHub Actions pins after Node 20 deprecation annotation
 - 2026-05-19: closed 077-npm-trusted-publishing-workflow — added npm trusted publishing workflow setup
 - 2026-05-19: closed 076-plan-wizard-package-release-sync — prepared plan wizard package release candidate
 - 2026-05-19: closed 052-interactive-plan-wizard — added interactive plan wizard


### PR DESCRIPTION
## Summary
- Bump first-party GitHub Actions pins from `actions/checkout@v4` / `actions/setup-node@v4` to `@v6` in CI and trusted publishing workflows.
- Close plan `078-github-actions-node24-runtime-refresh` with evidence after the Node.js 20 actions deprecation annotation surfaced on the publish run.
- Keep package version, CLI behavior, npm trusted publisher settings, npm publish, and GitHub Release state untouched.

## Verification
- `gh api repos/actions/checkout/git/ref/tags/v6 --jq .object.sha`
- `gh api repos/actions/setup-node/git/ref/tags/v6 --jq .object.sha`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'`
- `grep -RInE 'uses: actions/(checkout|setup-node)@' .github/workflows`
- `npm run build`
- `npm test -- --run` — 23 test files / 204 tests
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- `git diff --check`

## Gates / out of scope
- Does not run npm publish.
- Does not create/mark GitHub Release `v0.4.4`.
- Does not change package version, package payload, CLI behavior, templates, linter, dashboard, MCP, or runtime scope.
