### PR TITLE
Add run dry-run preview

### DIFF
--- a/.osc/plans/done/056-run-dry-run-preview.md
+++ b/.osc/plans/done/056-run-dry-run-preview.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog — depends on 050 (npm publish) for baseline `osc run` availability. This adds a preview mode to the run command that lets users and reviewers inspect what would happen before committing to a real run. Complements 055 (linter) as part of the pre-execution quality gate.
+done — implemented in this slice. `osc run <plan> --dry-run` now previews run packets without writing `.osc/runs/` artifacts.
 
 ## Context
 

--- a/.osc/releases/2026-05-19-056-run-dry-run-preview.md
+++ b/.osc/releases/2026-05-19-056-run-dry-run-preview.md
@@ -13,15 +13,16 @@ This slice adds `osc run <plan> --dry-run` so users can preview a run packet bef
 
 ## Verification
 
-- `npm test -- tests/artifacts.test.ts tests/cli-run-dry-run.test.ts --run` — pass; 2 files / 11 tests.
+- `npm test -- tests/artifacts.test.ts tests/cli-run-dry-run.test.ts --run` — pass; 2 files / 12 tests.
 - `npm run build` — pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded for package candidate `0.4.6`.
-- `npm test -- --run` — pass; 25 files / 215 tests.
+- `npm test -- --run` — pass; 25 files / 216 tests.
 - `git diff --check` — pass.
 - Manual dry-run smoke against `.osc/plans/done/056-run-dry-run-preview.md` with `--runtime omx --workflow plan` — pass; emitted schema `open-scaffold.run.v1`, executable `true`, executor `omx-codex`, workflow `plan`, harness `$ralplan`, package prompt present.
 - Dry-run no-write smoke — pass; `.osc/runs` entry count remained `14` before and after the preview.
 - `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn.
-- `npm pack --dry-run --json` — pass; produced `open-scaffold-0.4.6.tgz`, 95 files, unpacked size 601,373 bytes.
+- `npm pack --dry-run --json` — pass; produced `open-scaffold-0.4.6.tgz`, 95 files, unpacked size 601,776 bytes.
 - `npm publish --dry-run` — pass; dry-run only, reported `+ open-scaffold@0.4.6`.
+- Codex P2 root-resolution regression — fixed with a subdirectory dry-run test proving package quality resolves the plan scaffold root while preserving external-coordinator `--repo` behavior.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-19-056-run-dry-run-preview.md
+++ b/.osc/releases/2026-05-19-056-run-dry-run-preview.md
@@ -13,16 +13,18 @@ This slice adds `osc run <plan> --dry-run` so users can preview a run packet bef
 
 ## Verification
 
-- `npm test -- tests/artifacts.test.ts tests/cli-run-dry-run.test.ts --run` — pass; 2 files / 12 tests.
+- `npm test -- tests/cli-run-dry-run.test.ts tests/cli-init.test.ts --run` — pass; 2 files / 34 tests, including `osc run --help`, subdirectory root resolution, dry-run/write-mode artifact-root parity, and runtime-profile compatibility regressions.
 - `npm run build` — pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded for package candidate `0.4.6`.
-- `npm test -- --run` — pass; 25 files / 216 tests.
+- `npm test -- --run` — pass; 25 files / 218 tests.
 - `git diff --check` — pass.
 - Manual dry-run smoke against `.osc/plans/done/056-run-dry-run-preview.md` with `--runtime omx --workflow plan` — pass; emitted schema `open-scaffold.run.v1`, executable `true`, executor `omx-codex`, workflow `plan`, harness `$ralplan`, package prompt present.
 - Dry-run no-write smoke — pass; `.osc/runs` entry count remained `14` before and after the preview.
 - `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn.
-- `npm pack --dry-run --json` — pass; produced `open-scaffold-0.4.6.tgz`, 95 files, unpacked size 601,776 bytes.
+- `npm pack --dry-run --json` — pass; produced `open-scaffold-0.4.6.tgz`, 95 files, unpacked size 603,376 bytes.
 - `npm publish --dry-run` — pass; dry-run only, reported `+ open-scaffold@0.4.6`.
 - Codex P2 root-resolution regression — fixed with a subdirectory dry-run test proving package quality resolves the plan scaffold root while preserving external-coordinator `--repo` behavior.
+- Codex P1 dry-run/write-mode artifact-root parity regression — fixed so dry-run previews use the same caller-cwd artifact root as write-mode runs while using the plan scaffold root only for mission/package-quality checks.
+- Dogfood CLI-help pinpoint — fixed `osc run --help` so it prints run-specific usage instead of treating `--help` as a missing plan path.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-19-056-run-dry-run-preview.md
+++ b/.osc/releases/2026-05-19-056-run-dry-run-preview.md
@@ -1,0 +1,35 @@
+# Release / Evidence Note: 056-run-dry-run-preview
+
+## Summary
+
+This slice adds `osc run <plan> --dry-run` so users can preview a run packet before creating durable `.osc/runs/` artifacts. The preview renders the `run.json` payload and package markdown in memory, supports JSON-only output for tools, reports non-executable blockers, and keeps Open Scaffold core non-spawning.
+
+## Traceability
+
+- Roadmap / issue / task: Open Scaffold backlog plan 056; Kanban task `t_e3c46180`.
+- Plan: `.osc/plans/done/056-run-dry-run-preview.md`
+- Run ID / run packet: N/A — this slice explicitly implements dry-run previews that do not create run packets.
+- Branch / PR: branch `cli/run-dry-run-preview`; PR pending owner review.
+
+## Verification
+
+- `npm test -- tests/artifacts.test.ts tests/cli-run-dry-run.test.ts --run` — pass; 2 files / 11 tests.
+- `npm run build` — pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded for package candidate `0.4.6`.
+- `npm test -- --run` — pass; 25 files / 215 tests.
+- `git diff --check` — pass.
+- Manual dry-run smoke against `.osc/plans/done/056-run-dry-run-preview.md` with `--runtime omx --workflow plan` — pass; emitted schema `open-scaffold.run.v1`, executable `true`, executor `omx-codex`, workflow `plan`, harness `$ralplan`, package prompt present.
+- Dry-run no-write smoke — pass; `.osc/runs` entry count remained `14` before and after the preview.
+- `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn.
+- `npm pack --dry-run --json` — pass; produced `open-scaffold-0.4.6.tgz`, 95 files, unpacked size 601,373 bytes.
+- `npm publish --dry-run` — pass; dry-run only, reported `+ open-scaffold@0.4.6`.
+
+## Outcome
+
+`osc run` now accepts `--dry-run` and optional `--json`. Human output prints the generated `run.json`, package markdown, files-to-touch summary, blockers when present, and a no-write notice. JSON output emits `{ run, packageMarkdown, filesToTouch }` and exits non-zero when the package is not executable. Normal `osc run`, `delegate`, `review`, and `ultrareview` artifact creation behavior remains write-based and non-spawning.
+
+The package candidate version is `0.4.6` because the public CLI surface changed. Merge, npm publish, and GitHub Release creation remain owner-gated.
+
+## Follow-up
+
+- Owner review/merge gate for the PR.
+- If merged, verify npm/latest drift and publish `open-scaffold@0.4.6` only with explicit owner approval.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-19: closed 056-run-dry-run-preview — Added osc run --dry-run preview for run packets
 - 2026-05-19: closed 055-plan-linter — added mechanical plan validation CLI
 - 2026-05-19: closed 053-plan-template-library — added plan template library and template-based plan creation
 - 2026-05-19: closed 078-github-actions-node24-runtime-refresh — refreshed GitHub Actions pins after Node 20 deprecation annotation

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -70,6 +70,15 @@ Then fill every TODO before implementation. The helpers create and move structur
 
 Implement what the plan says. Independent tasks can run in parallel. Every change must trace back to a plan file or amendment.
 
+Before creating a durable run packet, preview what Open Scaffold would package:
+
+```bash
+osc run .osc/plans/active/<plan>.md --dry-run --runtime omx --workflow plan
+osc run .osc/plans/active/<plan>.md --dry-run --json
+```
+
+`--dry-run` validates the plan, renders the `run.json` and package markdown in memory, lists files from the plan, and exits without creating `.osc/runs/` artifacts. Re-run without `--dry-run` only when the preview is acceptable.
+
 > **With OMC harness:** `/ralph` for Claude Code autonomous completion loops; `/team` or `/ultrawork` for parallel fan-out across multiple Claude Code-oriented agents.
 >
 > **With OMX harness:** `$ralph` for Codex persistent completion loops; `$team` for tmux-backed Codex worker teams; `$ultrawork` for parallel execution; promote runtime evidence back into Open Scaffold.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import type { ParsedPlan } from './scaffold.js';
 
@@ -34,6 +34,88 @@ export interface RunArtifacts {
   promptPaths: string[];
 }
 
+export interface PackageQuality {
+  executable: boolean;
+  blockers: string[];
+  requiredAction: string | null;
+}
+
+export interface RunManifest {
+  schemaVersion: 'open-scaffold.run.v1';
+  runId: string;
+  taskId: string | null;
+  mode: ArtifactMode;
+  status: 'created';
+  lifecycleStates: string[];
+  createdAt: string;
+  updatedAt: string;
+  namespace: '.osc';
+  sourceRefs: string[];
+  plan: {
+    slug: string;
+    path: string;
+    goal: string;
+    filesToTouch: string[];
+    acceptanceCriteria: string[];
+    verificationSteps: string[];
+    openQuestions: string[];
+  };
+  packageQuality: PackageQuality;
+  runtimeSelection: {
+    runtime: string | null;
+    workflow: RuntimeWorkflow | null;
+    profileId: string | null;
+    profileSource: string | null;
+    note: string;
+  };
+  executor: {
+    lane: ExecutorLane | null;
+    harnessSkill: string | null;
+    spawning: false;
+    note: string;
+  };
+  runtime: {
+    repoPath: string | null;
+    worktreePath: string | null;
+    branch: string | null;
+    tmuxSession: null;
+    processId: null;
+  };
+  bindings: {
+    operatorSurface: OperatorSurface;
+    operatorThreadId: string | null;
+    githubIssue: string | null;
+    githubPr: string | null;
+  };
+  artifacts: {
+    runDir: string;
+    manifest: string;
+    prompts: string[];
+    logs: string[];
+    outputs: string[];
+    evidence: string[];
+  };
+  questions: string[];
+  commitPolicy: string;
+  note: string;
+}
+
+export interface PromptPreview {
+  relativePath: string;
+  absolutePath: string;
+  content: string;
+}
+
+export interface RunArtifactsPreview {
+  runId: string;
+  runDir: string;
+  manifestPath: string;
+  promptFiles: PromptPreview[];
+  manifest: RunManifest;
+  packageMarkdown: string;
+  filesToTouch: string[];
+}
+
 function timestamp(): string {
   return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
 }
@@ -56,8 +138,18 @@ function blockingOpenQuestions(plan: ParsedPlan): string[] {
   return plan.openQuestions.filter(isBlockingOpenQuestion);
 }
 
-function contextQuality(plan: ParsedPlan): { executable: boolean; blockers: string[]; requiredAction: string | null } {
+function missionBlocker(root: string): string | null {
+  const missionPath = join(root, 'MISSION.md');
+  if (!existsSync(missionPath)) return 'undefined mission';
+  const text = readFileSync(missionPath, 'utf8');
+  if (/mission:unset/i.test(text) || /TODO:\s*define mission/i.test(text)) return 'undefined mission';
+  return null;
+}
+
+function contextQuality(root: string, plan: ParsedPlan): PackageQuality {
   const blockers: string[] = [];
+  const mission = missionBlocker(root);
+  if (mission) blockers.push(mission);
   if (!plan.goal.trim()) blockers.push('missing goal');
   if (plan.acceptanceCriteria.length === 0) blockers.push('missing acceptance criteria');
   if (plan.verificationSteps.length === 0) blockers.push('missing verification steps');
@@ -111,24 +203,37 @@ function promptForGroup(plan: ParsedPlan, groupName: string, tasks: string, runI
   ].join('\n');
 }
 
-export function createRunArtifacts(root: string, plan: ParsedPlan, mode: ArtifactMode = 'run', options: RunArtifactOptions = {}): RunArtifacts {
+function packageMarkdownFor(promptFiles: PromptPreview[]): string {
+  const sections = promptFiles.flatMap((prompt) => [
+    `## ${prompt.relativePath}`,
+    '',
+    '```markdown',
+    prompt.content.trimEnd(),
+    '```',
+    '',
+  ]);
+  return ['# Open Scaffold Run Package', '', ...sections].join('\n');
+}
+
+function buildRunArtifacts(root: string, plan: ParsedPlan, mode: ArtifactMode, options: RunArtifactOptions): RunArtifactsPreview {
   const runId = `${timestamp()}-${slugify(plan.slug)}-${mode}`;
   const runDir = join(root, '.osc', 'runs', runId);
   const promptDir = join(runDir, 'prompts');
-  mkdirSync(promptDir, { recursive: true });
 
   const groups = plan.executionStrategy?.groups?.length
     ? plan.executionStrategy.groups.map((g) => ({ name: g.name, tasks: g.tasks }))
     : [{ name: 'Single Session', tasks: `Execute plan ${plan.slug}.` }];
 
-  const promptPaths: string[] = [];
-  for (const group of groups) {
-    const file = join(promptDir, `${slugify(group.name)}.md`);
-    writeFileSync(file, promptForGroup(plan, group.name, group.tasks, runId, options), 'utf8');
-    promptPaths.push(file);
-  }
+  const promptFiles = groups.map((group) => {
+    const absolutePath = join(promptDir, `${slugify(group.name)}.md`);
+    return {
+      absolutePath,
+      relativePath: relative(root, absolutePath),
+      content: promptForGroup(plan, group.name, group.tasks, runId, options),
+    };
+  });
 
-  const quality = contextQuality(plan);
+  const quality = contextQuality(root, plan);
   const createdAt = new Date().toISOString();
   const relativeOrNull = (value?: string) => value ?? null;
   const sourceRefs = [
@@ -139,7 +244,7 @@ export function createRunArtifacts(root: string, plan: ParsedPlan, mode: Artifac
   ].filter((value): value is string => Boolean(value));
 
   const manifestPath = join(runDir, 'run.json');
-  writeFileSync(manifestPath, JSON.stringify({
+  const manifest: RunManifest = {
     schemaVersion: 'open-scaffold.run.v1',
     runId,
     taskId: options.taskId ?? null,
@@ -154,6 +259,7 @@ export function createRunArtifacts(root: string, plan: ParsedPlan, mode: Artifac
       slug: plan.slug,
       path: relative(root, plan.path),
       goal: plan.goal,
+      filesToTouch: plan.filesToTouch,
       acceptanceCriteria: plan.acceptanceCriteria,
       verificationSteps: plan.verificationSteps,
       openQuestions: plan.openQuestions,
@@ -188,7 +294,7 @@ export function createRunArtifacts(root: string, plan: ParsedPlan, mode: Artifac
     artifacts: {
       runDir: relative(root, runDir),
       manifest: relative(root, manifestPath),
-      prompts: promptPaths.map((p) => relative(root, p)),
+      prompts: promptFiles.map((prompt) => prompt.relativePath),
       logs: [],
       outputs: [],
       evidence: [],
@@ -196,7 +302,34 @@ export function createRunArtifacts(root: string, plan: ParsedPlan, mode: Artifac
     questions: [],
     commitPolicy: options.commitPolicy ?? 'no commit/push unless explicitly approved by the operator',
     note: 'Canonical lifecycle belongs to the task/run record. Chat threads mirror/control via bindings; they are not canonical task identity.',
-  }, null, 2) + '\n', 'utf8');
+  };
 
-  return { runId, runDir, manifestPath, promptPaths };
+  return {
+    runId,
+    runDir,
+    manifestPath,
+    promptFiles,
+    manifest,
+    packageMarkdown: packageMarkdownFor(promptFiles),
+    filesToTouch: plan.filesToTouch,
+  };
+}
+
+export function previewRunArtifacts(root: string, plan: ParsedPlan, mode: ArtifactMode = 'run', options: RunArtifactOptions = {}): RunArtifactsPreview {
+  return buildRunArtifacts(root, plan, mode, options);
+}
+
+export function createRunArtifacts(root: string, plan: ParsedPlan, mode: ArtifactMode = 'run', options: RunArtifactOptions = {}): RunArtifacts {
+  const preview = buildRunArtifacts(root, plan, mode, options);
+  mkdirSync(join(preview.runDir, 'prompts'), { recursive: true });
+
+  const promptPaths: string[] = [];
+  for (const prompt of preview.promptFiles) {
+    writeFileSync(prompt.absolutePath, prompt.content, 'utf8');
+    promptPaths.push(prompt.absolutePath);
+  }
+
+  writeFileSync(preview.manifestPath, JSON.stringify(preview.manifest, null, 2) + '\n', 'utf8');
+
+  return { runId: preview.runId, runDir: preview.runDir, manifestPath: preview.manifestPath, promptPaths };
 }

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -25,6 +25,8 @@ export interface RunArtifactOptions {
   issue?: string;
   pr?: string;
   commitPolicy?: string;
+  /** Internal root used for mission/package-quality checks when artifacts are written elsewhere. */
+  scaffoldRoot?: string;
 }
 
 export interface RunArtifacts {
@@ -233,7 +235,7 @@ function buildRunArtifacts(root: string, plan: ParsedPlan, mode: ArtifactMode, o
     };
   });
 
-  const quality = contextQuality(root, plan);
+  const quality = contextQuality(options.scaffoldRoot ?? root, plan);
   const createdAt = new Date().toISOString();
   const relativeOrNull = (value?: string) => value ?? null;
   const sourceRefs = [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { renderAuditManifest, validateAuditManifestFile, writeAuditManifest, type AuditArtifactInput } from './audit.js';
-import { createRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
+import { createRunArtifacts, previewRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
 import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
@@ -29,7 +29,7 @@ Usage:
   osc evidence new <slug>
   osc close <plan-slug> [--message <text>]
   osc delegate <plan-path> [run binding options]
-  osc run <plan-path> [run binding options]
+  osc run <plan-path> [--dry-run] [--json] [run binding options]
   osc review <plan-path> [run binding options]
   osc ultrareview <plan-path> [run binding options]
   osc eval init <run-or-plan> [--out <path>]
@@ -138,10 +138,12 @@ function applyRuntimeSelection(options: RunArtifactOptions, root: string): void 
   }
 }
 
-function parseRunOptions(args: string[]): { planPathArg: string; options: RunArtifactOptions } {
+function parseRunOptions(args: string[]): { planPathArg: string; options: RunArtifactOptions; dryRun: boolean; json: boolean } {
   const planPathArg = requireArg(args, 'plan-path');
   const rest = args.slice(1);
   const options: RunArtifactOptions = {};
+  let dryRun = false;
+  let json = false;
 
   function takeValue(index: number, flag: string): string {
     const value = rest[index + 1];
@@ -211,6 +213,12 @@ function parseRunOptions(args: string[]): { planPathArg: string; options: RunArt
         options.commitPolicy = takeValue(i, flag);
         i += 1;
         break;
+      case '--dry-run':
+        dryRun = true;
+        break;
+      case '--json':
+        json = true;
+        break;
       default:
         console.error(`Unknown option for run artifacts: ${flag}`);
         printHelp();
@@ -219,7 +227,7 @@ function parseRunOptions(args: string[]): { planPathArg: string; options: RunArt
   }
 
   applyRuntimeSelection(options, options.repo ? resolve(options.repo) : process.cwd());
-  return { planPathArg, options };
+  return { planPathArg, options, dryRun, json };
 }
 
 function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string; force: boolean; fromExisting: boolean } {
@@ -635,13 +643,59 @@ function closeCommand(args: string[]): void {
 }
 
 function createArtifacts(args: string[], mode: ArtifactMode): void {
-  const { planPathArg, options } = parseRunOptions(args);
+  const { planPathArg, options, dryRun, json } = parseRunOptions(args);
   const planPath = resolve(planPathArg);
   if (!existsSync(planPath)) {
     console.error(`Plan not found: ${planPath}`);
     process.exit(1);
   }
   const plan = parsePlanFile(planPath);
+
+  if (dryRun) {
+    if (mode !== 'run') {
+      console.error('--dry-run is only supported for osc run');
+      process.exit(2);
+    }
+    const preview = previewRunArtifacts(process.cwd(), plan, mode, options);
+    const payload = {
+      run: preview.manifest,
+      packageMarkdown: preview.packageMarkdown,
+      filesToTouch: preview.filesToTouch,
+    };
+    if (json) {
+      console.log(JSON.stringify(payload, null, 2));
+    } else {
+      const executor = preview.manifest.executor.lane ?? 'unspecified';
+      const workflow = preview.manifest.runtimeSelection.workflow ?? 'unspecified';
+      const harnessSkill = preview.manifest.executor.harnessSkill ?? 'none';
+      console.log('Dry-run run.json:');
+      console.log(JSON.stringify(preview.manifest, null, 2));
+      console.log('');
+      console.log('Dry-run package.md:');
+      console.log(preview.packageMarkdown);
+      console.log('Dry-run summary:');
+      console.log(`Would create run ${preview.runId} in ${preview.manifest.artifacts.runDir} with executor ${executor}, workflow ${workflow}, harness skill ${harnessSkill}.`);
+      if (preview.filesToTouch.length) {
+        console.log('Files to touch:');
+        for (const file of preview.filesToTouch) console.log(`  - ${file}`);
+      } else {
+        console.log('Files to touch: none listed.');
+      }
+      if (!preview.manifest.packageQuality.executable) {
+        console.log('Blockers:');
+        for (const blocker of preview.manifest.packageQuality.blockers) console.log(`  - ${blocker}`);
+      }
+      console.log('No files were written. Re-run without --dry-run to create .osc/runs artifacts.');
+    }
+    if (!preview.manifest.packageQuality.executable) process.exit(1);
+    return;
+  }
+
+  if (json) {
+    console.error('--json is only supported with --dry-run for osc run');
+    process.exit(2);
+  }
+
   const run = createRunArtifacts(process.cwd(), plan, mode, options);
   console.log(`Created ${mode} artifacts:`);
   console.log(`  Run: ${run.runDir}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -226,7 +226,6 @@ function parseRunOptions(args: string[]): { planPathArg: string; options: RunArt
     }
   }
 
-  applyRuntimeSelection(options, options.repo ? resolve(options.repo) : process.cwd());
   return { planPathArg, options, dryRun, json };
 }
 
@@ -649,6 +648,10 @@ function createArtifacts(args: string[], mode: ArtifactMode): void {
     console.error(`Plan not found: ${planPath}`);
     process.exit(1);
   }
+  const scaffoldRoot = findScaffoldRoot(dirname(planPath)) ?? findScaffoldRoot(process.cwd()) ?? process.cwd();
+  applyRuntimeSelection(options, options.repo ? resolve(options.repo) : scaffoldRoot);
+  const artifactRoot = dryRun ? scaffoldRoot : process.cwd();
+  const artifactOptions: RunArtifactOptions = { ...options, scaffoldRoot };
   const plan = parsePlanFile(planPath);
 
   if (dryRun) {
@@ -656,7 +659,7 @@ function createArtifacts(args: string[], mode: ArtifactMode): void {
       console.error('--dry-run is only supported for osc run');
       process.exit(2);
     }
-    const preview = previewRunArtifacts(process.cwd(), plan, mode, options);
+    const preview = previewRunArtifacts(artifactRoot, plan, mode, artifactOptions);
     const payload = {
       run: preview.manifest,
       packageMarkdown: preview.packageMarkdown,
@@ -696,7 +699,7 @@ function createArtifacts(args: string[], mode: ArtifactMode): void {
     process.exit(2);
   }
 
-  const run = createRunArtifacts(process.cwd(), plan, mode, options);
+  const run = createRunArtifacts(artifactRoot, plan, mode, artifactOptions);
   console.log(`Created ${mode} artifacts:`);
   console.log(`  Run: ${run.runDir}`);
   console.log(`  Manifest: ${run.manifestPath}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { renderAuditManifest, validateAuditManifestFile, writeAuditManifest, type AuditArtifactInput } from './audit.js';
 import { createRunArtifacts, previewRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
@@ -227,6 +227,27 @@ function parseRunOptions(args: string[]): { planPathArg: string; options: RunArt
   }
 
   return { planPathArg, options, dryRun, json };
+}
+
+function printRunArtifactsUsage(mode: ArtifactMode): void {
+  const dryRunOptions = mode === 'run' ? ' [--dry-run] [--json]' : '';
+  console.log(`Usage: osc ${mode} <plan-path>${dryRunOptions} [run binding options]
+
+Run binding options:
+  --task-id <id>              Canonical task/card/issue id for this work item
+  --source-ref <ref>          Additional source ref; repeatable
+  --runtime <preset>          omc | omx | plain | human | custom
+  --workflow <workflow>       interview | plan | team | loop | execute | goal | custom
+  --executor <lane>           omc-claude | omx-codex | plain-agent | human | custom
+  --harness-skill <skill>     e.g. /ralplan, $ralplan, /ralph, $ultrawork
+  --repo <path>               Repository path for execution
+  --worktree <path>           Worktree path for isolated execution
+  --branch <name>             Branch expected for the run
+  --operator-surface <name>   discord | slack | telegram | github | cli | none | custom
+  --operator-thread <id>      Optional chat/thread/comment binding id
+  --issue <id-or-url>         Optional GitHub issue binding
+  --pr <id-or-url>            Optional PR binding
+  --commit-policy <text>      Commit/push approval rule${mode === 'run' ? '\n\nDry-run options:\n  --dry-run                   Preview run artifacts without writing .osc/runs files\n  --json                      With --dry-run, print only machine-readable JSON' : ''}`);
 }
 
 function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string; force: boolean; fromExisting: boolean } {
@@ -642,15 +663,20 @@ function closeCommand(args: string[]): void {
 }
 
 function createArtifacts(args: string[], mode: ArtifactMode): void {
+  if (args[0] === '-h' || args[0] === '--help' || args[0] === 'help') {
+    printRunArtifactsUsage(mode);
+    return;
+  }
   const { planPathArg, options, dryRun, json } = parseRunOptions(args);
-  const planPath = resolve(planPathArg);
-  if (!existsSync(planPath)) {
-    console.error(`Plan not found: ${planPath}`);
+  const absolutePlanPath = resolve(planPathArg);
+  if (!existsSync(absolutePlanPath)) {
+    console.error(`Plan not found: ${absolutePlanPath}`);
     process.exit(1);
   }
+  const planPath = realpathSync(absolutePlanPath);
   const scaffoldRoot = findScaffoldRoot(dirname(planPath)) ?? findScaffoldRoot(process.cwd()) ?? process.cwd();
   applyRuntimeSelection(options, options.repo ? resolve(options.repo) : scaffoldRoot);
-  const artifactRoot = dryRun ? scaffoldRoot : process.cwd();
+  const artifactRoot = process.cwd();
   const artifactOptions: RunArtifactOptions = { ...options, scaffoldRoot };
   const plan = parsePlanFile(planPath);
 

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mkdtempSync, mkdirSync, readdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createRunArtifacts } from '../src/artifacts.js';
+import { createRunArtifacts, previewRunArtifacts } from '../src/artifacts.js';
 
 function tempRepo() {
   const root = mkdtempSync(join(tmpdir(), 'osc-artifacts-'));
@@ -132,6 +132,33 @@ describe('run artifact generation', () => {
 
     expect(manifest.runtimeSelection).toMatchObject({ runtime: 'omx', workflow: 'plan' });
     expect(manifest.executor).toMatchObject({ lane: 'omx-codex', harnessSkill: '$ralplan', spawning: false });
+  });
+
+  it('previews run artifacts in memory without creating .osc/runs files', () => {
+    const root = tempRepo();
+    const planWithFiles = {
+      ...plan,
+      filesToTouch: ['src/artifacts.ts', 'src/cli.ts'],
+    };
+
+    const preview = previewRunArtifacts(root, planWithFiles as any, 'run', {
+      runtime: 'omx',
+      workflow: 'plan',
+      executor: 'omx-codex',
+      harnessSkill: '$ralplan',
+    });
+
+    expect(existsSync(join(root, '.osc/runs'))).toBe(false);
+    expect(preview.runId).toContain('001-demo-run');
+    expect(preview.manifest.runId).toBe(preview.runId);
+    expect(preview.manifest.artifacts.runDir).toContain('.osc/runs/');
+    expect(preview.manifest.artifacts.manifest).toContain('run.json');
+    expect(preview.manifest.executor).toMatchObject({ lane: 'omx-codex', harnessSkill: '$ralplan', spawning: false });
+    expect(preview.manifest.runtimeSelection).toMatchObject({ runtime: 'omx', workflow: 'plan' });
+    expect(preview.manifest.plan.filesToTouch).toEqual(['src/artifacts.ts', 'src/cli.ts']);
+    expect(preview.packageMarkdown).toContain('# Open Scaffold Prompt: Group A');
+    expect(preview.promptFiles).toHaveLength(1);
+    expect(preview.promptFiles[0].relativePath).toBe('.osc/runs/' + preview.runId + '/prompts/group-a.md');
   });
 
 });

--- a/tests/cli-run-dry-run.test.ts
+++ b/tests/cli-run-dry-run.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -102,6 +102,15 @@ This plan intentionally lacks dispatch-ready context.
 `;
 
 describe('osc run --dry-run', () => {
+  it('prints run-specific help instead of treating --help as a plan path', () => {
+    const result = spawnSync(tsx, [cli, 'run', '--help'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Usage: osc run <plan-path> [--dry-run] [--json] [run binding options]');
+    expect(result.stdout).toContain('Dry-run options:');
+  });
+
   it('prints a run preview and summary without creating .osc/runs files', () => {
     const target = initializedScaffold();
     const planPath = writePlan(target, '001-dry-run-demo', validPlan);
@@ -152,9 +161,35 @@ describe('osc run --dry-run', () => {
     const parsed = JSON.parse(result.stdout);
     expect(parsed.run.packageQuality.executable).toBe(true);
     expect(parsed.run.packageQuality.blockers).toEqual([]);
-    expect(parsed.run.artifacts.runDir).toContain('.osc/runs/');
-    expect(parsed.run.plan.path).toBe('.osc/plans/active/001-dry-run-demo.md');
-    expect(existsSync(join(target, '.osc/runs'))).toBe(false);
+    expect(existsSync(join(subdir, '.osc/runs'))).toBe(false);
+
+    const writeResult = spawnSync(tsx, [cli, 'run', planPath, '--runtime', 'omx', '--workflow', 'plan'], { cwd: subdir, encoding: 'utf8' });
+    expect(writeResult.status).toBe(0);
+    const runsDir = join(subdir, '.osc/runs');
+    const runId = readdirSync(runsDir).sort().at(-1) as string;
+    const manifest = JSON.parse(readFileSync(join(runsDir, runId, 'run.json'), 'utf8'));
+    expect(parsed.run.artifacts.runDir.replace(parsed.run.runId, '<run>')).toBe(manifest.artifacts.runDir.replace(manifest.runId, '<run>'));
+    expect(parsed.run.artifacts.manifest.replace(parsed.run.runId, '<run>')).toBe(manifest.artifacts.manifest.replace(manifest.runId, '<run>'));
+    expect(manifest.packageQuality.executable).toBe(true);
+  });
+
+  it('keeps dry-run artifact paths aligned with write-mode run paths from the caller cwd', () => {
+    const target = initializedScaffold();
+    const planPath = writePlan(target, '001-dry-run-demo', validPlan);
+    const subdir = join(target, 'src');
+    mkdirSync(subdir, { recursive: true });
+
+    const dryRun = spawnSync(tsx, [cli, 'run', planPath, '--dry-run', '--json'], { cwd: subdir, encoding: 'utf8' });
+    expect(dryRun.status).toBe(0);
+    const preview = JSON.parse(dryRun.stdout);
+    expect(preview.run.artifacts.runDir).toMatch(/^\.osc\/runs\//);
+    expect(existsSync(join(subdir, '.osc/runs'))).toBe(false);
+
+    const writeRun = spawnSync(tsx, [cli, 'run', planPath], { cwd: subdir, encoding: 'utf8' });
+    expect(writeRun.status).toBe(0);
+    expect(writeRun.stderr).toBe('');
+    expect(writeRun.stdout).toContain(join(subdir, '.osc/runs'));
+    expect(existsSync(join(subdir, '.osc/runs'))).toBe(true);
   });
 
   it('reports non-executable dry-runs without writing artifacts', () => {

--- a/tests/cli-run-dry-run.test.ts
+++ b/tests/cli-run-dry-run.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempDir(prefix = 'osc-run-dry-run-') {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function initializedScaffold() {
+  const target = tempDir();
+  execFileSync(tsx, [cli, 'init', '--tier', 'min', '--target', target], { encoding: 'utf8' });
+  writeFileSync(join(target, 'MISSION.md'), '# Mission\n\nTest repo mission for dry-run previews.\n', 'utf8');
+  return target;
+}
+
+function scaffoldWithUnsetMission() {
+  const target = tempDir();
+  execFileSync(tsx, [cli, 'init', '--tier', 'min', '--target', target], { encoding: 'utf8' });
+  return target;
+}
+
+function writePlan(root: string, slug: string, body: string) {
+  const path = join(root, '.osc/plans/active', `${slug}.md`);
+  writeFileSync(path, body, 'utf8');
+  return path;
+}
+
+const validPlan = `# Plan: 001-dry-run-demo
+
+## Status
+
+active
+
+## Context
+
+A valid plan for previewing a run packet.
+
+## Goal
+
+Preview run artifacts without writing a run directory.
+
+## Constraints / Out of scope
+
+- Do not spawn a runtime.
+
+## Files to touch
+
+- src/demo.ts
+- tests/demo.test.ts
+
+## Acceptance criteria
+
+- [ ] Dry-run emits a preview.
+- [ ] Dry-run leaves .osc/runs unchanged.
+
+## Verification steps
+
+1. Run npm test.
+2. Run ./verify.sh --strict.
+
+## Open questions
+
+None.
+`;
+
+const invalidPlan = `# Plan: 002-bad-dry-run
+
+## Status
+
+active
+
+## Context
+
+This plan intentionally lacks dispatch-ready context.
+
+## Goal
+
+
+## Constraints / Out of scope
+
+- None.
+
+## Files to touch
+
+- src/demo.ts
+
+## Acceptance criteria
+
+
+## Verification steps
+
+
+## Open questions
+
+- BLOCKING: Which acceptance criteria should this satisfy?
+`;
+
+describe('osc run --dry-run', () => {
+  it('prints a run preview and summary without creating .osc/runs files', () => {
+    const target = initializedScaffold();
+    const planPath = writePlan(target, '001-dry-run-demo', validPlan);
+    const before = existsSync(join(target, '.osc/runs')) ? readdirSync(join(target, '.osc/runs')) : [];
+
+    const result = spawnSync(tsx, [cli, 'run', planPath, '--dry-run', '--runtime', 'omx', '--workflow', 'plan'], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Dry-run run.json:');
+    expect(result.stdout).toContain('"schemaVersion": "open-scaffold.run.v1"');
+    expect(result.stdout).toContain('Dry-run package.md:');
+    expect(result.stdout).toContain('Would create run');
+    expect(result.stdout).toContain('executor omx-codex');
+    expect(result.stdout).toContain('workflow plan');
+    expect(result.stdout).toContain('harness skill $ralplan');
+    expect(result.stdout).toContain('src/demo.ts');
+    const after = existsSync(join(target, '.osc/runs')) ? readdirSync(join(target, '.osc/runs')) : [];
+    expect(after).toEqual(before);
+  });
+
+  it('supports JSON-only dry-run output for machine consumers', () => {
+    const target = initializedScaffold();
+    const planPath = writePlan(target, '001-dry-run-demo', validPlan);
+
+    const result = spawnSync(tsx, [cli, 'run', planPath, '--dry-run', '--json', '--executor', 'plain-agent', '--workflow', 'execute'], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.run.schemaVersion).toBe('open-scaffold.run.v1');
+    expect(parsed.run.executor).toMatchObject({ lane: 'plain-agent', spawning: false });
+    expect(parsed.run.runtimeSelection).toMatchObject({ workflow: 'execute' });
+    expect(parsed.packageMarkdown).toContain('# Open Scaffold Prompt: Single Session');
+    expect(parsed.filesToTouch).toEqual(['src/demo.ts', 'tests/demo.test.ts']);
+  });
+
+  it('reports non-executable dry-runs without writing artifacts', () => {
+    const target = initializedScaffold();
+    const planPath = writePlan(target, '002-bad-dry-run', invalidPlan);
+
+    const result = spawnSync(tsx, [cli, 'run', planPath, '--dry-run', '--json'], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.run.packageQuality.executable).toBe(false);
+    expect(parsed.run.packageQuality.blockers).toContain('missing goal');
+    expect(parsed.run.packageQuality.blockers).toContain('missing acceptance criteria');
+    expect(parsed.run.packageQuality.blockers).toContain('missing verification steps');
+    expect(parsed.run.packageQuality.blockers).toContain('blocking open questions present');
+    expect(existsSync(join(target, '.osc/runs'))).toBe(false);
+  });
+
+  it('treats an undefined mission as a dry-run blocker', () => {
+    const target = scaffoldWithUnsetMission();
+    const planPath = writePlan(target, '001-dry-run-demo', validPlan);
+
+    const result = spawnSync(tsx, [cli, 'run', planPath, '--dry-run', '--json'], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.run.packageQuality.executable).toBe(false);
+    expect(parsed.run.packageQuality.blockers).toContain('undefined mission');
+    expect(existsSync(join(target, '.osc/runs'))).toBe(false);
+  });
+
+  it('keeps missing-plan dry-runs read-only and reports the missing path', () => {
+    const target = initializedScaffold();
+    const result = spawnSync(tsx, [cli, 'run', '.osc/plans/active/nope.md', '--dry-run'], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Plan not found:');
+    expect(existsSync(join(target, '.osc/runs'))).toBe(false);
+  });
+});

--- a/tests/cli-run-dry-run.test.ts
+++ b/tests/cli-run-dry-run.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -137,6 +137,24 @@ describe('osc run --dry-run', () => {
     expect(parsed.run.runtimeSelection).toMatchObject({ workflow: 'execute' });
     expect(parsed.packageMarkdown).toContain('# Open Scaffold Prompt: Single Session');
     expect(parsed.filesToTouch).toEqual(['src/demo.ts', 'tests/demo.test.ts']);
+  });
+
+  it('resolves scaffold root from the plan path when run from a subdirectory', () => {
+    const target = initializedScaffold();
+    const planPath = writePlan(target, '001-dry-run-demo', validPlan);
+    const subdir = join(target, 'src');
+    mkdirSync(subdir, { recursive: true });
+
+    const result = spawnSync(tsx, [cli, 'run', planPath, '--dry-run', '--json', '--runtime', 'omx', '--workflow', 'plan'], { cwd: subdir, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.run.packageQuality.executable).toBe(true);
+    expect(parsed.run.packageQuality.blockers).toEqual([]);
+    expect(parsed.run.artifacts.runDir).toContain('.osc/runs/');
+    expect(parsed.run.plan.path).toBe('.osc/plans/active/001-dry-run-demo.md');
+    expect(existsSync(join(target, '.osc/runs'))).toBe(false);
   });
 
   it('reports non-executable dry-runs without writing artifacts', () => {


### PR DESCRIPTION
## Summary

Adds `osc run <plan> --dry-run` so users can preview run packets before creating durable `.osc/runs/` artifacts.

This PR:
- Adds in-memory run preview generation for `run.json` and package markdown.
- Adds `--json` output for machine consumers.
- Reports non-executable blockers, including missing mission, missing goal/AC/verification, and blocking open questions.
- Resolves package-quality/mission checks from the plan scaffold root while keeping dry-run artifact paths aligned with real write-mode `osc run` behavior.
- Preserves external-coordinator `osc run --repo <target>` behavior: project-local runtime profiles resolve from the target repo while artifacts write under the caller/coordinator cwd.
- Adds run-specific `osc run --help` output for the new dry-run flags.
- Lists planned files-to-touch and confirms no files were written.
- Keeps normal `osc run`, `delegate`, `review`, and `ultrareview` artifact creation write-based and non-spawning.
- Closes plan `056-run-dry-run-preview` and prepares package candidate `0.4.6` because the public CLI surface changed.

## Traceability

- Plan: `.osc/plans/done/056-run-dry-run-preview.md`
- Evidence: `.osc/releases/2026-05-19-056-run-dry-run-preview.md`
- Kanban: `t_e3c46180`
- Branch: `cli/run-dry-run-preview`

## Verification

- [x] `npm test -- tests/cli-run-dry-run.test.ts --run` — pass; 1 file / 8 tests
- [x] `npm test -- tests/cli-run-dry-run.test.ts tests/cli-init.test.ts --run` — pass; 2 files / 34 tests
- [x] `npm run build` — pass
- [x] `npm test -- --run` — pass; 25 files / 218 tests
- [x] `git diff --check` — pass
- [x] `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn
- [x] Manual dry-run smoke against `.osc/plans/done/056-run-dry-run-preview.md` with `--runtime omx --workflow plan` — pass; schema `open-scaffold.run.v1`, executable `true`, executor `omx-codex`, workflow `plan`, harness `$ralplan`, package prompt present
- [x] No-write smoke — pass; `.osc/runs` entry count stayed 14 before/after dry-run
- [x] `npm pack --dry-run --json` — pass; `open-scaffold-0.4.6.tgz`, 95 files, unpacked size 603,376 bytes
- [x] `npm publish --dry-run` — pass; dry-run only, reported `+ open-scaffold@0.4.6`

## Owner gates

- Merge is owner-gated.
- Real npm publish is owner-gated.
- GitHub Release `v0.4.6` creation is owner-gated and should happen only after npm/latest verification if this PR merges.

## Codex review

- Codex P2 root-resolution finding fixed in `b7e66e2` with a subdirectory dry-run regression test.
- Codex P1 dry-run/write-mode artifact-root parity finding fixed in `a607740` by using caller cwd as the artifact root for both dry-run and write-mode paths while retaining scaffold-root mission/package-quality checks.
- Latest-head Codex review has been re-triggered after `a607740`; final readiness is determined from the PR conversation after that push.
