### PR TITLE
Fix lifecycle help flags

### DIFF
--- a/.osc/plans/done/081-lifecycle-help-flags.md
+++ b/.osc/plans/done/081-lifecycle-help-flags.md
@@ -1,0 +1,46 @@
+# Plan: 081-lifecycle-help-flags
+
+## Status
+
+done
+
+## Context
+
+The pinpoint dogfood scout checked the day-two plan lifecycle surface after recent plan helper PRs. `osc plan --help`, `osc plan new --help`, `osc plan move --help`, `osc amend --help`, and `osc close --help` currently enter normal execution paths instead of printing usage. That makes scripted or exploratory users hit ENOENT, missing-option, or unsafe-slug errors while trying to learn the lifecycle commands.
+
+## Goal
+
+Make plan lifecycle help flags print command-specific usage with exit code 0 instead of treating `--help` as a plan path, slug, or missing option.
+
+## Constraints / Out of scope
+
+- Do not change plan creation, movement, amendment, or close semantics.
+- Do not add new lifecycle commands or broad command-parser refactors.
+- Do not move, publish, merge, or release anything outside this focused help behavior.
+- Keep help text concise and aligned with existing root CLI usage.
+
+## Files to touch
+
+- `src/cli.ts` — route plan/amend/close help flags before normal execution.
+- `tests/cli-lifecycle-help.test.ts` — regression coverage for lifecycle help flags.
+- `.osc/releases/2026-05-20-081-lifecycle-help-flags.md` — evidence note for the pinpoint delta.
+
+## Acceptance criteria
+
+- [x] `osc plan --help` exits 0 and prints plan-specific usage.
+- [x] `osc plan new --help`, `osc plan move --help`, `osc plan validate --help`, and `osc plan wizard --help` exit 0 and print subcommand-specific usage.
+- [x] `osc amend --help` and `osc close --help` exit 0 and print lifecycle usage instead of unsafe-slug errors.
+- [x] Existing lifecycle behavior and validation remain unchanged.
+
+## Verification steps
+
+1. `npm test -- tests/cli-lifecycle-help.test.ts --run` — targeted help regression tests pass.
+2. `npm run build` — TypeScript build passes.
+3. `npm test -- --run` — full Vitest suite passes.
+4. `./verify.sh --strict` — scaffold verification passes.
+5. `npm run osc -- verify` — CLI verifier passes.
+6. `git diff --check` — no whitespace errors.
+
+## Open questions
+
+- None.

--- a/.osc/releases/2026-05-20-081-lifecycle-help-flags.md
+++ b/.osc/releases/2026-05-20-081-lifecycle-help-flags.md
@@ -1,0 +1,37 @@
+# Release / Evidence Note: 081-lifecycle-help-flags
+
+## Summary
+
+Fixed a day-two plan lifecycle help gap: help flags for plan/amend/close commands now print command-specific usage instead of falling into execution paths. This keeps exploratory users and automation from seeing ENOENT, missing-option, or unsafe-slug errors when asking how to use the lifecycle helpers.
+
+## Traceability
+
+- Roadmap / issue / task: Open Scaffold pinpoint dogfood scout, plan lifecycle surface.
+- Plan: `.osc/plans/done/081-lifecycle-help-flags.md`.
+- Run ID / run packet: N/A — local CLI pinpoint fix, no runtime run packet needed.
+- Branch / PR: `fix/lifecycle-help-flags`; PR pending at initial commit time.
+- Automation provenance: Opened/advanced by John-Lo-Mein autopilot; cron job `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`; script `open-scaffold-prrunner-webhook-runner.py`; source `cron-open-scaffold-pr-runner`.
+- Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
+
+## Verification
+
+- Reproduction before fix: `node dist/cli.js plan --help` → exit 1, `ENOENT: no such file or directory, open '/Users/danimal/Projects/open-scaffold/--help'`.
+- Reproduction before fix: `node dist/cli.js plan new --help` / `plan move --help` → exit 2, missing required lifecycle options.
+- Reproduction before fix: `node dist/cli.js amend --help` / `close --help` → exit 2, unsafe slug errors.
+- `npm test -- tests/cli-lifecycle-help.test.ts --run` → pass; 1 file / 7 tests.
+- `npm run build` → pass.
+- `npm test -- --run` → pass; 27 files / 235 tests.
+- `./verify.sh --strict` → pass; 10 pass / 0 fail / 0 warn.
+- `npm run osc -- verify` → pass with one pre-existing backlog warning unrelated to this slice.
+- `git diff --check` → pass.
+
+## Outcome
+
+The lifecycle help pinpoint is fixed locally on `fix/lifecycle-help-flags`. `osc plan --help`, `osc plan new --help`, `osc plan validate --help`, `osc plan wizard --help`, `osc plan move --help`, `osc amend --help`, and `osc close --help` are covered by regression tests and route to usage output with exit code 0.
+
+Out of scope: parser refactor, new lifecycle commands, npm publish, GitHub Release changes, merge, or any plan lifecycle behavior change beyond help routing.
+
+## Follow-up
+
+- Open PR, trigger Codex, and keep latest-head review loop alive.
+- After merge approval, owner may separately decide whether to publish npm and create/move GitHub Release latest.

--- a/.osc/releases/2026-05-20-081-lifecycle-help-flags.md
+++ b/.osc/releases/2026-05-20-081-lifecycle-help-flags.md
@@ -9,7 +9,7 @@ Fixed a day-two plan lifecycle help gap: help flags for plan/amend/close command
 - Roadmap / issue / task: Open Scaffold pinpoint dogfood scout, plan lifecycle surface.
 - Plan: `.osc/plans/done/081-lifecycle-help-flags.md`.
 - Run ID / run packet: N/A — local CLI pinpoint fix, no runtime run packet needed.
-- Branch / PR: `fix/lifecycle-help-flags`; PR pending at initial commit time.
+- Branch / PR: `fix/lifecycle-help-flags`; PR #71, https://github.com/graphanov/open-scaffold/pull/71.
 - Automation provenance: Opened/advanced by John-Lo-Mein autopilot; cron job `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`; script `open-scaffold-prrunner-webhook-runner.py`; source `cron-open-scaffold-pr-runner`.
 - Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-20: closed 081-lifecycle-help-flags — Added lifecycle help flag handling
 - 2026-05-20: closed 057-automated-evidence-collection — added automated evidence collection CLI
 - 2026-05-20: align evidence collection with current .osc/releases evidence-note path — see .osc/plans/done/057-automated-evidence-collection-amendment-1.md
 - 2026-05-20: closed 080-readme-resume-screencast-dark-theme — README resume screencast replaced with dark theme media

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -352,8 +352,25 @@ interface PlanNewOptions {
   listTemplates: boolean;
 }
 
-function printPlanNewUsage(): void {
-  console.error('Usage: osc plan new <slug> --stage <active|backlog|blocked> [--from-template <name>] | osc plan new --from-template list');
+function printPlanUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc plan <plan-path>
+  osc plan new <slug> --stage <active|backlog|blocked> [--from-template <name>]
+  osc plan new --from-template list
+  osc plan validate <slug-or-path> [--json] [--strict]
+  osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]
+  osc plan move <slug> --to <active|backlog|blocked>`, stream);
+}
+
+function printPlanNewUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc plan new <slug> --stage <active|backlog|blocked> [--from-template <name>] | osc plan new --from-template list', stream);
+}
+
+function printPlanValidateUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc plan validate <slug-or-path> [--json] [--strict]', stream);
+}
+
+function printPlanMoveUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc plan move <slug> --to <active|backlog|blocked>', stream);
 }
 
 function parsePlanNewOptions(args: string[]): PlanNewOptions {
@@ -435,8 +452,8 @@ function parsePlanMoveDestination(args: string[]): PlanCreationStage {
   return toStage;
 }
 
-function printPlanWizardUsage(): void {
-  console.error('Usage: osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]');
+function printPlanWizardUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]', stream);
 }
 
 function parsePlanWizardOptions(args: string[]): { slug: string; stage: PlanCreationStage; nonInteractive: boolean; answersPath?: string } {
@@ -493,8 +510,18 @@ function parsePlanWizardOptions(args: string[]): { slug: string; stage: PlanCrea
 }
 
 async function planCommand(args: string[]): Promise<void> {
-  if (args[0] === 'new') {
-    const options = parsePlanNewOptions(args.slice(1));
+  const [subcommand, ...rest] = args;
+  if (subcommand === undefined || isHelpArg(subcommand)) {
+    printPlanUsage('stdout');
+    return;
+  }
+
+  if (subcommand === 'new') {
+    if (isHelpArg(rest[0])) {
+      printPlanNewUsage('stdout');
+      return;
+    }
+    const options = parsePlanNewOptions(rest);
     if (options.listTemplates) {
       try {
         const templates = listPlanTemplates(process.cwd());
@@ -519,17 +546,22 @@ async function planCommand(args: string[]): Promise<void> {
       exitForScaffoldHelperError(error);
     }
   }
-  if (args[0] === 'validate') {
-    const target = requireArg(args.slice(1), 'slug-or-path');
-    const rest = args.slice(2);
+
+  if (subcommand === 'validate') {
+    if (isHelpArg(rest[0])) {
+      printPlanValidateUsage('stdout');
+      return;
+    }
+    const target = requireArg(rest, 'slug-or-path');
+    const validateArgs = rest.slice(1);
     let json = false;
     let strict = false;
-    for (const flag of rest) {
+    for (const flag of validateArgs) {
       if (flag === '--json') json = true;
       else if (flag === '--strict') strict = true;
       else {
         console.error(`Unknown option for plan validate: ${flag}`);
-        console.error('Usage: osc plan validate <slug-or-path> [--json] [--strict]');
+        printPlanValidateUsage();
         process.exit(2);
       }
     }
@@ -547,8 +579,13 @@ async function planCommand(args: string[]): Promise<void> {
       exitForScaffoldHelperError(error);
     }
   }
-  if (args[0] === 'wizard') {
-    const options = parsePlanWizardOptions(args.slice(1));
+
+  if (subcommand === 'wizard') {
+    if (isHelpArg(rest[0])) {
+      printPlanWizardUsage('stdout');
+      return;
+    }
+    const options = parsePlanWizardOptions(rest);
     try {
       assertWizardReady(process.cwd());
       let answers: PlanWizardAnswers;
@@ -565,9 +602,14 @@ async function planCommand(args: string[]): Promise<void> {
       exitForScaffoldHelperError(error);
     }
   }
-  if (args[0] === 'move') {
-    const slug = requireArg(args.slice(1), 'slug');
-    const toStage = parsePlanMoveDestination(args.slice(2));
+
+  if (subcommand === 'move') {
+    if (isHelpArg(rest[0])) {
+      printPlanMoveUsage('stdout');
+      return;
+    }
+    const slug = requireArg(rest, 'slug');
+    const toStage = parsePlanMoveDestination(rest.slice(1));
     try {
       const result = movePlan(slug, toStage, process.cwd());
       if (result.alreadyInStage) {
@@ -583,6 +625,7 @@ async function planCommand(args: string[]): Promise<void> {
       exitForScaffoldHelperError(error);
     }
   }
+
   const planPath = resolve(requireArg(args, 'plan-path'));
   console.log(JSON.stringify(planToJson(parsePlanFile(planPath)), null, 2));
 }
@@ -675,6 +718,10 @@ function evidenceCommand(args: string[]): void {
   process.exit(2);
 }
 
+function printLifecycleUsage(command: 'amend' | 'close', stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc ${command} <plan-slug> [--message <text>]`, stream);
+}
+
 type LifecycleOptions = {
   slug: string;
   message: string;
@@ -697,13 +744,17 @@ function parseLifecycleOptions(args: string[], command: 'amend' | 'close'): Life
       continue;
     }
     console.error(`Unknown option for ${command}: ${flag}`);
-    console.error(`Usage: osc ${command} <plan-slug> [--message <text>]`);
+    printLifecycleUsage(command);
     process.exit(2);
   }
   return { slug, message };
 }
 
 function amendCommand(args: string[]): void {
+  if (isHelpArg(args[0])) {
+    printLifecycleUsage('amend', 'stdout');
+    return;
+  }
   const { slug, message } = parseLifecycleOptions(args, 'amend');
   try {
     const result = createPlanAmendment(slug, process.cwd(), message);
@@ -716,6 +767,10 @@ function amendCommand(args: string[]): void {
 }
 
 function closeCommand(args: string[]): void {
+  if (isHelpArg(args[0])) {
+    printLifecycleUsage('close', 'stdout');
+    return;
+  }
   const { slug, message } = parseLifecycleOptions(args, 'close');
   try {
     const result = closePlan(slug, process.cwd(), message);

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+type HelpCase = {
+  name: string;
+  args: string[];
+  expected: string;
+  forbidden?: string;
+};
+
+const cases: HelpCase[] = [
+  {
+    name: 'plan root',
+    args: ['plan', '--help'],
+    expected: 'Usage: osc plan <plan-path>',
+    forbidden: 'ENOENT',
+  },
+  {
+    name: 'plan new',
+    args: ['plan', 'new', '--help'],
+    expected: 'Usage: osc plan new <slug> --stage <active|backlog|blocked>',
+    forbidden: 'Missing required option',
+  },
+  {
+    name: 'plan validate',
+    args: ['plan', 'validate', '--help'],
+    expected: 'Usage: osc plan validate <slug-or-path> [--json] [--strict]',
+    forbidden: 'Missing required argument',
+  },
+  {
+    name: 'plan wizard',
+    args: ['plan', 'wizard', '--help'],
+    expected: 'Usage: osc plan wizard <slug>',
+    forbidden: 'Missing required argument',
+  },
+  {
+    name: 'plan move',
+    args: ['plan', 'move', '--help'],
+    expected: 'Usage: osc plan move <slug> --to <active|backlog|blocked>',
+    forbidden: 'Missing required option',
+  },
+  {
+    name: 'amend',
+    args: ['amend', '--help'],
+    expected: 'Usage: osc amend <plan-slug> [--message <text>]',
+    forbidden: 'Unsafe slug',
+  },
+  {
+    name: 'close',
+    args: ['close', '--help'],
+    expected: 'Usage: osc close <plan-slug> [--message <text>]',
+    forbidden: 'Unsafe slug',
+  },
+];
+
+describe('plan lifecycle help flags', () => {
+  for (const item of cases) {
+    it(`prints help for ${item.name}`, () => {
+      const result = spawnSync(tsx, [cli, ...item.args], { cwd: repoRoot, encoding: 'utf8' });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain(item.expected);
+      if (item.forbidden) expect(result.stdout + result.stderr).not.toContain(item.forbidden);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Routes `osc plan --help` plus lifecycle subcommand help flags to concise usage output with exit code 0.
- Adds regression coverage for `plan`, `plan new`, `plan validate`, `plan wizard`, `plan move`, `amend`, and `close` help paths.
- Closes the pinpoint dogfood plan and records release/evidence for the day-two lifecycle help gap.

## Traceability
- Plan: `.osc/plans/done/081-lifecycle-help-flags.md`
- Evidence: `.osc/releases/2026-05-20-081-lifecycle-help-flags.md`
- PR: https://github.com/graphanov/open-scaffold/pull/71
- Roadmap surface: Milestone 14 CLI and packaging UX / plan lifecycle friction
- Source: pinpoint dogfood scout surfaced the gap; John-Lo-Mein autopilot advanced it to PR.

## Automation provenance
Opened/advanced by John-Lo-Mein autopilot.
- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`
- Script: `open-scaffold-prrunner-webhook-runner.py`
- Source: `cron-open-scaffold-pr-runner`
- GitHub author/auth may display `graphanov`; this PR was opened by the autopilot lane using the owner's configured credentials.

## Verification
- `npm test -- tests/cli-lifecycle-help.test.ts --run` ✅ 1 file / 7 tests
- `npm run build` ✅ core + runtime-omx TypeScript build
- `npm test -- --run` ✅ 27 files / 235 tests
- `./verify.sh --strict` ✅ 10 pass / 0 fail / 0 warn
- `npm run osc -- verify` ✅ pass with one pre-existing backlog warning for `.osc/plans/backlog/062-glass-cockpit-webhooks.md`
- local help smoke for `node dist/cli.js plan --help`, `plan new --help`, `plan validate --help`, `plan wizard --help`, `plan move --help`, `amend --help`, and `close --help` ✅
- `npm pack --dry-run --json` ✅ package `open-scaffold@0.4.7`
- `git diff --check` ✅
- GitHub Actions `ci` ✅ success on head `4f8fdbeeef0daf106cf46feb9733308fef8204d1`

## Codex review
- Triggered with `@codex review` on 2026-05-20T10:42:38Z for head `4f8fdbeeef0daf106cf46feb9733308fef8204d1`.
- Latest Codex artifact: 2026-05-20T10:45:52Z, `Codex Review: Didn't find any major issues. Breezy!`
- Formal reviews inspected: none.
- Inline pull review comments inspected: none.
- Status: latest-head clean.

## Owner gates
- Merge is owner-gated.
- `npm publish` is owner-gated.
- GitHub Release creation/latest movement is owner-gated.
