### PR TITLE
Require plans before evidence notes

### DIFF
--- a/.osc/plans/done/082-evidence-new-plan-validation.md
+++ b/.osc/plans/done/082-evidence-new-plan-validation.md
@@ -1,0 +1,50 @@
+# Plan: 082-evidence-new-plan-validation
+
+## Status
+
+done
+
+## Context
+
+Pinpoint dogfood of the evidence flow found that `osc evidence new <slug>` can create a release/evidence note for a slug that has no matching plan. The next command in the same flow, `osc evidence collect <slug>`, then refuses the same slug because it cannot find a plan. This leaves a user with an orphan `.osc/releases/YYYY-MM-DD-<slug>.md` file and makes evidence traceability fail later instead of at creation time.
+
+## Goal
+
+Make `osc evidence new <slug>` require a matching plan in `.osc/plans/{active,backlog,blocked,done}` before writing a release/evidence note, aligning it with `osc evidence collect` and preserving the plan-to-evidence chain.
+
+## Constraints / Out of scope
+
+- Do not redesign evidence folders or introduce a separate `.osc/evidence/` store.
+- Do not change `osc evidence collect` collector behavior.
+- Do not edit existing done evidence notes except through a new release/evidence note for this slice.
+- Keep the failure message actionable and consistent with existing CLI helper wording.
+
+## Files to touch
+
+- `src/scaffold.ts` — add plan existence validation to `createEvidenceNoteSkeleton`.
+- `tests/cli-plan-evidence.test.ts` — require a plan before evidence note creation and cover missing-plan refusal.
+- `.osc/releases/2026-05-20-082-evidence-new-plan-validation.md` — capture traceability and verification evidence.
+- `.osc/plans/done/082-evidence-new-plan-validation.md` — close this plan after verification.
+- `MISSION.md` — close stamp from `osc close`.
+
+## Acceptance criteria
+
+- [ ] `osc evidence new <existing-plan-slug>` still creates `.osc/releases/YYYY-MM-DD-<slug>.md` with the existing skeleton content.
+- [ ] `osc evidence new <missing-plan-slug>` exits non-zero and does not create a release/evidence note.
+- [ ] The missing-plan error tells the user the matching plan was not found in `.osc/plans/{active,backlog,blocked,done}`.
+- [ ] Existing duplicate, unsafe slug, and missing-root evidence helper checks still pass.
+- [ ] Standard Open Scaffold verification, targeted evidence tests, full test suite, and build pass.
+
+## Verification steps
+
+1. Reproduce the bug in a temporary initialized scaffold before patching: `osc evidence new typo-noplan` creates an orphan note, then `osc evidence collect typo-noplan --dry-run` fails with `Plan not found`.
+2. Add a regression test for missing-plan evidence creation.
+3. Run `npm test -- tests/cli-plan-evidence.test.ts tests/evidence.test.ts --run`.
+4. Run `./verify.sh --strict`.
+5. Run `npm test -- --run`.
+6. Run `npm run build`.
+7. Re-run the temporary scaffold reproduction and confirm `osc evidence new typo-noplan` now fails before writing.
+
+## Open questions
+
+- None for this slice. A broader future enhancement could offer `osc evidence new --for-plan <slug>` aliases or plan search suggestions, but that is outside this pinpoint fix.

--- a/.osc/releases/2026-05-20-082-evidence-new-plan-validation.md
+++ b/.osc/releases/2026-05-20-082-evidence-new-plan-validation.md
@@ -9,7 +9,7 @@ This pinpoint dogfood slice tightens the evidence flow by making `osc evidence n
 - Roadmap / issue / task: Pinpoint dogfood surface `evidence flow`; no GitHub issue; not mirrored to a task board.
 - Plan: `.osc/plans/done/082-evidence-new-plan-validation.md`.
 - Run ID / run packet: N/A — direct pinpoint scout execution advanced by John-Lo-Mein autopilot.
-- Branch / PR: branch `fix/evidence-new-plan-validation`; PR pending.
+- Branch / PR: branch `fix/evidence-new-plan-validation`; PR https://github.com/graphanov/open-scaffold/pull/72.
 - Automation provenance: Opened/advanced by John-Lo-Mein autopilot; cron job `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`; script `open-scaffold-prrunner-webhook-runner.py`; source `cron-open-scaffold-pr-runner`.
 - Owner gates: merge, npm publish, GitHub Release.
 
@@ -30,5 +30,4 @@ This pinpoint dogfood slice tightens the evidence flow by making `osc evidence n
 
 ## Follow-up
 
-- Open the focused PR, patch this note with the PR URL, and run the latest-head Codex review loop.
-- Merge and npm/GitHub Release publication remain owner-gated.
+- Merge remains owner-gated; npm/GitHub Release publication remain owner-gated if this CLI behavior is released through the public package.

--- a/.osc/releases/2026-05-20-082-evidence-new-plan-validation.md
+++ b/.osc/releases/2026-05-20-082-evidence-new-plan-validation.md
@@ -23,6 +23,8 @@ This pinpoint dogfood slice tightens the evidence flow by making `osc evidence n
 - `npm run build` — pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
 - `node dist/cli.js evidence collect 082-evidence-new-plan-validation --dry-run` — pass; the collector finds the matching done plan and previews a collected evidence block without writing.
 - `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn.
+- Codex review fix — `findPlanBySlug` now requires matching plan paths to be regular files, and `tests/cli-plan-evidence.test.ts` covers a `.md/` directory masquerading as a plan.
+- Post-Codex verification: `git diff --check`, `npm test -- tests/scaffold.test.ts tests/cli-plan-evidence.test.ts tests/evidence.test.ts --run`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, and a temporary scaffold directory-plan reproduction all passed.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-20-082-evidence-new-plan-validation.md
+++ b/.osc/releases/2026-05-20-082-evidence-new-plan-validation.md
@@ -1,0 +1,34 @@
+# Release / Evidence Note: 082-evidence-new-plan-validation
+
+## Summary
+
+This pinpoint dogfood slice tightens the evidence flow by making `osc evidence new <slug>` refuse slugs that do not have a matching plan. Before the fix, `evidence new` could create an orphan release/evidence note and only `evidence collect` caught the missing plan later.
+
+## Traceability
+
+- Roadmap / issue / task: Pinpoint dogfood surface `evidence flow`; no GitHub issue; not mirrored to a task board.
+- Plan: `.osc/plans/done/082-evidence-new-plan-validation.md`.
+- Run ID / run packet: N/A — direct pinpoint scout execution advanced by John-Lo-Mein autopilot.
+- Branch / PR: branch `fix/evidence-new-plan-validation`; PR pending.
+- Automation provenance: Opened/advanced by John-Lo-Mein autopilot; cron job `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`; script `open-scaffold-prrunner-webhook-runner.py`; source `cron-open-scaffold-pr-runner`.
+- Owner gates: merge, npm publish, GitHub Release.
+
+## Verification
+
+- Pre-fix reproduction in a temporary min-tier scaffold — confirmed `osc evidence new typo-noplan` created `.osc/releases/2026-05-20-typo-noplan.md`, then `osc evidence collect typo-noplan --dry-run` failed with `Plan not found`.
+- Post-fix reproduction in a temporary min-tier scaffold — pass; `osc evidence new typo-noplan` exits 1 with `Plan not found: typo-noplan.md in .osc/plans/{active,backlog,blocked,done}. Create or move the plan before creating evidence.` and no evidence note is written.
+- `npm test -- tests/scaffold.test.ts tests/cli-plan-evidence.test.ts tests/evidence.test.ts --run` — pass; 3 files / 17 tests.
+- `git diff --check` — pass.
+- `npm test -- --run` — pass; 27 files / 235 tests.
+- `npm run build` — pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
+- `node dist/cli.js evidence collect 082-evidence-new-plan-validation --dry-run` — pass; the collector finds the matching done plan and previews a collected evidence block without writing.
+- `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn.
+
+## Outcome
+
+`createEvidenceNoteSkeleton` now validates that the slug exists as a plan in `.osc/plans/{active,backlog,blocked,done}` before writing into `.osc/releases/`. Evidence creation now fails at the first unsafe step instead of creating orphan notes that break the next command in the same flow.
+
+## Follow-up
+
+- Open the focused PR, patch this note with the PR URL, and run the latest-head Codex review loop.
+- Merge and npm/GitHub Release publication remain owner-gated.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-20: closed 082-evidence-new-plan-validation — validated evidence note creation against plan slugs
 - 2026-05-20: closed 081-lifecycle-help-flags — Added lifecycle help flag handling
 - 2026-05-20: closed 057-automated-evidence-collection — added automated evidence collection CLI
 - 2026-05-20: align evidence collection with current .osc/releases evidence-note path — see .osc/plans/done/057-automated-evidence-collection-amendment-1.md

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -333,7 +333,7 @@ function planStageSearchDirs(root: string, stages: readonly (PlanStage | 'root')
 function findPlanBySlug(root: string, slug: string, stages: readonly (PlanStage | 'root')[]): FoundPlan | null {
   for (const { stage, dir } of planStageSearchDirs(root, stages)) {
     const path = join(dir, `${slug}.md`);
-    if (existsSync(path)) return { path, dir, stage };
+    if (existsSync(path) && statSync(path).isFile()) return { path, dir, stage };
   }
   return null;
 }

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -397,6 +397,9 @@ export function createPlanSkeleton(slug: string, stage: PlanCreationStage, start
 export function createEvidenceNoteSkeleton(slug: string, start = process.cwd(), date = new Date()): CreatedScaffoldFile {
   const safeSlug = assertSafeSlug(slug);
   const root = requireScaffoldRoot(start);
+  if (!findPlanBySlug(root, safeSlug, PLAN_STAGES)) {
+    throw new Error(`Plan not found: ${safeSlug}.md in .osc/plans/{active,backlog,blocked,done}. Create or move the plan before creating evidence.`);
+  }
   const releasesDir = join(root, OSC_NAMESPACE, 'releases');
   if (!existsSync(releasesDir)) {
     throw new Error(`Open Scaffold releases folder missing: ${relative(root, releasesDir)}`);

--- a/tests/cli-plan-evidence.test.ts
+++ b/tests/cli-plan-evidence.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
@@ -114,6 +114,13 @@ describe('osc plan/evidence helper CLI', () => {
     expect(missingPlan.status).toBe(1);
     expect(missingPlan.stderr).toContain('Plan not found: 999-missing-plan.md in .osc/plans/{active,backlog,blocked,done}');
     expect(existsSync(join(target, `.osc/releases/${todayLocalDate()}-999-missing-plan.md`))).toBe(false);
+
+    const directoryPlanSlug = '998-directory-plan';
+    mkdirSync(join(target, `.osc/plans/active/${directoryPlanSlug}.md`));
+    const directoryPlan = spawnSync(tsx, [cli, 'evidence', 'new', directoryPlanSlug], { cwd: target, encoding: 'utf8' });
+    expect(directoryPlan.status).toBe(1);
+    expect(directoryPlan.stderr).toContain('Plan not found: 998-directory-plan.md in .osc/plans/{active,backlog,blocked,done}');
+    expect(existsSync(join(target, `.osc/releases/${todayLocalDate()}-998-directory-plan.md`))).toBe(false);
 
     const unsafe = spawnSync(tsx, [cli, 'evidence', 'new', '../outside'], { cwd: target, encoding: 'utf8' });
     expect(unsafe.status).toBe(2);

--- a/tests/cli-plan-evidence.test.ts
+++ b/tests/cli-plan-evidence.test.ts
@@ -80,8 +80,9 @@ describe('osc plan/evidence helper CLI', () => {
     expect(missingRoot.stderr).toContain('No Open Scaffold root found');
   }, CLI_TEST_TIMEOUT_MS);
 
-  it('creates an evidence note skeleton under .osc/releases without false proof claims', () => {
+  it('creates an evidence note skeleton under .osc/releases for an existing plan without false proof claims', () => {
     const target = initializedScaffold();
+    execFileSync(tsx, [cli, 'plan', 'new', '001-first-task', '--stage', 'active'], { cwd: target, encoding: 'utf8' });
 
     const output = execFileSync(tsx, [cli, 'evidence', 'new', '001-first-task'], { cwd: target, encoding: 'utf8' });
 
@@ -100,13 +101,19 @@ describe('osc plan/evidence helper CLI', () => {
     expect(text).not.toContain('Shipped.');
   });
 
-  it('refuses duplicate, unsafe-path, and missing-root evidence requests', () => {
+  it('refuses duplicate, missing-plan, unsafe-path, and missing-root evidence requests', () => {
     const target = initializedScaffold();
+    execFileSync(tsx, [cli, 'plan', 'new', '001-first-task', '--stage', 'active'], { cwd: target, encoding: 'utf8' });
     execFileSync(tsx, [cli, 'evidence', 'new', '001-first-task'], { cwd: target, encoding: 'utf8' });
 
     const duplicate = spawnSync(tsx, [cli, 'evidence', 'new', '001-first-task'], { cwd: target, encoding: 'utf8' });
     expect(duplicate.status).toBe(1);
     expect(duplicate.stderr).toContain('Refusing to overwrite existing evidence note');
+
+    const missingPlan = spawnSync(tsx, [cli, 'evidence', 'new', '999-missing-plan'], { cwd: target, encoding: 'utf8' });
+    expect(missingPlan.status).toBe(1);
+    expect(missingPlan.stderr).toContain('Plan not found: 999-missing-plan.md in .osc/plans/{active,backlog,blocked,done}');
+    expect(existsSync(join(target, `.osc/releases/${todayLocalDate()}-999-missing-plan.md`))).toBe(false);
 
     const unsafe = spawnSync(tsx, [cli, 'evidence', 'new', '../outside'], { cwd: target, encoding: 'utf8' });
     expect(unsafe.status).toBe(2);

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -108,6 +108,7 @@ describe('open-scaffold parser', () => {
     process.env.TZ = 'Pacific/Kiritimati';
     try {
       const root = tempRepo();
+      writeFileSync(join(root, '.osc/plans/active/001-local-date.md'), samplePlan.replace('# Plan: sample', '# Plan: 001-local-date'));
       const result = createEvidenceNoteSkeleton('001-local-date', root, new Date('2026-01-01T00:30:00+14:00'));
 
       expect(result.relativePath).toBe('.osc/releases/2026-01-01-001-local-date.md');


### PR DESCRIPTION
## Summary

- Makes `osc evidence new <slug>` require a matching plan before it writes `.osc/releases/YYYY-MM-DD-<slug>.md`.
- Adds regression coverage so missing-plan evidence creation fails without leaving an orphan note while existing duplicate, unsafe slug, missing-root, and directory-masquerading-as-plan checks still pass.
- Closes plan `082-evidence-new-plan-validation` with a focused release/evidence note.

## Traceability

- Plan: `.osc/plans/done/082-evidence-new-plan-validation.md`
- Evidence: `.osc/releases/2026-05-20-082-evidence-new-plan-validation.md`
- Surface: pinpoint dogfood of the evidence flow (`osc evidence new` -> `osc evidence collect`)
- Latest head after Codex fix: `b0a707a`
- Opened/advanced by John-Lo-Mein autopilot
- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`
- Script: `open-scaffold-prrunner-webhook-runner.py`
- Source: `cron-open-scaffold-pr-runner`
- Owner gates: merge, npm publish, GitHub Release

## Verification

- `git diff --check` ✅
- `npm test -- tests/scaffold.test.ts tests/cli-plan-evidence.test.ts tests/evidence.test.ts --run` ✅ — 3 files / 17 tests
- `./verify.sh --strict` ✅ — 10 pass / 0 fail / 0 warn
- `npm test -- --run` ✅ — 27 files / 235 tests
- `npm run build` ✅
- Temporary scaffold reproduction ✅ — `osc evidence new typo-noplan` exits 1 with `Plan not found...` and writes no orphan release/evidence note
- `node dist/cli.js evidence collect 082-evidence-new-plan-validation --dry-run` ✅
- Post-PR URL traceability patch: `git diff --check` ✅ and `./verify.sh --strict` ✅ — 10 pass / 0 fail / 0 warn
- Codex P2 fix verification ✅ — matching plan path must be a regular file; directory-plan reproduction exits 1 and writes no orphan release/evidence note
- `npm pack --dry-run --json` ✅ — `open-scaffold-0.4.7.tgz`, 97 files

## Codex review

- Initial Codex review on `6b3a4cf` found one P2 edge case: directory path masquerading as `.osc/plans/<stage>/<slug>.md`.
- Fixed in `b0a707a`, replied inline with verification, and re-triggered `@codex review`.
- Latest-head Codex artifact after the re-trigger: clean (`2026-05-20T11:54:21Z`, "Didn't find any major issues"). No newer inline findings appeared during the delayed polling window.

## Owner gates

- Do not merge without owner approval.
- Do not run `npm publish` without owner approval.
- Do not create or move a GitHub Release without owner approval.
