### PR TITLE
Fix verify help flags

### DIFF
--- a/.osc/plans/done/083-verify-help-flags.md
+++ b/.osc/plans/done/083-verify-help-flags.md
@@ -1,0 +1,47 @@
+# Plan: 083-verify-help-flags
+
+## Status
+
+done
+
+## Context
+
+The pinpoint dogfood scout targeted verification opacity after recent lifecycle help fixes. Live reproduction showed the verification surface still treats help/option probes poorly: `./verify.sh --help` exits 2 with `Unknown flag: --help`, while `osc verify --help` runs verification instead of printing usage. Automation and exploratory users need a safe way to ask how verification works before running or scripting it.
+
+## Goal
+
+Make shell and CLI verification help probes print explicit usage with exit code 0, and make unsupported `osc verify` options fail with a clear usage message instead of being silently ignored.
+
+## Constraints / Out of scope
+
+- Do not add a new machine-readable verifier format in this slice.
+- Do not change existing pass/fail semantics for `./verify.sh --quick|--standard|--strict` or `osc verify`.
+- Do not publish npm, move GitHub Release latest, merge, or make broad verifier redesign decisions.
+
+## Files to touch
+
+- `verify.sh` — add help handling and usage text for the shell verifier.
+- `src/cli.ts` — add `osc verify --help` and explicit unsupported-option handling.
+- `tests/verify-help.test.ts` — regression coverage for the verification help/option surface.
+- `.osc/releases/2026-05-20-083-verify-help-flags.md` — evidence note for this pinpoint slice.
+
+## Acceptance criteria
+
+- [ ] `./verify.sh --help` exits 0, prints verifier usage, and does not report `Unknown flag`.
+- [ ] `osc verify --help` exits 0, prints verifier usage, and does not run normal verification checks.
+- [ ] `osc verify --json` exits 2 with a clear unsupported-option message and usage instead of silently ignoring the flag.
+- [ ] Existing verification commands still pass unchanged.
+
+## Verification steps
+
+1. `./verify.sh --help` — exits 0 and prints usage.
+2. `npm run --silent osc -- verify --help` — exits 0 and prints usage.
+3. `npm test -- tests/verify-help.test.ts --run` — regression test passes.
+4. `git diff --check` — whitespace check passes.
+5. `npm test -- --run` — full test suite passes.
+6. `npm run build` — TypeScript build passes.
+7. `./verify.sh --strict` — scaffold strict verification passes.
+
+## Open questions
+
+None.

--- a/.osc/releases/2026-05-20-083-verify-help-flags.md
+++ b/.osc/releases/2026-05-20-083-verify-help-flags.md
@@ -1,0 +1,38 @@
+# Release / Evidence Note: 083-verify-help-flags
+
+## Summary
+
+This pinpoint dogfood slice tightens the verification opacity surface. `./verify.sh --help` now prints explicit verifier usage instead of exiting with `Unknown flag`, and `osc verify --help` now prints usage instead of running normal checks.
+
+## Traceability
+
+- Roadmap / issue / task: Pinpoint dogfood surface `verification opacity`; no GitHub issue; not mirrored to a task board.
+- Plan: `.osc/plans/done/083-verify-help-flags.md`.
+- Run ID / run packet: N/A — direct pinpoint scout execution, no runtime run packet needed.
+- Branch / PR: branch `fix/verify-help-flags`; PR blocked in this session because GitHub write authentication is unavailable.
+- Owner gates: push/PR, merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
+
+## Verification
+
+- Pre-fix reproduction: `./verify.sh --help` → exit 2, `Unknown flag: --help`.
+- Pre-fix reproduction: `npm run --silent osc -- verify --help` → exited 0 but ran normal verification and printed the existing warning instead of usage.
+- Pre-fix reproduction: `npm run --silent osc -- verify --json` → exited 0 and silently ignored the unsupported option.
+- Post-fix reproduction: `./verify.sh --help` → exit 0, prints `Usage: ./verify.sh [--quick|--standard|--strict] [--quiet] [--help]` and exit code meanings.
+- Post-fix reproduction: `npm run --silent osc -- verify --help` → exit 0, prints `Usage: osc verify` without running checks.
+- Post-fix reproduction: `npm run --silent osc -- verify --json` → exit 2 with `Unknown option for verify: --json` and `Usage: osc verify` instead of silently ignoring the flag.
+- `npm test -- tests/verify-help.test.ts --run` → pass; 1 file / 3 tests.
+- `git diff --check` → pass.
+- `npm test -- --run` → pass; 28 files / 238 tests.
+- `npm run build` → pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
+- `./verify.sh --strict` → pass; 10 pass / 0 fail / 0 warn.
+
+## Outcome
+
+Verification help/option probes now fail safely and explain themselves. The shell verifier has a real help screen, the CLI verifier has a safe `--help` path, and unsupported CLI verifier options no longer masquerade as successful verification.
+
+Out of scope: `osc verify --json` machine-readable output, shell verifier JSON, verifier redesign, npm publish, GitHub Release changes, or merge.
+
+## Follow-up
+
+- Push/open a focused PR once GitHub write authentication is available.
+- Consider a separate future `osc verify --json` plan if machine-readable verifier output becomes the next highest-friction surface.

--- a/.osc/releases/2026-05-20-083-verify-help-flags.md
+++ b/.osc/releases/2026-05-20-083-verify-help-flags.md
@@ -8,9 +8,17 @@ This pinpoint dogfood slice tightens the verification opacity surface. `./verify
 
 - Roadmap / issue / task: Pinpoint dogfood surface `verification opacity`; no GitHub issue; not mirrored to a task board.
 - Plan: `.osc/plans/done/083-verify-help-flags.md`.
-- Run ID / run packet: N/A — direct pinpoint scout execution, no runtime run packet needed.
-- Branch / PR: branch `fix/verify-help-flags`; PR blocked in this session because GitHub write authentication is unavailable.
-- Owner gates: push/PR, merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
+- Run ID / run packet: N/A — pinpoint scout reproduction plus John-Lo-Mein autopilot advancement; no runtime run packet needed.
+- Branch / PR: branch `fix/verify-help-flags`; PR pending John-Lo-Mein autopilot creation.
+- Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
+
+## Automation provenance
+
+- Opened/advanced by John-Lo-Mein autopilot.
+- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`.
+- Script: `open-scaffold-prrunner-webhook-runner.py`.
+- Source: `cron-open-scaffold-pr-runner`.
+- Owner gates: `merge`, `npm publish`, `GitHub Release`.
 
 ## Verification
 

--- a/.osc/releases/2026-05-20-083-verify-help-flags.md
+++ b/.osc/releases/2026-05-20-083-verify-help-flags.md
@@ -9,7 +9,7 @@ This pinpoint dogfood slice tightens the verification opacity surface. `./verify
 - Roadmap / issue / task: Pinpoint dogfood surface `verification opacity`; no GitHub issue; not mirrored to a task board.
 - Plan: `.osc/plans/done/083-verify-help-flags.md`.
 - Run ID / run packet: N/A — pinpoint scout reproduction plus John-Lo-Mein autopilot advancement; no runtime run packet needed.
-- Branch / PR: branch `fix/verify-help-flags`; PR pending John-Lo-Mein autopilot creation.
+- Branch / PR: branch `fix/verify-help-flags`; PR https://github.com/graphanov/open-scaffold/pull/73.
 - Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
 
 ## Automation provenance

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-20: closed 083-verify-help-flags — Added verify help flag handling
 - 2026-05-20: closed 082-evidence-new-plan-validation — validated evidence note creation against plan slugs
 - 2026-05-20: closed 081-lifecycle-help-flags — Added lifecycle help flag handling
 - 2026-05-20: closed 057-automated-evidence-collection — added automated evidence collection CLI

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -651,6 +651,10 @@ function printEvidenceCollectUsage(stream: 'stdout' | 'stderr' = 'stderr'): void
   printUsage('Usage: osc evidence collect <slug> [--ci] [--dry-run] [--verbose]', stream);
 }
 
+function printVerifyUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc verify', stream);
+}
+
 function evidenceCommand(args: string[]): void {
   const [subcommand, ...rest] = args;
   if (isHelpArg(subcommand) || subcommand === undefined) {
@@ -1168,6 +1172,15 @@ async function main(): Promise<void> {
       closeCommand(args);
       return;
     case 'verify': {
+      if (isHelpArg(args[0])) {
+        printVerifyUsage('stdout');
+        return;
+      }
+      if (args.length > 0) {
+        console.error(`Unknown option for verify: ${args[0]}`);
+        printVerifyUsage();
+        process.exit(2);
+      }
       const result = validateScaffold(process.cwd());
       for (const failure of result.failures) {
         console.error(`FAIL ${failure.code}: ${failure.message}${failure.path ? ` (${failure.path})` : ''}`);

--- a/tests/verify-help.test.ts
+++ b/tests/verify-help.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+describe('verification help flags', () => {
+  it('prints shell verifier help without running checks', () => {
+    const result = spawnSync('bash', ['verify.sh', '--help'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Usage: ./verify.sh [--quick|--standard|--strict] [--quiet] [--help]');
+    expect(result.stdout).toContain('Exit codes:');
+    expect(result.stdout).not.toContain('Unknown flag');
+    expect(result.stdout).not.toContain('open-scaffold compliance check');
+  });
+
+  it('prints CLI verifier help without running checks', () => {
+    const result = spawnSync(tsx, [cli, 'verify', '--help'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('Usage: osc verify\n');
+    expect(result.stdout).not.toContain('PASS mission defined');
+    expect(result.stdout).not.toContain('WARN ');
+  });
+
+  it('rejects unsupported CLI verifier options instead of silently ignoring them', () => {
+    const result = spawnSync(tsx, [cli, 'verify', '--json'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Unknown option for verify: --json');
+    expect(result.stderr).toContain('Usage: osc verify');
+    expect(result.stderr).not.toContain('PASS mission defined');
+  });
+});

--- a/verify.sh
+++ b/verify.sh
@@ -12,12 +12,32 @@ PASS_COUNT=0
 FAIL_COUNT=0
 WARN_COUNT=0
 
+print_help() {
+  printf '%s\n' \
+    'Usage: ./verify.sh [--quick|--standard|--strict] [--quiet] [--help]' \
+    '' \
+    'Tiers:' \
+    '  --quick      Mission and plan presence checks.' \
+    '  --standard   Quick checks plus amendment and changelog checks. Default.' \
+    '  --strict     Standard checks plus schema, drift, immutability, evidence, and stale-state checks.' \
+    '' \
+    'Options:' \
+    '  --quiet      Suppress pass/warn output; failures still print.' \
+    '  -h, --help   Print this usage text and exit 0.' \
+    '' \
+    'Exit codes:' \
+    '  0  All checks passed.' \
+    '  1  One or more checks failed.' \
+    '  2  Invalid option.'
+}
+
 # Parse flags (order-independent, bash 3.2 compatible)
 for arg in "$@"; do
   case "$arg" in
+    -h|--help|help) print_help; exit 0 ;;
     --quick|--standard|--strict) TIER="$arg" ;;
     --quiet) QUIET=true ;;
-    *) printf 'Unknown flag: %s\n' "$arg" >&2; exit 2 ;;
+    *) printf 'Unknown flag: %s\n' "$arg" >&2; print_help >&2; exit 2 ;;
   esac
 done
 


### PR DESCRIPTION
## Summary
- Adds `./verify.sh --help` usage output with exit code 0.
- Adds `osc verify --help` usage output without running verification checks.
- Rejects unsupported `osc verify` options such as `--json` with exit code 2 and usage text.
- Closes pinpoint plan `.osc/plans/done/083-verify-help-flags.md` and records evidence in `.osc/releases/2026-05-20-083-verify-help-flags.md`.

## Traceability
- Surface: verification opacity from the public pinpoint dogfood loop.
- Plan: `.osc/plans/done/083-verify-help-flags.md`.
- Evidence: `.osc/releases/2026-05-20-083-verify-help-flags.md`.
- GitHub issue: none; narrow dogfood friction slice.
- Latest autopilot evidence patch: `d70ccea` links this PR from the evidence note.

## Automation provenance
- Opened/advanced by John-Lo-Mein autopilot.
- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`.
- Script: `open-scaffold-prrunner-webhook-runner.py`.
- Source: `cron-open-scaffold-pr-runner`.
- Owner gates: `merge`, `npm publish`, `GitHub Release`.

## Verification
- [x] `./verify.sh --help`
- [x] `npm run --silent osc -- verify --help`
- [x] `npm run --silent osc -- verify --json` exits 2 with usage
- [x] `npm test -- tests/verify-help.test.ts --run`
- [x] `git diff --check`
- [x] `npm test -- --run`
- [x] `npm run build`
- [x] `./verify.sh --strict`
- [x] `node dist/cli.js verify --help`
- [x] `node dist/cli.js verify --json` exits 2 with usage
- [x] `npm pack --dry-run --json`
- [x] Post-PR evidence patch: `git diff --check`; `./verify.sh --strict`

## Review / gates
- Codex review: triggered for latest head after PR creation and evidence URL patch.
- Merge: owner-gated.
- npm publish: owner-gated.
- GitHub Release latest movement: owner-gated.
