### PR TITLE
Fix macOS tmp brownfield init

### DIFF
--- a/.osc/plans/done/084-macos-tmp-brownfield-init.md
+++ b/.osc/plans/done/084-macos-tmp-brownfield-init.md
@@ -1,0 +1,45 @@
+# Plan: 084-macos-tmp-brownfield-init
+
+## Status
+
+done
+
+## Context
+
+OSC Sentinel reproduced a first-run brownfield failure on macOS: `npx open-scaffold@latest init --from-existing --tier min --target /tmp/<dir> --force` refuses to run because `/tmp` is a system compatibility symlink to `/private/tmp`. The symlink guard is useful for project-owned paths, but rejecting the standard macOS `/tmp` alias makes copy-paste smoke commands fail before users even reach scaffold setup. The repo is clean, no PR is open, and this is a narrow product-friction fix from the build-in-public checker context.
+
+## Goal
+
+Allow brownfield init targets under the standard macOS `/tmp` compatibility alias by canonicalizing that alias to `/private/tmp`, while preserving symlink rejection for arbitrary project paths and scaffold-owned destinations.
+
+## Constraints / Out of scope
+
+- Do not weaken symlink safety for arbitrary user-created symlinks.
+- Do not broaden brownfield init beyond `--tier min` or change scaffold file sets.
+- Do not start a publish-only release loop; `package.json` already carries the current unpublished release-train candidate.
+- Do not mutate npm, GitHub Releases, secrets, or deployment surfaces.
+
+## Files to touch
+
+- `src/init.ts` — normalize the macOS `/tmp` alias before the existing symlink guard runs.
+- `tests/init.test.ts` — add regression coverage for the macOS `/tmp` brownfield path when the platform exposes that alias.
+- `README.md` or `docs/MINIMUM_VIABLE_SCAFFOLD.md` — document the canonical target behavior if user-visible output changes.
+- `.osc/releases/2026-05-20-084-macos-tmp-brownfield-init.md` — evidence note with automation provenance.
+
+## Acceptance criteria
+
+- [ ] On macOS, `init --from-existing --tier min --target /tmp/<dir> --force` succeeds instead of rejecting `/tmp` as a symlink.
+- [ ] Arbitrary symlinked target paths outside the known macOS `/tmp` alias remain rejected.
+- [ ] Brownfield init still preserves existing project files and scaffold-owned conflict behavior.
+- [ ] Evidence and PR body explicitly state John Lomein autopilot provenance and owner gates.
+- [ ] `git diff --check`, targeted tests, full tests, build, package dry-run, and `./verify.sh --strict` pass before reporting success.
+
+## Verification steps
+
+1. Run `npm test -- tests/init.test.ts --run` — targeted init regression tests pass.
+2. Run `node dist/cli.js init --from-existing --tier min --target /tmp/<fresh-dir> --force` after build on macOS — command succeeds and writes files under the canonical `/private/tmp` path.
+3. Run `git diff --check`, `npm test -- --run`, `npm run build`, `npm pack --dry-run --json`, and `./verify.sh --strict` — all pass.
+
+## Open questions
+
+None.

--- a/.osc/releases/2026-05-20-084-macos-tmp-brownfield-init.md
+++ b/.osc/releases/2026-05-20-084-macos-tmp-brownfield-init.md
@@ -9,7 +9,7 @@ This slice fixes a macOS first-run brownfield smoke failure where targets under 
 - Roadmap / issue / task: build-in-public Sentinel friction finding; Hermes Kanban card `t_217ac297`; no GitHub issue.
 - Plan: `.osc/plans/done/084-macos-tmp-brownfield-init.md`.
 - Run ID / run packet: N/A — direct John Lomein autopilot implementation; no runtime run packet needed.
-- Branch / PR: branch `fix/macos-tmp-brownfield-init`; PR pending.
+- Branch / PR: branch `fix/macos-tmp-brownfield-init`; PR https://github.com/graphanov/open-scaffold/pull/75.
 - Version candidate: `open-scaffold@0.4.8` remains the current unpublished release-train candidate; no publish-only bump in this PR.
 - Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
 

--- a/.osc/releases/2026-05-20-084-macos-tmp-brownfield-init.md
+++ b/.osc/releases/2026-05-20-084-macos-tmp-brownfield-init.md
@@ -1,0 +1,42 @@
+# Release / Evidence Note: 084-macos-tmp-brownfield-init
+
+## Summary
+
+This slice fixes a macOS first-run brownfield smoke failure where targets under `/tmp` were rejected because `/tmp` is a system compatibility symlink to `/private/tmp`. Open Scaffold now canonicalizes that known alias before the existing symlink guard runs, while keeping arbitrary symlinked project paths and scaffold-owned destinations protected.
+
+## Traceability
+
+- Roadmap / issue / task: build-in-public Sentinel friction finding; Hermes Kanban card `t_217ac297`; no GitHub issue.
+- Plan: `.osc/plans/done/084-macos-tmp-brownfield-init.md`.
+- Run ID / run packet: N/A — direct John Lomein autopilot implementation; no runtime run packet needed.
+- Branch / PR: branch `fix/macos-tmp-brownfield-init`; PR pending.
+- Version candidate: `open-scaffold@0.4.8` remains the current unpublished release-train candidate; no publish-only bump in this PR.
+- Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
+
+## Automation provenance
+
+- Opened/advanced by John Lomein autopilot.
+- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`.
+- Script: `open-scaffold-prrunner-webhook-runner.py`.
+- Source: `cron-open-scaffold-pr-runner`.
+- Owner gates: `merge`, `npm publish`, `GitHub Release`.
+
+## Verification
+
+- `npm test -- tests/init.test.ts --run` → pass; 1 file / 16 tests, including macOS `/tmp` alias regression coverage and existing arbitrary symlink rejection coverage.
+- `npm run build` → pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
+- `node dist/cli.js init --from-existing --tier min --target /tmp/osc-john-lomein-tmp-smoke-1779300306 --force` → pass; generated the scaffold under `/private/tmp/osc-john-lomein-tmp-smoke-1779300306` and verified `MISSION.md` exists with the mission-unset marker.
+- `git diff --check` → pass.
+- `npm test -- --run` → pass; 29 files / 249 tests.
+- `npm pack --dry-run --json` → pass; package candidate `open-scaffold@0.4.8`, 99 files.
+
+## Outcome
+
+`init --from-existing --tier min --target /tmp/<fresh-dir> --force` now works on macOS instead of failing on the system `/tmp` symlink. The fix is intentionally narrow: it recognizes only the standard Darwin `/tmp` → `/private/tmp` alias and leaves the existing symlink safety checks in place for arbitrary target ancestors and scaffold-owned destinations.
+
+Out of scope: broad brownfield redesign, standard/max brownfield tiers, arbitrary symlink allowance, npm publish, GitHub Release changes, merge, or deployment.
+
+## Follow-up
+
+- Patch this note with the real PR URL after PR creation.
+- Owner-gated release-train work remains: publish the accumulated `open-scaffold@0.4.8` candidate, verify registry + `npx`, then create/mark GitHub Release `v0.4.8` Latest if approved.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-20: closed 084-macos-tmp-brownfield-init — fixed macOS /tmp brownfield init
 - 2026-05-20: closed 058-doctor-auto-fix — added doctor auto-fix CLI
 - 2026-05-20: closed 083-verify-help-flags — Added verify help flag handling
 - 2026-05-20: closed 082-evidence-new-plan-validation — validated evidence note creation against plan slugs

--- a/docs/MINIMUM_VIABLE_SCAFFOLD.md
+++ b/docs/MINIMUM_VIABLE_SCAFFOLD.md
@@ -46,6 +46,8 @@ Brownfield init currently supports the `min` tier only. That keeps adoption safe
 
 It detects common project markers (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, and workspace files), writes a mission draft that names the detected project type, and adds scaffold files around the existing project. It does not edit package manifests, source trees, lockfiles, README content, or CI files. If scaffold-owned paths such as `MISSION.md`, `.osc/`, `AGENTS.md`, or `CLAUDE.md` already exist, it refuses and lists the conflicts; use `--force` only when you intend to replace those scaffold-owned files.
 
+On macOS, the CLI treats the standard `/tmp` compatibility alias as `/private/tmp` before applying symlink safety checks, so copy-paste smoke targets such as `--target /tmp/osc-smoke` work without weakening protection against project-owned symlinks.
+
 Then follow the loop:
 
 1. **Define mission** — run `./bootstrap.sh` or edit `MISSION.md` until the project-specific mission is real.

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,4 @@
-import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import type { Stats } from 'node:fs';
 import { dirname, join, relative as relativePath, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -619,6 +619,23 @@ function lstatIfPresent(path: string): Stats | null {
   }
 }
 
+function normalizeKnownSystemAlias(path: string): string {
+  const target = resolve(path);
+  if (process.platform !== 'darwin') return target;
+
+  const tmpAlias = resolve('/tmp');
+  if (target !== tmpAlias && !target.startsWith(`${tmpAlias}${sep}`)) return target;
+
+  const tmpStats = lstatIfPresent(tmpAlias);
+  if (!tmpStats?.isSymbolicLink()) return target;
+
+  const realTmp = realpathSync(tmpAlias);
+  if (realTmp !== '/private/tmp') return target;
+
+  const suffix = relativePath(tmpAlias, target);
+  return suffix ? join(realTmp, suffix) : realTmp;
+}
+
 function rejectSymlinkedExistingPath(path: string): void {
   let current = resolve(path);
 
@@ -660,7 +677,7 @@ export function initializeScaffold(options: InitializeScaffoldOptions): Initiali
   if (options.fromExisting && options.tier !== 'min') {
     throw new Error('Brownfield init currently supports --tier min only. Use greenfield init for standard/max docs, or add advanced docs manually after preserving existing project files.');
   }
-  const target = resolve(options.target);
+  const target = normalizeKnownSystemAlias(options.target);
   const fromExisting = Boolean(options.fromExisting);
   const protectedExistingProjectFiles = fromExisting && options.force
     ? ['verify.sh', 'close.sh', 'bootstrap.sh'].filter((file) => existsSync(join(target, file)))

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initializeScaffold, tierFiles } from '../src/init.js';
@@ -80,6 +80,20 @@ describe('tiered scaffold initialization', () => {
 
     expect(() => initializeScaffold({ tier: 'min', target: join(link, 'project') })).toThrow(/Refusing to write through symlinked path:/);
     expect(existsSync(join(outside, 'project'))).toBe(false);
+  });
+
+  it('allows the standard macOS /tmp alias for new brownfield targets', () => {
+    if (process.platform !== 'darwin' || !existsSync('/tmp') || !lstatSync('/tmp').isSymbolicLink() || realpathSync('/tmp') !== '/private/tmp') return;
+
+    const slug = `osc-init-macos-tmp-${process.pid}-${Date.now()}`;
+    const requestedTarget = join('/tmp', slug);
+    const canonicalTarget = join('/private/tmp', slug);
+
+    const result = initializeScaffold({ tier: 'min', target: requestedTarget, fromExisting: true, force: true });
+
+    expect(result.target).toBe(canonicalTarget);
+    expect(existsSync(join(canonicalTarget, 'MISSION.md'))).toBe(true);
+    expect(readFileSync(join(canonicalTarget, 'MISSION.md'), 'utf8')).toContain('<!-- mission:unset -->');
   });
 
   it('refuses dangling symlink destinations before writing outside target', () => {


### PR DESCRIPTION
## Summary
- Fixes macOS brownfield init targets under `/tmp` by canonicalizing the standard `/tmp` → `/private/tmp` compatibility alias before symlink safety checks.
- Keeps arbitrary symlinked project paths rejected and adds targeted regression coverage.
- Documents the macOS target behavior in the minimum viable scaffold guide.

## Traceability
- Plan: `.osc/plans/done/084-macos-tmp-brownfield-init.md`
- Evidence: `.osc/releases/2026-05-20-084-macos-tmp-brownfield-init.md`
- Kanban: `t_217ac297`
- PR: https://github.com/graphanov/open-scaffold/pull/75
- Source signal: OSC Sentinel build-in-public friction finding for `npx open-scaffold@latest init --from-existing --tier min --target /tmp/<dir> --force`
- Package/release: `package.json` remains `0.4.8`; this PR does not run a publish-only version loop.

## Automation provenance
- Opened/advanced by John Lomein autopilot.
- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`.
- Script: `open-scaffold-prrunner-webhook-runner.py`.
- Source: `cron-open-scaffold-pr-runner`.
- Owner gates: `merge`, `npm publish`, `GitHub Release`.

## Verification
- [x] `npm test -- tests/init.test.ts --run` — pass; 1 file / 16 tests.
- [x] `npm run build` — pass.
- [x] `node dist/cli.js init --from-existing --tier min --target /tmp/osc-john-lomein-tmp-smoke-1779300306 --force` — pass; generated under `/private/tmp/...` and verified `MISSION.md`.
- [x] `git diff --check` — pass.
- [x] `npm test -- --run` — pass; 29 files / 249 tests.
- [x] `npm pack --dry-run --json` — pass; package candidate `open-scaffold@0.4.8`, 99 files.
- [x] `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn.
- [x] Added-line static scan for secrets/injection patterns — pass.

## Codex review
- Triggered with `@codex review`; latest-head status pending until a post-trigger Codex artifact is inspected.

## Owner gates
- Do not merge without owner approval.
- Do not run `npm publish` without owner approval.
- Do not create or move GitHub Release Latest without owner approval.
