### PR TITLE
Add runtime profile list JSON output

### DIFF
--- a/.osc/plans/done/085-runtime-list-json.md
+++ b/.osc/plans/done/085-runtime-list-json.md
@@ -1,0 +1,46 @@
+# Plan: 085-runtime-list-json
+
+## Status
+
+done
+
+## Context
+
+The pinpoint dogfood scout targeted the runtime/profile boundary after the coordinator asked for another pass on runtime profiles, runtime packages, and no-spawn versus launch wording. Live reproduction showed `osc runtimes show <id>` is JSON by default, but `osc runtimes list --json` silently ignores the JSON flag and emits TSV. That makes the profile catalog harder for coordinators and public dogfood automation to inspect safely.
+
+## Goal
+
+Add a machine-readable JSON output path for runtime profile listing while preserving the existing TSV output and no-spawn runtime boundary.
+
+## Constraints / Out of scope
+
+- Do not change runtime profile semantics, launch behavior, adapter status, or no-spawn guarantees.
+- Do not add runtime install, network registry, marketplace, credential, or spawn behavior.
+- Do not publish npm, move GitHub Release latest, merge, or make broad runtime strategy decisions.
+
+## Files to touch
+
+- `src/cli.ts` — add `osc runtimes list --json` handling and clear unsupported-option handling for the runtimes list surface.
+- `tests/cli-init.test.ts` — add regression coverage for JSON list output and unsupported list options.
+- `docs/RUNTIME_PROFILES.md` — document the JSON list option for automation users.
+- `.osc/releases/2026-05-20-085-runtime-list-json.md` — evidence note for this pinpoint slice.
+
+## Acceptance criteria
+
+- [ ] `osc runtimes list --json` exits 0 and emits parseable JSON.
+- [ ] JSON list output includes built-in profiles with source metadata and no launch/spawn behavior changes.
+- [ ] `osc runtimes list --bogus` exits 2 with a clear usage/unknown-option message instead of silently ignoring the option.
+- [ ] Existing `osc runtimes list` TSV output remains available.
+
+## Verification steps
+
+1. `npm run --silent osc -- runtimes list --json` — exits 0 and emits parseable JSON.
+2. `npm test -- tests/cli-init.test.ts --run` — runtime CLI regression tests pass.
+3. `git diff --check` — whitespace check passes.
+4. `npm test -- --run` — full test suite passes.
+5. `npm run build` — TypeScript build passes.
+6. `./verify.sh --strict` — scaffold strict verification passes.
+
+## Open questions
+
+None.

--- a/.osc/releases/2026-05-20-085-runtime-list-json.md
+++ b/.osc/releases/2026-05-20-085-runtime-list-json.md
@@ -9,7 +9,7 @@ This pinpoint dogfood slice tightens the runtime/profile boundary surface for au
 - Roadmap / issue / task: Pinpoint dogfood surface `runtime/profile boundary`; no GitHub issue; not mirrored to a task board.
 - Plan: `.osc/plans/done/085-runtime-list-json.md`.
 - Run ID / run packet: N/A — pinpoint scout reproduction; no runtime run packet needed.
-- Branch / PR: branch `cli/runtime-list-json`; PR pending until John Lomein autopilot opens the focused GitHub PR.
+- Branch / PR: branch `cli/runtime-list-json`; PR https://github.com/graphanov/open-scaffold/pull/76.
 - Automation provenance: Opened/advanced by John Lomein autopilot; cron job `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`; script `open-scaffold-prrunner-webhook-runner.py`; source `cron-open-scaffold-pr-runner`.
 - Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
 
@@ -33,5 +33,5 @@ Out of scope: runtime install, runtime registry, marketplace behavior, credentia
 
 ## Follow-up
 
-- Push/open a focused PR once GitHub write authentication is available.
+- Review PR https://github.com/graphanov/open-scaffold/pull/76 and keep the owner merge gate explicit.
 - Keep bundle-release treatment for package/release drift; this pinpoint does not require immediate npm publish by itself.

--- a/.osc/releases/2026-05-20-085-runtime-list-json.md
+++ b/.osc/releases/2026-05-20-085-runtime-list-json.md
@@ -1,0 +1,37 @@
+# Release / Evidence Note: 085-runtime-list-json
+
+## Summary
+
+This pinpoint dogfood slice tightens the runtime/profile boundary surface for automation. `osc runtimes list --json` now emits a parseable runtime profile summary instead of silently ignoring the flag and printing TSV.
+
+## Traceability
+
+- Roadmap / issue / task: Pinpoint dogfood surface `runtime/profile boundary`; no GitHub issue; not mirrored to a task board.
+- Plan: `.osc/plans/done/085-runtime-list-json.md`.
+- Run ID / run packet: N/A — pinpoint scout reproduction; no runtime run packet needed.
+- Branch / PR: branch `cli/runtime-list-json`; PR pending until John Lomein autopilot opens the focused GitHub PR.
+- Automation provenance: Opened/advanced by John Lomein autopilot; cron job `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`; script `open-scaffold-prrunner-webhook-runner.py`; source `cron-open-scaffold-pr-runner`.
+- Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
+
+## Verification
+
+- Pre-fix reproduction: `npm run --silent osc -- runtimes list --json` → exited 0 but silently ignored `--json` and printed TSV.
+- Post-fix reproduction: `npm run --silent osc -- runtimes list --json` → exit 0; JSON parsed successfully; 5 runtime profiles returned.
+- Post-fix reproduction: `npm run --silent osc -- runtimes list --bogus` → exit 2 with `Unknown option for runtimes list: --bogus` and `Usage: osc runtimes list [--json]`.
+- Existing TSV path: `npm run --silent osc -- runtimes list` → exit 0; first row remained `omc\tbuiltin\tomc-claude\tadapter-candidate\tOMC / oh-my-claudecode`.
+- `npm test -- tests/cli-init.test.ts --run` → pass; 1 file / 26 tests.
+- `git diff --check` → pass.
+- `npm test -- --run` → pass; 29 files / 249 tests.
+- `npm run build` → pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
+- `./verify.sh --strict` → pass; 10 pass / 0 fail / 0 warn.
+
+## Outcome
+
+Runtime profile listing is now scriptable without changing runtime semantics. The human TSV list remains available, while agents/coordinators can request JSON for profile id, source, path, lane, status, and display name.
+
+Out of scope: runtime install, runtime registry, marketplace behavior, credential handling, real process spawning, npm publish, GitHub Release changes, or merge.
+
+## Follow-up
+
+- Push/open a focused PR once GitHub write authentication is available.
+- Keep bundle-release treatment for package/release drift; this pinpoint does not require immediate npm publish by itself.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-20: closed 085-runtime-list-json — added JSON output for runtime profile listing
 - 2026-05-20: closed 084-macos-tmp-brownfield-init — fixed macOS /tmp brownfield init
 - 2026-05-20: closed 058-doctor-auto-fix — added doctor auto-fix CLI
 - 2026-05-20: closed 083-verify-help-flags — Added verify help flag handling

--- a/docs/RUNTIME_PROFILES.md
+++ b/docs/RUNTIME_PROFILES.md
@@ -30,11 +30,12 @@ Keep the roles separate:
 
 ```bash
 osc runtimes list
+osc runtimes list --json
 osc runtimes show omx
 osc run .osc/plans/active/001-demo.md --runtime omx --workflow plan
 ```
 
-`osc runtimes list` prints the visible profile id, source, executor lane, status, and display name.
+`osc runtimes list` prints the visible profile id, source, executor lane, status, and display name as TSV for quick terminal scans. `osc runtimes list --json` prints the same summary as parseable JSON for coordinators and automation.
 
 `osc runtimes show <id>` prints the selected profile JSON plus its source.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ Usage:
   osc audit check <audit-manifest-path>
   osc verify
   osc doctor [--fix] [--dry-run] [--severity <info|warn|error>] [--check <name>]
-  osc runtimes list
+  osc runtimes list [--json]
   osc runtimes show <id>
 
 Run binding options:
@@ -1165,11 +1165,30 @@ function evalCommand(args: string[]): void {
 }
 
 function runtimes(args: string[]): void {
-  const [subcommand, id] = args;
+  const [subcommand, ...rest] = args;
   if (subcommand === 'list') {
+    const json = rest.includes('--json');
+    const unknown = rest.find((arg) => arg !== '--json');
+    if (unknown) {
+      console.error(`Unknown option for runtimes list: ${unknown}`);
+      console.error('Usage: osc runtimes list [--json]');
+      process.exit(2);
+    }
     try {
-      for (const entry of loadRuntimeProfiles(process.cwd())) {
-        console.log(`${entry.profile.id}\t${entry.source}\t${entry.profile.lane}\t${entry.profile.status}\t${entry.profile.displayName}`);
+      const entries = loadRuntimeProfiles(process.cwd());
+      if (json) {
+        console.log(JSON.stringify(entries.map((entry) => ({
+          id: entry.profile.id,
+          source: entry.source,
+          path: entry.path ?? null,
+          lane: entry.profile.lane,
+          status: entry.profile.status,
+          displayName: entry.profile.displayName,
+        })), null, 2));
+      } else {
+        for (const entry of entries) {
+          console.log(`${entry.profile.id}\t${entry.source}\t${entry.profile.lane}\t${entry.profile.status}\t${entry.profile.displayName}`);
+        }
       }
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));
@@ -1178,6 +1197,7 @@ function runtimes(args: string[]): void {
     return;
   }
   if (subcommand === 'show') {
+    const [id] = rest;
     if (!id) {
       console.error('Missing required argument: runtime id');
       process.exit(2);
@@ -1196,7 +1216,7 @@ function runtimes(args: string[]): void {
     console.log(JSON.stringify({ ...resolved.profile, source: resolved.source, path: resolved.path ?? null }, null, 2));
     return;
   }
-  console.error('Usage: osc runtimes list | osc runtimes show <id>');
+  console.error('Usage: osc runtimes list [--json] | osc runtimes show <id>');
   process.exit(2);
 }
 

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -272,6 +272,15 @@ describe('osc init CLI', () => {
     const list = execFileSync(tsx, [cli, 'runtimes', 'list'], { cwd: target, encoding: 'utf8' });
     expect(list).toContain('omx\tbuiltin\tomx-codex\tadapter-candidate');
 
+    const listJson = JSON.parse(execFileSync(tsx, [cli, 'runtimes', 'list', '--json'], { cwd: target, encoding: 'utf8' }));
+    expect(listJson).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'omx', source: 'builtin', lane: 'omx-codex', status: 'adapter-candidate' }),
+    ]));
+
+    const invalidList = spawnSync(tsx, [cli, 'runtimes', 'list', '--bogus'], { cwd: target, encoding: 'utf8' });
+    expect(invalidList.status).toBe(2);
+    expect(invalidList.stderr).toContain('Unknown option for runtimes list: --bogus');
+
     const shown = JSON.parse(execFileSync(tsx, [cli, 'runtimes', 'show', 'omx'], { cwd: target, encoding: 'utf8' }));
     expect(shown).toMatchObject({ id: 'omx', source: 'builtin', lane: 'omx-codex' });
   }, 15_000);


### PR DESCRIPTION
## Summary
- Add `osc runtimes list --json` for parseable runtime profile catalog output.
- Preserve the existing TSV `osc runtimes list` output for humans.
- Reject unsupported `runtimes list` options with a clear usage error instead of silently ignoring them.
- Close the pinpoint dogfood plan/evidence slice for `085-runtime-list-json`.

## Traceability
- Plan: `.osc/plans/done/085-runtime-list-json.md`
- Evidence: `.osc/releases/2026-05-20-085-runtime-list-json.md`
- Branch: `cli/runtime-list-json`
- PR: https://github.com/graphanov/open-scaffold/pull/76
- Latest head when opened/advanced: `57540f2`
- Source surface: runtime/profile boundary dogfood (`osc runtimes list --json`)
- Public package drift observed: local repo is `0.4.8`; npm latest and GitHub Latest are `0.4.7`. This PR does not publish or move releases; treat that as a bundled release-train candidate, not an automatic per-PR publish loop.

## Automation provenance
Opened/advanced by John Lomein autopilot.

- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`
- Script: `open-scaffold-prrunner-webhook-runner.py`
- Source: `cron-open-scaffold-pr-runner`
- Owner gates still required: merge, npm publish, and GitHub Release creation/latest movement.

GitHub may display the branch/PR author as `graphanov` because automation uses the owner's local GitHub auth; this provenance block is the source of truth for the automation lane.

## Verification
- `npx --yes open-scaffold@latest runtimes list --json` reproduced the published-package gap: exits 0 but prints TSV; JSON parse fails as expected.
- `npm run --silent osc -- runtimes list --json` passed: JSON parsed successfully; 5 runtime profiles returned.
- `npm run --silent osc -- runtimes list --bogus` passed: exits 2 with `Unknown option for runtimes list: --bogus` and `Usage: osc runtimes list [--json]`.
- `npm run --silent osc -- runtimes list` passed: TSV output preserved.
- `npm test -- tests/cli-init.test.ts --run` passed: 1 file / 26 tests.
- `git diff --check origin/main...HEAD` passed.
- `npm test -- --run` passed: 29 files / 249 tests.
- `npm run build` passed.
- `./verify.sh --strict` passed: 10 pass / 0 fail / 0 warn.
- Post-PR traceability commit: `git diff --check` passed and `./verify.sh --strict` passed again at 10 pass / 0 fail / 0 warn.

## Codex review
- Requested with `@codex review` after final head `57540f2`.

## Out of scope
- Runtime install, network registry, marketplace behavior, credential handling, or real process spawning.
- npm publish.
- GitHub Release creation/latest movement.
- Merge.
