### PR TITLE
Fix init help flags

### DIFF
--- a/.osc/plans/done/086-init-help-flags.md
+++ b/.osc/plans/done/086-init-help-flags.md
@@ -1,0 +1,47 @@
+# Plan: 086-init-help-flags
+
+## Status
+
+done
+
+## Context
+
+The pinpoint dogfood scout targeted the brownfield init / first-run CLI surface after recent help-flag hardening for lifecycle and verifier commands. Live reproduction showed `osc init --help` is still routed through normal init option parsing: it exits 2 with `Unknown option for init: --help` and prints the global CLI help instead of a safe init-specific usage message. A user exploring `osc init --from-existing` should be able to ask for help before choosing a target directory.
+
+## Goal
+
+Make init help probes print concise init-specific usage with exit code 0, and make unsupported init options show init-specific usage rather than the whole root command surface.
+
+## Constraints / Out of scope
+
+- Do not change greenfield or brownfield init write semantics.
+- Do not broaden into a command-parser refactor or help overhaul for every command.
+- Do not publish npm, move GitHub Release latest, merge, or create release artifacts outside this focused pinpoint.
+- Keep package/release drift as a bundle-release candidate, not an immediate publish gate.
+
+## Files to touch
+
+- `src/cli.ts` — add init-specific help/usage routing.
+- `tests/cli-init.test.ts` — add regression coverage for `osc init --help` and unsupported init options.
+- `.osc/releases/2026-05-20-086-init-help-flags.md` — evidence note for this pinpoint slice.
+
+## Acceptance criteria
+
+- [x] `osc init --help` exits 0, prints init-specific usage, and does not report `Unknown option for init`.
+- [x] `osc init --json` exits 2 with a clear unsupported-option message and init-specific usage.
+- [x] Existing brownfield init behavior remains unchanged.
+- [x] Repo verification gates pass locally.
+
+## Verification steps
+
+1. `npm test -- tests/cli-init.test.ts --run` — targeted init CLI tests pass.
+2. `npm run --silent osc -- init --help` — help exits 0 and prints init usage.
+3. `npm run --silent osc -- init --json` — exits 2 with init-specific usage.
+4. `git diff --check` — whitespace check passes.
+5. `npm test -- --run` — full Vitest suite passes.
+6. `npm run build` — TypeScript build passes.
+7. `./verify.sh --strict` — scaffold strict verification passes.
+
+## Open questions
+
+None.

--- a/.osc/releases/2026-05-20-086-init-help-flags.md
+++ b/.osc/releases/2026-05-20-086-init-help-flags.md
@@ -9,7 +9,7 @@ This pinpoint dogfood slice tightens the first-run / brownfield init CLI surface
 - Roadmap / issue / task: Pinpoint dogfood surface `brownfield init`; no GitHub issue; not mirrored to a task board.
 - Plan: `.osc/plans/done/086-init-help-flags.md`.
 - Run ID / run packet: N/A — pinpoint scout reproduction; no runtime run packet needed.
-- Branch / PR: branch `fix/init-help-flags`; PR URL to be inserted after creation.
+- Branch / PR: branch `fix/init-help-flags`; PR https://github.com/graphanov/open-scaffold/pull/77.
 - Automation provenance: opened/advanced by John Lomein autopilot; cron job `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`; script `open-scaffold-prrunner-webhook-runner.py`; source `cron-open-scaffold-pr-runner`.
 - Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
 

--- a/.osc/releases/2026-05-20-086-init-help-flags.md
+++ b/.osc/releases/2026-05-20-086-init-help-flags.md
@@ -1,0 +1,36 @@
+# Release / Evidence Note: 086-init-help-flags
+
+## Summary
+
+This pinpoint dogfood slice tightens the first-run / brownfield init CLI surface. `osc init --help` now prints concise init-specific usage instead of exiting 2 with `Unknown option for init: --help` and dumping the full root help surface.
+
+## Traceability
+
+- Roadmap / issue / task: Pinpoint dogfood surface `brownfield init`; no GitHub issue; not mirrored to a task board.
+- Plan: `.osc/plans/done/086-init-help-flags.md`.
+- Run ID / run packet: N/A — pinpoint scout reproduction; no runtime run packet needed.
+- Branch / PR: branch `fix/init-help-flags`; PR URL to be inserted after creation.
+- Automation provenance: opened/advanced by John Lomein autopilot; cron job `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`; script `open-scaffold-prrunner-webhook-runner.py`; source `cron-open-scaffold-pr-runner`.
+- Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.
+
+## Verification
+
+- Pre-fix reproduction: `node dist/cli.js init --help` → exited 2 with `Unknown option for init: --help` and printed the root CLI help.
+- Post-fix reproduction: `npm run --silent osc -- init --help` → exit 0; printed only init usage including `osc init --from-existing --tier min --target <dir> [--force]`.
+- Post-fix reproduction: `npm run --silent osc -- init --json` → exit 2 with `Unknown option for init: --json` and init-specific usage.
+- `npm test -- tests/cli-init.test.ts --run` → pass; 1 file / 28 tests.
+- `git diff --check` → pass.
+- `npm test -- --run` → pass; 29 files / 251 tests.
+- `npm run build` → pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
+- `./verify.sh --strict` → pass; 10 pass / 0 fail / 0 warn.
+
+## Outcome
+
+Init help probes are now safe for first-run and brownfield users. The fix does not alter scaffold generation, conflict handling, existing project preservation, or package/release behavior.
+
+Out of scope: command-parser rewrite, semantic mission generation, package publish, GitHub Release latest movement, merge, or broader first-run strategy changes.
+
+## Follow-up
+
+- PR opened by John Lomein autopilot; continue latest-head CI/Codex review loop.
+- Keep package/release drift bundled with other user-visible slices; this pinpoint does not require immediate npm publish by itself.

--- a/.osc/releases/2026-05-20-086-init-help-flags.md
+++ b/.osc/releases/2026-05-20-086-init-help-flags.md
@@ -18,15 +18,15 @@ This pinpoint dogfood slice tightens the first-run / brownfield init CLI surface
 - Pre-fix reproduction: `node dist/cli.js init --help` → exited 2 with `Unknown option for init: --help` and printed the root CLI help.
 - Post-fix reproduction: `npm run --silent osc -- init --help` → exit 0; printed only init usage including `osc init --from-existing --tier min --target <dir> [--force]`.
 - Post-fix reproduction: `npm run --silent osc -- init --json` → exit 2 with `Unknown option for init: --json` and init-specific usage.
-- `npm test -- tests/cli-init.test.ts --run` → pass; 1 file / 28 tests.
+- `npm test -- tests/cli-init.test.ts --run` → pass; 1 file / 30 tests, including Codex-regression coverage for `--target help` and invalid `--tier help` values.
 - `git diff --check` → pass.
-- `npm test -- --run` → pass; 29 files / 251 tests.
+- `npm test -- --run` → pass; 29 files / 253 tests.
 - `npm run build` → pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
 - `./verify.sh --strict` → pass; 10 pass / 0 fail / 0 warn.
 
 ## Outcome
 
-Init help probes are now safe for first-run and brownfield users. The fix does not alter scaffold generation, conflict handling, existing project preservation, or package/release behavior.
+Init help probes are now safe for first-run and brownfield users. The fix does not alter scaffold generation, conflict handling, existing project preservation, or package/release behavior. A Codex review P1 on PR #77 also hardened the parser so option values named `help` remain normal values instead of becoming help requests.
 
 Out of scope: command-parser rewrite, semantic mission generation, package publish, GitHub Release latest movement, merge, or broader first-run strategy changes.
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-20: closed 086-init-help-flags — Added init help flag handling
 - 2026-05-20: closed 085-runtime-list-json — added JSON output for runtime profile listing
 - 2026-05-20: closed 084-macos-tmp-brownfield-init — fixed macOS /tmp brownfield init
 - 2026-05-20: closed 058-doctor-auto-fix — added doctor auto-fix CLI

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -253,6 +253,12 @@ Run binding options:
   --commit-policy <text>      Commit/push approval rule${mode === 'run' ? '\n\nDry-run options:\n  --dry-run                   Preview run artifacts without writing .osc/runs files\n  --json                      With --dry-run, print only machine-readable JSON' : ''}`);
 }
 
+function printInitUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc init --tier <min|standard|max> --target <dir> [--force]
+  osc init --from-existing --tier min --target <dir> [--force]
+  osc init --min|--standard|--max --target <dir> [--force]`, stream);
+}
+
 function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string; force: boolean; fromExisting: boolean } {
   let tier: ScaffoldTier | undefined;
   let target: string | undefined;
@@ -296,7 +302,7 @@ function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string;
         break;
       default:
         console.error(`Unknown option for init: ${flag}`);
-        printHelp();
+        printInitUsage();
         process.exit(2);
     }
   }
@@ -313,6 +319,10 @@ function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string;
 }
 
 function init(args: string[]): void {
+  if (args.some(isHelpArg)) {
+    printInitUsage('stdout');
+    return;
+  }
   const options = parseInitOptions(args);
   try {
     const result = initializeScaffold(options);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -259,6 +259,22 @@ function printInitUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
   osc init --min|--standard|--max --target <dir> [--force]`, stream);
 }
 
+function hasInitHelpRequest(args: string[]): boolean {
+  let previousFlagNeedsValue = false;
+  for (const arg of args) {
+    if (previousFlagNeedsValue) {
+      previousFlagNeedsValue = false;
+      continue;
+    }
+    if (arg === '--tier' || arg === '--target') {
+      previousFlagNeedsValue = true;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') return true;
+  }
+  return args.length === 1 && args[0] === 'help';
+}
+
 function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string; force: boolean; fromExisting: boolean } {
   let tier: ScaffoldTier | undefined;
   let target: string | undefined;
@@ -319,7 +335,7 @@ function parseInitOptions(args: string[]): { tier: ScaffoldTier; target: string;
 }
 
 function init(args: string[]): void {
-  if (args.some(isHelpArg)) {
+  if (hasInitHelpRequest(args)) {
     printInitUsage('stdout');
     return;
   }

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -196,6 +196,26 @@ describe('osc init CLI', () => {
     expect(result.stderr).not.toContain('Run binding options:');
   });
 
+  it('does not treat a target value named help as an init help request', () => {
+    const parent = tempTarget();
+    const result = spawnSync(tsx, [cli, 'init', '--target', 'help', '--tier', 'min'], { cwd: parent, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Generated min Open Scaffold');
+    expect(existsSync(join(parent, 'help', 'MISSION.md'))).toBe(true);
+  });
+
+  it('does not treat an invalid tier value named help as an init help request', () => {
+    const target = tempTarget();
+    const result = spawnSync(tsx, [cli, 'init', '--tier', 'help', '--target', target], { encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Invalid value for --tier: help');
+    expect(result.stderr).not.toContain('Usage: osc init');
+  });
+
   it('maps runtime and workflow presets into a run packet without spawning', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -175,6 +175,27 @@ describe('osc init CLI', () => {
     expect(result.stdout).toContain('osc init --from-existing --tier min --target <dir> [--force]');
   });
 
+  it('prints init-specific help without treating --help as an unknown option', () => {
+    const result = spawnSync(tsx, [cli, 'init', '--help'], { encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Usage: osc init --tier <min|standard|max> --target <dir> [--force]');
+    expect(result.stdout).toContain('osc init --from-existing --tier min --target <dir> [--force]');
+    expect(result.stdout).not.toContain('Unknown option for init');
+    expect(result.stdout).not.toContain('Run binding options:');
+  });
+
+  it('shows init-specific usage for unsupported init options', () => {
+    const result = spawnSync(tsx, [cli, 'init', '--json'], { encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Unknown option for init: --json');
+    expect(result.stderr).toContain('Usage: osc init --tier <min|standard|max> --target <dir> [--force]');
+    expect(result.stderr).not.toContain('Run binding options:');
+  });
+
   it('maps runtime and workflow presets into a run packet without spawning', () => {
     const target = tempTarget();
     execFileSync(tsx, [cli, 'init', '--standard', '--target', target], { encoding: 'utf8' });


### PR DESCRIPTION
## Summary
- Adds init-specific help output for `osc init --help` with exit code 0.
- Routes unsupported init options such as `--json` to init-specific usage instead of the full root command surface.
- Fixes the Codex-discovered regression where option values named `help` were accidentally treated as help requests.
- Closes pinpoint plan `.osc/plans/done/086-init-help-flags.md` with release/evidence note `.osc/releases/2026-05-20-086-init-help-flags.md`.

## Traceability
- Plan: `.osc/plans/done/086-init-help-flags.md`
- Evidence: `.osc/releases/2026-05-20-086-init-help-flags.md`
- Source surface: pinpoint dogfood / brownfield init first-run help
- No GitHub issue; this came from the build-in-public dogfood scout surface.

## Automation provenance
Opened/advanced by John Lomein autopilot.

- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`
- Script: `open-scaffold-prrunner-webhook-runner.py`
- Source: `cron-open-scaffold-pr-runner`
- Owner gates: merge, npm publish, and GitHub Release creation/latest movement remain owner-gated.

## Verification
- `npm test -- tests/cli-init.test.ts --run` ✅ — 30 tests, including `--target help` and invalid `--tier help` regression coverage
- `npm run --silent osc -- init --help` ✅
- `npm run --silent osc -- init --json` exits 2 with init-specific usage ✅
- `git diff --check` ✅
- `npm test -- --run` ✅ — 29 files / 253 tests
- `npm run build` ✅
- `./verify.sh --strict` ✅ — 10 pass / 0 fail / 0 warn
- GitHub Actions CI ✅ on first head; rerunning on latest fix head

## Out of scope
- No command-parser rewrite.
- No scaffold generation behavior change.
- No npm publish.
- No GitHub Release latest movement.
- No merge without owner approval.

## Codex review
- First Codex pass on `a5c8bba641` found one P1 (`help` as option value was treated as a help request).
- Fixed manually in `548211444ad5685ff1586f4971e74ba12eb7f278` with regression tests and updated evidence.
- Latest-head Codex review re-triggered after the fix; merge remains owner-gated.
