### PR TITLE
Close agentic orchestration model-lab hypothesis

### DIFF
--- a/.osc/plans/done/031-agentic-orchestration-model-lab-vision.md
+++ b/.osc/plans/done/031-agentic-orchestration-model-lab-vision.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog — captured hypothesis, not approved implementation. 2026-05-15 sparring synthesis: no V1 promotion, no MISSION/ROADMAP edit, no AI-research-lab framing in public docs. This inherits the runtime-selection constraints from `.osc/runs/20260515T125857-v1-runtime-choice-sparring/HERMES_SYNTHESIS.md` and is blocked on V1.x adapter evidence: fake/local adapter package, adapter conformance fixture, and Milestone 9 adapter refresh before any multi-lane comparison or evidence-comparability work.
+done
 
 ## Context
 

--- a/.osc/releases/2026-05-21-031-agentic-orchestration-model-lab-vision.md
+++ b/.osc/releases/2026-05-21-031-agentic-orchestration-model-lab-vision.md
@@ -1,0 +1,29 @@
+# Release / Evidence Note: 031-agentic-orchestration-model-lab-vision
+
+## Summary
+
+Closed the agentic orchestration / model-lab vision slice as a no-promotion decision for Open Scaffold core. The PR preserves the useful hypothesis as public-safe wiki knowledge and adds a separate model-task-fit concept page while keeping model routing, benchmarking, and native orchestration out of core.
+
+## Traceability
+
+- Roadmap / issue / task: `ROADMAP.md` Milestone 9 runtime-status hypothesis; no GitHub issue selected by the slice selector.
+- Plan: `.osc/plans/done/031-agentic-orchestration-model-lab-vision.md`
+- Run ID / run packet: `.osc/runs/20260515T132056-agentic-orchestration-roadmap-sparring/`; comparison corpus `.osc/runs/20260515T125857-v1-runtime-choice-sparring/`.
+- Branch / PR: `vision/031-agentic-orchestration-model-lab`; PR pending.
+
+## Verification
+
+- `python3 /Users/danimal/.hermes/scripts/open-scaffold-select-next.py --json` — selected `backlog_plan` `.osc/plans/backlog/031-agentic-orchestration-model-lab-vision.md` with no open PRs/issues and npm `0.4.10` aligned.
+- `for f in .osc/runs/20260515T132056-agentic-orchestration-roadmap-sparring/reports/*.md .osc/runs/20260515T125857-v1-runtime-choice-sparring/reports/*.md; do tail -n 5 "$f" | grep -c 'REPORT_COMPLETE'; done` — all six prior review reports include `REPORT_COMPLETE`.
+- `git diff --check && ./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
+- `npm test -- --run` — 31 files passed, 272 tests passed.
+- `npm run build` — TypeScript core and runtime-omx builds passed.
+- `npm run osc -- plan validate 031-agentic-orchestration-model-lab-vision --json` — `[]`.
+
+## Outcome
+
+The shipped decision is a boundary clarification, not a new runtime feature: Open Scaffold core remains the source-of-truth and evidence substrate; adapters/coordinators may orchestrate externally; model-task-fit observations require a future lab-grade methodology or sibling package. Out of scope: `osc orchestrate`, model rankings, benchmark claims, init-time model/runtime selection, native multi-agent spawning, npm publish, GitHub Release changes, and merge.
+
+## Follow-up
+
+- Owner gate remains for merge. Any future promotion of model/task-fit or orchestration capabilities requires separate evidence, a tracked plan/issue, and explicit owner approval.

--- a/.osc/releases/2026-05-21-031-agentic-orchestration-model-lab-vision.md
+++ b/.osc/releases/2026-05-21-031-agentic-orchestration-model-lab-vision.md
@@ -13,7 +13,7 @@ Closed the agentic orchestration / model-lab vision slice as a no-promotion deci
 
 ## Verification
 
-- `python3 /Users/danimal/.hermes/scripts/open-scaffold-select-next.py --json` — selected `backlog_plan` `.osc/plans/backlog/031-agentic-orchestration-model-lab-vision.md` with no open PRs/issues and npm `0.4.10` aligned.
+- Selector context — autopilot selected `backlog_plan` plan 031 with no open PRs/issues and npm `0.4.10` aligned.
 - `for f in .osc/runs/20260515T132056-agentic-orchestration-roadmap-sparring/reports/*.md .osc/runs/20260515T125857-v1-runtime-choice-sparring/reports/*.md; do tail -n 5 "$f" | grep -c 'REPORT_COMPLETE'; done` — all six prior review reports include `REPORT_COMPLETE`.
 - `git diff --check && ./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
 - `npm test -- --run` — 31 files passed, 272 tests passed.

--- a/.osc/releases/2026-05-21-031-agentic-orchestration-model-lab-vision.md
+++ b/.osc/releases/2026-05-21-031-agentic-orchestration-model-lab-vision.md
@@ -9,7 +9,7 @@ Closed the agentic orchestration / model-lab vision slice as a no-promotion deci
 - Roadmap / issue / task: `ROADMAP.md` Milestone 9 runtime-status hypothesis; no GitHub issue selected by the slice selector.
 - Plan: `.osc/plans/done/031-agentic-orchestration-model-lab-vision.md`
 - Run ID / run packet: `.osc/runs/20260515T132056-agentic-orchestration-roadmap-sparring/`; comparison corpus `.osc/runs/20260515T125857-v1-runtime-choice-sparring/`.
-- Branch / PR: `vision/031-agentic-orchestration-model-lab`; PR pending.
+- Branch / PR: `vision/031-agentic-orchestration-model-lab`; https://github.com/graphanov/open-scaffold/pull/83.
 
 ## Verification
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-21: closed 031-agentic-orchestration-model-lab-vision — closed model-lab hypothesis as evidence-gated non-core direction
 - 2026-05-21: closed 089-runtime-omx-evolution-ledger-package-sync — published 0.4.10 and aligned runtime OMX ledger package surfaces
 - 2026-05-21: closed 088-runtime-omx-evolution-ledger-bridge — Close 088 runtime OMX evolution ledger bridge
 - 2026-05-21: closed 087-closed-evolution-loop-contract — added evolution loop contract CLI

--- a/docs/wiki/concepts/agentic-orchestration.md
+++ b/docs/wiki/concepts/agentic-orchestration.md
@@ -4,7 +4,7 @@ created: 2026-05-15
 updated: 2026-05-21
 type: concept
 tags: [open-scaffold, agent-orchestration, model-routing, evolutionary-loops]
-sources: [MISSION.md, ROADMAP.md, docs/RUNTIME_BINDING_CONTRACT.md, docs/SPAWNING_BOUNDARY.md, docs/AGENTIC_RUNTIME_LAYER.md, docs/EVOLUTION_LOOP.md, .osc/plans/backlog/031-agentic-orchestration-model-lab-vision.md, .osc/plans/done/087-closed-evolution-loop-contract.md, .osc/plans/done/046-executable-open-scaffold-architecture.md]
+sources: [MISSION.md, ROADMAP.md, docs/RUNTIME_BINDING_CONTRACT.md, docs/SPAWNING_BOUNDARY.md, docs/AGENTIC_RUNTIME_LAYER.md, docs/EVOLUTION_LOOP.md, .osc/plans/done/031-agentic-orchestration-model-lab-vision.md, .osc/plans/done/087-closed-evolution-loop-contract.md, .osc/plans/done/046-executable-open-scaffold-architecture.md, docs/wiki/concepts/model-task-fit.md]
 confidence: low
 contested: true
 ---
@@ -54,7 +54,7 @@ As of 2026-05-15, agentic orchestration is a contested product hypothesis, not a
 - **Multi-attempt evolution contract:** now concrete through `docs/EVOLUTION_LOOP.md` and `osc evolve init|record|check`: plan/run attempts can be journaled, evaluated, and promoted to a frontier without core spawning.
 - **OMX-based agentic runtime path:** the preferred serious runtime-engine investment path is explicit packages/adapters around OMX / oh-my-codex, with Open Scaffold core preserving contracts/evidence and `packages/runtime-omx/` owning OMX-specific execution mechanics.
 - **Multi-agent orchestration as contract:** possible V1.x research direction after adapter conformance evidence exists.
-- **Model evaluation lab and model/task-fit map:** not Open Scaffold core; possible sibling product or community-maintained reference if evidence and demand justify it.
+- **Model evaluation lab and model/task-fit map:** not Open Scaffold core; possible sibling product or community-maintained reference if reproducible evidence and demand justify it. See [[model-task-fit]] for the narrower hypothesis.
 - **Native multi-agent runtime:** explicitly deferred; reopen only with a proofability, auditability, or governed-execution driver.
 
 Open Scaffold core stays runtime-neutral and orchestration-neutral. Multi-lane orchestration may be performed by an external coordinator using the existing run packet, evidence receipt, and slice-close contracts. The scaffold provides the evidence substrate, not the orchestrator and not the lab.
@@ -73,4 +73,4 @@ The strongest version of the idea is:
 
 The concrete near-term product path is narrower: `osc evolve` records attempts/frontiers, while OMX-based runtime packages can become the serious execution engine layer that consumes Open Scaffold run packets and returns evidence.
 
-Related: [[agent-runtime-selection]], [[run-packets]], [[evidence-first-development]], [[human-in-the-loop-governance]], [[source-of-truth-first-development]].
+Related: [[agent-runtime-selection]], [[model-task-fit]], [[run-packets]], [[evidence-first-development]], [[human-in-the-loop-governance]], [[source-of-truth-first-development]].

--- a/docs/wiki/concepts/model-task-fit.md
+++ b/docs/wiki/concepts/model-task-fit.md
@@ -1,0 +1,68 @@
+---
+title: Model Task Fit
+created: 2026-05-21
+updated: 2026-05-21
+type: concept
+tags: [open-scaffold, model-routing, evaluation, agent-orchestration]
+sources: [.osc/plans/done/031-agentic-orchestration-model-lab-vision.md, docs/wiki/concepts/agentic-orchestration.md, docs/wiki/summaries/runtime-orchestration-sparring-synthesis.md, docs/EVOLUTION_LOOP.md, docs/RUNTIME_BINDING_CONTRACT.md]
+confidence: low
+contested: true
+---
+
+# Model Task Fit
+
+Model task fit is the hypothesis that an Open Scaffold project could eventually record which models, runtimes, or evaluator lanes work better for specific classes of work.
+
+This is not a shipped Open Scaffold capability and it is not a core promise. It is a research/lab-layer idea that may become useful only when observations come from reproducible evidence rather than preference, anecdotes, or vendor claims.
+
+## Why the idea matters
+
+Open Scaffold already records plans, run packets, evidence notes, evaluations, audit manifests, and evolution-loop attempts. Those artifacts could make future model/task-fit observations more grounded than chat memory or ad-hoc benchmark screenshots.
+
+A credible observation would answer questions like:
+
+- What task class was attempted?
+- Which model, runtime, workflow, and prompt/plan contract were used?
+- What acceptance criteria and evaluator judged the result?
+- What evidence proves the result was better, worse, cheaper, safer, or more reliable?
+- Could another project reproduce the comparison?
+
+## Boundary
+
+Model task fit should stay out of Open Scaffold core until there is lab-grade evidence and a maintenance owner.
+
+Open Scaffold core may provide:
+
+- stable task/run/evidence identifiers;
+- evaluation and audit envelope structures;
+- evolution-loop attempt/frontier records;
+- optional metadata fields that a lab or adapter can consume later.
+
+Open Scaffold core should not provide:
+
+- model rankings;
+- “best model for task” tables;
+- benchmark claims;
+- vendor certification;
+- automatic model routing;
+- init-time model/runtime pickers.
+
+## Smallest credible future artifact
+
+The smallest credible artifact is not a public leaderboard. It is a reproducible evidence profile for one task class:
+
+1. define the task class and acceptance criteria;
+2. run comparable attempts through bounded run packets;
+3. record evaluator identity, model/runtime versions, cost/time, and failure modes;
+4. publish evidence and caveats;
+5. state only what the evidence supports.
+
+That belongs in a future lab, adapter, or sibling package unless the owner explicitly promotes it into the roadmap.
+
+## Current recommendation
+
+- **V1:** do not include model task fit beyond hypothesis docs and source-of-truth evidence primitives.
+- **V1.x:** consider optional evidence-comparability metadata only after adapter conformance and real runtime evidence make comparisons meaningful.
+- **V2 or sibling package:** if demand appears, explore an evaluation lab package that consumes Open Scaffold evidence but owns benchmark methodology and maintenance.
+
+Related: [[agentic-orchestration]], [[agent-runtime-selection]], [[evidence-first-development]], [[run-packets]], [[human-in-the-loop-governance]].

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,7 +1,7 @@
 # Open Scaffold Project Wiki Index
 
 > Public-safe compiled knowledge for Open Scaffold as a body of work. This is not the task board, release log, or product reference.
-> Last updated: 2026-05-21 | Total pages: 18
+> Last updated: 2026-05-21 | Total pages: 19
 
 ## Meta / Operating Contracts
 
@@ -17,6 +17,7 @@
 - [[glass-cockpit]] — Operator visibility layer for agentic work.
 - [[human-in-the-loop-governance]] — Human gates for taste, risk, publication, and scope.
 - [[implementation-architecture-lens]] — How Open Scaffold maps workflow design, audit envelopes, evaluation envelopes, feedback routing, and runtime/system boundaries.
+- [[model-task-fit]] — Contested lab-layer idea for evidence-backed model/task observations, not core model routing.
 - [[repo-native-agent-operating-system]] — The repository as the durable operating substrate.
 - [[run-packets]] — Bounded execution contracts for runtime attempts.
 - [[scaffold-tiers]] — Matching scaffold structure to project risk and coordination cost.

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,11 @@
 > Chronological record of project wiki actions. Append-only.
 > Format: `## [YYYY-MM-DD] action | subject`
 
+## [2026-05-21] decide | Agentic orchestration model-lab hypothesis
+- Closed `031-agentic-orchestration-model-lab-vision` against the existing three-lane orchestration sparring evidence and runtime-selection comparison corpus.
+- Added `docs/wiki/concepts/model-task-fit.md` to preserve the model/task-fit idea as a contested lab-layer hypothesis, not an Open Scaffold core routing promise.
+- Preserved the current stance: orchestration is expressible by contract, model/task observations require reproducible lab evidence, and core remains the source-of-truth substrate.
+
 ## [2026-05-21] implement | Evolution loop contract
 - Added `docs/EVOLUTION_LOOP.md` and `osc evolve init|record|check` as a contract-first attempt/frontier ledger for multi-attempt improvement loops.
 - Clarified that the OMX-based agentic runtime/engine path can execute attempts externally while Open Scaffold core records plans, run packets, evaluations, audit/evolution state, and approval boundaries.

--- a/docs/wiki/summaries/runtime-orchestration-sparring-synthesis.md
+++ b/docs/wiki/summaries/runtime-orchestration-sparring-synthesis.md
@@ -1,10 +1,10 @@
 ---
 title: Runtime And Orchestration Sparring Synthesis
 created: 2026-05-15
-updated: 2026-05-15
+updated: 2026-05-21
 type: summary
 tags: [open-scaffold, agent-orchestration, runtime, evidence, product-vision]
-sources: [.osc/plans/done/030-agent-runtime-selection-vision.md, .osc/plans/backlog/031-agentic-orchestration-model-lab-vision.md, docs/wiki/concepts/agent-runtime-selection.md, docs/wiki/concepts/agentic-orchestration.md]
+sources: [.osc/plans/done/030-agent-runtime-selection-vision.md, .osc/plans/done/031-agentic-orchestration-model-lab-vision.md, docs/wiki/concepts/agent-runtime-selection.md, docs/wiki/concepts/agentic-orchestration.md, docs/wiki/concepts/model-task-fit.md]
 confidence: medium
 contested: true
 ---
@@ -87,4 +87,10 @@ Promote runtime/orchestration capability only when there is evidence beyond owne
 - at least one external user or adapter author requests the next layer;
 - any native runtime or lab direction is justified by proofability, auditability, or governed execution.
 
-Related: [[agent-runtime-selection]], [[agentic-orchestration]], [[run-packets]], [[evidence-first-development]], [[human-in-the-loop-governance]].
+## 2026-05-21 closure update
+
+The orchestration/model-lab hypothesis is closed as a no-promotion decision for Open Scaffold core. The useful durable result is the layer split: core records contracts and evidence; adapters/coordinators execute orchestration; any model/task-fit map belongs in a lab or sibling package with reproducible methodology.
+
+The new [[model-task-fit]] concept preserves the research seam without claiming model routing, benchmark results, or supported-model recommendations.
+
+Related: [[agent-runtime-selection]], [[agentic-orchestration]], [[model-task-fit]], [[run-packets]], [[evidence-first-development]], [[human-in-the-loop-governance]].


### PR DESCRIPTION
## Summary

- Closes `.osc/plans/done/031-agentic-orchestration-model-lab-vision.md` as an evidence-backed no-promotion decision for Open Scaffold core.
- Adds `docs/wiki/concepts/model-task-fit.md` as a contested lab-layer hypothesis, not a core model-routing promise.
- Updates the runtime/orchestration wiki synthesis and evidence note to preserve the layer split: core records contracts/evidence, adapters/coordinators execute, any model/task-fit map belongs in a future lab or sibling package.

## Traceability

- Selected source: `backlog_plan`
- Selected plan: `.osc/plans/backlog/031-agentic-orchestration-model-lab-vision.md`
- Final plan path: `.osc/plans/done/031-agentic-orchestration-model-lab-vision.md`
- Evidence note: `.osc/releases/2026-05-21-031-agentic-orchestration-model-lab-vision.md`
- GitHub issue: none selected by deterministic selector

## Autopilot provenance

Opened/advanced by John Lomein autopilot.

- Cron job: `open-scaffold-autopilot-pr-runner` / `13dc0942e2e9`
- Script: `open-scaffold-prrunner-webhook-runner.py`
- Source: `cron-open-scaffold-pr-runner`
- Selector mode: `backlog_plan`
- Selected source: `repo_backlog`
- Owner gates: merge, npm publish, GitHub Release

## Verification

- Selector context — autopilot selected plan 031 with no open PRs/issues and npm `0.4.10` aligned.
- Prior sparring reports — all six compared reports include `REPORT_COMPLETE`.
- `git diff --check && ./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
- `npm test -- --run` — 31 files passed, 272 tests passed.
- `npm run build` — passed.
- `npm run osc -- plan validate 031-agentic-orchestration-model-lab-vision --json` — `[]`.
- GitHub `ci` — passed on latest head `d5da483`.

## Out of scope

- `osc orchestrate`
- model rankings or benchmark claims
- init-time model/runtime selection
- native multi-agent spawning
- npm publish
- GitHub Release changes
- merge

## Codex review

Latest-head clean. Initial Codex finding on head `559591a` asked to remove an owner-local selector command path from the public evidence note. Fixed in `d5da483`; post-fix `@codex review` returned “Didn't find any major issues” at 2026-05-21T16:00:34Z, and no newer inline findings appeared.
