### PR TITLE
Make evolution loops comparable

### DIFF
--- a/.osc/plans/done/090-evolution-compare.md
+++ b/.osc/plans/done/090-evolution-compare.md
@@ -1,0 +1,66 @@
+# Plan: 090-evolution-compare
+
+## Status
+
+active
+
+## Context
+
+An outside reader reviewed Open Scaffold at v0.4.10 and identified the evolution loop as the project’s strongest differentiated product surface. The current `osc evolve` contract records `loop.json`, `attempts.jsonl`, and `frontier.json`, but reviewers still have to open raw JSONL to understand why one attempt beat another. This plan makes the loop visible without changing runtime authority.
+
+## Goal
+
+Add a read-only `osc evolve compare <loop-dir>` command that explains two evolution attempts side by side so a reviewer can understand the frontier decision in terminal, markdown, or JSON output.
+
+## Constraints / Out of scope
+
+- Do not add a top-level CLI command; keep the surface under `osc evolve`.
+- Do not spawn runtimes, run agents, rank models, certify compliance, or approve release.
+- Do not add runtime dependencies for this slice.
+- Do not implement `osc evolve report`, `replay`, `diff-evidence`, adapter cloning, importers, SDKs, or static share sites in this slice.
+- Do not publish npm or create a GitHub Release without a separate owner gate after merge.
+- Do not include the raw private author report in tracked public artifacts.
+
+## Files to touch
+
+- `src/evolution.ts` — load loop state and render compare results.
+- `src/cli.ts` — add `osc evolve compare` arguments, help text, output writing, and exit behavior.
+- `tests/evolution.test.ts` — unit coverage for compare selection, rendering, and edge cases.
+- `tests/cli-evolution.test.ts` or existing CLI test file — CLI coverage for compare help/output.
+- `README.md` — lightly reposition `What you get` and document `evolve compare` in the repeated-attempt workflow.
+- `.osc/releases/2026-05-22-090-evolution-compare.md` — evidence note with verification results.
+
+## Implementation Architecture Coverage
+
+- Strengthens: evaluation, audit trails, recovery/ownership, adoption trust.
+- Audit envelope: plan `090-evolution-compare`, release/evidence note, PR, tests, and compare output examples.
+- Evaluation envelope: unit and CLI tests prove compare resolves attempts and renders metadata without mutating loop state.
+- Feedback routing: follow-up ideas (`report`, `replay`, adapter expansion, static share, badge, compliance export) remain backlog candidates, not scope creep.
+- Boundary: Open Scaffold core remains a recorder/renderer. Attempt execution, runtime spawning, model judging, compliance certification, and release decisions remain outside core.
+
+## Acceptance criteria
+
+- [ ] `osc evolve compare <loop-dir>` defaults to previous frontier versus current frontier when frontier history and current frontier are present.
+- [ ] `--a <attempt-id|run-id|frontier>` and `--b <attempt-id|run-id|frontier>` resolve explicit comparison targets with clear errors for unknown attempts.
+- [ ] A loop with only one recorded attempt exits successfully with a clear “nothing to compare” message.
+- [ ] Terminal output includes loop objective, strategy, attempt count, A/B decision, score/delta, run ID, evidence count/membership summary, evaluation presence, rationale, boundary differences, and frontier history.
+- [ ] `--format markdown` renders a PR-comment-friendly comparison table and rationale block.
+- [ ] `--format json` emits machine-readable comparison data.
+- [ ] `--out <path>` writes markdown or JSON output without mutating loop files.
+- [ ] README and CLI help mention the compare command without adding new top-level CLI vocabulary.
+- [ ] Verification passes: `git diff --check`, `npm test -- --run`, `npm run build`, and `./verify.sh --strict`.
+
+## Verification steps
+
+1. Run targeted RED/GREEN tests for the compare unit coverage.
+2. Run targeted CLI tests for `osc evolve compare` and help output.
+3. Run `npm test -- --run` and expect all tests to pass.
+4. Run `npm run build` and expect TypeScript build success.
+5. Run `git diff --check` and expect no whitespace errors.
+6. Run `./verify.sh --strict` and expect no failures.
+7. Run a manual smoke on a temporary loop and verify terminal/markdown/json outputs are readable and no loop state changes.
+
+## Open questions
+
+- Whether to add richer evaluation criterion diffing now or keep the first slice to evaluation presence/metadata until evaluation envelopes expose stable per-criterion fields.
+- Whether README repositioning should be a tiny paragraph only or a larger front-page rewrite after Daniel reviews the first compare output.

--- a/.osc/releases/2026-05-22-090-evolution-compare.md
+++ b/.osc/releases/2026-05-22-090-evolution-compare.md
@@ -86,7 +86,27 @@ Result:
 
 ```text
 Test Files  2 passed (2)
-Tests       20 passed (20)
+Tests       22 passed (22)
+```
+
+### Codex review fix round
+
+Codex reviewed PR #87 at head `4cc533f56742f58dd0e752e8d3550711a198b23c` and found two valid issues:
+
+1. Default compare should not fall back to the last two non-frontier attempts when no previous-frontier/current-frontier comparison exists.
+2. Markdown output should not label side B as `current frontier` unless side B is actually the current frontier.
+
+Fixes added:
+
+- Regression: two rejected/retry attempts without a promoted frontier now return a successful “No previous frontier/current frontier comparison is recorded yet.” message instead of inventing a comparison.
+- Regression: explicit `--a frontier --b <non-frontier>` markdown labels A as current and B as non-current.
+- Renderer history markers now distinguish `A`, `B`, and `current` independently.
+
+Post-fix targeted result:
+
+```text
+npm test -- --run tests/evolution.test.ts -> 1 file / 14 tests passed
+npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts -> 2 files / 22 tests passed
 ```
 
 ### Full test suite
@@ -99,7 +119,7 @@ Result:
 
 ```text
 Test Files  32 passed (32)
-Tests       284 passed (284)
+Tests       286 passed (286)
 ```
 
 ### Build

--- a/.osc/releases/2026-05-22-090-evolution-compare.md
+++ b/.osc/releases/2026-05-22-090-evolution-compare.md
@@ -1,0 +1,157 @@
+# 090 — Evolution compare CLI
+
+Date: 2026-05-22
+Plan: `.osc/plans/done/090-evolution-compare.md`
+Branch: `feat/evolve-compare-visible-loop`
+Package candidate: `open-scaffold@0.4.12`
+
+## Summary
+
+Added a read-only `osc evolve compare <loop-dir>` command that renders two evolution attempts side by side so reviewers can understand a frontier decision without manually opening `attempts.jsonl` and `frontier.json`.
+
+This slice implements the first execution step from the private author-notes action map: make the evolution loop visible before adding more runtime adapters or new top-level product surfaces.
+
+## Traceability
+
+- Plan: `.osc/plans/done/090-evolution-compare.md`
+- Changelog stamp: `MISSION.md` entry for `090-evolution-compare`
+- Private decision support: ignored `.osc/research/2026-05-22-author-notes-action-map.md`
+- Tests: `tests/evolution.test.ts`, `tests/cli-evolution.test.ts`
+- Candidate package: `open-scaffold@0.4.12`
+
+## Outcome
+
+Open Scaffold now has a visible comparison surface for recorded evolution loops. A maintainer can compare the previous frontier attempt against the current frontier in terminal, markdown, or JSON form, including score delta, decision/rationale, evidence membership, evaluation presence, boundary differences, and frontier history.
+
+## What changed
+
+- `src/evolution.ts`
+  - Added compare data loading for `loop.json`, `attempts.jsonl`, and `frontier.json`.
+  - Added default previous-frontier vs current-frontier target resolution.
+  - Added explicit `--a` / `--b` target support for attempt IDs, run IDs, and `frontier`.
+  - Added terminal, markdown, and JSON renderers.
+  - Added single-attempt success messaging instead of treating “nothing to compare yet” as an error.
+- `src/cli.ts`
+  - Added `osc evolve compare <loop-dir>` CLI parsing.
+  - Added `--format terminal|markdown|json` and `--out <path>`.
+  - Updated CLI help.
+- `tests/evolution.test.ts`
+  - Added unit coverage for default comparison, markdown/json/terminal rendering, unknown target errors, and single-attempt loops.
+- `tests/cli-evolution.test.ts`
+  - Added CLI coverage for markdown export.
+- `README.md`
+  - Repositioned the “What you get” section to lead with the evolution ledger.
+  - Added `osc evolve compare` to the repeated-attempt workflow.
+- `package.json` / `package-lock.json`
+  - Bumped package candidate to `0.4.12` for the new public CLI command.
+
+## Boundary
+
+This command is read-only. It does not:
+
+- spawn runtimes;
+- rerun attempts;
+- rank models;
+- certify compliance;
+- approve releases;
+- mutate loop files;
+- add runtime dependencies.
+
+Future report/replay/diff-evidence/static-site/adapter/importer work remains out of scope for this slice.
+
+## Verification
+
+### TDD RED
+
+Targeted tests were written first and failed before implementation:
+
+```text
+npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts
+```
+
+Expected RED failures observed:
+
+```text
+compareEvolutionLoop is not a function
+Usage: osc evolve init ... | osc evolve check <loop-dir>
+```
+
+### Targeted GREEN
+
+```text
+npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       20 passed (20)
+```
+
+### Full test suite
+
+```text
+npm test -- --run
+```
+
+Result:
+
+```text
+Test Files  32 passed (32)
+Tests       284 passed (284)
+```
+
+### Build
+
+```text
+npm run build
+```
+
+Result:
+
+```text
+build:core        pass
+build:runtime-omx pass
+```
+
+### Manual smoke
+
+Created a temporary min scaffold, created a plan, wrote two run packets, initialized an evolution loop, recorded two promoted attempts, and rendered terminal/markdown/json compare outputs with `node dist/cli.js evolve compare`.
+
+Key observed terminal output:
+
+```text
+Evolution Loop: compare-demo
+Strategy: greedy
+Attempts: 2 recorded
+Comparing: A -> attempt-a (promote)
+           B -> attempt-b (promote)
+Score: A=0.62 | B=0.94 | Δ=+0.32 ▲
+Only in A: docs/evidence/attempt-a-proof.md
+Only in B: docs/evidence/attempt-b-proof.md
+Frontier history
+  attempt-a -> promote (0.62) ← A
+  attempt-b -> promote (0.94) ← B/current
+```
+
+Markdown and JSON exports were parsed/checked successfully:
+
+```text
+manual smoke ok
+```
+
+## Remaining gates
+
+- PR creation and Codex latest-head review loop.
+- Merge remains owner-gated.
+- npm publish and GitHub Release `v0.4.12` remain separate owner-gated post-merge public-surface actions.
+
+## Final branch verification
+
+```text
+git diff --check -> pass
+./verify.sh --strict -> 10 pass, 0 fail, 0 warn after release-note section patch
+npm pack --dry-run --json -> open-scaffold-0.4.12.tgz, 106 files, no .osc/research payload
+npm publish --dry-run -> + open-scaffold@0.4.12
+```

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-22: closed 090-evolution-compare — added evolution compare CLI
 - 2026-05-21: closed 059-adoption-metrics — added local adoption metrics CLI
 - 2026-05-21: closed 054-multi-language-agent-entry-points — translated agent entry points shipped in PR #84
 - 2026-05-21: Tighten translation verification: preserve heading order and documented source literals — see .osc/plans/done/054-multi-language-agent-entry-points-amendment-1.md

--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ Want the underlying files? Read [`docs/EXAMPLES.md`](docs/EXAMPLES.md#60-second-
 
 ## What you get
 
+- **Evolution ledger:** `osc evolve` records repeated attempts, frontier promotion, and `osc evolve compare` explains why one attempt beat another.
+- **Evaluation and audit envelopes:** `osc eval` and `osc audit` keep acceptance-criteria checks and artifact integrity attached to the work.
 - **Direction:** `MISSION.md` and `ROADMAP.md` keep intent visible.
 - **Work specs:** `.osc/plans/` holds small, immutable plans with acceptance criteria.
 - **Change history:** amendments record scope changes without rewriting the original plan.
 - **Work packages (run packets):** `.osc/runs/<run_id>/run.json` packages a plan for a chosen runtime lane.
-- **Evaluation and evolution:** `osc eval`, `osc audit`, and `osc evolve` record acceptance-criteria evaluation, artifact integrity, repeated attempts, and frontier promotion.
 - **Evidence:** `.osc/releases/` records what shipped, how it was verified, and what follows.
 - **Checks:** `./verify.sh` and `osc verify` catch stale state, broken evidence, and plan drift.
 - **Agent entry points:** `AGENTS.md` and `CLAUDE.md` tell coding agents how to operate without fresh explanations.
@@ -195,10 +196,11 @@ For repeated attempts, record the loop separately instead of burying the frontie
 ```bash
 npx open-scaffold evolve init .osc/plans/active/my-first-task.md --out .osc/evolution/my-first-task --strategy manual
 npx open-scaffold evolve record .osc/evolution/my-first-task --run .osc/runs/<run_id>/run.json --decision promote --rationale "Best evidence so far."
+npx open-scaffold evolve compare .osc/evolution/my-first-task --format markdown --out .osc/releases/evolution-compare.md
 npx open-scaffold evolve check .osc/evolution/my-first-task
 ```
 
-`osc evolve` records attempt/frontier state only. External adapters or runtime packages execute attempts.
+`osc evolve` records attempt/frontier state only. `osc evolve compare` renders the ledger for review without rerunning attempts. External adapters or runtime packages execute attempts.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { createRunArtifacts, previewRunArtifacts, type ArtifactMode, type Execut
 import { doctorExitCode, formatDoctorReport, parseDoctorCheckName, runDoctor, type DoctorOptions, type DoctorSeverity } from './doctor.js';
 import { collectEvidence } from './evidence.js';
 import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
-import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, recordEvolutionAttempt, validateEvolutionLoopDir, writeEvolutionLoop, type EvolutionDecision, type EvolutionStrategy } from './evolution.js';
+import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, compareEvolutionLoop, recordEvolutionAttempt, renderEvolutionComparison, validateEvolutionLoopDir, writeEvolutionLoop, type EvolutionCompareFormat, type EvolutionDecision, type EvolutionStrategy } from './evolution.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { computeMetrics, formatMetrics, parseSinceDate } from './metrics.js';
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
@@ -43,6 +43,7 @@ Usage:
   osc audit check <audit-manifest-path>
   osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>]
   osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text>
+  osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>]
   osc evolve check <loop-dir>
   osc metrics [--json] [--since <date>] [--lookback <weeks>] [--table] [--verbose]
   osc verify
@@ -1197,7 +1198,7 @@ function evalCommand(args: string[]): void {
 }
 
 function printEvolutionUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
-  printUsage('Usage: osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>] | osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text> | osc evolve check <loop-dir>', stream);
+  printUsage('Usage: osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>] | osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text> | osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>] | osc evolve check <loop-dir>', stream);
 }
 
 function takeEvolutionValue(args: string[], index: number, flag: string): string {
@@ -1219,6 +1220,13 @@ function parseEvolutionStrategy(value: string): EvolutionStrategy {
 function parseEvolutionDecision(value: string): EvolutionDecision {
   if ((EVOLUTION_DECISIONS as readonly string[]).includes(value)) return value as EvolutionDecision;
   console.error(`Invalid value for --decision: ${value}. Expected one of: ${EVOLUTION_DECISIONS.join(', ')}`);
+  printEvolutionUsage();
+  process.exit(2);
+}
+
+function parseEvolutionCompareFormat(value: string): EvolutionCompareFormat {
+  if (value === 'terminal' || value === 'markdown' || value === 'json') return value;
+  console.error(`Invalid value for --format: ${value}. Expected one of: terminal, markdown, json`);
   printEvolutionUsage();
   process.exit(2);
 }
@@ -1358,6 +1366,60 @@ function evolutionCommand(args: string[]): void {
       console.log(`Recorded evolution attempt: ${String(result.attempt.attempt_id)}`);
       if (result.frontierUpdated) console.log(`Updated frontier: ${String(result.attempt.attempt_id)}`);
       console.log('Note: this recorded an attempt decision only; scorer output is evidence, not automatic approval.');
+      return;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  }
+
+  if (subcommand === 'compare') {
+    if (!sourceOrPath) {
+      printEvolutionUsage();
+      process.exit(2);
+    }
+    let a: string | undefined;
+    let b: string | undefined;
+    let format: EvolutionCompareFormat = 'terminal';
+    let outPath: string | undefined;
+    for (let i = 0; i < rest.length; i += 1) {
+      const flag = rest[i];
+      switch (flag) {
+        case '--a':
+          a = takeEvolutionValue(rest, i, flag);
+          i += 1;
+          break;
+        case '--b':
+          b = takeEvolutionValue(rest, i, flag);
+          i += 1;
+          break;
+        case '--format':
+          format = parseEvolutionCompareFormat(takeEvolutionValue(rest, i, flag));
+          i += 1;
+          break;
+        case '--out':
+        case '--output':
+          outPath = takeEvolutionValue(rest, i, flag);
+          i += 1;
+          break;
+        default:
+          console.error(`Unknown option for evolve compare: ${flag}`);
+          printEvolutionUsage();
+          process.exit(2);
+      }
+    }
+    try {
+      const loopDir = resolve(sourceOrPath);
+      const root = evolutionRootFor(loopDir);
+      const comparison = compareEvolutionLoop(loopDir, { a, b }, root);
+      const rendered = renderEvolutionComparison(comparison, format);
+      if (outPath) {
+        const resolvedOut = resolve(outPath);
+        writeFileSync(resolvedOut, rendered, 'utf8');
+        console.log(`Wrote evolution comparison: ${resolvedOut}`);
+      } else {
+        process.stdout.write(rendered.endsWith('\n') ? rendered : `${rendered}\n`);
+      }
       return;
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -530,15 +530,13 @@ export function compareEvolutionLoop(loopDir: string, options: EvolutionCompareO
     return { kind: 'message', loop: loopInfo, message: 'Only one attempt recorded; nothing to compare yet.' };
   }
 
-  const defaultA = frontierIds.previous ?? (attempts.length >= 2 ? attempts[attempts.length - 2].attemptId : null);
-  const defaultB = frontierIds.current ?? (attempts.length >= 1 ? attempts[attempts.length - 1].attemptId : null);
-  const aTarget = hasExplicitTarget ? (options.a ?? 'frontier') : defaultA;
-  const bTarget = hasExplicitTarget ? (options.b ?? 'frontier') : defaultB;
-  if (!aTarget || !bTarget) {
-    return { kind: 'message', loop: loopInfo, message: 'No comparable frontier attempts recorded yet.' };
+  const defaultA = hasExplicitTarget ? (options.a ?? 'frontier') : frontierIds.previous;
+  const defaultB = hasExplicitTarget ? (options.b ?? 'frontier') : frontierIds.current;
+  if (!defaultA || !defaultB) {
+    return { kind: 'message', loop: loopInfo, message: 'No previous frontier/current frontier comparison is recorded yet.' };
   }
-  const a = resolveAttemptTarget(aTarget, attempts, frontierIds.current);
-  const b = resolveAttemptTarget(bTarget, attempts, frontierIds.current);
+  const a = resolveAttemptTarget(defaultA, attempts, frontierIds.current);
+  const b = resolveAttemptTarget(defaultB, attempts, frontierIds.current);
   const scoreDelta = a.score !== null && b.score !== null ? Number((b.score - a.score).toFixed(6)) : null;
   const evidence = evidenceDelta(a.evidenceRefs, b.evidenceRefs);
   const attemptById = new Map(attempts.map((attempt) => [attempt.attemptId, attempt]));
@@ -579,7 +577,25 @@ function linesOrNone(lines: string[], indent = '  '): string[] {
   return lines.length > 0 ? lines.map((line) => `${indent}${line}`) : [`${indent}—`];
 }
 
+function currentFrontierAttemptId(comparison: Extract<EvolutionCompareResult, { kind: 'comparison' }>): string | null {
+  return comparison.frontierHistory.length > 0 ? comparison.frontierHistory[comparison.frontierHistory.length - 1].attemptId : null;
+}
+
+function attemptLabel(attempt: EvolutionCompareAttempt, currentAttemptId: string | null): string {
+  const decision = attempt.decision ?? 'recorded';
+  return attempt.attemptId === currentAttemptId ? `${decision}, current frontier` : decision;
+}
+
+function historyMarkers(item: { attemptId: string }, comparison: Extract<EvolutionCompareResult, { kind: 'comparison' }>, currentAttemptId: string | null): string {
+  const markers = [];
+  if (item.attemptId === comparison.a.attemptId) markers.push('A');
+  if (item.attemptId === comparison.b.attemptId) markers.push('B');
+  if (item.attemptId === currentAttemptId) markers.push('current');
+  return markers.length > 0 ? ` ← ${markers.join('/')}` : '';
+}
+
 function renderTerminalComparison(comparison: Extract<EvolutionCompareResult, { kind: 'comparison' }>): string {
+  const currentAttemptId = currentFrontierAttemptId(comparison);
   const evidenceDeltaLabel = comparison.evidence.onlyInB.length - comparison.evidence.onlyInA.length;
   const evidenceDeltaText = evidenceDeltaLabel === 0 ? '0' : `${evidenceDeltaLabel > 0 ? '+' : ''}${evidenceDeltaLabel}`;
   const lines = [
@@ -618,7 +634,7 @@ function renderTerminalComparison(comparison: Extract<EvolutionCompareResult, { 
     '',
     'Frontier history',
     ...(comparison.frontierHistory.length > 0
-      ? comparison.frontierHistory.map((item) => `  ${item.attemptId} -> ${item.decision ?? 'recorded'} (${formatScore(item.score)})${item.attemptId === comparison.a.attemptId ? ' ← A' : ''}${item.attemptId === comparison.b.attemptId ? ' ← B/current' : ''}`)
+      ? comparison.frontierHistory.map((item) => `  ${item.attemptId} -> ${item.decision ?? 'recorded'} (${formatScore(item.score)})${historyMarkers(item, comparison, currentAttemptId)}`)
       : ['  —']),
     '',
     'Use --format markdown --out <path> to export this comparison for a PR or review thread.',
@@ -627,12 +643,13 @@ function renderTerminalComparison(comparison: Extract<EvolutionCompareResult, { 
 }
 
 function renderMarkdownComparison(comparison: Extract<EvolutionCompareResult, { kind: 'comparison' }>): string {
+  const currentAttemptId = currentFrontierAttemptId(comparison);
   const evidenceDeltaLabel = comparison.evidence.onlyInB.length - comparison.evidence.onlyInA.length;
   const evidenceDeltaText = evidenceDeltaLabel === 0 ? '0' : `${evidenceDeltaLabel > 0 ? '+' : ''}${evidenceDeltaLabel}`;
   const lines = [
     `# Evolution loop: ${comparison.loop.loopDir} — A vs B`,
     '',
-    `**Comparing:** \`${comparison.a.attemptId}\` (${comparison.a.decision ?? 'recorded'}) → \`${comparison.b.attemptId}\` (${comparison.b.decision ?? 'recorded'}, current frontier)`,
+    `**Comparing:** \`${comparison.a.attemptId}\` (${attemptLabel(comparison.a, currentAttemptId)}) → \`${comparison.b.attemptId}\` (${attemptLabel(comparison.b, currentAttemptId)})`,
     '',
     '| Field | A | B | Δ |',
     '|---|---|---|---|',
@@ -656,7 +673,7 @@ function renderMarkdownComparison(comparison: Extract<EvolutionCompareResult, { 
     '',
     '## Frontier history',
     '',
-    ...(comparison.frontierHistory.length > 0 ? comparison.frontierHistory.map((item) => `- \`${item.attemptId}\` → ${item.decision ?? 'recorded'} (${formatScore(item.score)})${item.attemptId === comparison.a.attemptId ? ' ← A' : ''}${item.attemptId === comparison.b.attemptId ? ' ← B/current' : ''}`) : ['- —']),
+    ...(comparison.frontierHistory.length > 0 ? comparison.frontierHistory.map((item) => `- \`${item.attemptId}\` → ${item.decision ?? 'recorded'} (${formatScore(item.score)})${historyMarkers(item, comparison, currentAttemptId)}`) : ['- —']),
   ];
   return `${lines.join('\n')}\n`;
 }

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -101,6 +101,10 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 }
 
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 function meaningfulString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0 && !/^(todo|tbd|n\/a|none)$/i.test(value.trim());
 }
@@ -388,6 +392,283 @@ function readAttempts(attemptsPath: string): Array<Record<string, unknown>> {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+export type EvolutionCompareFormat = 'terminal' | 'markdown' | 'json';
+
+export interface EvolutionCompareOptions {
+  a?: string;
+  b?: string;
+}
+
+export interface EvolutionCompareAttempt {
+  attemptId: string;
+  runId: string | null;
+  taskId: string | null;
+  recordedAt: string | null;
+  decision: string | null;
+  score: number | null;
+  rationale: string;
+  runPacket: string | null;
+  evidenceRefs: string[];
+  adapterReceipts: string[];
+  evaluation: string | null;
+  evaluationId: string | null;
+  evaluationDecision: string | null;
+  boundary: Record<string, unknown>;
+}
+
+export type EvolutionCompareResult =
+  | {
+      kind: 'message';
+      loop: { loopDir: string; loopId: string | null; objective: string | null; strategy: string | null; attemptCount: number };
+      message: string;
+    }
+  | {
+      kind: 'comparison';
+      loop: { loopDir: string; loopId: string | null; objective: string | null; strategy: string | null; attemptCount: number };
+      a: EvolutionCompareAttempt;
+      b: EvolutionCompareAttempt;
+      scoreDelta: number | null;
+      evidence: { onlyInA: string[]; onlyInB: string[]; inBoth: string[] };
+      evaluation: { a: { present: boolean; path: string | null; id: string | null; decision: string | null }; b: { present: boolean; path: string | null; id: string | null; decision: string | null } };
+      boundaryDifferences: Array<{ field: string; a: unknown; b: unknown }>;
+      frontierHistory: Array<{ attemptId: string; runId: string | null; score: number | null; promotedAt: string | null; decision: string | null }>;
+    };
+
+function normalizeCompareAttempt(attempt: Record<string, unknown>): EvolutionCompareAttempt {
+  const attemptId = asString(attempt.attempt_id);
+  if (!attemptId) throw new Error('Evolution attempt is missing attempt_id.');
+  const boundaryValue = isRecord(attempt.boundary) ? attempt.boundary : {};
+  return {
+    attemptId,
+    runId: asString(attempt.run_id),
+    taskId: asString(attempt.task_id),
+    recordedAt: asString(attempt.recorded_at),
+    decision: asString(attempt.decision),
+    score: asNumber(attempt.score),
+    rationale: asString(attempt.rationale) ?? '',
+    runPacket: asString(attempt.run_packet),
+    evidenceRefs: asStringArray(attempt.evidence_refs),
+    adapterReceipts: asStringArray(attempt.adapter_receipts),
+    evaluation: asString(attempt.evaluation),
+    evaluationId: asString(attempt.evaluation_id),
+    evaluationDecision: asString(attempt.evaluation_decision),
+    boundary: boundaryValue,
+  };
+}
+
+function formatScore(score: number | null): string {
+  return score === null ? '—' : Number(score.toFixed(6)).toString();
+}
+
+function formatDelta(delta: number | null): string {
+  if (delta === null) return '—';
+  const rounded = Number(delta.toFixed(6));
+  if (rounded === 0) return '0';
+  return `${rounded > 0 ? '+' : ''}${rounded} ${rounded > 0 ? '▲' : '▼'}`;
+}
+
+function evidenceDelta(aRefs: string[], bRefs: string[]) {
+  const aSet = new Set(aRefs);
+  const bSet = new Set(bRefs);
+  return {
+    onlyInA: aRefs.filter((ref) => !bSet.has(ref)),
+    onlyInB: bRefs.filter((ref) => !aSet.has(ref)),
+    inBoth: aRefs.filter((ref) => bSet.has(ref)),
+  };
+}
+
+function boundaryDelta(a: Record<string, unknown>, b: Record<string, unknown>) {
+  const fields = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
+  return fields
+    .filter((field) => JSON.stringify(a[field]) !== JSON.stringify(b[field]))
+    .map((field) => ({ field, a: a[field], b: b[field] }));
+}
+
+function resolveAttemptTarget(target: string, attempts: EvolutionCompareAttempt[], currentFrontierId: string | null): EvolutionCompareAttempt {
+  const resolvedTarget = target === 'frontier' ? currentFrontierId : target;
+  if (!resolvedTarget) throw new Error('No current frontier attempt is recorded.');
+  const found = attempts.find((attempt) => attempt.attemptId === resolvedTarget || attempt.runId === resolvedTarget);
+  if (!found) throw new Error(`Unknown evolution attempt target: ${target}`);
+  return found;
+}
+
+function frontierAttemptIds(frontier: Record<string, unknown>): { current: string | null; previous: string | null; history: Array<Record<string, unknown>> } {
+  const current = isRecord(frontier.current) ? asString(frontier.current.attempt_id) : null;
+  const history = Array.isArray(frontier.history) ? frontier.history.filter(isRecord) : [];
+  const previous = history.length > 0 ? asString(history[history.length - 1].attempt_id) : null;
+  return { current, previous, history };
+}
+
+export function compareEvolutionLoop(loopDir: string, options: EvolutionCompareOptions = {}, root = process.cwd()): EvolutionCompareResult {
+  const absoluteLoopDir = isAbsolute(loopDir) ? loopDir : resolve(root, loopDir);
+  const loopPath = join(absoluteLoopDir, 'loop.json');
+  const attemptsPath = join(absoluteLoopDir, 'attempts.jsonl');
+  const frontierPath = join(absoluteLoopDir, 'frontier.json');
+  const loop = readJson(loopPath);
+  if (!isRecord(loop) || loop.schema !== EVOLUTION_LOOP_SCHEMA) {
+    throw new Error(`Evolution loop must declare schema: ${EVOLUTION_LOOP_SCHEMA}`);
+  }
+  const frontier = readJson(frontierPath);
+  if (!isRecord(frontier) || frontier.schema !== EVOLUTION_FRONTIER_SCHEMA) {
+    throw new Error(`Evolution frontier must declare schema: ${EVOLUTION_FRONTIER_SCHEMA}`);
+  }
+  const attempts = readAttempts(attemptsPath).map(normalizeCompareAttempt);
+  const strategy = isRecord(loop.strategy) ? asString(loop.strategy.name) : null;
+  const loopInfo = {
+    loopDir: basename(absoluteLoopDir),
+    loopId: asString(loop.loop_id),
+    objective: asString(loop.objective),
+    strategy,
+    attemptCount: attempts.length,
+  };
+  const frontierIds = frontierAttemptIds(frontier);
+  const hasExplicitTarget = Boolean(options.a || options.b);
+
+  if (!hasExplicitTarget && attempts.length < 2) {
+    return { kind: 'message', loop: loopInfo, message: 'Only one attempt recorded; nothing to compare yet.' };
+  }
+
+  const defaultA = frontierIds.previous ?? (attempts.length >= 2 ? attempts[attempts.length - 2].attemptId : null);
+  const defaultB = frontierIds.current ?? (attempts.length >= 1 ? attempts[attempts.length - 1].attemptId : null);
+  const aTarget = hasExplicitTarget ? (options.a ?? 'frontier') : defaultA;
+  const bTarget = hasExplicitTarget ? (options.b ?? 'frontier') : defaultB;
+  if (!aTarget || !bTarget) {
+    return { kind: 'message', loop: loopInfo, message: 'No comparable frontier attempts recorded yet.' };
+  }
+  const a = resolveAttemptTarget(aTarget, attempts, frontierIds.current);
+  const b = resolveAttemptTarget(bTarget, attempts, frontierIds.current);
+  const scoreDelta = a.score !== null && b.score !== null ? Number((b.score - a.score).toFixed(6)) : null;
+  const evidence = evidenceDelta(a.evidenceRefs, b.evidenceRefs);
+  const attemptById = new Map(attempts.map((attempt) => [attempt.attemptId, attempt]));
+  const frontierHistory = [
+    ...frontierIds.history.map((entry) => ({
+      attemptId: asString(entry.attempt_id),
+      runId: asString(entry.run_id),
+      score: asNumber(entry.score),
+      promotedAt: asString(entry.promoted_at),
+    })),
+    ...(frontierIds.current ? [{
+      attemptId: frontierIds.current,
+      runId: isRecord(frontier.current) ? asString(frontier.current.run_id) : null,
+      score: isRecord(frontier.current) ? asNumber(frontier.current.score) : null,
+      promotedAt: isRecord(frontier.current) ? asString(frontier.current.promoted_at) : null,
+    }] : []),
+  ]
+    .filter((entry): entry is { attemptId: string; runId: string | null; score: number | null; promotedAt: string | null } => Boolean(entry.attemptId))
+    .map((entry) => ({ ...entry, decision: attemptById.get(entry.attemptId)?.decision ?? null }));
+
+  return {
+    kind: 'comparison',
+    loop: loopInfo,
+    a,
+    b,
+    scoreDelta,
+    evidence,
+    evaluation: {
+      a: { present: Boolean(a.evaluation), path: a.evaluation, id: a.evaluationId, decision: a.evaluationDecision },
+      b: { present: Boolean(b.evaluation), path: b.evaluation, id: b.evaluationId, decision: b.evaluationDecision },
+    },
+    boundaryDifferences: boundaryDelta(a.boundary, b.boundary),
+    frontierHistory,
+  };
+}
+
+function linesOrNone(lines: string[], indent = '  '): string[] {
+  return lines.length > 0 ? lines.map((line) => `${indent}${line}`) : [`${indent}—`];
+}
+
+function renderTerminalComparison(comparison: Extract<EvolutionCompareResult, { kind: 'comparison' }>): string {
+  const evidenceDeltaLabel = comparison.evidence.onlyInB.length - comparison.evidence.onlyInA.length;
+  const evidenceDeltaText = evidenceDeltaLabel === 0 ? '0' : `${evidenceDeltaLabel > 0 ? '+' : ''}${evidenceDeltaLabel}`;
+  const lines = [
+    `Evolution Loop: ${comparison.loop.loopDir}`,
+    `Objective: ${comparison.loop.objective ?? '—'}`,
+    `Strategy: ${comparison.loop.strategy ?? '—'}`,
+    `Attempts: ${comparison.loop.attemptCount} recorded`,
+    '',
+    `Comparing: A -> ${comparison.a.attemptId} (${comparison.a.decision ?? 'unknown'})`,
+    `           B -> ${comparison.b.attemptId} (${comparison.b.decision ?? 'unknown'})`,
+    '',
+    'Summary',
+    `  Decision: A=${comparison.a.decision ?? '—'} | B=${comparison.b.decision ?? '—'}`,
+    `  Score: A=${formatScore(comparison.a.score)} | B=${formatScore(comparison.b.score)} | Δ=${formatDelta(comparison.scoreDelta)}`,
+    `  Run ID: A=${comparison.a.runId ?? '—'} | B=${comparison.b.runId ?? '—'}`,
+    `  Evidence files: A=${comparison.a.evidenceRefs.length} | B=${comparison.b.evidenceRefs.length} | Δ=${evidenceDeltaText}`,
+    `  Evaluation present?: A=${comparison.evaluation.a.present ? 'yes' : 'no'} | B=${comparison.evaluation.b.present ? 'yes' : 'no'}`,
+    `  Receipt present?: A=${comparison.a.adapterReceipts.length > 0 ? 'yes' : 'no'} | B=${comparison.b.adapterReceipts.length > 0 ? 'yes' : 'no'}`,
+    '',
+    'Rationale',
+    `  A (${comparison.a.decision ?? 'unknown'}): ${comparison.a.rationale || '—'}`,
+    `  B (${comparison.b.decision ?? 'unknown'}): ${comparison.b.rationale || '—'}`,
+    '',
+    'Evidence files',
+    '  Only in A:',
+    ...linesOrNone(comparison.evidence.onlyInA, '    '),
+    '  Only in B:',
+    ...linesOrNone(comparison.evidence.onlyInB, '    '),
+    '  In both:',
+    ...linesOrNone(comparison.evidence.inBoth, '    '),
+    '',
+    'Boundary differences',
+    ...(comparison.boundaryDifferences.length > 0
+      ? comparison.boundaryDifferences.map((diff) => `  ${diff.field}: A=${JSON.stringify(diff.a)} | B=${JSON.stringify(diff.b)}`)
+      : ['  —']),
+    '',
+    'Frontier history',
+    ...(comparison.frontierHistory.length > 0
+      ? comparison.frontierHistory.map((item) => `  ${item.attemptId} -> ${item.decision ?? 'recorded'} (${formatScore(item.score)})${item.attemptId === comparison.a.attemptId ? ' ← A' : ''}${item.attemptId === comparison.b.attemptId ? ' ← B/current' : ''}`)
+      : ['  —']),
+    '',
+    'Use --format markdown --out <path> to export this comparison for a PR or review thread.',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function renderMarkdownComparison(comparison: Extract<EvolutionCompareResult, { kind: 'comparison' }>): string {
+  const evidenceDeltaLabel = comparison.evidence.onlyInB.length - comparison.evidence.onlyInA.length;
+  const evidenceDeltaText = evidenceDeltaLabel === 0 ? '0' : `${evidenceDeltaLabel > 0 ? '+' : ''}${evidenceDeltaLabel}`;
+  const lines = [
+    `# Evolution loop: ${comparison.loop.loopDir} — A vs B`,
+    '',
+    `**Comparing:** \`${comparison.a.attemptId}\` (${comparison.a.decision ?? 'recorded'}) → \`${comparison.b.attemptId}\` (${comparison.b.decision ?? 'recorded'}, current frontier)`,
+    '',
+    '| Field | A | B | Δ |',
+    '|---|---|---|---|',
+    `| Decision | ${comparison.a.decision ?? '—'} | ${comparison.b.decision ?? '—'} | ${comparison.a.decision === comparison.b.decision ? '—' : 'changed'} |`,
+    `| Score | ${formatScore(comparison.a.score)} | ${formatScore(comparison.b.score)} | ${formatDelta(comparison.scoreDelta)} |`,
+    `| Run ID | ${comparison.a.runId ?? '—'} | ${comparison.b.runId ?? '—'} | ${comparison.a.runId === comparison.b.runId ? '—' : 'changed'} |`,
+    `| Evidence files | ${comparison.a.evidenceRefs.length} | ${comparison.b.evidenceRefs.length} | ${evidenceDeltaText} |`,
+    `| Evaluation envelope | ${comparison.evaluation.a.present ? '✓' : '—'} | ${comparison.evaluation.b.present ? '✓' : '—'} | ${comparison.evaluation.a.present === comparison.evaluation.b.present ? '—' : 'changed'} |`,
+    '',
+    '## Rationale',
+    '',
+    `**A (${comparison.a.decision ?? 'recorded'}):** ${comparison.a.rationale || '—'}`,
+    '',
+    `**B (${comparison.b.decision ?? 'recorded'}):** ${comparison.b.rationale || '—'}`,
+    '',
+    '## Evidence files',
+    '',
+    `- Only in A: ${comparison.evidence.onlyInA.length > 0 ? comparison.evidence.onlyInA.map((ref) => `\`${ref}\``).join(', ') : '—'}`,
+    `- Only in B: ${comparison.evidence.onlyInB.length > 0 ? comparison.evidence.onlyInB.map((ref) => `\`${ref}\``).join(', ') : '—'}`,
+    `- In both: ${comparison.evidence.inBoth.length > 0 ? comparison.evidence.inBoth.map((ref) => `\`${ref}\``).join(', ') : '—'}`,
+    '',
+    '## Frontier history',
+    '',
+    ...(comparison.frontierHistory.length > 0 ? comparison.frontierHistory.map((item) => `- \`${item.attemptId}\` → ${item.decision ?? 'recorded'} (${formatScore(item.score)})${item.attemptId === comparison.a.attemptId ? ' ← A' : ''}${item.attemptId === comparison.b.attemptId ? ' ← B/current' : ''}`) : ['- —']),
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderEvolutionComparison(comparison: EvolutionCompareResult, format: EvolutionCompareFormat = 'terminal'): string {
+  if (format === 'json') return `${JSON.stringify(comparison, null, 2)}\n`;
+  if (comparison.kind === 'message') {
+    if (format === 'markdown') return `> ${comparison.message}\n`;
+    return `${comparison.message}\n`;
+  }
+  if (format === 'markdown') return renderMarkdownComparison(comparison);
+  return renderTerminalComparison(comparison);
 }
 
 export function recordEvolutionAttempt(loopDir: string, options: RecordEvolutionAttemptOptions, root = process.cwd()): RecordEvolutionAttemptResult {

--- a/tests/cli-evolution.test.ts
+++ b/tests/cli-evolution.test.ts
@@ -8,6 +8,22 @@ const repoRoot = resolve(import.meta.dirname, '..');
 const tsx = join(repoRoot, 'node_modules/.bin/tsx');
 const cli = join(repoRoot, 'src/cli.ts');
 
+function writeRunPacket(root: string, runId: string) {
+  const runDir = join(root, `.osc/runs/${runId}`);
+  mkdirSync(runDir, { recursive: true });
+  const runPath = join(runDir, 'run.json');
+  const proofPath = join(root, `docs/evidence/${runId}-proof.md`);
+  writeFileSync(runPath, JSON.stringify({
+    schemaVersion: 'open-scaffold.run.v1',
+    runId,
+    taskId: 'task-123',
+    plan: { slug: '087-demo', path: '.osc/plans/active/087-demo.md', acceptanceCriteria: ['Loop state is created.', 'Frontier promotion is explicit.'] },
+    artifacts: { evidence: [`docs/evidence/${runId}-proof.md`] },
+  }, null, 2));
+  writeFileSync(proofPath, `${runId} proof`);
+  return runPath;
+}
+
 function tempRepo() {
   const root = mkdtempSync(join(tmpdir(), 'osc-cli-evolution-'));
   mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
@@ -50,15 +66,7 @@ Improve the run contract.
 
 - None.
 `);
-  const runPath = join(root, '.osc/runs/demo-run/run.json');
-  writeFileSync(runPath, JSON.stringify({
-    schemaVersion: 'open-scaffold.run.v1',
-    runId: 'demo-run',
-    taskId: 'task-123',
-    plan: { slug: '087-demo', path: '.osc/plans/active/087-demo.md', acceptanceCriteria: ['Loop state is created.', 'Frontier promotion is explicit.'] },
-    artifacts: { evidence: ['docs/evidence/proof.md'] },
-  }, null, 2));
-  writeFileSync(join(root, 'docs/evidence/proof.md'), 'proof');
+  const runPath = writeRunPacket(root, 'demo-run');
   const evalPath = join(root, 'docs/evidence/evaluation.json');
   writeFileSync(evalPath, JSON.stringify({
     schema: 'open-scaffold.evaluation.v1',
@@ -216,6 +224,24 @@ describe('osc evolve CLI', () => {
     expect(result.stderr).toContain('Promotion, rejection, retry, and block decisions require a rationale');
     const frontier = JSON.parse(readFileSync(join(outDir, 'frontier.json'), 'utf8'));
     expect(frontier.current).toBeNull();
+  });
+
+  it('compares evolution attempts and writes markdown output', () => {
+    const { root, planPath, runPath } = tempRepo();
+    const runB = writeRunPacket(root, 'attempt-b');
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    const reportPath = join(root, 'docs/evidence/evolution-compare.md');
+    execFileSync(tsx, [cli, 'evolve', 'init', planPath, '--out', outDir, '--strategy', 'greedy'], { cwd: root, encoding: 'utf8' });
+    execFileSync(tsx, [cli, 'evolve', 'record', outDir, '--run', runPath, '--decision', 'promote', '--score', '0.62', '--rationale', 'First promoted frontier.'], { cwd: root, encoding: 'utf8' });
+    execFileSync(tsx, [cli, 'evolve', 'record', outDir, '--run', runB, '--decision', 'promote', '--score', '0.94', '--rationale', 'Better frontier.'], { cwd: root, encoding: 'utf8' });
+
+    const output = execFileSync(tsx, [cli, 'evolve', 'compare', outDir, '--format', 'markdown', '--out', reportPath], { cwd: root, encoding: 'utf8' });
+
+    expect(output).toContain('Wrote evolution comparison:');
+    const report = readFileSync(reportPath, 'utf8');
+    expect(report).toContain('# Evolution loop: demo-loop — A vs B');
+    expect(report).toContain('| Score | 0.62 | 0.94 | +0.32 ▲ |');
+    expect(report).toContain('**B (promote):** Better frontier.');
   });
 
   it('rejects unknown strategies and prints evolve usage', () => {

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -416,4 +416,37 @@ describe('evolution comparison rendering', () => {
     expect(comparison.kind).toBe('message');
     expect(renderEvolutionComparison(comparison, 'terminal')).toContain('Only one attempt recorded; nothing to compare yet.');
   });
+
+  it('does not default to last two attempts when no frontier comparison exists', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z') });
+    recordEvolutionAttempt(outDir, { runPath: runA, decision: 'reject', score: 0.25, rationale: 'Rejected first.', now: new Date('2026-05-21T08:10:00.000Z') }, root);
+    recordEvolutionAttempt(outDir, { runPath: runB, decision: 'retry', score: 0.4, rationale: 'Needs another attempt.', now: new Date('2026-05-21T08:20:00.000Z') }, root);
+
+    const comparison = compareEvolutionLoop(outDir, {}, root);
+
+    expect(comparison.kind).toBe('message');
+    expect(renderEvolutionComparison(comparison, 'terminal')).toContain('No previous frontier/current frontier comparison is recorded yet.');
+  });
+
+  it('marks side B as current frontier only when B is actually the current frontier', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z') });
+    recordEvolutionAttempt(outDir, { runPath: runA, decision: 'promote', score: 0.75, rationale: 'Current frontier.', now: new Date('2026-05-21T08:10:00.000Z') }, root);
+    recordEvolutionAttempt(outDir, { runPath: runB, decision: 'reject', score: 0.5, rationale: 'Rejected non-frontier.', now: new Date('2026-05-21T08:20:00.000Z') }, root);
+
+    const comparison = compareEvolutionLoop(outDir, { a: 'frontier', b: 'attempt-b' }, root);
+    const markdown = renderEvolutionComparison(comparison, 'markdown');
+
+    expect(markdown).toContain('`attempt-a` (promote, current frontier) → `attempt-b` (reject)');
+    expect(markdown).not.toContain('`attempt-b` (reject, current frontier)');
+  });
 });

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   EVOLUTION_LOOP_SCHEMA,
+  compareEvolutionLoop,
   loadEvolutionSource,
   recordEvolutionAttempt,
+  renderEvolutionComparison,
   renderEvolutionLoopFiles,
   validateEvolutionLoopDir,
   writeEvolutionLoop,
@@ -329,5 +331,89 @@ describe('evolution attempt recording and validation', () => {
     expect(result.failures.map((failure) => failure.code)).toContain('evolution.boundary.unsupported_true');
     expect(result.failures.map((failure) => failure.code)).toContain('evolution.source_ref.private_path');
     expect(result.failures.map((failure) => failure.code)).toContain('evolution.attempt.duplicate_id');
+  });
+});
+
+describe('evolution comparison rendering', () => {
+  it('compares the previous frontier attempt against the current frontier by default', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const evalB = writeEvaluation(root, 'attempt-b');
+    const evidenceB = join(root, 'docs/evidence/attempt-b-extra.md');
+    writeFileSync(evidenceB, 'attempt b extra proof');
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z'), strategy: 'greedy' });
+    recordEvolutionAttempt(outDir, {
+      runPath: runA,
+      decision: 'promote',
+      score: 0.62,
+      rationale: 'Handled easy cases but failed BOM input.',
+      now: new Date('2026-05-21T08:10:00.000Z'),
+    }, root);
+    recordEvolutionAttempt(outDir, {
+      runPath: runB,
+      evaluationPath: evalB,
+      evidencePaths: [evidenceB],
+      decision: 'promote',
+      score: 0.94,
+      rationale: 'Handled BOM input and all edge cases.',
+      now: new Date('2026-05-21T08:20:00.000Z'),
+    }, root);
+
+    const comparison = compareEvolutionLoop(outDir, {}, root);
+
+    expect(comparison.kind).toBe('comparison');
+    if (comparison.kind !== 'comparison') throw new Error('expected comparison');
+    expect(comparison.a.attemptId).toBe('attempt-a');
+    expect(comparison.b.attemptId).toBe('attempt-b');
+    expect(comparison.loop.strategy).toBe('greedy');
+    expect(comparison.scoreDelta).toBeCloseTo(0.32);
+    expect(comparison.evidence.onlyInB).toContain('docs/evidence/attempt-b-extra.md');
+    expect(comparison.evaluation.b.present).toBe(true);
+    expect(comparison.frontierHistory.map((item) => item.attemptId)).toEqual(['attempt-a', 'attempt-b']);
+
+    const terminal = renderEvolutionComparison(comparison, 'terminal');
+    expect(terminal).toContain('Evolution Loop: demo-loop');
+    expect(terminal).toContain('A -> attempt-a');
+    expect(terminal).toContain('B -> attempt-b');
+    expect(terminal).toContain('+0.32');
+    expect(terminal).toContain('Only in B');
+    expect(terminal).toContain('Frontier history');
+
+    const markdown = renderEvolutionComparison(comparison, 'markdown');
+    expect(markdown).toContain('# Evolution loop: demo-loop — A vs B');
+    expect(markdown).toContain('| Score | 0.62 | 0.94 | +0.32 ▲ |');
+    expect(markdown).toContain('**B (promote):** Handled BOM input and all edge cases.');
+
+    const json = JSON.parse(renderEvolutionComparison(comparison, 'json'));
+    expect(json.a.attemptId).toBe('attempt-a');
+    expect(json.b.attemptId).toBe('attempt-b');
+  });
+
+  it('throws a clear error for unknown explicit compare targets', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runPath = writeRunPacket(root, 'attempt-a');
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z') });
+    recordEvolutionAttempt(outDir, { runPath, decision: 'promote', rationale: 'Only attempt.', now: new Date('2026-05-21T08:10:00.000Z') }, root);
+
+    expect(() => compareEvolutionLoop(outDir, { a: 'missing-attempt', b: 'frontier' }, root)).toThrow(/Unknown evolution attempt target: missing-attempt/);
+  });
+
+  it('returns a successful message for single-attempt loops instead of failing', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runPath = writeRunPacket(root, 'attempt-a');
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z') });
+    recordEvolutionAttempt(outDir, { runPath, decision: 'promote', score: 0.75, rationale: 'Only attempt.', now: new Date('2026-05-21T08:10:00.000Z') }, root);
+
+    const comparison = compareEvolutionLoop(outDir, {}, root);
+
+    expect(comparison.kind).toBe('message');
+    expect(renderEvolutionComparison(comparison, 'terminal')).toContain('Only one attempt recorded; nothing to compare yet.');
   });
 });


### PR DESCRIPTION
## Summary

- Add read-only `osc evolve compare <loop-dir>` for previous-frontier/current-frontier attempt comparison.
- Render terminal, markdown, and JSON views with decision/score/rationale/evidence/evaluation/boundary/frontier-history context.
- Reposition README around the evolution ledger and bump the package candidate to `0.4.12`.

## Traceability

- Plan: `.osc/plans/done/090-evolution-compare.md`
- Evidence: `.osc/releases/2026-05-22-090-evolution-compare.md`
- Private decision support: ignored `.osc/research/2026-05-22-author-notes-action-map.md` was used locally but is not tracked/published.

## Verification

- [x] RED first: targeted compare tests failed before implementation (`compareEvolutionLoop is not a function`; CLI usage lacked `compare`).
- [x] Initial targeted GREEN: `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — 2 files / 20 tests passed.
- [x] Codex fix regressions added for frontier-only default semantics and accurate current-frontier labeling.
- [x] Post-fix targeted: `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — 2 files / 22 tests passed.
- [x] `npm test -- --run` — 32 files / 286 tests passed.
- [x] `npm run build` — core + runtime-omx build passed.
- [x] Manual smoke: temp scaffold, two run packets, two promoted attempts, terminal/markdown/json `osc evolve compare` outputs parsed/checked.
- [x] `git diff --check` — pass.
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
- [x] `npm pack --dry-run --json` — `open-scaffold-0.4.12.tgz`, 106 files, no `.osc/research` payload.
- [x] `npm publish --dry-run` — `+ open-scaffold@0.4.12`.
- [x] CI — pass.
- [x] Codex latest-head review — clean after fixes; unresolved review threads resolved to zero.

## Boundaries

This PR does **not** spawn runtimes, rerun attempts, rank models, certify compliance, approve releases, add runtime dependencies, or implement `evolve report/replay/diff-evidence`.

## Owner gates

- Merge remains owner-gated.
- Publishing `open-scaffold@0.4.12` and creating GitHub Release `v0.4.12` remain separate owner-gated post-merge actions.
