### PR TITLE
Clarify README around work records and evolution ledgers

### DIFF
--- a/.osc/plans/done/091-readme-work-record-evolution-ledger.md
+++ b/.osc/plans/done/091-readme-work-record-evolution-ledger.md
@@ -1,0 +1,64 @@
+# Plan: 091-readme-work-record-evolution-ledger
+
+## Status
+
+done
+
+## Context
+
+PR #87 shipped `osc evolve compare`, which made the evolution loop visible in the CLI. The README now mentions the feature, but the first-touch story is still too protocol-heavy: repo-native source of truth, runtime-neutral protocol, run packets, envelopes, profiles, and adapters appear before a new reader has a simple mental model.
+
+The next README slice should combine the existing Open Scaffold proposition with the newer evolution-ledger direction:
+
+- work should not disappear into chat logs;
+- humans should keep control and reviewability;
+- agents/runtimes need clear handoff files;
+- evidence should stay attached to the work;
+- repeated attempts need a ledger that explains which attempt became the frontier and why.
+
+Oh My Codex is useful as style inspiration because its README has a clear identity, default flow, and mental model even though it is not short. This slice should borrow that simplicity without copying content or changing Open Scaffold's boundaries.
+
+## Goal
+
+Rewrite the README front door so a new reader understands Open Scaffold as a repo-native work record and evolution ledger for AI-assisted software, while preserving the core handoff/evidence proposition and making the evolution loop visually clear with compact ASCII diagrams.
+
+## Constraints / Out of scope
+
+- Do not add new CLI behavior or runtime behavior.
+- Do not publish npm, create a GitHub Release, or claim `open-scaffold@0.4.12` is public until the separate package gate is approved and completed.
+- Do not claim Open Scaffold launches, supervises, ranks, certifies, or approves agents/models.
+- Do not use raw private author notes or private Command Center details in public README copy.
+- Do not attack BMAD/spec-kit/Agent OS or compare against them directly.
+- Do not move broad runtime adapter expansion into this README slice.
+
+## Files to touch
+
+- `README.md` — rewrite first-touch positioning, default flow, mental model, diagrams, and concise links.
+- `.osc/plans/done/091-readme-work-record-evolution-ledger.md` — this scope contract, closed after acceptance criteria passed.
+- `.osc/releases/2026-05-22-091-readme-work-record-evolution-ledger.md` — evidence note after verification.
+- `MISSION.md` — changelog stamp from `osc close`.
+
+## Acceptance criteria
+
+- [x] README opens with a plain statement of what Open Scaffold is: work record + evolution ledger for AI-assisted software.
+- [x] README uses `reviewability` as the first-touch proof word instead of leading with heavier compliance/audit language.
+- [x] README explains the core value before internal ontology: control, clarity, reviewability, handoff, evidence, and improvement loops.
+- [x] README includes one compact ASCII workflow diagram for goal/plan/handoff/evidence/review.
+- [x] README includes one compact ASCII evolution-loop diagram for multiple attempts -> compare -> frontier.
+- [x] README preserves current core proposition: mission/plans, handoff package/run.json, evidence/release notes, human approval, and runtime-neutral boundaries.
+- [x] README avoids unsupported claims about spawning, supervising agents, model ranking, compliance certification, automatic skill self-improvement, or release approval.
+- [x] README remains materially simpler than current first-touch copy; target `wc -c README.md <= 9000` unless preserving essential install/quickstart commands requires a small documented exception.
+- [x] Links to deeper docs remain available without front-loading every concept.
+
+## Verification steps
+
+1. `wc -c README.md` — target <= 9000 bytes or evidence note explains any small exception.
+2. `grep -RniE "glass cockpit|operator surface|runtime binding|dispatch receipt|harness skill|slice close|task bridge|evaluation envelope|audit envelope|run packet|substrate|governance|orchestration layer" README.md docs .osc/plans 2>/dev/null || true` — review README hits for plain-language aliases and no unsupported claims.
+3. `./verify.sh --strict` — repository checks pass.
+4. `npm test -- --run` — tests pass.
+5. `npm run build` — package builds.
+6. `git diff --check` — no whitespace errors.
+
+## Open questions
+
+- Keep npm/GitHub Release `0.4.12` publication as a separate owner gate. This README slice may mention `osc evolve compare` because it is now on `main`, but public npm users will not receive it until the separate publish gate is completed.

--- a/.osc/releases/2026-05-22-091-readme-work-record-evolution-ledger.md
+++ b/.osc/releases/2026-05-22-091-readme-work-record-evolution-ledger.md
@@ -1,0 +1,135 @@
+# 091 — README work record + evolution ledger positioning
+
+Date: 2026-05-22
+Plan: `.osc/plans/done/091-readme-work-record-evolution-ledger.md`
+Branch: `docs/readme-work-record-evolution-ledger`
+Package state: repo `package.json` is `0.4.12`; npm latest was observed as `0.4.11` before this docs slice.
+
+## Summary
+
+Rewrote the README front door around a simpler Oh-My-Codex-inspired structure: clear identity, default flow, simple mental model, then advanced boundaries.
+
+The README now leads with Open Scaffold as a repo-native work record and evolution ledger for AI-assisted software. It keeps the existing handoff/evidence proposition while making the evolution loop visible through compact ASCII diagrams.
+
+## Traceability
+
+- Plan: `.osc/plans/done/091-readme-work-record-evolution-ledger.md`
+- Changelog stamp: `MISSION.md` entry for `091-readme-work-record-evolution-ledger`
+- Prior enabling slice: PR #87 / `.osc/plans/done/090-evolution-compare.md`
+- Private decision support: ignored `.osc/research/2026-05-22-author-notes-action-map.md`
+- Style inspiration: `Yeachan-Heo/oh-my-codex` README shape — clear identity, default flow, simple mental model
+
+## Outcome
+
+The README now explains Open Scaffold in plain terms before internal ontology:
+
+```text
+work record + evolution ledger
+control + clarity + reviewability + handoff + improvement loops
+agent/runtime does the work; Open Scaffold records the work
+```
+
+It includes:
+
+- a compact “basic loop” ASCII diagram from goal to durable repo record;
+- a compact evolution-loop ASCII diagram from multiple attempts to `evolve compare` to frontier;
+- a default flow for init, mission, plan, verify/evidence/close, and optional handoff package;
+- a simple mental model that preserves human approval and runtime-neutral boundaries.
+
+## What changed
+
+- `README.md`
+  - Replaced the protocol-heavy opening with a direct work-record/evolution-ledger explanation.
+  - Added `reviewability` as the first-touch proof word instead of leading with audit/compliance language.
+  - Added two text diagrams for the basic work loop and repeated-attempt evolution loop.
+  - Preserved required first-run install and lifecycle helper commands, including local `osc`, `npx open-scaffold`, and shell fallbacks.
+  - Reduced README size from 14,481 bytes to 8,995 bytes.
+- `.osc/plans/done/091-readme-work-record-evolution-ledger.md`
+  - Captured scope, acceptance criteria, and verification plan.
+- `MISSION.md`
+  - Stamped the close entry through `osc close`.
+
+## Boundary
+
+This is a documentation/positioning slice only. It does not:
+
+- add CLI behavior;
+- change runtime behavior;
+- spawn agents;
+- rank models;
+- certify compliance;
+- approve merges/releases;
+- publish npm or create a GitHub Release.
+
+The existing `0.4.12` npm/GitHub Release public-surface gate remains separate and owner-gated.
+
+## Verification
+
+### README size
+
+```text
+wc -c README.md
+8995 README.md
+```
+
+### README first-touch jargon scan
+
+```text
+grep -nEi "glass cockpit|operator surface|runtime binding|dispatch receipt|harness skill|slice close|task bridge|evaluation envelope|audit envelope|run packet|substrate|governance|orchestration layer" README.md || true
+```
+
+Result: no README hits.
+
+### Plan validation
+
+```text
+node dist/cli.js plan validate 091-readme-work-record-evolution-ledger --strict
+0 issues found
+```
+
+### Strict verification
+
+```text
+./verify.sh --strict
+10 pass, 0 fail, 0 warn
+```
+
+### Test suite
+
+```text
+npm test -- --run
+```
+
+Result:
+
+```text
+Test Files  32 passed (32)
+Tests       286 passed (286)
+```
+
+### Build
+
+```text
+npm run build
+```
+
+Result:
+
+```text
+build:core        pass
+build:runtime-omx pass
+```
+
+### Whitespace
+
+```text
+git diff --check
+```
+
+Result: pass.
+
+## Remaining gates
+
+- Open PR and run the normal review loop.
+- Merge remains owner-gated.
+- The `open-scaffold@0.4.12` npm publish and GitHub Release alignment from the prior command-surface slice remain a separate owner-gated public-surface action.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-22: closed 091-readme-work-record-evolution-ledger — clarified README around work records and evolution ledgers
 - 2026-05-22: closed 090-evolution-compare — added evolution compare CLI
 - 2026-05-21: closed 059-adoption-metrics — added local adoption metrics CLI
 - 2026-05-21: closed 054-multi-language-agent-entry-points — translated agent entry points shipped in PR #84

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🧱 open-scaffold
 
-**A repo-native source of truth for AI-assisted software work.**
+**A work record and evolution ledger for AI-assisted software.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-black.svg)](LICENSE)
 [![Template](https://img.shields.io/badge/GitHub-Template-blue.svg)](https://github.com/graphanov/open-scaffold/generate)
@@ -10,83 +10,126 @@
 
 </div>
 
-Open Scaffold gives solo devs and small teams repo files and rules for AI coding work. It stores the mission, roadmap, plans, evidence, decisions, and handoff notes where humans and agents can see what was asked, changed, verified, and approved.
+AI work should not disappear into chat logs.
 
-Use it when AI work spans sessions, PRs, agents, or review gates — when you need proof without a documentation swamp.
+Open Scaffold keeps the important parts in your repo: the goal, the plan, the handoff package, the evidence, the approval trail, and the lessons from repeated attempts.
 
-> **What it is:** a repo-native source of truth: files and rules that package work for humans, agents, coordinators, and runtime adapters.
->
-> **What it is not:** an agent runtime, Discord bot, daemon, task database, model ranker, or code reviewer. Those live in tools you choose; the scaffold is what they read and write.
+Use it when AI-assisted work needs **control**, **clarity**, **reviewability**, **handoff**, or **improvement over time**.
 
-Runtime handoff is optional: Open Scaffold writes a `run.json` work package, an external adapter/runtime works outside core, evidence comes back, and humans approve. See [Step 5](#5-optional-package-a-plan-for-an-agentruntime).
-
-## Languages
-
-English is canonical. Machine-assisted agent entry-point translations are provided for Chinese ([AGENTS-zh.md](AGENTS-zh.md), [CLAUDE-zh.md](CLAUDE-zh.md)), Japanese ([AGENTS-ja.md](AGENTS-ja.md), [CLAUDE-ja.md](CLAUDE-ja.md)), Korean ([AGENTS-ko.md](AGENTS-ko.md), [CLAUDE-ko.md](CLAUDE-ko.md)), Spanish ([AGENTS-es.md](AGENTS-es.md), [CLAUDE-es.md](CLAUDE-es.md)), and Portuguese ([AGENTS-pt.md](AGENTS-pt.md), [CLAUDE-pt.md](CLAUDE-pt.md)). See [`docs/TRANSLATIONS.md`](docs/TRANSLATIONS.md) for contribution and maintenance rules.
+It does not replace your agent, IDE, task tracker, or CI. Those tools do the work. Open Scaffold records what was asked, what was handed off, what came back, what was checked, and what humans approved.
 
 ---
 
-## The problem
+## What Open Scaffold adds
 
-AI agents can write useful code, but the workflow often disappears into chat logs and terminal sessions:
+- **Control** — scope, constraints, and approval gates stay visible.
+- **Clarity** — the mission, plan, and next action live in the repo.
+- **Reviewability** — evidence, checks, and decisions stay attached to the work.
+- **Handoff** — `run.json` packages work for an agent, runtime, teammate, or future session.
+- **Improvement loops** — `osc evolve` records repeated attempts, compares them, and explains which one became the frontier.
+
+Under the hood, this is just files:
 
 ```text
-Idea -> chat thread -> agent session -> PR -> "looks done?"
-```
-
-Weeks later nobody can reconstruct intent, acceptance criteria, verification evidence, or human approval.
-
-Open Scaffold fixes that by making the repository the shared memory. Chat, Discord, terminals, GitHub comments, and agent transcripts can help operate the work, but durable truth lives in files and PRs.
-
-For the same idea in three diagrams (problem, loop, system boundary), see [`docs/WHY_OPEN_SCAFFOLD.md`](docs/WHY_OPEN_SCAFFOLD.md).
-
----
-
-## Demo: work resumes from the repo
-
-![Open Scaffold resume loop: an old session loses context, a new session reads repo files, and work resumes](.github/assets/readme-resume-screencast.gif)
-
-The chat can fade. The repository keeps the work. A fresh session reads `.osc/plans/active/`, recovers the goal, checks, and next action, then continues from repo truth.
-
-Want the underlying files? Read [`docs/EXAMPLES.md`](docs/EXAMPLES.md#60-second-viewer-demo) for the four-artifact loop, or the [downstream walkthrough](docs/examples/downstream-walkthrough.md) for a full day-2 resume example.
-
----
-
-## What you get
-
-- **Evolution ledger:** `osc evolve` records repeated attempts, frontier promotion, and `osc evolve compare` explains why one attempt beat another.
-- **Evaluation and audit envelopes:** `osc eval` and `osc audit` keep acceptance-criteria checks and artifact integrity attached to the work.
-- **Direction:** `MISSION.md` and `ROADMAP.md` keep intent visible.
-- **Work specs:** `.osc/plans/` holds small, immutable plans with acceptance criteria.
-- **Change history:** amendments record scope changes without rewriting the original plan.
-- **Work packages (run packets):** `.osc/runs/<run_id>/run.json` packages a plan for a chosen runtime lane.
-- **Evidence:** `.osc/releases/` records what shipped, how it was verified, and what follows.
-- **Checks:** `./verify.sh` and `osc verify` catch stale state, broken evidence, and plan drift.
-- **Agent entry points:** `AGENTS.md` and `CLAUDE.md` tell coding agents how to operate without fresh explanations.
-
-The loop:
-
-```text
-Roadmap or issue
-  -> plan
-  -> run.json package / task id
-  -> branch / PR
-  -> verification evidence
-  -> approval / amendment / next slice
+MISSION.md                         why this repo exists
+.osc/plans/                        scoped work with acceptance criteria
+.osc/runs/<run_id>/run.json         handoff package for a worker or reviewer
+.osc/releases/                     evidence notes and release records
+.osc/evolution/<loop_id>/           attempts, comparison, and frontier history
 ```
 
 ---
 
-## Quickstart
+## The basic loop
 
-### 1. Choose how many Open Scaffold files to add
+```text
+        goal
+         │
+         ▼
+      plan.md
+         │
+         ▼
+  handoff package
+      run.json
+         │
+         ▼
+ agent / runtime / human
+         │
+         ▼
+      output
+         │
+         ▼
+ evidence + verification
+         │
+         ▼
+ review / approve / amend
+         │
+         ▼
+ durable repo record
+```
 
-Use npm for the normal first run. Use `--target .` to add scaffold files to the current repo, or `--target my-app` to create/init a project folder named `my-app`:
+Chat, Discord, terminals, GitHub comments, and agent transcripts can help operate the work. They are not the source of truth. The repo record is.
+
+---
+
+## When one attempt is not enough
+
+Modern AI work often means trying the same task more than once: a better prompt, a different runtime, a stronger review pass, or a repaired implementation.
+
+Open Scaffold records that loop instead of burying the decision in chat.
+
+```text
+One task, several attempts
+
+                ┌─ attempt A ─ evidence ─ result
+                │
+goal + plan ────┼─ attempt B ─ evidence ─ result
+                │
+                └─ attempt C ─ evidence ─ result
+                                      │
+                                      ▼
+                                evolve compare
+                                      │
+                                      ▼
+                           frontier: "C won because..."
+```
+
+Example:
+
+```bash
+npx open-scaffold evolve init .osc/plans/active/my-task.md \
+  --out .osc/evolution/my-task \
+  --strategy manual
+
+npx open-scaffold evolve record .osc/evolution/my-task \
+  --run .osc/runs/<run_id>/run.json \
+  --decision promote \
+  --rationale "Best evidence so far."
+
+npx open-scaffold evolve compare .osc/evolution/my-task \
+  --format markdown \
+  --out .osc/releases/evolution-compare.md
+```
+
+`osc evolve` records attempt/frontier state only. It does not launch agents, rank models, certify compliance, or approve releases.
+
+---
+
+## Recommended default flow
+
+### 1. Add Open Scaffold to a repo
 
 ```bash
 npx open-scaffold init --tier min --target <your-project>
-# existing repo: npx open-scaffold init --from-existing --tier min --target .
 cd <your-project>
+```
+
+Use `--tier standard` for README/roadmap, agent instructions, and core docs.
+
+For an existing repo:
+
+```bash
+npx open-scaffold init --from-existing --tier min --target .
 ```
 
 Source checkout fallback:
@@ -96,85 +139,72 @@ git clone https://github.com/graphanov/open-scaffold open-scaffold
 cd open-scaffold
 npm install
 npm run build
-node dist/cli.js init --tier min --target <your-project>
-cd <your-project>
+node dist/cli.js init --tier standard --target <your-project>
 ```
 
-Tiers:
-
-- `min` — smallest useful setup: mission, rules, plan template/workflow, evidence folder, verification, and close helper.
-- `standard` — recommended starter: `min` plus README/roadmap, agent instructions, amendment helper, and core docs.
-- `max` — advanced/team setup: `standard` plus GitHub, runtime, status/control-room docs, delegation helper, and advanced `.osc/` folders.
-
-The initializer is local-only: it does not require network access after the package is present, does not call GitHub or agent services, and refuses to overwrite existing files unless `--force` is supplied.
-
-Prefer the npm path above for first use. If you prefer GitHub's template flow, use GitHub's **Use this template** button or `gh repo create <your-project> --template graphanov/open-scaffold --clone`.
-
-### 2. Bootstrap the mission
+### 2. Define the mission
 
 ```bash
 ./bootstrap.sh
 ```
 
-Bootstrap asks what the project is, what it should achieve, and what it should not do. That mission gates later plans.
+The mission says what this repo is trying to do and what it should not do. Plans are blocked until the mission exists.
 
-### 3. Write the first plan
-
-If the goal is clear, tell your agent:
-
-```text
-Write a plan in .osc/plans/active/ for <task> using .osc/plans/handoff-template.md.
-```
-
-If the goal is fuzzy, park the plan in backlog first, then move it to active when it becomes the work you are actually doing. Fill the template with short bullets; the important parts are goal, acceptance criteria, and verification. The helpers create files and prompts; they do **not** invent acceptance criteria for you:
+### 3. Write a plan
 
 ```bash
-osc plan new my-first-task --stage backlog
-osc plan new my-first-bug --stage backlog --from-template bug-fix
-osc plan new --from-template list
-osc plan validate my-first-bug
-osc plan move my-first-task --to active
-# or, without local install:
-npx open-scaffold plan new my-first-task --stage backlog
-npx open-scaffold plan new my-first-bug --stage backlog --from-template bug-fix
-npx open-scaffold plan validate my-first-bug
-npx open-scaffold plan move my-first-task --to active
+osc plan new my-first-task --stage active
+osc plan validate my-first-task
+# or without local install:
+npx open-scaffold plan new my-first-task --stage active
+npx open-scaffold plan validate my-first-task
 ```
 
-Use `--to blocked` when a plan needs to wait for input, credentials, or a product decision.
+If the goal is fuzzy, create it in backlog first:
 
-Shell fallback remains supported:
+```bash
+osc plan new my-idea --stage backlog
+osc plan move my-idea --to active
+# or without local install:
+npx open-scaffold plan new my-idea --stage backlog
+npx open-scaffold plan move my-idea --to active
+```
+
+Shell fallback:
 
 ```bash
 cp .osc/plans/handoff-template.md .osc/plans/active/my-first-task.md
 ```
 
-### 4. Verify, amend if needed, record evidence, and close
+### 4. Verify, record evidence, and close
 
 ```bash
-./verify.sh
-osc amend my-first-task --message "scope changed" # only when new learning changes the plan
-# or, without local install: npx open-scaffold amend my-first-task --message "scope changed"
+./verify.sh --standard
 osc evidence new my-first-task
-# or, without local install: npx open-scaffold evidence new my-first-task
 osc close my-first-task --message "verified first task"
-# or, without local install: npx open-scaffold close my-first-task --message "verified first task"
+# or without local install:
+npx open-scaffold evidence new my-first-task
+npx open-scaffold close my-first-task --message "verified first task"
 ```
 
-Use `./verify.sh --standard` before calling a meaningful slice done. The amendment helper creates `<slug>-amendment-N.md` with TODO prompts and stamps `MISSION.md`; fill those TODOs before continuing. The evidence helper creates `.osc/releases/<date>-my-first-task.md` with TODO prompts; replace them with real commands, results, PR links, and follow-up before closing the plan.
-
-Shell fallbacks remain supported:
+If the scope changes, amend instead of rewriting history:
 
 ```bash
-./amend.sh my-first-task --message "scope changed"
+osc amend my-first-task --message "scope changed after review"
+# or without local install:
+npx open-scaffold amend my-first-task --message "scope changed after review"
+```
+
+Shell fallbacks remain available:
+
+```bash
+./amend.sh my-first-task --message "scope changed after review"
 ./close.sh my-first-task --message "verified first task"
 ```
 
-### 5. Optional: package a plan for an agent/runtime
+### 5. Optional: package work for another tool
 
-You can stop after verification and evidence. Only create a `run.json` work package — the run packet — when another tool, adapter, or human needs a structured handoff file. Open Scaffold still does not spawn agents.
-
-Example:
+Open Scaffold can write a handoff file for an agent, runtime, teammate, or future session:
 
 ```bash
 npx open-scaffold run .osc/plans/active/my-first-task.md \
@@ -185,81 +215,74 @@ npx open-scaffold run .osc/plans/active/my-first-task.md \
   --repo "$PWD"
 ```
 
-Here `--operator-surface` means the place humans see status and approvals, such as GitHub comments, chat, or a CLI. For custom runtimes, add a project-local profile in `.osc/runtimes/<id>.json`, then use `--runtime <id>`. Read this in layers:
+That creates a `run.json` work package. The outside tool executes. Evidence comes back into the repo.
 
-1. [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — choosing `--runtime` and `--workflow`;
-2. [`docs/RUNTIME_PROFILES.md`](docs/RUNTIME_PROFILES.md) — built-in and project-local runtime profiles;
-3. [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md) — what an adapter/coordinator must do after the `run.json` package exists.
+---
 
-For repeated attempts, record the loop separately instead of burying the frontier decision in chat:
+## Simple mental model
 
-```bash
-npx open-scaffold evolve init .osc/plans/active/my-first-task.md --out .osc/evolution/my-first-task --strategy manual
-npx open-scaffold evolve record .osc/evolution/my-first-task --run .osc/runs/<run_id>/run.json --decision promote --rationale "Best evidence so far."
-npx open-scaffold evolve compare .osc/evolution/my-first-task --format markdown --out .osc/releases/evolution-compare.md
-npx open-scaffold evolve check .osc/evolution/my-first-task
-```
+- **You** decide the goal, taste, risk, merge, and publish gates.
+- **Your agent or runtime** does the implementation work.
+- **Open Scaffold** keeps the work record in files.
+- **A handoff package** tells a worker what to do and what evidence to return.
+- **Evidence notes** show what happened and how it was checked.
+- **The evolution ledger** compares repeated attempts and records the current best one.
 
-`osc evolve` records attempt/frontier state only. `osc evolve compare` renders the ledger for review without rerunning attempts. External adapters or runtime packages execute attempts.
+If you want a plain one-off agent session with no later review, you probably do not need Open Scaffold.
 
 ---
 
 ## Runtime-neutral by design
 
-Open Scaffold is not an agent runtime, Discord bot, PR reviewer, or task database. It is the repo protocol those tools can share.
+Open Scaffold is not an agent runtime, Discord bot, daemon, task database, model ranker, or code reviewer.
 
-- **Coordinators / task state:** GitHub Issues, Linear/Jira, custom bots, or private deployment examples such as Hermes Kanban decide what should happen next.
-- **Runtime lanes:** Claude Code, Codex, Cursor, Gemini, OMC, OMX, Aider, or a human terminal can execute bounded work outside Open Scaffold core.
-- **Status / approval channels (operator surfaces):** Discord, Slack, Telegram, GitHub comments, or CLI dashboards can show status and collect approvals.
-- **Core truth:** mission, plans, amendments, `run.json` work packages, evidence, decisions, and release notes stay in the repo.
+It is the repo record those tools can share.
 
-Full map: [`docs/OPEN_SCAFFOLD_SYSTEM.md`](docs/OPEN_SCAFFOLD_SYSTEM.md), [`docs/TASK_RUN_MODEL.md`](docs/TASK_RUN_MODEL.md), [`docs/GITHUB_WORKFLOW.md`](docs/GITHUB_WORKFLOW.md), and [`docs/REFERENCE_TRUTH.md`](docs/REFERENCE_TRUTH.md).
+```text
+Open Scaffold core = plan + handoff package + evidence expectations
+Runtime adapter    = translate + launch outside core + return receipt/evidence
+Runtime harness    = execute while alive
+Human/operator     = approve, reject, merge, publish, or redirect
+```
+
+Supported tools can include Claude Code, Codex, Cursor, Gemini, OMC, OMX, Aider, GitHub Issues, Linear/Jira, Discord, Slack, Telegram, or a human terminal. Core stays portable: files first, no hidden spawning.
 
 ---
 
 ## When it helps
 
-Open Scaffold is useful when work needs to survive context loss:
+Use Open Scaffold for:
 
 - multi-session AI-assisted development;
-- consulting and client delivery, where "what was asked, decided, and verified" must be reviewable later;
-- compliance or audit-sensitive work that wants lightweight, file-level evidence instead of a heavier governance stack;
+- PRs where reviewers need intent, checks, and evidence;
+- consulting or client delivery where the work must be explainable later;
+- audit-sensitive or regulated-adjacent work that needs lightweight file-level evidence;
 - multi-agent handoffs where chat history is not enough;
-- projects where "done" needs acceptance criteria and verification, not vibes.
+- repeated attempts where you need to know which one won and why.
 
-It is overkill for one-off scripts, disposable prototypes, or tasks that fit in a single clean session. The scaffold is the repo foundation; it does not replace SOC 2, ISO, or formal audit tooling — it gives those processes durable repo artifacts to point at.
+Skip it for:
 
----
-
-## Where the roadmap is going
-
-The current product direction is: make the source-of-truth loop undeniable, then let external runtimes plug into it through profiles, adapters, and explicit agentic runtime packages. Open Scaffold now supports runtime selection, runtime profiles, evaluation/audit envelopes, and evolution-loop ledgers. The first serious runtime-engine investment path is OMX / oh-my-codex through `packages/runtime-omx/`, while core still does not silently install, spawn, supervise, or benchmark runtimes.
-
-Package note: the root `open-scaffold` npm package ships the core CLI, scaffold files, and docs. In-repo runtime package paths such as `packages/runtime-omx/` are GitHub source references today; they are not included in the root npm payload and would need a separate owner-approved runtime-package release before package users can install them from npm.
-
-Near-term roadmap work should improve clarity, adapter evidence, and validation. Real runtime launching, hosted registries, marketplace behavior, and model/task recommendations remain future hypotheses until separately designed and proven. See the [roadmap](ROADMAP.md) for the current milestone list.
+- one-off scripts;
+- disposable prototypes;
+- tiny tasks that fit in one clean session;
+- work nobody needs to review later.
 
 ---
 
 ## Key docs
 
-- [`docs/WHY_OPEN_SCAFFOLD.md`](docs/WHY_OPEN_SCAFFOLD.md) — visual story: problem, loop, system boundary, fit.
-- [`MISSION.md`](MISSION.md) — product goals, non-goals, and scope changelog.
-- [`ROADMAP.md`](ROADMAP.md) — product direction and milestones.
-- [`docs/COMPARISON.md`](docs/COMPARISON.md) — honest orientation against adjacent AI workflow systems.
-- [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — runtime selection flow for OMC/OMX-style lanes.
-- [`docs/RUNTIME_PROFILES.md`](docs/RUNTIME_PROFILES.md) — built-in and project-local runtime profile contract.
-- [`.osc/RULES.md`](.osc/RULES.md) — compact operating rules.
-- [`.osc/plans/WORKFLOW.md`](.osc/plans/WORKFLOW.md) — how plans move through backlog, active, done, and blocked.
-- [`docs/WORKFLOW.md`](docs/WORKFLOW.md) — phase-to-tool guide.
-- [`docs/SLICE_CLOSE_PROTOCOL.md`](docs/SLICE_CLOSE_PROTOCOL.md) — evidence-backed completion / slice closure.
-- [`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md) — multi-attempt loops, attempt journals, and frontier promotion.
-- [`docs/GLASS_COCKPIT_PROTOCOL.md`](docs/GLASS_COCKPIT_PROTOCOL.md) — chat/control-room status surfaces.
-- [`docs/FAQ.md`](docs/FAQ.md) — deeper explanations.
-- [`docs/REFERENCE_TRUTH.md`](docs/REFERENCE_TRUTH.md) — labels for public, private, future, and adapter tool references.
+- [`docs/WHY_OPEN_SCAFFOLD.md`](docs/WHY_OPEN_SCAFFOLD.md) — visual story and fit.
+- [`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md) — attempts, frontier promotion, and `osc evolve`.
+- [`docs/EXAMPLES.md`](docs/EXAMPLES.md) — examples and viewer demos.
+- [`docs/OPEN_SCAFFOLD_SYSTEM.md`](docs/OPEN_SCAFFOLD_SYSTEM.md) — full system map and boundaries.
+- [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — choosing runtime lanes and profiles.
+- [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md) — adapter responsibilities after `run.json` exists.
+- [`docs/FAQ.md`](docs/FAQ.md) — deeper docs.
+
+Translations for agent entry files: Chinese, Japanese, Korean, Spanish, Portuguese. See [`docs/TRANSLATIONS.md`](docs/TRANSLATIONS.md).
 
 ---
 
 ## Dogfooded
 
-Open Scaffold is built with Open Scaffold. The repo contains its own roadmap, plans, evidence notes, decisions, and PR history so the method can be inspected instead of merely claimed.
+Open Scaffold is built with Open Scaffold. This repo contains its own roadmap, plans, evidence notes, decisions, releases, and PR history so the method can be inspected instead of merely claimed.


### PR DESCRIPTION
## Summary

- Reframes the README around Open Scaffold as a repo-native work record and evolution ledger for AI-assisted software.
- Adds compact ASCII diagrams for the basic work loop and repeated-attempt evolution loop.
- Keeps the first-run command contract visible (`npx open-scaffold`, local `osc`, shell fallbacks) while reducing README size.
- Closes plan `091-readme-work-record-evolution-ledger` and records release/evidence note.

## Verification

- `wc -c README.md` -> `8995 README.md`
- `node dist/cli.js plan validate 091-readme-work-record-evolution-ledger --strict` -> `0 issues found`
- `./verify.sh --strict` -> `10 pass, 0 fail, 0 warn`
- `npm test -- --run` -> `32 passed (32)`, `286 passed (286)`
- `npm run build` -> pass
- `git diff --check` -> pass

## Gates

- Merge remains owner-gated.
- No npm publish or GitHub Release in this PR.
- `open-scaffold@0.4.12` public package/release alignment remains a separate owner-gated action.
