### PR TITLE
Make evolution loop comparison visible

### DIFF
--- a/.osc/plans/done/092-evolution-loop-visibility-v1.md
+++ b/.osc/plans/done/092-evolution-loop-visibility-v1.md
@@ -1,0 +1,99 @@
+# Plan: 092-evolution-loop-visibility-v1
+
+## Status
+
+active
+
+## Context
+
+Plans `087`, `090`, and `091` shipped the closed evolution-loop contract, `osc evolve compare`, and README repositioning around work records and evolution ledgers. The remaining adoption gap is visibility: a fresh reader needs one small public-safe path that shows two attempts, the comparison, and why the promoted frontier won without reading raw JSONL.
+
+## Goal
+
+Make the shipped evolution ledger and `osc evolve compare` flow obvious through one public-safe docs/example path and one focused compare-output improvement that turns evaluation envelopes into reviewer-readable acceptance-criteria deltas.
+
+## Constraints / Out of scope
+
+- Do not publish raw private notes or private owner/deployment context.
+- Do not add runtime adapters, native spawning, model ranking, benchmark claims, compliance certification claims, or approval automation.
+- Do not add new top-level CLI commands.
+- Do not implement `osc evolve report`, `replay`, HTML output, `--range`, `--code`, or full evidence/code diffing in this slice.
+- Do not change npm package version, publish npm, or create/edit GitHub Releases without a separate owner gate.
+- Keep README changes tiny; the README already carries the work-record/evolution-ledger positioning from plan `091`.
+
+## Files to touch
+
+- `src/evolution.ts` — read linked evaluation envelopes during compare and render criteria deltas.
+- `tests/evolution.test.ts` — unit coverage for criteria delta rendering and graceful missing-evaluation behavior.
+- `tests/cli-evolution.test.ts` — CLI coverage that markdown `--out` includes the criteria delta table.
+- `docs/EVOLUTION_LOOP.md` — link the existing contract doc to the one-screen walkthrough.
+- `docs/examples/evolution-loop-compare.md` — public-safe walkthrough of two attempts, compare output, and frontier rationale.
+- `docs/examples/README.md` — add the evolution-compare example to the examples index.
+- `docs/EXAMPLES.md` — add a short pointer from the top-level examples page.
+- `README.md` — add at most one pointer to the walkthrough if needed.
+- `.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md` — final evidence note after verification.
+- `MISSION.md` — closeout changelog stamp when the plan is complete.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Write failing tests for acceptance-criteria delta output | None | A |
+| T2 | Implement compare criteria-delta parsing/rendering | T1 | B |
+| T3 | Add the public-safe evolution-loop compare walkthrough | T1 | B |
+| T4 | Wire docs/index/README pointers | T3 | C |
+| T5 | Create release evidence note and close the plan | T2, T3, T4 | D |
+| T6 | Run verification gates and prepare PR-ready report | T5 | E |
+
+### Parallel groups
+
+- **Group A**: define behavior through tests first.
+- **Group B**: implementation and docs can progress after tests describe the output contract.
+- **Group C**: link the new docs once the target page exists.
+- **Group D/E**: closeout and verification after code/docs settle.
+
+### Dependencies
+
+- T2 depends on T1 so compare behavior is test-first.
+- T4 depends on T3 because docs links should point at a real page.
+- T5/T6 depend on all changed artifacts so evidence and verification reflect final state.
+
+### Delegation notes
+
+This is small enough for direct implementation. Do not spawn runtime workers or external automation for this slice.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adoption trust, evaluation readability, audit trails, recovery/ownership.
+- Audit envelope: plan `092`, release/evidence note, tests, verification commands, branch/PR-ready report.
+- Evaluation envelope: `osc evolve compare` should surface existing `open-scaffold.evaluation.v1` acceptance-criteria statuses without becoming an evaluator.
+- Feedback routing: larger ideas (`report`, replay, HTML, range, code/evidence diffs, adapters, launch work) remain follow-up candidates.
+- Boundary: Open Scaffold core remains read-only for compare; runtime execution, model ranking, compliance certification, and release approval stay outside core.
+
+## Acceptance criteria
+
+- [ ] A fresh reader can open one public docs page and understand in under five minutes: one task can have multiple attempts, `compare` shows why the frontier changed, and the repo keeps that decision reconstructable.
+- [ ] `osc evolve compare --format markdown` includes a PR-ready acceptance-criteria delta table when evaluation envelopes are present.
+- [ ] `osc evolve compare` still exits cleanly for one-attempt loops and loops without frontier comparison state.
+- [ ] Compare output does not mutate `loop.json`, `attempts.jsonl`, or `frontier.json`.
+- [ ] Docs and examples use public-safe, owner-neutral wording and contain no private paths, raw notes, private deployment internals, credentials, or personal context.
+- [ ] No docs claim that Open Scaffold launches agents, ranks models, certifies compliance, or approves releases.
+- [ ] README remains compact; any README change is a pointer, not another broad positioning rewrite.
+- [ ] Verification passes: targeted evolution tests, full tests, build, strict scaffold verification, and whitespace check.
+
+## Verification steps
+
+1. `git diff --check` — no whitespace errors.
+2. `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — targeted evolution tests pass.
+3. `npm test -- --run` — full suite passes.
+4. `npm run build` — package builds.
+5. `./verify.sh --strict` — scaffold verification passes.
+6. Manual smoke: `npm run osc -- evolve compare <tmp-loop-dir> --format terminal`, `--format markdown --out /tmp/osc-evolution-compare.md`, and `--format json` produce readable output without mutating loop files.
+7. Public-safety review confirms no private notes, owner paths, runtime-spawning/model-ranking/compliance/approval overclaims, or private deployment context entered public docs.
+
+## Open questions
+
+- Should a follow-up slice add `osc evolve report` or static HTML after this v1 visibility proof? Deferred.
+- Should adapter expansion start immediately after this? Deferred until the ledger story is visibly useful.

--- a/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
+++ b/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
@@ -56,6 +56,7 @@ one task -> attempt A -> attempt B -> osc evolve compare -> frontier rationale
   - Adds unit coverage for criteria delta rendering.
   - Adds regression coverage for absolute loop-dir compare calls resolving evaluation refs from the loop scaffold root, not caller cwd.
   - Adds regression coverage for partial historical scaffolds where the loop still lives under `.osc/` but strict root detection cannot find `.osc/releases`.
+  - Adds regression coverage that Windows absolute evaluation refs are not reinterpreted as repo-relative paths on POSIX.
   - Adds one-side-missing evaluation coverage.
   - Adds regression coverage for missing/stale evaluation file refs so compare remains readable for historical loops.
 - `tests/cli-evolution.test.ts`
@@ -104,7 +105,7 @@ After implementation:
 
 ```text
 Test Files  2 passed (2)
-Tests       27 passed (27)
+Tests       28 passed (28)
 ```
 
 ### Required verification gates
@@ -123,7 +124,7 @@ Result:
 
 ```text
 Test Files  2 passed (2)
-Tests       27 passed (27)
+Tests       28 passed (28)
 ```
 
 ```text
@@ -134,7 +135,7 @@ Result:
 
 ```text
 Test Files  32 passed (32)
-Tests       291 passed (291)
+Tests       292 passed (292)
 ```
 
 ```text

--- a/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
+++ b/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
@@ -55,6 +55,7 @@ one task -> attempt A -> attempt B -> osc evolve compare -> frontier rationale
 - `tests/evolution.test.ts`
   - Adds unit coverage for criteria delta rendering.
   - Adds one-side-missing evaluation coverage.
+  - Adds regression coverage for missing/stale evaluation file refs so compare remains readable for historical loops.
 - `tests/cli-evolution.test.ts`
   - Verifies markdown `--out` includes the criteria delta table.
 - `docs/examples/evolution-loop-compare.md`
@@ -101,7 +102,7 @@ After implementation:
 
 ```text
 Test Files  2 passed (2)
-Tests       24 passed (24)
+Tests       25 passed (25)
 ```
 
 ### Required verification gates
@@ -120,7 +121,7 @@ Result:
 
 ```text
 Test Files  2 passed (2)
-Tests       24 passed (24)
+Tests       25 passed (25)
 ```
 
 ```text
@@ -131,7 +132,7 @@ Result:
 
 ```text
 Test Files  32 passed (32)
-Tests       288 passed (288)
+Tests       289 passed (289)
 ```
 
 ```text

--- a/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
+++ b/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
@@ -55,6 +55,7 @@ one task -> attempt A -> attempt B -> osc evolve compare -> frontier rationale
 - `tests/evolution.test.ts`
   - Adds unit coverage for criteria delta rendering.
   - Adds regression coverage for absolute loop-dir compare calls resolving evaluation refs from the loop scaffold root, not caller cwd.
+  - Adds regression coverage for partial historical scaffolds where the loop still lives under `.osc/` but strict root detection cannot find `.osc/releases`.
   - Adds one-side-missing evaluation coverage.
   - Adds regression coverage for missing/stale evaluation file refs so compare remains readable for historical loops.
 - `tests/cli-evolution.test.ts`
@@ -103,7 +104,7 @@ After implementation:
 
 ```text
 Test Files  2 passed (2)
-Tests       26 passed (26)
+Tests       27 passed (27)
 ```
 
 ### Required verification gates
@@ -122,7 +123,7 @@ Result:
 
 ```text
 Test Files  2 passed (2)
-Tests       26 passed (26)
+Tests       27 passed (27)
 ```
 
 ```text
@@ -133,7 +134,7 @@ Result:
 
 ```text
 Test Files  32 passed (32)
-Tests       290 passed (290)
+Tests       291 passed (291)
 ```
 
 ```text

--- a/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
+++ b/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
@@ -54,6 +54,7 @@ one task -> attempt A -> attempt B -> osc evolve compare -> frontier rationale
   - Preserves read-only compare behavior; `loop.json`, `attempts.jsonl`, and `frontier.json` are not mutated by compare.
 - `tests/evolution.test.ts`
   - Adds unit coverage for criteria delta rendering.
+  - Adds regression coverage for absolute loop-dir compare calls resolving evaluation refs from the loop scaffold root, not caller cwd.
   - Adds one-side-missing evaluation coverage.
   - Adds regression coverage for missing/stale evaluation file refs so compare remains readable for historical loops.
 - `tests/cli-evolution.test.ts`
@@ -102,7 +103,7 @@ After implementation:
 
 ```text
 Test Files  2 passed (2)
-Tests       25 passed (25)
+Tests       26 passed (26)
 ```
 
 ### Required verification gates
@@ -121,7 +122,7 @@ Result:
 
 ```text
 Test Files  2 passed (2)
-Tests       25 passed (25)
+Tests       26 passed (26)
 ```
 
 ```text
@@ -132,7 +133,7 @@ Result:
 
 ```text
 Test Files  32 passed (32)
-Tests       289 passed (289)
+Tests       290 passed (290)
 ```
 
 ```text

--- a/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
+++ b/.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md
@@ -1,0 +1,187 @@
+# 092 — Evolution loop visibility v1
+
+Date: 2026-05-22
+Plan: `.osc/plans/done/092-evolution-loop-visibility-v1.md`
+Branch: `docs/evolution-loop-visibility-v1`
+Package state: repo `package.json` remains `0.4.12`; npm/GitHub Release publication is a separate owner gate.
+
+## Summary
+
+Made the already-shipped evolution loop easier to understand and review by adding a public-safe compare walkthrough and enriching `osc evolve compare` output with acceptance-criteria deltas from linked evaluation envelopes.
+
+This slice keeps Open Scaffold core as a recorder/renderer. It does not execute attempts, spawn runtimes, rank models, certify compliance, or approve releases.
+
+## Traceability
+
+- Plan: `.osc/plans/done/092-evolution-loop-visibility-v1.md`
+- Changelog stamp: `MISSION.md` entry for `092-evolution-loop-visibility-v1`
+- Prior enabling slices:
+  - `.osc/plans/done/087-closed-evolution-loop-contract.md`
+  - `.osc/plans/done/090-evolution-compare.md`
+  - `.osc/plans/done/091-readme-work-record-evolution-ledger.md`
+- Private planning support stayed private and was not copied into public docs.
+
+## Outcome
+
+A reviewer can now compare attempts and see acceptance-criteria movement directly in the rendered output:
+
+```text
+AC2: A=fail | B=pass ▲ — Frontier promotion is explicit.
+```
+
+Markdown output includes a PR-ready section:
+
+```markdown
+## Acceptance criteria delta
+
+| Criterion | A | B |
+|---|---|---|
+| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |
+```
+
+The new walkthrough at `docs/examples/evolution-loop-compare.md` shows the same flow without private context:
+
+```text
+one task -> attempt A -> attempt B -> osc evolve compare -> frontier rationale
+```
+
+## What changed
+
+- `src/evolution.ts`
+  - Reads linked `open-scaffold.evaluation.v1` envelopes during compare.
+  - Builds a union of acceptance-criteria ids across A/B attempts.
+  - Renders criteria deltas in terminal and markdown output.
+  - Preserves read-only compare behavior; `loop.json`, `attempts.jsonl`, and `frontier.json` are not mutated by compare.
+- `tests/evolution.test.ts`
+  - Adds unit coverage for criteria delta rendering.
+  - Adds one-side-missing evaluation coverage.
+- `tests/cli-evolution.test.ts`
+  - Verifies markdown `--out` includes the criteria delta table.
+- `docs/examples/evolution-loop-compare.md`
+  - Adds a public-safe walkthrough for the evolution-ledger wedge.
+- `docs/EVOLUTION_LOOP.md`, `docs/examples/README.md`, `docs/EXAMPLES.md`, `README.md`
+  - Add short pointers to the walkthrough without broad README repositioning.
+- `.osc/plans/done/092-evolution-loop-visibility-v1.md`
+  - Captures scope, acceptance criteria, and verification plan.
+- `MISSION.md`
+  - Stamped the close entry through `osc close`.
+
+## Boundary
+
+This slice does not:
+
+- publish raw private notes;
+- add runtime adapters;
+- add native spawning;
+- add new top-level CLI commands;
+- implement `osc evolve report`, replay, HTML, range, code diff, or evidence diff;
+- publish npm;
+- create or edit GitHub Releases;
+- approve merge/release decisions.
+
+## Verification
+
+### RED/GREEN targeted tests
+
+A failing test pass was run first after adding criteria-delta expectations:
+
+```text
+npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts
+```
+
+Initial RED result:
+
+```text
+2 failed files
+3 failed tests
+Expected: ## Acceptance criteria delta
+```
+
+After implementation:
+
+```text
+Test Files  2 passed (2)
+Tests       24 passed (24)
+```
+
+### Required verification gates
+
+```text
+git diff --check
+```
+
+Result: pass.
+
+```text
+npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       24 passed (24)
+```
+
+```text
+npm test -- --run
+```
+
+Result:
+
+```text
+Test Files  32 passed (32)
+Tests       288 passed (288)
+```
+
+```text
+npm run build
+```
+
+Result:
+
+```text
+build:core        pass
+build:runtime-omx pass
+```
+
+```text
+./verify.sh --strict
+```
+
+Result:
+
+```text
+10 pass, 0 fail, 0 warn
+```
+
+### Manual smoke
+
+Created a temporary loop with two attempts and evaluation envelopes, then ran:
+
+```text
+./node_modules/.bin/tsx src/cli.ts evolve compare <tmp-loop-dir> --format terminal
+./node_modules/.bin/tsx src/cli.ts evolve compare <tmp-loop-dir> --format markdown --out /tmp/osc-smoke-compare.md
+./node_modules/.bin/tsx src/cli.ts evolve compare <tmp-loop-dir> --format json
+```
+
+Observed:
+
+```text
+Acceptance criteria delta
+  AC2: A=fail | B=pass ▲ — Frontier promotion is explicit.
+
+## Acceptance criteria delta
+| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |
+
+json smoke ok
+compare-read-only: pass
+```
+
+Note: the JSON smoke used the direct local CLI (`./node_modules/.bin/tsx src/cli.ts`) so npm script banner output would not pollute machine-readable JSON redirection.
+
+## Remaining gates
+
+- Open/push PR if desired; merge remains owner-gated.
+- If merged and treated as a package-visible CLI/docs slice, npm trusted publishing and GitHub Latest Release alignment remain separate owner gates.
+- Do not resume Control Room automation from this slice.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-22: closed 092-evolution-loop-visibility-v1 — made evolution loop comparison visible
 - 2026-05-22: closed 091-readme-work-record-evolution-ledger — clarified README around work records and evolution ledgers
 - 2026-05-22: closed 090-evolution-compare — added evolution compare CLI
 - 2026-05-21: closed 059-adoption-metrics — added local adoption metrics CLI

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ npx open-scaffold evolve compare .osc/evolution/my-task \
 
 `osc evolve` records attempt/frontier state only. It does not launch agents, rank models, certify compliance, or approve releases.
 
+For the one-screen version, see [`docs/examples/evolution-loop-compare.md`](docs/examples/evolution-loop-compare.md).
+
 ---
 
 ## Recommended default flow

--- a/docs/EVOLUTION_LOOP.md
+++ b/docs/EVOLUTION_LOOP.md
@@ -72,6 +72,16 @@ osc evolve check .osc/evolution/demo-loop
 
 `osc evolve` does not create a run, launch a runtime, call an LLM, publish benchmark rankings, certify compliance, approve a merge, or decide product taste. It only records curated loop state.
 
+## See it in one screen
+
+The quickest way to understand the value is the compare walkthrough:
+
+```text
+one task -> attempt A -> attempt B -> osc evolve compare -> frontier rationale
+```
+
+Read [`docs/examples/evolution-loop-compare.md`](examples/evolution-loop-compare.md) for a small public-safe example that shows two attempts, linked evaluation envelopes, a PR-ready markdown comparison, and an acceptance-criteria delta table.
+
 ## Concepts
 
 ### Loop

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -2,7 +2,7 @@
 
 Short examples for understanding Open Scaffold without reading every protocol page.
 
-For four worked example modes — solo developer, team control-room, GitHub-only workflow, and runtime harness handoff — see [`examples/README.md`](examples/README.md). The 60-second demo below is the solo-developer reading path; the runtime handoff path now starts with `--runtime` selection and project-local runtime profiles.
+For four worked operating modes — solo developer, team control-room, GitHub-only workflow, and runtime harness handoff — see [`examples/README.md`](examples/README.md). For the evolution-ledger wedge, see [`examples/evolution-loop-compare.md`](examples/evolution-loop-compare.md): two attempts, `osc evolve compare`, and a PR-ready frontier rationale.
 
 For the next reproducible proof layer, see [Lifecycle E2E Smoke Strategy](E2E_SMOKE.md). It defines and links the local smoke test that proves a fresh downstream project can move through mission → plan → verification → evidence → close without Hermes, Discord, or private infrastructure.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,13 +1,14 @@
 # Examples
 
-Four worked example modes a fresh user or agent can read end-to-end. Each mode is a thin walkthrough that links to existing protocol docs and shipped fixtures rather than inventing new machinery.
+Five worked example paths a fresh user or agent can read end-to-end. The first four are operating modes; the fifth shows the evolution-ledger comparison wedge directly. Each path links to existing protocol docs and shipped fixtures rather than inventing new machinery.
 
-The four modes:
+The example paths:
 
 1. [Solo developer](#1-solo-developer) — one human, one repo, AI assist.
 2. [Team control-room](#2-team-control-room) — multiple humans/agents coordinating with the repo as truth.
 3. [GitHub-only workflow](#3-github-only-workflow) — issue → plan → PR → evidence with no chat coordinator.
 4. [Runtime harness handoff](#4-runtime-harness-handoff) — packaging work for an external runtime lane to execute.
+5. [Evolution loop compare](evolution-loop-compare.md) — two attempts → `osc evolve compare` → frontier rationale.
 
 If you want one complete non-recursive example first, start with [`downstream-walkthrough.md`](downstream-walkthrough.md). It shows the full mission → plan → optional `run.json` work package → evidence → close loop on a tiny shell CLI that is not Open Scaffold itself, then shows how a second session reconstructs the current state from files alone.
 

--- a/docs/examples/evolution-loop-compare.md
+++ b/docs/examples/evolution-loop-compare.md
@@ -1,0 +1,149 @@
+# Evolution loop compare walkthrough
+
+This walkthrough shows the smallest useful `osc evolve` story:
+
+```text
+one task
+  -> attempt A with evidence/evaluation
+  -> attempt B with evidence/evaluation
+  -> compare
+  -> frontier rationale a reviewer can read
+```
+
+Open Scaffold core records and compares the loop. It does **not** launch agents, rank models, certify compliance, or approve a release.
+
+## Scenario
+
+A small task has two attempts:
+
+- `attempt-a` handled the easy cases but failed `AC2`.
+- `attempt-b` kept `AC1` passing and fixed `AC2`.
+
+The useful reviewer question is:
+
+```text
+Why did B become the current frontier instead of A?
+```
+
+`osc evolve compare` answers that from repo files instead of asking a reviewer to open raw JSONL.
+
+## 1. Initialize the loop
+
+Start from a plan or run packet:
+
+```bash
+osc evolve init .osc/plans/active/csv-importer.md \
+  --out .osc/evolution/csv-importer \
+  --strategy greedy
+```
+
+This creates:
+
+```text
+.osc/evolution/csv-importer/
+  loop.json
+  attempts.jsonl
+  frontier.json
+```
+
+## 2. Record attempt A
+
+Record the first attempt with its run packet and evaluation envelope:
+
+```bash
+osc evolve record .osc/evolution/csv-importer \
+  --run .osc/runs/attempt-a/run.json \
+  --evaluation docs/evidence/attempt-a-evaluation.json \
+  --decision promote \
+  --score 0.62 \
+  --rationale "First useful frontier, but AC2 still fails."
+```
+
+Example evaluation status:
+
+```text
+AC1 Parse quoted CSV rows          pass
+AC2 Reject malformed input clearly fail
+```
+
+## 3. Record attempt B
+
+Record the improved attempt:
+
+```bash
+osc evolve record .osc/evolution/csv-importer \
+  --run .osc/runs/attempt-b/run.json \
+  --evaluation docs/evidence/attempt-b-evaluation.json \
+  --decision promote \
+  --score 0.94 \
+  --rationale "Keeps AC1 passing and fixes AC2 with clear error handling."
+```
+
+Example evaluation status:
+
+```text
+AC1 Parse quoted CSV rows          pass
+AC2 Reject malformed input clearly pass
+```
+
+Because this second record uses `--decision promote`, `frontier.json` now points at `attempt-b` while preserving the prior frontier in history.
+
+## 4. Compare previous frontier vs current frontier
+
+Default compare target is the common question: previous frontier vs current frontier.
+
+```bash
+osc evolve compare .osc/evolution/csv-importer \
+  --format markdown \
+  --out docs/evidence/csv-importer-frontier-compare.md
+```
+
+The markdown output is designed to paste into a PR description or review thread:
+
+```markdown
+# Evolution loop: csv-importer — A vs B
+
+**Comparing:** `attempt-a` (promote) → `attempt-b` (promote, current frontier)
+
+| Field | A | B | Δ |
+|---|---|---|---|
+| Decision | promote | promote | — |
+| Score | 0.62 | 0.94 | +0.32 ▲ |
+| Run ID | attempt-a | attempt-b | changed |
+| Evidence files | 2 | 3 | +1 |
+| Evaluation envelope | ✓ | ✓ | — |
+
+## Rationale
+
+**A (promote):** First useful frontier, but AC2 still fails.
+
+**B (promote):** Keeps AC1 passing and fixes AC2 with clear error handling.
+
+## Acceptance criteria delta
+
+| Criterion | A | B |
+|---|---|---|
+| AC1 — Parse quoted CSV rows | ✓ pass | ✓ pass |
+| AC2 — Reject malformed input clearly | ✗ fail | ✓ pass ▲ |
+```
+
+That table is the point: a reviewer can see the frontier decision without reconstructing it from `attempts.jsonl`, evaluation JSON, and evidence files by hand.
+
+## 5. Use explicit targets when needed
+
+Compare by attempt id, run id, or the reserved `frontier` keyword:
+
+```bash
+osc evolve compare .osc/evolution/csv-importer \
+  --a attempt-a \
+  --b frontier \
+  --format terminal
+```
+
+## What this proves
+
+- The repo records which attempts happened.
+- The frontier promotion has a rationale.
+- Evaluation envelopes make acceptance-criteria changes visible.
+- The comparison is read-only; it does not mutate loop state.
+- Human maintainers still own taste, risk, merge, publish, and release decisions.

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
-import { basename, extname, isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'node:path';
 import { parsePlanFile, findScaffoldRoot } from './scaffold.js';
 import type { ValidationIssue, ValidationResult } from './validation.js';
 
@@ -602,9 +602,19 @@ function frontierAttemptIds(frontier: Record<string, unknown>): { current: strin
   return { current, previous, history };
 }
 
+function inferScaffoldRootFromLoopDir(loopDir: string): string | null {
+  let current = resolve(loopDir);
+  while (true) {
+    if (basename(current) === '.osc') return dirname(current);
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
 export function compareEvolutionLoop(loopDir: string, options: EvolutionCompareOptions = {}, root = process.cwd()): EvolutionCompareResult {
   const absoluteLoopDir = isAbsolute(loopDir) ? loopDir : resolve(root, loopDir);
-  const comparisonRoot = findScaffoldRoot(absoluteLoopDir) ?? root;
+  const comparisonRoot = findScaffoldRoot(absoluteLoopDir) ?? inferScaffoldRootFromLoopDir(absoluteLoopDir) ?? root;
   const loopPath = join(absoluteLoopDir, 'loop.json');
   const attemptsPath = join(absoluteLoopDir, 'attempts.jsonl');
   const frontierPath = join(absoluteLoopDir, 'frontier.json');

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import { basename, extname, isAbsolute, join, relative, resolve } from 'node:path';
-import { parsePlanFile } from './scaffold.js';
+import { parsePlanFile, findScaffoldRoot } from './scaffold.js';
 import type { ValidationIssue, ValidationResult } from './validation.js';
 
 export const EVOLUTION_LOOP_SCHEMA = 'open-scaffold.evolution-loop.v1';
@@ -604,6 +604,7 @@ function frontierAttemptIds(frontier: Record<string, unknown>): { current: strin
 
 export function compareEvolutionLoop(loopDir: string, options: EvolutionCompareOptions = {}, root = process.cwd()): EvolutionCompareResult {
   const absoluteLoopDir = isAbsolute(loopDir) ? loopDir : resolve(root, loopDir);
+  const comparisonRoot = findScaffoldRoot(absoluteLoopDir) ?? root;
   const loopPath = join(absoluteLoopDir, 'loop.json');
   const attemptsPath = join(absoluteLoopDir, 'attempts.jsonl');
   const frontierPath = join(absoluteLoopDir, 'frontier.json');
@@ -658,7 +659,7 @@ export function compareEvolutionLoop(loopDir: string, options: EvolutionCompareO
     .filter((entry): entry is { attemptId: string; runId: string | null; score: number | null; promotedAt: string | null } => Boolean(entry.attemptId))
     .map((entry) => ({ ...entry, decision: attemptById.get(entry.attemptId)?.decision ?? null }));
 
-  const acceptanceCriteria = acceptanceCriteriaDelta(root, a, b);
+  const acceptanceCriteria = acceptanceCriteriaDelta(comparisonRoot, a, b);
 
   return {
     kind: 'comparison',

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -534,14 +534,12 @@ interface CompareCriterionStatus {
   status: string | null;
 }
 
-function readEvaluationCriteriaForCompare(root: string, evaluationRef: string | null, attemptId: string): CompareCriterionStatus[] {
+function readEvaluationCriteriaForCompare(root: string, evaluationRef: string | null): CompareCriterionStatus[] {
   if (!evaluationRef) return [];
   const evaluationPath = isAbsolute(evaluationRef) ? evaluationRef : resolve(root, evaluationRef);
   try {
     const parsed = readJson(evaluationPath);
-    if (!isRecord(parsed) || parsed.schema !== EVALUATION_SCHEMA) {
-      throw new Error(`Evaluation envelope must declare schema: ${EVALUATION_SCHEMA}`);
-    }
+    if (!isRecord(parsed) || parsed.schema !== EVALUATION_SCHEMA) return [];
     const criteria = Array.isArray(parsed.acceptance_criteria) ? parsed.acceptance_criteria.filter(isRecord) : [];
     return criteria.map((criterion, index) => {
       const id = asString(criterion.id) ?? `AC${index + 1}`;
@@ -551,14 +549,14 @@ function readEvaluationCriteriaForCompare(root: string, evaluationRef: string | 
         status: asString(criterion.status),
       };
     });
-  } catch (error) {
-    throw new Error(`Unable to read evaluation criteria for ${attemptId}: ${error instanceof Error ? error.message : String(error)}`);
+  } catch {
+    return [];
   }
 }
 
 function acceptanceCriteriaDelta(root: string, a: EvolutionCompareAttempt, b: EvolutionCompareAttempt) {
-  const aCriteria = readEvaluationCriteriaForCompare(root, a.evaluation, a.attemptId);
-  const bCriteria = readEvaluationCriteriaForCompare(root, b.evaluation, b.attemptId);
+  const aCriteria = readEvaluationCriteriaForCompare(root, a.evaluation);
+  const bCriteria = readEvaluationCriteriaForCompare(root, b.evaluation);
   const rows = new Map<string, EvolutionCompareCriterionDelta>();
   for (const criterion of aCriteria) {
     rows.set(criterion.id, {

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
-import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, win32 } from 'node:path';
 import { parsePlanFile, findScaffoldRoot } from './scaffold.js';
 import type { ValidationIssue, ValidationResult } from './validation.js';
 
@@ -536,7 +536,7 @@ interface CompareCriterionStatus {
 
 function readEvaluationCriteriaForCompare(root: string, evaluationRef: string | null): CompareCriterionStatus[] {
   if (!evaluationRef) return [];
-  const evaluationPath = isAbsolute(evaluationRef) ? evaluationRef : resolve(root, evaluationRef);
+  const evaluationPath = isAbsolute(evaluationRef) || win32.isAbsolute(evaluationRef) ? evaluationRef : resolve(root, evaluationRef);
   try {
     const parsed = readJson(evaluationPath);
     if (!isRecord(parsed) || parsed.schema !== EVALUATION_SCHEMA) return [];

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -418,6 +418,13 @@ export interface EvolutionCompareAttempt {
   boundary: Record<string, unknown>;
 }
 
+export interface EvolutionCompareCriterionDelta {
+  id: string;
+  text: string;
+  aStatus: string | null;
+  bStatus: string | null;
+}
+
 export type EvolutionCompareResult =
   | {
       kind: 'message';
@@ -432,6 +439,7 @@ export type EvolutionCompareResult =
       scoreDelta: number | null;
       evidence: { onlyInA: string[]; onlyInB: string[]; inBoth: string[] };
       evaluation: { a: { present: boolean; path: string | null; id: string | null; decision: string | null }; b: { present: boolean; path: string | null; id: string | null; decision: string | null } };
+      acceptanceCriteria: { rows: EvolutionCompareCriterionDelta[]; aPresent: boolean; bPresent: boolean };
       boundaryDifferences: Array<{ field: string; a: unknown; b: unknown }>;
       frontierHistory: Array<{ attemptId: string; runId: string | null; score: number | null; promotedAt: string | null; decision: string | null }>;
     };
@@ -469,6 +477,40 @@ function formatDelta(delta: number | null): string {
   return `${rounded > 0 ? '+' : ''}${rounded} ${rounded > 0 ? '▲' : '▼'}`;
 }
 
+function formatCriterionStatus(status: string | null): string {
+  switch (status) {
+    case 'pass':
+      return '✓ pass';
+    case 'fail':
+      return '✗ fail';
+    case 'partial':
+      return '◐ partial';
+    case 'blocked':
+      return 'blocked';
+    case 'not_evaluated':
+      return 'not evaluated';
+    case null:
+      return '—';
+    default:
+      return status;
+  }
+}
+
+function formatPlainCriterionStatus(status: string | null): string {
+  return status ?? '—';
+}
+
+function criterionDeltaMarker(aStatus: string | null, bStatus: string | null): string {
+  if (aStatus === bStatus || bStatus === null) return '';
+  if (bStatus === 'pass' && aStatus !== 'pass') return ' ▲';
+  if (aStatus === 'pass' && bStatus !== 'pass') return ' ▼';
+  return ' changed';
+}
+
+function escapeMarkdownTableCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, '<br>');
+}
+
 function evidenceDelta(aRefs: string[], bRefs: string[]) {
   const aSet = new Set(aRefs);
   const bSet = new Set(bRefs);
@@ -484,6 +526,67 @@ function boundaryDelta(a: Record<string, unknown>, b: Record<string, unknown>) {
   return fields
     .filter((field) => JSON.stringify(a[field]) !== JSON.stringify(b[field]))
     .map((field) => ({ field, a: a[field], b: b[field] }));
+}
+
+interface CompareCriterionStatus {
+  id: string;
+  text: string;
+  status: string | null;
+}
+
+function readEvaluationCriteriaForCompare(root: string, evaluationRef: string | null, attemptId: string): CompareCriterionStatus[] {
+  if (!evaluationRef) return [];
+  const evaluationPath = isAbsolute(evaluationRef) ? evaluationRef : resolve(root, evaluationRef);
+  try {
+    const parsed = readJson(evaluationPath);
+    if (!isRecord(parsed) || parsed.schema !== EVALUATION_SCHEMA) {
+      throw new Error(`Evaluation envelope must declare schema: ${EVALUATION_SCHEMA}`);
+    }
+    const criteria = Array.isArray(parsed.acceptance_criteria) ? parsed.acceptance_criteria.filter(isRecord) : [];
+    return criteria.map((criterion, index) => {
+      const id = asString(criterion.id) ?? `AC${index + 1}`;
+      return {
+        id,
+        text: asString(criterion.text) ?? id,
+        status: asString(criterion.status),
+      };
+    });
+  } catch (error) {
+    throw new Error(`Unable to read evaluation criteria for ${attemptId}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function acceptanceCriteriaDelta(root: string, a: EvolutionCompareAttempt, b: EvolutionCompareAttempt) {
+  const aCriteria = readEvaluationCriteriaForCompare(root, a.evaluation, a.attemptId);
+  const bCriteria = readEvaluationCriteriaForCompare(root, b.evaluation, b.attemptId);
+  const rows = new Map<string, EvolutionCompareCriterionDelta>();
+  for (const criterion of aCriteria) {
+    rows.set(criterion.id, {
+      id: criterion.id,
+      text: criterion.text,
+      aStatus: criterion.status,
+      bStatus: null,
+    });
+  }
+  for (const criterion of bCriteria) {
+    const existing = rows.get(criterion.id);
+    if (existing) {
+      existing.text = existing.text || criterion.text;
+      existing.bStatus = criterion.status;
+    } else {
+      rows.set(criterion.id, {
+        id: criterion.id,
+        text: criterion.text,
+        aStatus: null,
+        bStatus: criterion.status,
+      });
+    }
+  }
+  return {
+    rows: [...rows.values()],
+    aPresent: Boolean(a.evaluation),
+    bPresent: Boolean(b.evaluation),
+  };
 }
 
 function resolveAttemptTarget(target: string, attempts: EvolutionCompareAttempt[], currentFrontierId: string | null): EvolutionCompareAttempt {
@@ -557,6 +660,8 @@ export function compareEvolutionLoop(loopDir: string, options: EvolutionCompareO
     .filter((entry): entry is { attemptId: string; runId: string | null; score: number | null; promotedAt: string | null } => Boolean(entry.attemptId))
     .map((entry) => ({ ...entry, decision: attemptById.get(entry.attemptId)?.decision ?? null }));
 
+  const acceptanceCriteria = acceptanceCriteriaDelta(root, a, b);
+
   return {
     kind: 'comparison',
     loop: loopInfo,
@@ -568,6 +673,7 @@ export function compareEvolutionLoop(loopDir: string, options: EvolutionCompareO
       a: { present: Boolean(a.evaluation), path: a.evaluation, id: a.evaluationId, decision: a.evaluationDecision },
       b: { present: Boolean(b.evaluation), path: b.evaluation, id: b.evaluationId, decision: b.evaluationDecision },
     },
+    acceptanceCriteria,
     boundaryDifferences: boundaryDelta(a.boundary, b.boundary),
     frontierHistory,
   };
@@ -619,6 +725,11 @@ function renderTerminalComparison(comparison: Extract<EvolutionCompareResult, { 
     `  A (${comparison.a.decision ?? 'unknown'}): ${comparison.a.rationale || '—'}`,
     `  B (${comparison.b.decision ?? 'unknown'}): ${comparison.b.rationale || '—'}`,
     '',
+    ...(comparison.acceptanceCriteria.rows.length > 0 ? [
+      'Acceptance criteria delta',
+      ...comparison.acceptanceCriteria.rows.map((row) => `  ${row.id}: A=${formatPlainCriterionStatus(row.aStatus)} | B=${formatPlainCriterionStatus(row.bStatus)}${criterionDeltaMarker(row.aStatus, row.bStatus)} — ${row.text}`),
+      '',
+    ] : []),
     'Evidence files',
     '  Only in A:',
     ...linesOrNone(comparison.evidence.onlyInA, '    '),
@@ -665,6 +776,18 @@ function renderMarkdownComparison(comparison: Extract<EvolutionCompareResult, { 
     '',
     `**B (${comparison.b.decision ?? 'recorded'}):** ${comparison.b.rationale || '—'}`,
     '',
+    ...(comparison.acceptanceCriteria.rows.length > 0 ? [
+      '## Acceptance criteria delta',
+      '',
+      '| Criterion | A | B |',
+      '|---|---|---|',
+      ...comparison.acceptanceCriteria.rows.map((row) => {
+        const criterion = `${row.id} — ${row.text}`;
+        const marker = criterionDeltaMarker(row.aStatus, row.bStatus);
+        return `| ${escapeMarkdownTableCell(criterion)} | ${formatCriterionStatus(row.aStatus)} | ${formatCriterionStatus(row.bStatus)}${marker} |`;
+      }),
+      '',
+    ] : []),
     '## Evidence files',
     '',
     `- Only in A: ${comparison.evidence.onlyInA.length > 0 ? comparison.evidence.onlyInA.map((ref) => `\`${ref}\``).join(', ') : '—'}`,

--- a/tests/cli-evolution.test.ts
+++ b/tests/cli-evolution.test.ts
@@ -72,6 +72,24 @@ Improve the run contract.
     schema: 'open-scaffold.evaluation.v1',
     evaluation_id: 'eval-001',
     subject: { source: 'run', plan: '.osc/plans/active/087-demo.md', plan_slug: '087-demo', task_id: 'task-123', run_id: 'demo-run', run_packet: '.osc/runs/demo-run/run.json' },
+    acceptance_criteria: [
+      {
+        id: 'AC1',
+        text: 'Loop state is created.',
+        status: 'pass',
+        evaluator: { kind: 'human', name: 'reviewer', ref: null },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/demo-run-proof.md', summary: 'Synthetic CLI evidence.' }],
+        rationale: 'Loop state exists.',
+      },
+      {
+        id: 'AC2',
+        text: 'Frontier promotion is explicit.',
+        status: 'fail',
+        evaluator: { kind: 'human', name: 'reviewer', ref: null },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/demo-run-proof.md', summary: 'Synthetic CLI evidence.' }],
+        rationale: 'Frontier rationale needs a clearer comparison.',
+      },
+    ],
     decision: { status: 'approved', approver: 'human', rationale: 'Evidence reviewed.' },
     improvement: { route: 'close', target: null, carried_forward: [], do_not_assume: ['No model benchmark claim.'] },
   }, null, 2));
@@ -226,14 +244,40 @@ describe('osc evolve CLI', () => {
     expect(frontier.current).toBeNull();
   });
 
-  it('compares evolution attempts and writes markdown output', () => {
-    const { root, planPath, runPath } = tempRepo();
+  it('compares evolution attempts and writes markdown output with acceptance criteria delta', () => {
+    const { root, planPath, runPath, evalPath } = tempRepo();
     const runB = writeRunPacket(root, 'attempt-b');
+    const evalB = join(root, 'docs/evidence/attempt-b-evaluation.json');
+    writeFileSync(evalB, JSON.stringify({
+      schema: 'open-scaffold.evaluation.v1',
+      evaluation_id: 'eval-attempt-b',
+      subject: { source: 'run', plan: '.osc/plans/active/087-demo.md', plan_slug: '087-demo', task_id: 'task-123', run_id: 'attempt-b', run_packet: '.osc/runs/attempt-b/run.json' },
+      acceptance_criteria: [
+        {
+          id: 'AC1',
+          text: 'Loop state is created.',
+          status: 'pass',
+          evaluator: { kind: 'human', name: 'reviewer', ref: null },
+          evidence: [{ kind: 'path', ref: 'docs/evidence/attempt-b-proof.md', summary: 'Synthetic CLI evidence.' }],
+          rationale: 'Loop state exists.',
+        },
+        {
+          id: 'AC2',
+          text: 'Frontier promotion is explicit.',
+          status: 'pass',
+          evaluator: { kind: 'human', name: 'reviewer', ref: null },
+          evidence: [{ kind: 'path', ref: 'docs/evidence/attempt-b-proof.md', summary: 'Synthetic CLI evidence.' }],
+          rationale: 'Frontier rationale is explicit.',
+        },
+      ],
+      decision: { status: 'approved', approver: 'human', rationale: 'Evidence reviewed.' },
+      improvement: { route: 'close', target: null, carried_forward: [], do_not_assume: ['No model benchmark claim.'] },
+    }, null, 2));
     const outDir = join(root, '.osc/evolution/demo-loop');
     const reportPath = join(root, 'docs/evidence/evolution-compare.md');
     execFileSync(tsx, [cli, 'evolve', 'init', planPath, '--out', outDir, '--strategy', 'greedy'], { cwd: root, encoding: 'utf8' });
-    execFileSync(tsx, [cli, 'evolve', 'record', outDir, '--run', runPath, '--decision', 'promote', '--score', '0.62', '--rationale', 'First promoted frontier.'], { cwd: root, encoding: 'utf8' });
-    execFileSync(tsx, [cli, 'evolve', 'record', outDir, '--run', runB, '--decision', 'promote', '--score', '0.94', '--rationale', 'Better frontier.'], { cwd: root, encoding: 'utf8' });
+    execFileSync(tsx, [cli, 'evolve', 'record', outDir, '--run', runPath, '--evaluation', evalPath, '--decision', 'promote', '--score', '0.62', '--rationale', 'First promoted frontier.'], { cwd: root, encoding: 'utf8' });
+    execFileSync(tsx, [cli, 'evolve', 'record', outDir, '--run', runB, '--evaluation', evalB, '--decision', 'promote', '--score', '0.94', '--rationale', 'Better frontier.'], { cwd: root, encoding: 'utf8' });
 
     const output = execFileSync(tsx, [cli, 'evolve', 'compare', outDir, '--format', 'markdown', '--out', reportPath], { cwd: root, encoding: 'utf8' });
 
@@ -242,6 +286,8 @@ describe('osc evolve CLI', () => {
     expect(report).toContain('# Evolution loop: demo-loop — A vs B');
     expect(report).toContain('| Score | 0.62 | 0.94 | +0.32 ▲ |');
     expect(report).toContain('**B (promote):** Better frontier.');
+    expect(report).toContain('## Acceptance criteria delta');
+    expect(report).toContain('| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |');
   });
 
   it('rejects unknown strategies and prints evolve usage', () => {

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -16,6 +16,7 @@ import {
 function tempRepo() {
   const root = mkdtempSync(join(tmpdir(), 'osc-evolution-'));
   mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
   mkdirSync(join(root, '.osc/runs/demo-run'), { recursive: true });
   mkdirSync(join(root, 'docs/evidence'), { recursive: true });
   writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild the thing.\n');
@@ -439,6 +440,38 @@ describe('evolution comparison rendering', () => {
     expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |');
     expect(terminal).toContain('Acceptance criteria delta');
     expect(terminal).toContain('AC2: A=fail | B=pass ▲ — Frontier promotion is explicit.');
+  });
+
+  it('resolves compare evaluation refs from the loop scaffold root instead of caller cwd', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const evalA = writeEvaluation(root, 'attempt-a', { AC2: 'fail' });
+    const evalB = writeEvaluation(root, 'attempt-b', { AC2: 'pass' });
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z'), strategy: 'greedy' });
+    recordEvolutionAttempt(outDir, {
+      runPath: runA,
+      evaluationPath: evalA,
+      decision: 'promote',
+      score: 0.62,
+      rationale: 'First frontier still failed AC2.',
+      now: new Date('2026-05-21T08:10:00.000Z'),
+    }, root);
+    recordEvolutionAttempt(outDir, {
+      runPath: runB,
+      evaluationPath: evalB,
+      decision: 'promote',
+      score: 0.94,
+      rationale: 'Second frontier passes AC2.',
+      now: new Date('2026-05-21T08:20:00.000Z'),
+    }, root);
+
+    const comparison = compareEvolutionLoop(outDir);
+    const markdown = renderEvolutionComparison(comparison, 'markdown');
+
+    expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |');
   });
 
   it('shows known acceptance criteria when only one side has an evaluation envelope', () => {

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -507,6 +507,45 @@ describe('evolution comparison rendering', () => {
     expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |');
   });
 
+  it('does not reinterpret Windows absolute evaluation refs as repo-relative paths on POSIX', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const evalB = writeEvaluation(root, 'attempt-b', { AC2: 'pass' });
+    const windowsRef = 'C:\\tmp\\attempt-b-evaluation.json';
+    writeFileSync(join(root, windowsRef), readFileSync(evalB, 'utf8'));
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z'), strategy: 'greedy' });
+    recordEvolutionAttempt(outDir, {
+      runPath: runA,
+      decision: 'promote',
+      score: 0.62,
+      rationale: 'First frontier had no evaluation envelope.',
+      now: new Date('2026-05-21T08:10:00.000Z'),
+    }, root);
+    recordEvolutionAttempt(outDir, {
+      runPath: runB,
+      decision: 'promote',
+      score: 0.94,
+      rationale: 'Second frontier records a Windows absolute evaluation ref.',
+      now: new Date('2026-05-21T08:20:00.000Z'),
+    }, root);
+    const attemptsPath = join(outDir, 'attempts.jsonl');
+    const attempts = readFileSync(attemptsPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    attempts[1].evaluation = windowsRef;
+    attempts[1].evaluation_id = 'eval-attempt-b';
+    writeFileSync(attemptsPath, `${attempts.map((attempt) => JSON.stringify(attempt)).join('\n')}\n`);
+
+    const comparison = compareEvolutionLoop(outDir, {}, root);
+    const markdown = renderEvolutionComparison(comparison, 'markdown');
+
+    expect(markdown).not.toContain('AC2 — Frontier promotion is explicit. | — | ✓ pass ▲');
+  });
+
   it('shows known acceptance criteria when only one side has an evaluation envelope', () => {
     const root = tempRepo();
     const planPath = writePlan(root);

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -469,6 +469,42 @@ describe('evolution comparison rendering', () => {
     const markdown = renderEvolutionComparison(comparison, 'markdown');
 
     expect(markdown).toContain('## Acceptance criteria delta');
+    expect(markdown).toContain('| AC1 — Loop state is created. | — | ✓ pass ▲ |');
+    expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | — | ✓ pass ▲ |');
+  });
+
+  it('ignores missing evaluation envelopes while keeping comparison output available', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const evalA = writeEvaluation(root, 'attempt-a', { AC2: 'fail' });
+    const evalB = writeEvaluation(root, 'attempt-b', { AC2: 'pass' });
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z'), strategy: 'greedy' });
+    recordEvolutionAttempt(outDir, {
+      runPath: runA,
+      evaluationPath: evalA,
+      decision: 'promote',
+      score: 0.62,
+      rationale: 'First frontier pointed at evaluation evidence that was later moved.',
+      now: new Date('2026-05-21T08:10:00.000Z'),
+    }, root);
+    recordEvolutionAttempt(outDir, {
+      runPath: runB,
+      evaluationPath: evalB,
+      decision: 'promote',
+      score: 0.94,
+      rationale: 'Second frontier still has evaluation evidence.',
+      now: new Date('2026-05-21T08:20:00.000Z'),
+    }, root);
+    rmSync(evalA);
+
+    const comparison = compareEvolutionLoop(outDir, {}, root);
+    const markdown = renderEvolutionComparison(comparison, 'markdown');
+
+    expect(markdown).toContain('# Evolution loop: demo-loop — A vs B');
+    expect(markdown).toContain('| Evaluation envelope | ✓ | ✓ | — |');
     expect(markdown).toContain('| AC1 — Loop state is created. | — | ✓ pass ▲ |');
     expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | — | ✓ pass ▲ |');
   });

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -84,12 +84,24 @@ function writeRunPacket(root: string, runId = 'demo-run') {
   return runPath;
 }
 
-function writeEvaluation(root: string, runId = 'demo-run') {
-  const evalPath = join(root, 'docs/evidence/evaluation.json');
+function writeEvaluation(root: string, runId = 'demo-run', statuses: Record<string, 'pass' | 'partial' | 'fail' | 'blocked' | 'not_evaluated'> = {}) {
+  const evalPath = join(root, `docs/evidence/${runId}-evaluation.json`);
+  const criteria = [
+    { id: 'AC1', text: 'Loop state is created.', status: statuses.AC1 ?? 'pass' },
+    { id: 'AC2', text: 'Frontier promotion is explicit.', status: statuses.AC2 ?? 'pass' },
+  ];
   writeFileSync(evalPath, JSON.stringify({
     schema: 'open-scaffold.evaluation.v1',
-    evaluation_id: 'eval-001',
+    evaluation_id: `eval-${runId}`,
     subject: { source: 'run', plan: '.osc/plans/active/087-demo.md', plan_slug: '087-demo', task_id: 'task-123', run_id: runId, run_packet: `.osc/runs/${runId}/run.json` },
+    acceptance_criteria: criteria.map((criterion) => ({
+      id: criterion.id,
+      text: criterion.text,
+      status: criterion.status,
+      evaluator: { kind: 'human', name: 'reviewer', ref: null },
+      evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Synthetic test evidence.' }],
+      rationale: `${criterion.id} ${criterion.status}`,
+    })),
     decision: { status: 'approved', approver: 'human', rationale: 'Evidence reviewed.' },
     improvement: { route: 'close', target: null, carried_forward: [], do_not_assume: ['No model benchmark claim.'] },
   }, null, 2));
@@ -181,7 +193,7 @@ describe('evolution attempt recording and validation', () => {
 
     expect(result.attempt.attempt_id).toBe('demo-run');
     expect(attempts).toHaveLength(1);
-    expect(attempts[0]).toMatchObject({ run_id: 'demo-run', evaluation_id: 'eval-001', decision: 'promote', score: 0.92 });
+    expect(attempts[0]).toMatchObject({ run_id: 'demo-run', evaluation_id: 'eval-demo-run', decision: 'promote', score: 0.92 });
     expect(frontier.current).toMatchObject({ attempt_id: 'demo-run', run_id: 'demo-run', score: 0.92, rationale: 'Best evidence so far.' });
     expect(frontier.boundary).toMatchObject({ approval_or_release_decision: false, model_benchmarking: false });
   });
@@ -260,7 +272,7 @@ describe('evolution attempt recording and validation', () => {
     expect(result.attempt.adapter_receipts).toEqual(['.osc/runs/demo-run/dispatch-receipt.json']);
     expect(attempts[0].evidence_refs).toEqual(expect.arrayContaining([
       'docs/evidence/proof.md',
-      'docs/evidence/evaluation.json',
+      'docs/evidence/demo-run-evaluation.json',
       '.osc/runs/demo-run/dispatch-receipt.json',
       '.osc/runs/demo-run/runtime-omx-evidence.md',
       '.osc/runs/demo-run/runtime-omx.log',
@@ -390,6 +402,75 @@ describe('evolution comparison rendering', () => {
     const json = JSON.parse(renderEvolutionComparison(comparison, 'json'));
     expect(json.a.attemptId).toBe('attempt-a');
     expect(json.b.attemptId).toBe('attempt-b');
+  });
+
+  it('renders acceptance criteria deltas from linked evaluation envelopes', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const evalA = writeEvaluation(root, 'attempt-a', { AC2: 'fail' });
+    const evalB = writeEvaluation(root, 'attempt-b', { AC2: 'pass' });
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z'), strategy: 'greedy' });
+    recordEvolutionAttempt(outDir, {
+      runPath: runA,
+      evaluationPath: evalA,
+      decision: 'promote',
+      score: 0.62,
+      rationale: 'First frontier still failed AC2.',
+      now: new Date('2026-05-21T08:10:00.000Z'),
+    }, root);
+    recordEvolutionAttempt(outDir, {
+      runPath: runB,
+      evaluationPath: evalB,
+      decision: 'promote',
+      score: 0.94,
+      rationale: 'Second frontier passes AC2.',
+      now: new Date('2026-05-21T08:20:00.000Z'),
+    }, root);
+
+    const comparison = compareEvolutionLoop(outDir, {}, root);
+    const markdown = renderEvolutionComparison(comparison, 'markdown');
+    const terminal = renderEvolutionComparison(comparison, 'terminal');
+
+    expect(markdown).toContain('## Acceptance criteria delta');
+    expect(markdown).toContain('| AC1 — Loop state is created. | ✓ pass | ✓ pass |');
+    expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |');
+    expect(terminal).toContain('Acceptance criteria delta');
+    expect(terminal).toContain('AC2: A=fail | B=pass ▲ — Frontier promotion is explicit.');
+  });
+
+  it('shows known acceptance criteria when only one side has an evaluation envelope', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const evalB = writeEvaluation(root, 'attempt-b', { AC1: 'pass', AC2: 'pass' });
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z'), strategy: 'greedy' });
+    recordEvolutionAttempt(outDir, {
+      runPath: runA,
+      decision: 'promote',
+      score: 0.62,
+      rationale: 'First frontier had no evaluation envelope.',
+      now: new Date('2026-05-21T08:10:00.000Z'),
+    }, root);
+    recordEvolutionAttempt(outDir, {
+      runPath: runB,
+      evaluationPath: evalB,
+      decision: 'promote',
+      score: 0.94,
+      rationale: 'Second frontier added evaluation coverage.',
+      now: new Date('2026-05-21T08:20:00.000Z'),
+    }, root);
+
+    const comparison = compareEvolutionLoop(outDir, {}, root);
+    const markdown = renderEvolutionComparison(comparison, 'markdown');
+
+    expect(markdown).toContain('## Acceptance criteria delta');
+    expect(markdown).toContain('| AC1 — Loop state is created. | — | ✓ pass ▲ |');
+    expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | — | ✓ pass ▲ |');
   });
 
   it('throws a clear error for unknown explicit compare targets', () => {

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -474,6 +474,39 @@ describe('evolution comparison rendering', () => {
     expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |');
   });
 
+  it('uses the loop .osc parent as compare root for partial historical scaffolds', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runA = writeRunPacket(root, 'attempt-a');
+    const runB = writeRunPacket(root, 'attempt-b');
+    const evalA = writeEvaluation(root, 'attempt-a', { AC2: 'fail' });
+    const evalB = writeEvaluation(root, 'attempt-b', { AC2: 'pass' });
+    const outDir = join(root, '.osc/evolution/demo-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-21T08:00:00.000Z'), strategy: 'greedy' });
+    recordEvolutionAttempt(outDir, {
+      runPath: runA,
+      evaluationPath: evalA,
+      decision: 'promote',
+      score: 0.62,
+      rationale: 'First frontier still failed AC2.',
+      now: new Date('2026-05-21T08:10:00.000Z'),
+    }, root);
+    recordEvolutionAttempt(outDir, {
+      runPath: runB,
+      evaluationPath: evalB,
+      decision: 'promote',
+      score: 0.94,
+      rationale: 'Second frontier passes AC2.',
+      now: new Date('2026-05-21T08:20:00.000Z'),
+    }, root);
+    rmSync(join(root, '.osc/releases'), { recursive: true, force: true });
+
+    const comparison = compareEvolutionLoop(outDir);
+    const markdown = renderEvolutionComparison(comparison, 'markdown');
+
+    expect(markdown).toContain('| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |');
+  });
+
   it('shows known acceptance criteria when only one side has an evaluation envelope', () => {
     const root = tempRepo();
     const planPath = writePlan(root);


### PR DESCRIPTION
## Summary
- Render acceptance-criteria deltas in `osc evolve compare` when linked evaluation envelopes are present.
- Add a public-safe evolution-loop compare walkthrough showing two attempts, frontier rationale, and markdown output.
- Resolve compare evaluation refs from the loop scaffold root, including partial historical `.osc/` loops, so absolute loop-dir compare calls are independent of caller cwd.
- Preserve portable absolute evaluation refs, including Windows absolute paths, instead of reinterpreting them as repo-relative on POSIX.
- Keep `compare` readable for historical loops when recorded evaluation file refs are missing/stale.
- Close plan `092-evolution-loop-visibility-v1` with a repo-local release/evidence note.

## Verification
- `git diff --check`
- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — 2 files / 28 tests passed
- `npm test -- --run` — 32 files / 292 tests passed
- `npm run build`
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn

## Boundary / gates
- No runtime adapters, native spawning, model ranking, compliance certification, approval automation, npm publish, or GitHub Release changes.
- Merge remains owner-gated.
- npm/GitHub Release/public-surface changes, if any, require a separate gate.
