### PR TITLE
Close 0.4.13 public-surface sync

### DIFF
--- a/.osc/plans/done/093-pr89-public-surface-sync.md
+++ b/.osc/plans/done/093-pr89-public-surface-sync.md
@@ -1,0 +1,95 @@
+# Plan: 093-pr89-public-surface-sync
+
+## Status
+
+active
+
+## Context
+
+PR #89 (`Make evolution loop comparison visible`) landed on `main` after `open-scaffold@0.4.12` was already published to npm and after GitHub Release `v0.4.12` was marked Latest. The repository `main` now includes the evolution-loop compare walkthrough and acceptance-criteria delta rendering, but the public package/release surfaces still predate that landing.
+
+This is a narrow public-surface sync candidate. It prepares the next patch package version so the PR #89 work can be published and released after explicit owner approval.
+
+## Goal
+
+Prepare `open-scaffold@0.4.13` as the release-sync candidate for PR #89 so the npm package, fresh `npx open-scaffold@latest`, and GitHub Latest Release can be aligned after the owner approves publish/release follow-through.
+
+## Constraints / Out of scope
+
+- Do not run real `npm publish` in this PR.
+- Do not create, edit, move, or mark a GitHub Release as Latest in this PR.
+- Do not merge this PR without owner approval.
+- Do not archive this plan or stamp `MISSION.md` until npm registry, fresh `npx`, and GitHub Latest Release proof exist after owner-gated follow-through.
+- Do not change evolution-loop product behavior beyond the already-landed PR #89 work.
+- Do not add runtime adapters, native spawning, model ranking, compliance certification, or approval automation.
+- Keep scope to package metadata/version, candidate evidence, and package verification.
+
+## Files to touch
+
+- `package.json` — bump package candidate version to `0.4.13`.
+- `package-lock.json` — align lockfile package version to `0.4.13`.
+- `.osc/plans/active/093-pr89-public-surface-sync.md` — keep this plan active until post-merge publish/release proof exists.
+- `.osc/releases/2026-05-22-093-pr89-public-surface-sync.md` — candidate evidence note and owner gates.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Confirm repo, npm, GitHub Release, and PR #89 public-surface drift | None | A |
+| T2 | Bump candidate package metadata to `0.4.13` | T1 | B |
+| T3 | Write candidate evidence note with owner-gated publish/release follow-through | T2 | B |
+| T4 | Run local verification and package dry-run gates | T2, T3 | C |
+| T5 | Open PR and request review; stop before merge/publish/release | T4 | D |
+
+### Parallel groups
+
+- **A**: read-only drift confirmation.
+- **B**: metadata/evidence preparation.
+- **C**: verification and package candidate inspection.
+- **D**: PR preparation and review loop.
+
+### Dependencies
+
+- T2 depends on T1 because npm versions are immutable and the next version must be chosen from live registry truth.
+- T4 depends on all candidate files so evidence reflects the exact branch contents.
+- T5 depends on verification passing.
+
+### Delegation notes
+
+This is a small, deterministic release-sync candidate. Direct Hermes execution is appropriate. No runtime worker, automation runner, or Control Room proof lane should be resumed for this slice.
+
+## Implementation Architecture Coverage
+
+- Strengthens: public package truth, external install trust, GitHub Release alignment readiness.
+- Audit envelope: plan `093`, candidate evidence note, package version bump, package dry-run output, verification commands, PR review status.
+- Evaluation envelope: no new evaluator behavior; this only prepares the package surface for already-landed code/docs.
+- Feedback routing: npm publication, fresh `npx` verification, GitHub Release creation/update, and plan archive remain owner-gated follow-through after PR approval.
+- Boundary: Open Scaffold core remains non-spawning; this release-sync candidate does not add runtime or approval authority.
+
+## Acceptance criteria
+
+- [ ] `package.json` and `package-lock.json` are updated to `0.4.13`.
+- [ ] Candidate evidence explains that PR #89 landed after `0.4.12` publish/release and that `0.4.13` is needed for public `npx` alignment.
+- [ ] `npm pack --dry-run --json` includes the PR #89 public docs and package-visible code required for the evolution-loop compare visibility work.
+- [ ] Local verification passes: `git diff --check`, `./verify.sh --strict`, targeted evolution tests, full test suite, build, `npm pack --dry-run --json`, and `npm publish --dry-run`.
+- [ ] Fresh current `npx open-scaffold@latest` smoke is recorded as the pre-release baseline, not proof that `0.4.13` is live.
+- [ ] PR is opened for review with clear owner gates.
+- [ ] The plan remains active until owner-gated PR approval, trusted npm publication, fresh post-publish `npx`, GitHub Latest Release alignment, and final evidence are all real.
+
+## Verification steps
+
+1. `git diff --check` — no whitespace errors.
+2. `./verify.sh --strict` — scaffold verification passes while plan remains active.
+3. `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — targeted evolution compare tests pass.
+4. `npm test -- --run` — full suite passes.
+5. `npm run build` — package builds.
+6. `npm pack --dry-run --json` — package payload is inspectable and includes PR #89 public docs/code surfaces.
+7. `npm publish --dry-run` — publish candidate dry-run passes without publishing.
+8. Fresh `npx open-scaffold@latest --help` and `npx open-scaffold@latest evolve --help` baseline is recorded.
+
+## Open questions
+
+- Should `0.4.13` GitHub Release title emphasize evolution-loop comparison visibility or broader public-surface sync? Deferred to the owner-gated release step.
+- Should the plan be archived in this same branch? No. It remains active until real npm/GitHub Release proof exists after owner approval.

--- a/.osc/releases/2026-05-22-093-pr89-public-surface-sync.md
+++ b/.osc/releases/2026-05-22-093-pr89-public-surface-sync.md
@@ -1,48 +1,39 @@
-# 093 — PR #89 Public-Surface Sync Candidate
+# 093 — PR #89 Public-Surface Sync
 
 Date: 2026-05-22
-Plan: `.osc/plans/active/093-pr89-public-surface-sync.md`
+Plan: `.osc/plans/done/093-pr89-public-surface-sync.md`
 Branch: `release/pr89-public-surface-sync`
-Package candidate: `open-scaffold@0.4.13`
-PR: `https://github.com/graphanov/open-scaffold/pull/90`
+Package version: `open-scaffold@0.4.13`
+Release: `https://github.com/graphanov/open-scaffold/releases/tag/v0.4.13`
 
 ## Summary
 
-Prepared a narrow patch release candidate so the PR #89 evolution-loop visibility work can reach the public npm / `npx` surface after owner approval.
+Published `open-scaffold@0.4.13` and aligned the public npm / `npx` surface plus GitHub Latest Release with the PR #89 evolution-loop visibility work.
 
-PR #89 landed on `main` after `open-scaffold@0.4.12` had already been published and after GitHub Release `v0.4.12` had been marked Latest. The repository now contains the public walkthrough and acceptance-criteria delta rendering, while the current npm/GitHub Latest surfaces still predate that work.
-
-This branch does not publish npm, create a GitHub Release, mark any release Latest, or archive the plan. Those remain owner-gated follow-through actions after PR review and approval.
+PR #89 landed on `main` after `open-scaffold@0.4.12` had already been published and after GitHub Release `v0.4.12` had been marked Latest. PR #90 prepared the patch release-sync candidate, then the owner approved follow-through.
 
 ## Traceability
 
-- Prior slice: PR #89 — `Make evolution loop comparison visible`
-- Prior evidence: `.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md`
-- Current plan: `.osc/plans/active/093-pr89-public-surface-sync.md`
-- Package candidate: `0.4.13`
-- npm latest before this candidate: `0.4.12`
-- GitHub Latest Release before this candidate: `v0.4.12 — README work records and evolution ledgers`
+- Source feature slice: PR #89 — `Make evolution loop comparison visible`
+- Source feature evidence: `.osc/releases/2026-05-22-092-evolution-loop-visibility-v1.md`
+- Release-sync PR: `https://github.com/graphanov/open-scaffold/pull/90`
+- PR #90 merge commit: `a5ee3b6bb7039a4862b0518ce6b6f5019b483f54`
+- Trusted publishing workflow: `https://github.com/graphanov/open-scaffold/actions/runs/26298500793`
+- GitHub Release: `https://github.com/graphanov/open-scaffold/releases/tag/v0.4.13`
 
 ## Outcome
 
-Candidate prepared for review:
+Public surfaces are aligned:
 
-- `package.json` version is `0.4.13`.
-- `package-lock.json` root package version is `0.4.13`.
-- The plan remains active because npm publication, fresh post-publish `npx` proof, GitHub Latest Release alignment, and final evidence are not done yet.
-- The dry-run package payload includes the PR #89 public docs and built code surfaces:
-  - `docs/examples/evolution-loop-compare.md`
-  - `docs/EVOLUTION_LOOP.md`
-  - `dist/evolution.js`
-  - `dist/cli.js`
-- The dry-run payload excludes forbidden private/dogfood/runtime state prefixes:
-  - `.osc/plans/done/`
-  - `.osc/plans/backlog/`
-  - `.osc/runs/`
-  - `.osc/research/`
-  - `.osc-dev/`
-  - `.git/`
-  - `node_modules/`
+- `package.json` on `main`: `0.4.13`
+- npm registry: `open-scaffold@0.4.13`
+- npm `latest` dist-tag: `0.4.13`
+- GitHub Latest Release: `v0.4.13 — Evolution loop comparison visibility`
+- Fresh isolated-cache `npx open-scaffold@latest --help`: passed
+- Fresh isolated-cache `npx open-scaffold@latest evolve --help`: passed
+- Fresh isolated-cache `npx open-scaffold@latest init --tier min`: passed
+
+Plan `093` was moved to `done/` only after the registry, `npx`, and GitHub Release surfaces were verified.
 
 ## What changed
 
@@ -50,86 +41,63 @@ Candidate prepared for review:
   - Bumped from `0.4.12` to `0.4.13`.
 - `package-lock.json`
   - Aligned package/root version metadata to `0.4.13`.
-- `.osc/plans/active/093-pr89-public-surface-sync.md`
-  - Added active release-sync plan for the owner-gated public-surface follow-through.
+- `.osc/plans/done/093-pr89-public-surface-sync.md`
+  - Archived the release-sync plan after public-surface proof.
 - `.osc/releases/2026-05-22-093-pr89-public-surface-sync.md`
-  - Added this candidate evidence note.
+  - Updated this evidence note with final npm, `npx`, and GitHub Release proof.
+- `MISSION.md`
+  - Changelog stamped by `close.sh`.
 
 ## Boundary
 
-This candidate does not:
+This release did not add:
 
-- run real `npm publish`;
-- create or edit GitHub Releases;
-- mark a GitHub Release as Latest;
-- merge the PR;
-- archive/finish plan `093`;
-- add runtime adapters, native spawning, model ranking, compliance certification, or approval automation.
+- runtime adapters;
+- native spawning;
+- model ranking;
+- compliance certification;
+- approval automation.
 
-## Pre-release public baseline
-
-Live registry before this candidate:
-
-```text
-npm latest: open-scaffold@0.4.12
-npm 0.4.12 publish time: 2026-05-22T11:29:03.625Z
-GitHub Latest Release: v0.4.12 — README work records and evolution ledgers
-PR #89 merge time: 2026-05-22T15:29:10Z
-```
-
-Fresh `npx open-scaffold@latest --help` and `npx open-scaffold@latest evolve --help` still run, but they are the `0.4.12` public package surface and therefore predate this candidate.
+Open Scaffold core remains runtime-neutral and non-spawning.
 
 ## Verification
 
+PR #90 candidate verification:
+
 ```text
 git diff --check
-```
-
-Result: pass.
-
-```text
 ./verify.sh --strict
-```
-
-Result after active-plan wording adjustment:
-
-```text
-10 pass, 0 fail, 0 warn
-```
-
-```text
 npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts
-```
-
-Result:
-
-```text
-Test Files  2 passed (2)
-Tests       28 passed (28)
-```
-
-```text
 npm test -- --run
-```
-
-Result:
-
-```text
-Test Files  32 passed (32)
-Tests       292 passed (292)
-```
-
-```text
 npm run build
+npm pack --dry-run --json
+npm publish --dry-run
 ```
 
-Result: `build:core` and `build:runtime-omx` passed.
+Results before merge:
 
 ```text
-npm pack --dry-run --json
+./verify.sh --strict — 10 pass, 0 fail, 0 warn
+Targeted evolution tests — 2 files / 28 tests passed
+Full tests — 32 files / 292 tests passed
+npm pack --dry-run --json — open-scaffold-0.4.13.tgz, 107 files
+npm publish --dry-run — + open-scaffold@0.4.13
+CI — success
+Codex latest-head review — no major issues; 0 unresolved current review threads
 ```
 
-Result:
+Post-merge local publish gates from `main`:
+
+```text
+git diff --check
+./verify.sh --strict — 10 pass, 0 fail, 0 warn
+npm test -- --run — 32 files / 292 tests passed
+npm run build — passed
+npm pack --dry-run --json — open-scaffold-0.4.13.tgz, 107 files
+npm publish --dry-run — + open-scaffold@0.4.13
+```
+
+Dry-run package payload proof:
 
 ```text
 filename open-scaffold-0.4.13.tgz
@@ -148,25 +116,44 @@ forbidden .git/ 0
 forbidden node_modules/ 0
 ```
 
-```text
-npm publish --dry-run
-```
-
-Result:
+Trusted publishing:
 
 ```text
-+ open-scaffold@0.4.13
+workflow: publish-npm.yml
+run: 26298500793
+head: a5ee3b6bb7039a4862b0518ce6b6f5019b483f54
+conclusion: success
 ```
 
-No actual npm publication was performed.
+npm registry proof:
 
-## Remaining owner gates
+```text
+version: 0.4.13
+dist-tags.latest: 0.4.13
+0.4.13 publish time: 2026-05-22T16:05:46.588Z
+```
 
-After PR review and owner approval:
+Fresh `npx` proof:
 
-1. Merge the release-sync PR.
-2. Run/approve npm Trusted Publishing for `open-scaffold@0.4.13`.
-3. Verify registry and fresh isolated-cache `npx open-scaffold@latest` exposes the PR #89 work.
-4. Create or update GitHub Release `v0.4.13` and mark it Latest.
-5. Update this evidence with final publish/release proof.
-6. Archive/finish plan `093` only after the public surfaces are truly aligned.
+```text
+npx --yes open-scaffold@latest --help — passed
+npx --yes open-scaffold@latest evolve --help — passed
+npx --yes open-scaffold@latest init --tier min --target <tmp> — generated expected min-tier files
+```
+
+GitHub Release proof:
+
+```text
+tag: v0.4.13
+name: v0.4.13 — Evolution loop comparison visibility
+target: a5ee3b6bb7039a4862b0518ce6b6f5019b483f54
+published: 2026-05-22T16:12:09Z
+latest: yes
+url: https://github.com/graphanov/open-scaffold/releases/tag/v0.4.13
+```
+
+## Remaining gates
+
+No public package/release gates remain for this slice.
+
+The only remaining hygiene gate is merging the closeout PR that moves plan `093` to `done/` and records this final evidence on `main`.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-22: closed 093-pr89-public-surface-sync — published 0.4.13 and aligned public package/release surfaces
 - 2026-05-22: closed 092-evolution-loop-visibility-v1 — made evolution loop comparison visible
 - 2026-05-22: closed 091-readme-work-record-evolution-ledger — clarified README around work records and evolution ledgers
 - 2026-05-22: closed 090-evolution-compare — added evolution compare CLI


### PR DESCRIPTION
## Summary
- Close plan `093-pr89-public-surface-sync` after the approved `0.4.13` npm/GitHub Release follow-through completed.
- Update the evidence note with final trusted-publishing, registry, fresh `npx`, and GitHub Release proof.
- Stamp `MISSION.md` via `close.sh`.

## Verification
- `git diff --check`
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- npm registry — `open-scaffold@0.4.13` is `latest`
- fresh isolated-cache `npx open-scaffold@latest --help` — passed
- fresh isolated-cache `npx open-scaffold@latest evolve --help` — passed
- fresh isolated-cache `npx open-scaffold@latest init --tier min` — passed
- GitHub Release `v0.4.13` — created and marked Latest

## Scope
- Evidence/plan closeout only.
- No package code or package metadata changes.
- No npm publish or GitHub Release mutation in this PR; those already completed under owner-approved follow-through.
