### PR TITLE
Add optional MCP server interface

### DIFF
--- a/.osc/plans/done/060-mcp-server.md
+++ b/.osc/plans/done/060-mcp-server.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-22-060-mcp-server.md
+++ b/.osc/releases/2026-05-22-060-mcp-server.md
@@ -16,7 +16,7 @@ The server is read-only by default, keeps all data local, exposes write helpers 
 ## Verification
 
 - `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 7 MCP tests covered tool handlers, resources, JSON-RPC envelopes, notifications, batches, read-only gating, validate mode, and stdio responses.
-- `npm test -- --reporter=verbose` — pass; 33 files / 302 tests passed after MCP changes, package payload expectations, and Codex-requested JSON-RPC notification/batch hardening.
+- `npm test -- --reporter=verbose` — pass; 33 files / 302 tests passed after MCP changes, package payload expectations, JSON-RPC notification/batch hardening, and evidence symlink-read guards.
 - `npm run build` — pass; core TypeScript and runtime OMX package built successfully.
 - `git diff --check` — pass; no whitespace errors.
 - `npm pack --dry-run --json` — pass; dry-run tarball `open-scaffold-0.4.14.tgz` includes `dist/mcp-cli.js`, `dist/mcp-server.js`, and `docs/MCP.md`.

--- a/.osc/releases/2026-05-22-060-mcp-server.md
+++ b/.osc/releases/2026-05-22-060-mcp-server.md
@@ -15,8 +15,8 @@ The server is read-only by default, keeps all data local, exposes write helpers 
 
 ## Verification
 
-- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 7 MCP tests covered tool handlers, resources, JSON-RPC envelopes, notifications, batches, read-only gating, validate mode, and stdio responses.
-- `npm test -- --reporter=verbose` — pass; 33 files / 302 tests passed after MCP changes, package payload expectations, JSON-RPC notification/batch hardening, and evidence symlink-read guards.
+- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 8 MCP tests covered tool handlers, resources, JSON-RPC envelopes, notifications, batches, read-only gating, validate mode, stdio responses, and symlinked read guards.
+- `npm test -- --reporter=verbose` — pass; 33 files / 303 tests passed after MCP changes, package payload expectations, JSON-RPC notification/batch hardening, and symlink-read guards for evidence, plans, and fixed markdown resources.
 - `npm run build` — pass; core TypeScript and runtime OMX package built successfully.
 - `git diff --check` — pass; no whitespace errors.
 - `npm pack --dry-run --json` — pass; dry-run tarball `open-scaffold-0.4.14.tgz` includes `dist/mcp-cli.js`, `dist/mcp-server.js`, and `docs/MCP.md`.

--- a/.osc/releases/2026-05-22-060-mcp-server.md
+++ b/.osc/releases/2026-05-22-060-mcp-server.md
@@ -15,8 +15,8 @@ The server is read-only by default, keeps all data local, exposes write helpers 
 
 ## Verification
 
-- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 10 MCP tests covered tool handlers, resources, JSON-RPC envelopes, notifications, batches, read-only gating, validate mode, newline/stdout compatibility, MCP content-length stdio framing, and symlinked read guards.
-- `npm test -- --reporter=verbose` — pass; 33 files / 305 tests passed after MCP changes, package payload expectations, JSON-RPC notification/batch hardening, MCP stdio framing, and symlink-read guards for evidence, plans, fixed markdown resources, and releases directory containment.
+- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 11 MCP tests covered tool handlers, resources, JSON-RPC envelopes, notifications, batches, read-only gating, validate mode, newline/stdout compatibility, MCP content-length stdio framing, split-frame-header handling, and symlinked read guards.
+- `npm test -- --reporter=verbose` — pass; 33 files / 306 tests passed after MCP changes, package payload expectations, JSON-RPC notification/batch hardening, MCP stdio framing, and symlink-read guards for evidence, plans, fixed markdown resources, and releases directory containment.
 - `npm run build` — pass; core TypeScript and runtime OMX package built successfully.
 - `git diff --check` — pass; no whitespace errors.
 - `npm pack --dry-run --json` — pass; dry-run tarball `open-scaffold-0.4.14.tgz` includes `dist/mcp-cli.js`, `dist/mcp-server.js`, and `docs/MCP.md`.

--- a/.osc/releases/2026-05-22-060-mcp-server.md
+++ b/.osc/releases/2026-05-22-060-mcp-server.md
@@ -15,8 +15,8 @@ The server is read-only by default, keeps all data local, exposes write helpers 
 
 ## Verification
 
-- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 6 MCP tests covered tool handlers, resources, JSON-RPC envelopes, read-only gating, validate mode, and stdio responses.
-- `npm test -- --reporter=verbose` — pass; 33 files / 301 tests passed after MCP changes and package payload expectations.
+- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 7 MCP tests covered tool handlers, resources, JSON-RPC envelopes, notifications, batches, read-only gating, validate mode, and stdio responses.
+- `npm test -- --reporter=verbose` — pass; 33 files / 302 tests passed after MCP changes, package payload expectations, and Codex-requested JSON-RPC notification/batch hardening.
 - `npm run build` — pass; core TypeScript and runtime OMX package built successfully.
 - `git diff --check` — pass; no whitespace errors.
 - `npm pack --dry-run --json` — pass; dry-run tarball `open-scaffold-0.4.14.tgz` includes `dist/mcp-cli.js`, `dist/mcp-server.js`, and `docs/MCP.md`.

--- a/.osc/releases/2026-05-22-060-mcp-server.md
+++ b/.osc/releases/2026-05-22-060-mcp-server.md
@@ -1,0 +1,34 @@
+# Release / Evidence Note: 060-mcp-server
+
+## Summary
+
+Added an optional stdio MCP server for Open Scaffold. MCP-capable tools can now query local mission, plan, amendment, evidence, status, rules, and roadmap state through `osc mcp serve` or the `osc-mcp` bin without parsing markdown directly.
+
+The server is read-only by default, keeps all data local, exposes write helpers only behind `--allow-write`, and does not spawn agents, launch runtimes, deploy, publish, or approve work.
+
+## Traceability
+
+- Roadmap / issue / task: backlog plan `060-mcp-server`
+- Plan: `.osc/plans/done/060-mcp-server.md`
+- Run ID / run packet: N/A — Open Scaffold runner automation executed the selected backlog plan directly.
+- Branch / PR: `feat/060-mcp-server` / PR pending
+
+## Verification
+
+- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 6 MCP tests covered tool handlers, resources, JSON-RPC envelopes, read-only gating, validate mode, and stdio responses.
+- `npm test -- --reporter=verbose` — pass; 33 files / 301 tests passed after MCP changes and package payload expectations.
+- `npm run build` — pass; core TypeScript and runtime OMX package built successfully.
+- `git diff --check` — pass; no whitespace errors.
+- `npm pack --dry-run --json` — pass; dry-run tarball `open-scaffold-0.4.14.tgz` includes `dist/mcp-cli.js`, `dist/mcp-server.js`, and `docs/MCP.md`.
+- `node dist/cli.js mcp serve --repo <repo-root> --validate` — pass; returned mission defined, active plan count, and local scaffold validation OK.
+- `node dist/mcp-cli.js --repo <repo-root> --validate` — pass; bin alias returned the same local scaffold validation status.
+
+## Outcome
+
+The MCP server v1 surface is implemented as an optional local stdio interface. It exposes the accepted read tools/resources, blocks write tools without `--allow-write` using JSON-RPC error code `-32000`, adds `docs/MCP.md` client setup examples, documents the MCP layer in the system ontology, and prepares package version `0.4.14` for owner-gated publication.
+
+## Follow-up
+
+- Owner gate: merge the PR if accepted.
+- Owner gate: publish `open-scaffold@0.4.14` and create/update the matching GitHub Release only after merge approval.
+- Future extension: HTTP/SSE transports, streaming, or broader write automation remain out of scope for this v1 slice.

--- a/.osc/releases/2026-05-22-060-mcp-server.md
+++ b/.osc/releases/2026-05-22-060-mcp-server.md
@@ -15,8 +15,8 @@ The server is read-only by default, keeps all data local, exposes write helpers 
 
 ## Verification
 
-- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 8 MCP tests covered tool handlers, resources, JSON-RPC envelopes, notifications, batches, read-only gating, validate mode, stdio responses, and symlinked read guards.
-- `npm test -- --reporter=verbose` — pass; 33 files / 303 tests passed after MCP changes, package payload expectations, JSON-RPC notification/batch hardening, and symlink-read guards for evidence, plans, and fixed markdown resources.
+- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — pass; 10 MCP tests covered tool handlers, resources, JSON-RPC envelopes, notifications, batches, read-only gating, validate mode, newline/stdout compatibility, MCP content-length stdio framing, and symlinked read guards.
+- `npm test -- --reporter=verbose` — pass; 33 files / 305 tests passed after MCP changes, package payload expectations, JSON-RPC notification/batch hardening, MCP stdio framing, and symlink-read guards for evidence, plans, fixed markdown resources, and releases directory containment.
 - `npm run build` — pass; core TypeScript and runtime OMX package built successfully.
 - `git diff --check` — pass; no whitespace errors.
 - `npm pack --dry-run --json` — pass; dry-run tarball `open-scaffold-0.4.14.tgz` includes `dist/mcp-cli.js`, `dist/mcp-server.js`, and `docs/MCP.md`.

--- a/.osc/releases/2026-05-22-060-mcp-server.md
+++ b/.osc/releases/2026-05-22-060-mcp-server.md
@@ -11,7 +11,7 @@ The server is read-only by default, keeps all data local, exposes write helpers 
 - Roadmap / issue / task: backlog plan `060-mcp-server`
 - Plan: `.osc/plans/done/060-mcp-server.md`
 - Run ID / run packet: N/A — Open Scaffold runner automation executed the selected backlog plan directly.
-- Branch / PR: `feat/060-mcp-server` / PR pending
+- Branch / PR: `feat/060-mcp-server` / https://github.com/graphanov/open-scaffold/pull/94
 
 ## Verification
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-22: closed 060-mcp-server — added optional read-only MCP server
 - 2026-05-22: closed 094-evolution-ledger-demo-proof — added reproducible evolution-ledger demo proof
 - 2026-05-22: closed 093-pr89-public-surface-sync — published 0.4.13 and aligned public package/release surfaces
 - 2026-05-22: closed 092-evolution-loop-visibility-v1 — made evolution loop comparison visible

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,205 @@
+# Open Scaffold MCP Server
+
+Open Scaffold can expose repository truth through MCP (Model Context Protocol) so MCP-capable agents can inspect plans, mission context, evidence notes, and scaffold health without reimplementing markdown parsing.
+
+The server is local-first and optional:
+
+- stdio transport only;
+- no network access required;
+- read-only by default;
+- write tools are visible but blocked unless the server starts with `--allow-write`;
+- no agent spawning, runtime launching, deployment, publication, or approval automation.
+
+## Start the server
+
+From an Open Scaffold repository:
+
+```bash
+npx open-scaffold@latest mcp serve
+```
+
+From any directory, point at a repository root:
+
+```bash
+npx open-scaffold@latest mcp serve --repo /absolute/path/to/repo
+```
+
+After local install/build, these are equivalent:
+
+```bash
+osc mcp serve --repo /absolute/path/to/repo
+osc-mcp --repo /absolute/path/to/repo
+node dist/cli.js mcp serve --repo /absolute/path/to/repo
+node dist/mcp-cli.js --repo /absolute/path/to/repo
+```
+
+Health check without starting the stdio loop:
+
+```bash
+npx open-scaffold@latest mcp serve --repo /absolute/path/to/repo --validate
+```
+
+That prints JSON with mission status, plan counts, and the same local scaffold validation used by `osc verify`, without launching runtimes or subprocesses.
+
+## Tools
+
+Read tools work without extra flags:
+
+- `list_plans` — list plan slugs and paths, optionally filtered by `active`, `backlog`, `blocked`, or `done`.
+- `get_plan` — parse one plan into structured sections, acceptance criteria, verification steps, and raw markdown.
+- `get_mission` — return mission status, goals, non-goals, and recent changelog entries.
+- `list_evidence` — list `.osc/releases/` evidence notes, optionally filtered by slug.
+- `get_evidence` — read an evidence note by path, file name, or latest note matching a slug.
+- `get_status` — return mission state, plan counts, and local verification status.
+- `search_plans` — full-text search across plan markdown.
+- `list_amendments` — list amendment files for a plan.
+
+Write tools are intentionally gated:
+
+- `create_plan`
+- `amend_plan`
+- `close_plan`
+- `create_evidence`
+
+Without `--allow-write`, write tools return JSON-RPC error code `-32000` with:
+
+```text
+Write operations require --allow-write flag
+```
+
+Only enable writes for a trusted local client and a repository where the operator expects file mutation:
+
+```bash
+npx open-scaffold@latest mcp serve --repo /absolute/path/to/repo --allow-write
+```
+
+## Resources
+
+The server exposes these resource URIs:
+
+- `osc://plans/active`
+- `osc://plans/backlog`
+- `osc://plans/done`
+- `osc://plans/blocked`
+- `osc://releases/latest`
+- `osc://mission/goals`
+- `osc://mission/changelog`
+- `osc://rules`
+- `osc://roadmap`
+
+Plan resources return JSON. Rules, roadmap, and latest evidence return markdown.
+
+## JSON-RPC smoke checks
+
+Initialize:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' \
+  | npx open-scaffold@latest mcp serve --repo /absolute/path/to/repo
+```
+
+List tools:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | npx open-scaffold@latest mcp serve --repo /absolute/path/to/repo
+```
+
+Read-only write gate:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"create_plan","arguments":{"slug":"test-plan","stage":"backlog"}}}' \
+  | npx open-scaffold@latest mcp serve --repo /absolute/path/to/repo
+```
+
+Expected result: JSON-RPC error code `-32000`.
+
+## Client configuration examples
+
+Replace `/absolute/path/to/repo` with the Open Scaffold repository you want the client to inspect.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "open-scaffold": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "open-scaffold@latest",
+        "mcp",
+        "serve",
+        "--repo",
+        "/absolute/path/to/repo"
+      ]
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "open-scaffold": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "open-scaffold@latest",
+        "mcp",
+        "serve",
+        "--repo",
+        "/absolute/path/to/repo"
+      ]
+    }
+  }
+}
+```
+
+### Continue
+
+```json
+{
+  "experimental": {
+    "modelContextProtocolServers": [
+      {
+        "name": "open-scaffold",
+        "command": "npx",
+        "args": [
+          "-y",
+          "open-scaffold@latest",
+          "mcp",
+          "serve",
+          "--repo",
+          "/absolute/path/to/repo"
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Hermes Agent
+
+Hermes configuration uses YAML, but the command shape is the same:
+
+```yaml
+mcp_servers:
+  open_scaffold:
+    command: npx
+    args:
+      - -y
+      - open-scaffold@latest
+      - mcp
+      - serve
+      - --repo
+      - /absolute/path/to/repo
+```
+
+## Boundary notes
+
+- MCP exposes local scaffold state; it does not make MCP the source of truth.
+- Git-tracked Open Scaffold files, GitHub issues/PRs, evidence notes, and operator approvals remain the durable record.
+- `--allow-write` only enables scaffold file helpers. It still does not authorize merge, publication, release mutation, deployment, credential changes, or runtime spawning.

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -15,6 +15,7 @@ This document is the full ontology. Most readers do not need every protocol page
 - Understanding runtime handoff progressively: [`docs/RUNTIME_SELECTION.md`](RUNTIME_SELECTION.md) for choosing a lane, [`docs/RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md) for profile metadata, then [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) and [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md) for adapter/runtime responsibilities.
 - Closing a slice and producing evidence: [`docs/SLICE_CLOSE_PROTOCOL.md`](SLICE_CLOSE_PROTOCOL.md).
 - Recording multi-attempt improvement loops and frontier promotion: [`docs/EVOLUTION_LOOP.md`](EVOLUTION_LOOP.md).
+- Exposing repo truth to MCP-capable tools: [`docs/MCP.md`](MCP.md).
 - Reading public mentions of named tools (Hermes, OMC, OMX, Discord, etc.): [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md) for the public/private/adapter labels.
 
 ## Layers
@@ -33,10 +34,11 @@ Open Scaffold core owns the portable project substrate:
 - `docs/RUNTIME_BINDING_CONTRACT.md` — binding lifecycle and responsibilities for OMC/OMX/plain-agent/human lanes that consume `run.json` work packages (run packets) outside core.
 - `docs/SLICE_CLOSE_PROTOCOL.md` — evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance.
 - `docs/EVOLUTION_LOOP.md` — multi-attempt loop state, attempt journals, frontier promotion, and improvement routing.
+- `osc mcp serve` / `osc-mcp` — optional stdio MCP server that exposes local mission, plan, evidence, status, rules, and roadmap state to MCP-capable tools without requiring each agent to parse markdown directly.
 - `verify.sh` / `osc verify` — methodology compliance checks.
 - `.github/` templates — issue and PR traceability for GitHub-centered workflows.
 
-Core does **not** spawn agents. It defines the contract that agents and tools can use.
+Core does **not** spawn agents. It defines the contract that agents and tools can use. The MCP server is an interface over local repo truth, not a planner, task database, or runtime launcher.
 
 ### 2. Coordinators, orchestrators, and agents
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",
-        "osc": "dist/cli.js"
+        "osc": "dist/cli.js",
+        "osc-mcp": "dist/mcp-cli.js"
       },
       "devDependencies": {
         "@types/node": "^20.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {
@@ -24,6 +24,7 @@
   "type": "module",
   "bin": {
     "osc": "dist/cli.js",
+    "osc-mcp": "dist/mcp-cli.js",
     "open-scaffold": "dist/cli.js"
   },
   "scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvel
 import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, compareEvolutionLoop, recordEvolutionAttempt, renderEvolutionComparison, validateEvolutionLoopDir, writeEvolutionLoop, type EvolutionCompareFormat, type EvolutionDecision, type EvolutionStrategy } from './evolution.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { computeMetrics, formatMetrics, parseSinceDate } from './metrics.js';
+import { runMcpCommand } from './mcp-server.js';
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
 import { closePlan, createEvidenceNoteSkeleton, createPlanAmendment, createPlanSkeleton, inspectScaffold, listPlanTemplates, movePlan, parsePlanFile, planToJson, PLAN_CREATION_STAGES, type PlanCreationStage } from './scaffold.js';
 import { validateScaffold } from './validation.js';
@@ -45,6 +46,7 @@ Usage:
   osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text>
   osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>]
   osc evolve check <loop-dir>
+  osc mcp serve [--repo <path>] [--allow-write] [--validate]
   osc metrics [--json] [--since <date>] [--lookback <weeks>] [--table] [--verbose]
   osc verify
   osc doctor [--fix] [--dry-run] [--severity <info|warn|error>] [--check <name>]
@@ -1629,6 +1631,11 @@ async function main(): Promise<void> {
     case 'evolve':
       evolutionCommand(args);
       return;
+    case 'mcp': {
+      const exitCode = await runMcpCommand(args, process.cwd());
+      if (exitCode !== 0) process.exit(exitCode);
+      return;
+    }
     case 'metrics':
       metricsCommand(args);
       return;

--- a/src/mcp-cli.ts
+++ b/src/mcp-cli.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import { runMcpCommand } from './mcp-server.js';
+
+const args = process.argv.slice(2);
+const commandArgs = args[0] === 'serve' ? args : ['serve', ...args];
+
+runMcpCommand(commandArgs).then((code) => {
+  if (code !== 0) process.exit(code);
+}).catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -1,0 +1,118 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { inspectScaffold, PLAN_STAGES, type PlanStage } from './scaffold.js';
+import { McpJsonRpcError, readMissionSummary } from './mcp-tools.js';
+
+export interface McpResourceDefinition {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+}
+
+export interface McpResourceContext {
+  root: string;
+}
+
+export interface McpResourceContent {
+  uri: string;
+  mimeType: string;
+  text: string;
+}
+
+export function listMcpResources(root: string): McpResourceDefinition[] {
+  const latestEvidence = latestEvidenceFile(root);
+  return [
+    ...PLAN_STAGES.map((stage) => ({
+      uri: `osc://plans/${stage}`,
+      name: `${stage} plans`,
+      description: `Open Scaffold ${stage} plan slugs and paths`,
+      mimeType: 'application/json',
+    })),
+    {
+      uri: 'osc://releases/latest',
+      name: 'latest evidence note',
+      description: latestEvidence ? `Most recent scaffold evidence note: ${latestEvidence}` : 'Most recent scaffold evidence note',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'osc://mission/goals',
+      name: 'mission goals',
+      description: 'Goals from MISSION.md',
+      mimeType: 'application/json',
+    },
+    {
+      uri: 'osc://mission/changelog',
+      name: 'mission changelog',
+      description: 'Recent changelog entries from MISSION.md',
+      mimeType: 'application/json',
+    },
+    {
+      uri: 'osc://rules',
+      name: 'Open Scaffold quick rules',
+      description: 'Content of .osc/RULES.md',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'osc://roadmap',
+      name: 'roadmap',
+      description: 'Content of ROADMAP.md',
+      mimeType: 'text/markdown',
+    },
+  ];
+}
+
+export function readMcpResource(uri: string, context: McpResourceContext): McpResourceContent {
+  const root = context.root;
+  const planMatch = uri.match(/^osc:\/\/plans\/(active|backlog|blocked|done)$/);
+  if (planMatch) {
+    const stage = planMatch[1] as PlanStage;
+    const state = inspectScaffold(root);
+    const plans = state.plans[stage].filter((plan) => !/-amendment-\d+$/.test(plan.slug));
+    return {
+      uri,
+      mimeType: 'application/json',
+      text: JSON.stringify({ stage, plans }, null, 2),
+    };
+  }
+
+  switch (uri) {
+    case 'osc://releases/latest': {
+      const latest = latestEvidenceFile(root);
+      if (!latest) throw new McpJsonRpcError(-32004, 'No evidence notes found in .osc/releases');
+      const path = join(root, '.osc', 'releases', latest);
+      return { uri, mimeType: 'text/markdown', text: readFileSync(path, 'utf8') };
+    }
+    case 'osc://mission/goals': {
+      const mission = readMissionSummary(root) as { goals?: unknown[] };
+      return { uri, mimeType: 'application/json', text: JSON.stringify({ goals: mission.goals ?? [] }, null, 2) };
+    }
+    case 'osc://mission/changelog': {
+      const mission = readMissionSummary(root) as { changelog?: unknown[] };
+      return { uri, mimeType: 'application/json', text: JSON.stringify({ changelog: mission.changelog ?? [] }, null, 2) };
+    }
+    case 'osc://rules':
+      return readMarkdownResource(root, uri, '.osc/RULES.md');
+    case 'osc://roadmap':
+      return readMarkdownResource(root, uri, 'ROADMAP.md');
+    default:
+      throw new McpJsonRpcError(-32004, `Unknown MCP resource: ${uri}`);
+  }
+}
+
+function readMarkdownResource(root: string, uri: string, relativePath: string): McpResourceContent {
+  const path = resolve(root, relativePath);
+  const relativeToRoot = relative(root, path);
+  if (relativeToRoot.startsWith('..')) throw new McpJsonRpcError(-32602, `Resource path escapes repository: ${relativePath}`);
+  if (!existsSync(path)) throw new McpJsonRpcError(-32004, `Resource file not found: ${relativePath}`);
+  return { uri, mimeType: 'text/markdown', text: readFileSync(path, 'utf8') };
+}
+
+function latestEvidenceFile(root: string): string | null {
+  const dir = join(root, '.osc', 'releases');
+  if (!existsSync(dir)) return null;
+  return readdirSync(dir)
+    .filter((file) => file.endsWith('.md') && file !== 'README.md')
+    .sort()
+    .at(-1) ?? null;
+}

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { inspectScaffold, PLAN_STAGES, type PlanStage } from './scaffold.js';
 import { McpJsonRpcError, readMissionSummary } from './mcp-tools.js';
@@ -113,6 +113,13 @@ function latestEvidenceFile(root: string): string | null {
   if (!existsSync(dir)) return null;
   return readdirSync(dir)
     .filter((file) => file.endsWith('.md') && file !== 'README.md')
+    .filter((file) => {
+      try {
+        return lstatSync(join(dir, file)).isFile();
+      } catch {
+        return false;
+      }
+    })
     .sort()
     .at(-1) ?? null;
 }

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve, sep, win32 } from 'node:path';
 import { inspectScaffold, PLAN_STAGES, type PlanStage } from './scaffold.js';
 import { McpJsonRpcError, readMissionSummary } from './mcp-tools.js';
@@ -68,7 +68,7 @@ export function readMcpResource(uri: string, context: McpResourceContext): McpRe
   if (planMatch) {
     const stage = planMatch[1] as PlanStage;
     const state = inspectScaffold(root);
-    const plans = state.plans[stage].filter((plan) => !/-amendment-\d+$/.test(plan.slug));
+    const plans = state.plans[stage].filter((plan) => !/-amendment-\d+$/.test(plan.slug) && isRegularResourceFile(join(root, plan.path), root));
     return {
       uri,
       mimeType: 'application/json',
@@ -106,7 +106,29 @@ function readMarkdownResource(root: string, uri: string, relativePath: string): 
   if (!isSafeResourceRelativePath(relativeToRoot)) throw new McpJsonRpcError(-32602, `Resource path escapes repository: ${relativePath}`);
   if (!existsSync(path)) throw new McpJsonRpcError(-32004, `Resource file not found: ${relativePath}`);
   if (!lstatSync(path).isFile()) throw new McpJsonRpcError(-32602, `Resource path must be a regular file under the repository: ${relativePath}`);
+  const realRelativeToRoot = relative(realpathSync(root), realpathSync(path));
+  if (!isSafeResourceRelativePath(realRelativeToRoot)) throw new McpJsonRpcError(-32602, `Resource path escapes repository: ${relativePath}`);
   return { uri, mimeType: 'text/markdown', text: readFileSync(path, 'utf8') };
+}
+
+function isRegularResourceFile(path: string, root: string): boolean {
+  try {
+    if (!lstatSync(path).isFile()) return false;
+    const relativeToRoot = relative(realpathSync(root), realpathSync(path));
+    return isSafeResourceRelativePath(relativeToRoot);
+  } catch {
+    return false;
+  }
+}
+
+function isRegularResourceDirectory(path: string, root: string): boolean {
+  try {
+    if (!lstatSync(path).isDirectory()) return false;
+    const relativeToRoot = relative(realpathSync(root), realpathSync(path));
+    return isSafeResourceRelativePath(relativeToRoot);
+  } catch {
+    return false;
+  }
 }
 
 function isSafeResourceRelativePath(relativePath: string): boolean {
@@ -122,12 +144,15 @@ function isSafeResourceRelativePath(relativePath: string): boolean {
 
 function latestEvidenceFile(root: string): string | null {
   const dir = join(root, '.osc', 'releases');
-  if (!existsSync(dir)) return null;
+  if (!existsSync(dir) || !isRegularResourceDirectory(dir, root)) return null;
+  const canonicalDir = realpathSync(dir);
   return readdirSync(dir)
     .filter((file) => file.endsWith('.md') && file !== 'README.md')
     .filter((file) => {
       try {
-        return lstatSync(join(dir, file)).isFile();
+        const path = join(dir, file);
+        if (!lstatSync(path).isFile()) return false;
+        return isSafeResourceRelativePath(relative(canonicalDir, realpathSync(path)));
       } catch {
         return false;
       }

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -1,5 +1,5 @@
 import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve, sep, win32 } from 'node:path';
 import { inspectScaffold, PLAN_STAGES, type PlanStage } from './scaffold.js';
 import { McpJsonRpcError, readMissionSummary } from './mcp-tools.js';
 
@@ -103,9 +103,21 @@ export function readMcpResource(uri: string, context: McpResourceContext): McpRe
 function readMarkdownResource(root: string, uri: string, relativePath: string): McpResourceContent {
   const path = resolve(root, relativePath);
   const relativeToRoot = relative(root, path);
-  if (relativeToRoot.startsWith('..')) throw new McpJsonRpcError(-32602, `Resource path escapes repository: ${relativePath}`);
+  if (!isSafeResourceRelativePath(relativeToRoot)) throw new McpJsonRpcError(-32602, `Resource path escapes repository: ${relativePath}`);
   if (!existsSync(path)) throw new McpJsonRpcError(-32004, `Resource file not found: ${relativePath}`);
+  if (!lstatSync(path).isFile()) throw new McpJsonRpcError(-32602, `Resource path must be a regular file under the repository: ${relativePath}`);
   return { uri, mimeType: 'text/markdown', text: readFileSync(path, 'utf8') };
+}
+
+function isSafeResourceRelativePath(relativePath: string): boolean {
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${sep}`) &&
+    !relativePath.startsWith(`..${win32.sep}`) &&
+    !isAbsolute(relativePath) &&
+    !win32.isAbsolute(relativePath)
+  );
 }
 
 function latestEvidenceFile(root: string): string | null {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -124,8 +124,14 @@ export async function runMcpStdioServer(context: McpToolContext, input: Readable
       frameBuffer = Buffer.concat([frameBuffer, chunkBuffer]);
       const probe = frameBuffer.toString('utf8').trimStart();
       if (!probe) continue;
-      mode = probe.toLowerCase().startsWith('content-length:') ? 'framed' : 'line';
-      if (mode === 'line') {
+      const lowerProbe = probe.toLowerCase();
+      const hasCompleteFrameHeader = frameHeaderSeparator(frameBuffer) !== null;
+      if (hasCompleteFrameHeader && lowerProbe.startsWith('content-length:')) {
+        mode = 'framed';
+      } else if (lowerProbe.startsWith('content-length:') || 'content-length:'.startsWith(lowerProbe)) {
+        continue;
+      } else {
+        mode = 'line';
         lineBuffer = frameBuffer.toString('utf8');
         frameBuffer = Buffer.alloc(0);
       }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -28,10 +28,11 @@ export interface McpJsonRpcFailure {
 }
 
 export type McpJsonRpcResponse = McpJsonRpcSuccess | McpJsonRpcFailure;
+export type McpJsonRpcLineResult = McpJsonRpcResponse | McpJsonRpcResponse[] | null;
 
 type JsonRecord = Record<string, unknown>;
 
-export function handleMcpJsonRpcLine(line: string, context: McpToolContext): McpJsonRpcResponse | null {
+export function handleMcpJsonRpcLine(line: string, context: McpToolContext): McpJsonRpcLineResult {
   const trimmed = line.trim();
   if (!trimmed) return null;
   let parsed: unknown;
@@ -40,6 +41,13 @@ export function handleMcpJsonRpcLine(line: string, context: McpToolContext): Mcp
   } catch (error) {
     return errorResponse(null, -32700, 'Parse error', error instanceof Error ? error.message : String(error));
   }
+  if (Array.isArray(parsed)) {
+    if (parsed.length === 0) return errorResponse(null, -32600, 'Invalid Request');
+    const responses = parsed
+      .map((request) => handleMcpJsonRpcRequest(request, context))
+      .filter((response): response is McpJsonRpcResponse => response !== null);
+    return responses.length > 0 ? responses : null;
+  }
   return handleMcpJsonRpcRequest(parsed, context);
 }
 
@@ -47,7 +55,9 @@ export function handleMcpJsonRpcRequest(parsed: unknown, context: McpToolContext
   if (!isRecord(parsed) || parsed.jsonrpc !== '2.0' || typeof parsed.method !== 'string') {
     return errorResponse(extractId(parsed), -32600, 'Invalid Request');
   }
-  const id = parsed.id === undefined ? null : normalizeId(parsed.id);
+  const hasId = Object.prototype.hasOwnProperty.call(parsed, 'id');
+  if (!hasId) return null;
+  const id = normalizeId(parsed.id);
 
   try {
     switch (parsed.method) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,213 @@
+import { resolve } from 'node:path';
+import { createInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import { callMcpTool, listMcpTools, McpJsonRpcError, type McpToolContext } from './mcp-tools.js';
+import { listMcpResources, readMcpResource } from './mcp-resources.js';
+
+export interface McpJsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+}
+
+export interface McpJsonRpcSuccess {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result: unknown;
+}
+
+export interface McpJsonRpcFailure {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export type McpJsonRpcResponse = McpJsonRpcSuccess | McpJsonRpcFailure;
+
+type JsonRecord = Record<string, unknown>;
+
+export function handleMcpJsonRpcLine(line: string, context: McpToolContext): McpJsonRpcResponse | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    return errorResponse(null, -32700, 'Parse error', error instanceof Error ? error.message : String(error));
+  }
+  return handleMcpJsonRpcRequest(parsed, context);
+}
+
+export function handleMcpJsonRpcRequest(parsed: unknown, context: McpToolContext): McpJsonRpcResponse | null {
+  if (!isRecord(parsed) || parsed.jsonrpc !== '2.0' || typeof parsed.method !== 'string') {
+    return errorResponse(extractId(parsed), -32600, 'Invalid Request');
+  }
+  const id = parsed.id === undefined ? null : normalizeId(parsed.id);
+
+  try {
+    switch (parsed.method) {
+      case 'initialize':
+        return successResponse(id, {
+          protocolVersion: protocolVersion(parsed.params),
+          capabilities: {
+            tools: {},
+            resources: {},
+          },
+          serverInfo: {
+            name: 'open-scaffold-mcp',
+            title: 'Open Scaffold MCP Server',
+          },
+        });
+      case 'tools/list':
+        return successResponse(id, { tools: listMcpTools() });
+      case 'tools/call': {
+        const params = asRecord(parsed.params, 'tools/call params must be an object');
+        const name = requiredString(params, 'name');
+        const toolArgs = params.arguments ?? {};
+        const result = callMcpTool(name, toolArgs, context);
+        return successResponse(id, {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        });
+      }
+      case 'resources/list':
+        return successResponse(id, { resources: listMcpResources(context.root) });
+      case 'resources/read': {
+        const params = asRecord(parsed.params, 'resources/read params must be an object');
+        const uri = requiredString(params, 'uri');
+        const content = readMcpResource(uri, { root: context.root });
+        return successResponse(id, { contents: [content] });
+      }
+      case 'notifications/initialized':
+        return parsed.id === undefined ? null : successResponse(id, {});
+      default:
+        return errorResponse(id, -32601, `Method not found: ${parsed.method}`);
+    }
+  } catch (error) {
+    if (error instanceof McpJsonRpcError) return errorResponse(id, error.code, error.message, error.data);
+    return errorResponse(id, -32603, error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function renderMcpValidationStatus(root: string): string {
+  const result = callMcpTool('get_status', {}, { root, allowWrite: false });
+  return JSON.stringify(result, null, 2);
+}
+
+export async function runMcpStdioServer(context: McpToolContext, input: Readable = process.stdin, output: Writable = process.stdout): Promise<void> {
+  const reader = createInterface({ input, crlfDelay: Infinity });
+  for await (const line of reader) {
+    const response = handleMcpJsonRpcLine(line, context);
+    if (response) output.write(`${JSON.stringify(response)}\n`);
+  }
+}
+
+export async function runMcpCommand(args: string[], root = process.cwd()): Promise<number> {
+  const [subcommand, ...rest] = args;
+  if (subcommand === undefined || isHelpArg(subcommand)) {
+    printMcpUsage(process.stdout);
+    return 0;
+  }
+  if (subcommand !== 'serve') {
+    process.stderr.write(`Unknown mcp command: ${subcommand}\n`);
+    printMcpUsage(process.stderr);
+    return 2;
+  }
+
+  let allowWrite = false;
+  let validate = false;
+  let serverRoot = root;
+  for (let i = 0; i < rest.length; i += 1) {
+    const flag = rest[i];
+    switch (flag) {
+      case '--allow-write':
+        allowWrite = true;
+        break;
+      case '--validate':
+        validate = true;
+        break;
+      case '--repo': {
+        const value = rest[i + 1];
+        if (!value || value.startsWith('--')) {
+          process.stderr.write('Missing value for --repo\n');
+          printMcpServeUsage(process.stderr);
+          return 2;
+        }
+        serverRoot = resolve(root, value);
+        i += 1;
+        break;
+      }
+      case '-h':
+      case '--help':
+      case 'help':
+        printMcpServeUsage(process.stdout);
+        return 0;
+      default:
+        process.stderr.write(`Unknown option for mcp serve: ${flag}\n`);
+        printMcpServeUsage(process.stderr);
+        return 2;
+    }
+  }
+
+  if (validate) {
+    process.stdout.write(`${renderMcpValidationStatus(serverRoot)}\n`);
+    return 0;
+  }
+
+  await runMcpStdioServer({ root: serverRoot, allowWrite });
+  return 0;
+}
+
+function printMcpUsage(stream: Writable): void {
+  stream.write('Usage: osc mcp serve [--repo <path>] [--allow-write] [--validate]\n');
+}
+
+function printMcpServeUsage(stream: Writable): void {
+  stream.write('Usage: osc mcp serve [--repo <path>] [--allow-write] [--validate]\n\nOptions:\n  --repo <path>  Open Scaffold repository root to expose. Defaults to the current working directory.\n  --allow-write  Enable write tools such as create_plan, amend_plan, close_plan, and create_evidence.\n  --validate     Print local scaffold status JSON and exit without starting stdio.\n');
+}
+
+function isHelpArg(value: string | undefined): boolean {
+  return value === '-h' || value === '--help' || value === 'help';
+}
+
+function protocolVersion(params: unknown): string {
+  if (isRecord(params) && typeof params.protocolVersion === 'string' && params.protocolVersion.trim()) return params.protocolVersion;
+  return '2024-11-05';
+}
+
+function successResponse(id: string | number | null, result: unknown): McpJsonRpcSuccess {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function errorResponse(id: string | number | null, code: number, message: string, data?: unknown): McpJsonRpcFailure {
+  return { jsonrpc: '2.0', id, error: data === undefined ? { code, message } : { code, message, data } };
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown, message: string): JsonRecord {
+  if (!isRecord(value)) throw new McpJsonRpcError(-32602, message);
+  return value;
+}
+
+function requiredString(value: JsonRecord, key: string): string {
+  const raw = value[key];
+  if (typeof raw !== 'string' || !raw.trim()) throw new McpJsonRpcError(-32602, `Missing required string param: ${key}`);
+  return raw.trim();
+}
+
+function normalizeId(value: unknown): string | number | null {
+  if (typeof value === 'string' || typeof value === 'number' || value === null) return value;
+  return null;
+}
+
+function extractId(value: unknown): string | number | null {
+  return isRecord(value) ? normalizeId(value.id) : null;
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -32,6 +32,7 @@ export type McpJsonRpcResponse = McpJsonRpcSuccess | McpJsonRpcFailure;
 export type McpJsonRpcLineResult = McpJsonRpcResponse | McpJsonRpcResponse[] | null;
 
 type JsonRecord = Record<string, unknown>;
+const MCP_PROTOCOL_VERSION = '2024-11-05';
 
 export function handleMcpJsonRpcLine(line: string, context: McpToolContext): McpJsonRpcLineResult {
   const trimmed = line.trim();
@@ -189,8 +190,8 @@ function isHelpArg(value: string | undefined): boolean {
 }
 
 function protocolVersion(params: unknown): string {
-  if (isRecord(params) && typeof params.protocolVersion === 'string' && params.protocolVersion.trim()) return params.protocolVersion;
-  return '2024-11-05';
+  if (isRecord(params) && params.protocolVersion === MCP_PROTOCOL_VERSION) return MCP_PROTOCOL_VERSION;
+  return MCP_PROTOCOL_VERSION;
 }
 
 function successResponse(id: string | number | null, result: unknown): McpJsonRpcSuccess {
@@ -221,8 +222,8 @@ function normalizeId(value: unknown): string | number | null {
   return null;
 }
 
-function isValidId(value: unknown): value is string | number | null {
-  return typeof value === 'string' || typeof value === 'number' || value === null;
+function isValidId(value: unknown): value is string | number {
+  return typeof value === 'string' || typeof value === 'number';
 }
 
 function extractId(value: unknown): string | number | null {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { createInterface } from 'node:readline';
 import type { Readable, Writable } from 'node:stream';
 import { callMcpTool, listMcpTools, McpJsonRpcError, type McpToolContext } from './mcp-tools.js';
 import { listMcpResources, readMcpResource } from './mcp-resources.js';
@@ -114,11 +113,96 @@ export function renderMcpValidationStatus(root: string): string {
 }
 
 export async function runMcpStdioServer(context: McpToolContext, input: Readable = process.stdin, output: Writable = process.stdout): Promise<void> {
-  const reader = createInterface({ input, crlfDelay: Infinity });
-  for await (const line of reader) {
-    const response = handleMcpJsonRpcLine(line, context);
-    if (response) output.write(`${JSON.stringify(response)}\n`);
+  let mode: 'unknown' | 'framed' | 'line' = 'unknown';
+  let frameBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  let lineBuffer = '';
+
+  for await (const chunk of input) {
+    const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+
+    if (mode === 'unknown') {
+      frameBuffer = Buffer.concat([frameBuffer, chunkBuffer]);
+      const probe = frameBuffer.toString('utf8').trimStart();
+      if (!probe) continue;
+      mode = probe.toLowerCase().startsWith('content-length:') ? 'framed' : 'line';
+      if (mode === 'line') {
+        lineBuffer = frameBuffer.toString('utf8');
+        frameBuffer = Buffer.alloc(0);
+      }
+    } else if (mode === 'framed') {
+      frameBuffer = Buffer.concat([frameBuffer, chunkBuffer]);
+    } else {
+      lineBuffer += chunkBuffer.toString('utf8');
+    }
+
+    if (mode === 'framed') frameBuffer = processMcpFrameBuffer(frameBuffer, context, output);
+    if (mode === 'line') lineBuffer = processMcpLineBuffer(lineBuffer, context, output);
   }
+
+  if (mode === 'line' && lineBuffer.trim()) {
+    writeMcpJsonRpcResponse(output, handleMcpJsonRpcLine(lineBuffer, context), false);
+  }
+}
+
+function processMcpLineBuffer(buffer: string, context: McpToolContext, output: Writable): string {
+  let remaining = buffer;
+  while (true) {
+    const newline = remaining.search(/\r?\n/);
+    if (newline < 0) return remaining;
+    const line = remaining.slice(0, newline);
+    const nextOffset = remaining[newline] === '\r' && remaining[newline + 1] === '\n' ? newline + 2 : newline + 1;
+    remaining = remaining.slice(nextOffset);
+    writeMcpJsonRpcResponse(output, handleMcpJsonRpcLine(line, context), false);
+  }
+}
+
+function processMcpFrameBuffer(buffer: Buffer, context: McpToolContext, output: Writable): Buffer {
+  let remaining = buffer;
+  while (remaining.length > 0) {
+    const separator = frameHeaderSeparator(remaining);
+    if (!separator) return remaining;
+
+    const header = remaining.slice(0, separator.index).toString('utf8');
+    const length = contentLengthFromHeader(header);
+    const bodyStart = separator.index + separator.length;
+    if (length === null) {
+      writeMcpJsonRpcResponse(output, errorResponse(null, -32700, 'Parse error', 'Missing or invalid Content-Length header'), true);
+      remaining = remaining.slice(bodyStart);
+      continue;
+    }
+    if (remaining.length < bodyStart + length) return remaining;
+
+    const body = remaining.slice(bodyStart, bodyStart + length).toString('utf8');
+    remaining = remaining.slice(bodyStart + length);
+    writeMcpJsonRpcResponse(output, handleMcpJsonRpcLine(body, context), true);
+  }
+  return remaining;
+}
+
+function frameHeaderSeparator(buffer: Buffer): { index: number; length: number } | null {
+  const crlf = buffer.indexOf('\r\n\r\n');
+  const lf = buffer.indexOf('\n\n');
+  if (crlf < 0 && lf < 0) return null;
+  if (crlf >= 0 && (lf < 0 || crlf <= lf)) return { index: crlf, length: 4 };
+  return { index: lf, length: 2 };
+}
+
+function contentLengthFromHeader(header: string): number | null {
+  for (const line of header.split(/\r?\n/)) {
+    const match = /^content-length:\s*(\d+)\s*$/i.exec(line.trim());
+    if (match) return Number(match[1]);
+  }
+  return null;
+}
+
+function writeMcpJsonRpcResponse(output: Writable, response: McpJsonRpcLineResult, framed: boolean): void {
+  if (!response) return;
+  const serialized = JSON.stringify(response);
+  if (framed) {
+    output.write(`Content-Length: ${Buffer.byteLength(serialized, 'utf8')}\r\n\r\n${serialized}`);
+    return;
+  }
+  output.write(`${serialized}\n`);
 }
 
 export async function runMcpCommand(args: string[], root = process.cwd()): Promise<number> {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 import type { Readable, Writable } from 'node:stream';
@@ -57,7 +58,8 @@ export function handleMcpJsonRpcRequest(parsed: unknown, context: McpToolContext
   }
   const hasId = Object.prototype.hasOwnProperty.call(parsed, 'id');
   if (!hasId) return null;
-  const id = normalizeId(parsed.id);
+  if (!isValidId(parsed.id)) return errorResponse(null, -32600, 'Invalid Request');
+  const id = parsed.id;
 
   try {
     switch (parsed.method) {
@@ -70,6 +72,7 @@ export function handleMcpJsonRpcRequest(parsed: unknown, context: McpToolContext
           },
           serverInfo: {
             name: 'open-scaffold-mcp',
+            version: packageVersion(),
             title: 'Open Scaffold MCP Server',
           },
         });
@@ -218,6 +221,19 @@ function normalizeId(value: unknown): string | number | null {
   return null;
 }
 
+function isValidId(value: unknown): value is string | number | null {
+  return typeof value === 'string' || typeof value === 'number' || value === null;
+}
+
 function extractId(value: unknown): string | number | null {
   return isRecord(value) ? normalizeId(value.id) : null;
+}
+
+function packageVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version?: unknown };
+    return typeof pkg.version === 'string' && pkg.version.trim() ? pkg.version : '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
 }

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,0 +1,403 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, join, relative, resolve, sep } from 'node:path';
+import {
+  closePlan,
+  createEvidenceNoteSkeleton,
+  createPlanAmendment,
+  createPlanSkeleton,
+  inspectScaffold,
+  parsePlanFile,
+  PLAN_CREATION_STAGES,
+  PLAN_STAGES,
+  splitSections,
+  type PlanCreationStage,
+  type PlanStage,
+} from './scaffold.js';
+import { validateScaffold } from './validation.js';
+
+export class McpJsonRpcError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(message);
+    this.name = 'McpJsonRpcError';
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export interface McpToolContext {
+  root: string;
+  allowWrite: boolean;
+}
+
+export interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+interface PlanLocation {
+  slug: string;
+  stage: PlanStage;
+  absolutePath: string;
+  relativePath: string;
+}
+
+const WRITE_TOOLS = new Set(['create_plan', 'amend_plan', 'close_plan', 'create_evidence']);
+
+function objectSchema(properties: Record<string, unknown>, required: string[] = []): Record<string, unknown> {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties,
+    required,
+  };
+}
+
+function stringEnum(values: readonly string[]): Record<string, unknown> {
+  return { type: 'string', enum: values };
+}
+
+export function listMcpTools(): McpToolDefinition[] {
+  const stage = stringEnum(PLAN_STAGES);
+  const stageCreation = stringEnum(PLAN_CREATION_STAGES);
+  return [
+    {
+      name: 'list_plans',
+      description: 'List Open Scaffold plan slugs by stage. Optional stage filter: active, backlog, blocked, or done.',
+      inputSchema: objectSchema({ stage }),
+      outputSchema: objectSchema({ plans: { type: 'array' } }, ['plans']),
+    },
+    {
+      name: 'get_plan',
+      description: 'Read a plan by slug and return parsed sections plus raw markdown.',
+      inputSchema: objectSchema({ slug: { type: 'string' } }, ['slug']),
+      outputSchema: objectSchema({ slug: { type: 'string' }, sections: { type: 'object' }, raw_markdown: { type: 'string' } }, ['slug', 'sections', 'raw_markdown']),
+    },
+    {
+      name: 'get_mission',
+      description: 'Return mission status, goals, non-goals, and recent changelog entries from MISSION.md.',
+      inputSchema: objectSchema({}),
+      outputSchema: objectSchema({ defined: { type: 'boolean' }, goals: { type: 'array' }, non_goals: { type: 'array' }, changelog: { type: 'array' } }, ['defined', 'goals', 'non_goals', 'changelog']),
+    },
+    {
+      name: 'list_evidence',
+      description: 'List scaffold-native evidence/release notes, optionally filtered by plan slug.',
+      inputSchema: objectSchema({ slug: { type: 'string' } }),
+      outputSchema: objectSchema({ evidence: { type: 'array' } }, ['evidence']),
+    },
+    {
+      name: 'get_evidence',
+      description: 'Read an evidence/release note by repo-relative path, file name, or latest note matching a slug.',
+      inputSchema: objectSchema({ path: { type: 'string' }, slug: { type: 'string' } }),
+      outputSchema: objectSchema({ content: { type: 'string' } }, ['content']),
+    },
+    {
+      name: 'get_status',
+      description: 'Return scaffold health, mission state, plan counts, and local verify result when available.',
+      inputSchema: objectSchema({}),
+      outputSchema: objectSchema({ mission: { type: 'object' }, plan_counts: { type: 'object' }, verify: { type: 'object' } }, ['mission', 'plan_counts', 'verify']),
+    },
+    {
+      name: 'search_plans',
+      description: 'Full-text search across plan markdown, goals, and acceptance criteria. Optional stage filter.',
+      inputSchema: objectSchema({ query: { type: 'string' }, stage }, ['query']),
+      outputSchema: objectSchema({ results: { type: 'array' } }, ['results']),
+    },
+    {
+      name: 'list_amendments',
+      description: 'List amendment files for a plan slug.',
+      inputSchema: objectSchema({ slug: { type: 'string' } }, ['slug']),
+      outputSchema: objectSchema({ amendments: { type: 'array' } }, ['amendments']),
+    },
+    {
+      name: 'create_plan',
+      description: 'Create a plan skeleton. Requires server --allow-write.',
+      inputSchema: objectSchema({ slug: { type: 'string' }, stage: stageCreation }, ['slug', 'stage']),
+    },
+    {
+      name: 'amend_plan',
+      description: 'Create an amendment for an existing plan. Requires server --allow-write.',
+      inputSchema: objectSchema({ slug: { type: 'string' }, message: { type: 'string' } }, ['slug']),
+    },
+    {
+      name: 'close_plan',
+      description: 'Close a plan by moving it to done and stamping the changelog. Requires server --allow-write.',
+      inputSchema: objectSchema({ slug: { type: 'string' }, message: { type: 'string' } }, ['slug']),
+    },
+    {
+      name: 'create_evidence',
+      description: 'Create an evidence note skeleton for a plan slug. Requires server --allow-write.',
+      inputSchema: objectSchema({ slug: { type: 'string' } }, ['slug']),
+    },
+  ];
+}
+
+export function callMcpTool(name: string, args: unknown, context: McpToolContext): unknown {
+  const input = asRecord(args);
+  if (WRITE_TOOLS.has(name) && !context.allowWrite) {
+    throw new McpJsonRpcError(-32000, 'Write operations require --allow-write flag');
+  }
+
+  switch (name) {
+    case 'list_plans':
+      return { plans: listPlans(context.root, optionalStage(input, 'stage')) };
+    case 'get_plan':
+      return getPlan(context.root, requiredString(input, 'slug'));
+    case 'get_mission':
+      return readMissionSummary(context.root);
+    case 'list_evidence':
+      return { evidence: listEvidence(context.root, optionalString(input, 'slug')) };
+    case 'get_evidence':
+      return getEvidence(context.root, optionalString(input, 'path'), optionalString(input, 'slug'));
+    case 'get_status':
+      return getStatus(context.root);
+    case 'search_plans':
+      return searchPlans(context.root, requiredString(input, 'query'), optionalStage(input, 'stage'));
+    case 'list_amendments':
+      return listAmendments(context.root, requiredString(input, 'slug'));
+    case 'create_plan': {
+      const result = createPlanSkeleton(requiredString(input, 'slug'), requiredCreationStage(input, 'stage'), context.root);
+      return { slug: result.slug, path: result.relativePath, stage: result.stage };
+    }
+    case 'amend_plan': {
+      const result = createPlanAmendment(requiredString(input, 'slug'), context.root, optionalString(input, 'message') ?? '');
+      return { slug: result.slug, path: result.relativePath, amendment_number: result.amendmentNumber, changelog_stamped: result.changelogStamped };
+    }
+    case 'close_plan': {
+      const result = closePlan(requiredString(input, 'slug'), context.root, optionalString(input, 'message') ?? '');
+      return { slug: result.slug, moved_files: result.movedFiles, changelog_stamped: result.changelogStamped, already_done: result.alreadyDone };
+    }
+    case 'create_evidence': {
+      const result = createEvidenceNoteSkeleton(requiredString(input, 'slug'), context.root);
+      return { slug: result.slug, path: result.relativePath };
+    }
+    default:
+      throw new McpJsonRpcError(-32601, `Unknown MCP tool: ${name}`);
+  }
+}
+
+function asRecord(value: unknown): JsonRecord {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== 'object' || Array.isArray(value)) throw new McpJsonRpcError(-32602, 'Tool arguments must be an object');
+  return value as JsonRecord;
+}
+
+function requiredString(args: JsonRecord, key: string): string {
+  const value = args[key];
+  if (typeof value !== 'string' || !value.trim()) throw new McpJsonRpcError(-32602, `Missing required string argument: ${key}`);
+  return value.trim();
+}
+
+function optionalString(args: JsonRecord, key: string): string | undefined {
+  const value = args[key];
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value !== 'string') throw new McpJsonRpcError(-32602, `Argument ${key} must be a string`);
+  return value.trim();
+}
+
+function optionalStage(args: JsonRecord, key: string): PlanStage | undefined {
+  const value = optionalString(args, key);
+  if (!value) return undefined;
+  if (!(PLAN_STAGES as readonly string[]).includes(value)) {
+    throw new McpJsonRpcError(-32602, `Invalid stage: ${value}. Expected one of: ${PLAN_STAGES.join(', ')}`);
+  }
+  return value as PlanStage;
+}
+
+function requiredCreationStage(args: JsonRecord, key: string): PlanCreationStage {
+  const value = requiredString(args, key);
+  if (!(PLAN_CREATION_STAGES as readonly string[]).includes(value)) {
+    throw new McpJsonRpcError(-32602, `Invalid stage: ${value}. Expected one of: ${PLAN_CREATION_STAGES.join(', ')}`);
+  }
+  return value as PlanCreationStage;
+}
+
+function safeSlug(slug: string): string {
+  const value = slug.endsWith('.md') ? slug.slice(0, -3) : slug;
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value) || value.includes('..')) {
+    throw new McpJsonRpcError(-32602, `Unsafe slug: ${slug}`);
+  }
+  return value;
+}
+
+function listPlans(root: string, stage?: PlanStage): Array<{ slug: string; stage: PlanStage; path: string }> {
+  const state = inspectScaffold(root);
+  const stages = stage ? [stage] : PLAN_STAGES;
+  return stages.flatMap((currentStage) =>
+    state.plans[currentStage]
+      .filter((plan) => !isAmendmentSlug(plan.slug))
+      .map((plan) => ({ slug: plan.slug, stage: currentStage, path: plan.path })),
+  );
+}
+
+function isAmendmentSlug(slug: string): boolean {
+  return /-amendment-\d+$/.test(slug);
+}
+
+function findPlan(root: string, slug: string): PlanLocation {
+  const normalized = safeSlug(slug);
+  for (const stage of PLAN_STAGES) {
+    const absolutePath = join(root, '.osc', 'plans', stage, `${normalized}.md`);
+    if (existsSync(absolutePath) && statSync(absolutePath).isFile()) {
+      return { slug: normalized, stage, absolutePath, relativePath: relative(root, absolutePath) };
+    }
+  }
+  throw new McpJsonRpcError(-32004, `Plan not found: ${normalized}`);
+}
+
+function getPlan(root: string, slug: string): Record<string, unknown> {
+  const found = findPlan(root, slug);
+  const plan = parsePlanFile(found.absolutePath);
+  const raw = readFileSync(found.absolutePath, 'utf8');
+  return {
+    slug: plan.slug,
+    stage: found.stage,
+    path: found.relativePath,
+    status: plan.status,
+    goal: plan.goal,
+    files_to_touch: plan.filesToTouch,
+    acceptance_criteria: plan.acceptanceCriteria,
+    verification_steps: plan.verificationSteps,
+    open_questions: plan.openQuestions,
+    sections: Object.fromEntries(plan.sections.entries()),
+    raw_markdown: raw,
+  };
+}
+
+function bulletItems(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^[-*]\s+/.test(line))
+    .map((line) => line.replace(/^[-*]\s+/, '').trim())
+    .filter(Boolean);
+}
+
+export function readMissionSummary(root: string): Record<string, unknown> {
+  const missionPath = join(root, 'MISSION.md');
+  if (!existsSync(missionPath)) return { defined: false, reason: 'MISSION.md not found', goals: [], non_goals: [], changelog: [] };
+  const raw = readFileSync(missionPath, 'utf8');
+  const defined = !raw.includes('mission:unset') && !raw.includes('TODO: define mission');
+  const sections = splitSections(raw);
+  const changelog = (sections.get('Changelog') ?? '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.replace(/^-\s+/, ''))
+    .slice(0, 10);
+  return {
+    defined,
+    reason: defined ? undefined : 'mission unset marker present',
+    path: 'MISSION.md',
+    goals: bulletItems(sections.get('Goals') ?? ''),
+    non_goals: bulletItems(sections.get('Non-Goals') ?? ''),
+    changelog,
+  };
+}
+
+function evidenceSlug(file: string): string {
+  return file.replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/\.md$/, '');
+}
+
+function listEvidence(root: string, slug?: string): Array<{ slug: string; file: string; path: string }> {
+  const dir = join(root, '.osc', 'releases');
+  if (!existsSync(dir)) return [];
+  const normalizedSlug = slug ? safeSlug(slug) : undefined;
+  return readdirSync(dir)
+    .filter((file) => file.endsWith('.md') && file !== 'README.md')
+    .sort()
+    .filter((file) => !normalizedSlug || evidenceSlug(file) === normalizedSlug)
+    .map((file) => ({ slug: evidenceSlug(file), file, path: relative(root, join(dir, file)) }));
+}
+
+function safeEvidencePath(root: string, value: string): string {
+  const releasesDir = resolve(root, '.osc', 'releases');
+  const candidate = value.includes('/') || value.includes(sep) ? resolve(root, value) : resolve(releasesDir, value);
+  const relativeToReleases = relative(releasesDir, candidate);
+  if (relativeToReleases.startsWith('..') || relativeToReleases === '' || resolve(candidate) === releasesDir) {
+    throw new McpJsonRpcError(-32602, `Evidence path must stay under .osc/releases: ${value}`);
+  }
+  if (!existsSync(candidate) || !statSync(candidate).isFile()) throw new McpJsonRpcError(-32004, `Evidence not found: ${value}`);
+  return candidate;
+}
+
+function getEvidence(root: string, pathArg?: string, slug?: string): Record<string, unknown> {
+  let evidencePath: string | null = null;
+  if (pathArg) evidencePath = safeEvidencePath(root, pathArg);
+  else if (slug) {
+    const matches = listEvidence(root, slug);
+    const latest = matches.at(-1);
+    if (latest) evidencePath = join(root, latest.path);
+  }
+  if (!evidencePath) throw new McpJsonRpcError(-32602, 'Provide either path or slug for get_evidence');
+  const file = basename(evidencePath);
+  return {
+    slug: evidenceSlug(file),
+    file,
+    path: relative(root, evidencePath),
+    content: readFileSync(evidencePath, 'utf8'),
+  };
+}
+
+function getStatus(root: string): Record<string, unknown> {
+  const state = inspectScaffold(root);
+  const planCounts = Object.fromEntries(PLAN_STAGES.map((stage) => [stage, state.plans[stage].filter((plan) => !isAmendmentSlug(plan.slug)).length]));
+  const validation = validateScaffold(root);
+  const verify = {
+    available: true,
+    ok: validation.ok,
+    failure_count: validation.failures.length,
+    warning_count: validation.warnings.length,
+    failures: validation.failures,
+    warnings: validation.warnings,
+    note: 'Equivalent to osc verify validation; no runtime or subprocess is launched.',
+  };
+  return {
+    namespace: state.namespace,
+    root: state.root,
+    mission: state.mission,
+    plan_counts: planCounts,
+    verify,
+  };
+}
+
+function snippetFor(text: string, query: string): string {
+  const compact = text.replace(/\s+/g, ' ').trim();
+  const index = compact.toLowerCase().indexOf(query.toLowerCase());
+  if (index < 0) return compact.slice(0, 180);
+  const start = Math.max(0, index - 60);
+  const end = Math.min(compact.length, index + query.length + 120);
+  return compact.slice(start, end);
+}
+
+function searchPlans(root: string, query: string, stage?: PlanStage): Record<string, unknown> {
+  const needle = query.trim().toLowerCase();
+  if (!needle) throw new McpJsonRpcError(-32602, 'query must not be empty');
+  const results = listPlans(root, stage)
+    .map((plan) => {
+      const location = findPlan(root, plan.slug);
+      const raw = readFileSync(location.absolutePath, 'utf8');
+      if (!raw.toLowerCase().includes(needle)) return null;
+      const parsed = parsePlanFile(location.absolutePath);
+      return { slug: plan.slug, stage: plan.stage, path: plan.path, goal: parsed.goal, snippet: snippetFor(raw, query) };
+    })
+    .filter((entry): entry is { slug: string; stage: PlanStage; path: string; goal: string; snippet: string } => entry !== null);
+  return { query, results };
+}
+
+function listAmendments(root: string, slug: string): Record<string, unknown> {
+  const found = findPlan(root, slug);
+  const dir = join(root, '.osc', 'plans', found.stage);
+  const prefix = `${found.slug}-amendment-`;
+  const amendments = readdirSync(dir)
+    .filter((file) => file.startsWith(prefix) && file.endsWith('.md'))
+    .sort()
+    .map((file) => ({ file, path: relative(root, join(dir, file)) }));
+  return { slug: found.slug, stage: found.stage, amendments };
+}

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
 import { basename, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path';
 import {
   closePlan,
@@ -231,7 +231,7 @@ function listPlans(root: string, stage?: PlanStage): Array<{ slug: string; stage
   const stages = stage ? [stage] : PLAN_STAGES;
   return stages.flatMap((currentStage) =>
     state.plans[currentStage]
-      .filter((plan) => !isAmendmentSlug(plan.slug))
+      .filter((plan) => !isAmendmentSlug(plan.slug) && isRegularMcpFile(join(root, plan.path)))
       .map((plan) => ({ slug: plan.slug, stage: currentStage, path: plan.path })),
   );
 }
@@ -244,11 +244,19 @@ function findPlan(root: string, slug: string): PlanLocation {
   const normalized = safeSlug(slug);
   for (const stage of PLAN_STAGES) {
     const absolutePath = join(root, '.osc', 'plans', stage, `${normalized}.md`);
-    if (existsSync(absolutePath) && statSync(absolutePath).isFile()) {
+    if (existsSync(absolutePath) && isRegularMcpFile(absolutePath)) {
       return { slug: normalized, stage, absolutePath, relativePath: relative(root, absolutePath) };
     }
   }
   throw new McpJsonRpcError(-32004, `Plan not found: ${normalized}`);
+}
+
+function isRegularMcpFile(path: string): boolean {
+  try {
+    return lstatSync(path).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function getPlan(root: string, slug: string): Record<string, unknown> {
@@ -370,7 +378,7 @@ function getEvidence(root: string, pathArg?: string, slug?: string): Record<stri
 
 function getStatus(root: string): Record<string, unknown> {
   const state = inspectScaffold(root);
-  const planCounts = Object.fromEntries(PLAN_STAGES.map((stage) => [stage, state.plans[stage].filter((plan) => !isAmendmentSlug(plan.slug)).length]));
+  const planCounts = Object.fromEntries(PLAN_STAGES.map((stage) => [stage, listPlans(root, stage).length]));
   const validation = validateScaffold(root);
   const verify = {
     available: true,

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { basename, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path';
 import {
   closePlan,
@@ -231,7 +231,7 @@ function listPlans(root: string, stage?: PlanStage): Array<{ slug: string; stage
   const stages = stage ? [stage] : PLAN_STAGES;
   return stages.flatMap((currentStage) =>
     state.plans[currentStage]
-      .filter((plan) => !isAmendmentSlug(plan.slug) && isRegularMcpFile(join(root, plan.path)))
+      .filter((plan) => !isAmendmentSlug(plan.slug) && isRegularMcpFile(join(root, plan.path), root))
       .map((plan) => ({ slug: plan.slug, stage: currentStage, path: plan.path })),
   );
 }
@@ -244,16 +244,18 @@ function findPlan(root: string, slug: string): PlanLocation {
   const normalized = safeSlug(slug);
   for (const stage of PLAN_STAGES) {
     const absolutePath = join(root, '.osc', 'plans', stage, `${normalized}.md`);
-    if (existsSync(absolutePath) && isRegularMcpFile(absolutePath)) {
+    if (existsSync(absolutePath) && isRegularMcpFile(absolutePath, root)) {
       return { slug: normalized, stage, absolutePath, relativePath: relative(root, absolutePath) };
     }
   }
   throw new McpJsonRpcError(-32004, `Plan not found: ${normalized}`);
 }
 
-function isRegularMcpFile(path: string): boolean {
+function isRegularMcpFile(path: string, root: string): boolean {
   try {
-    return lstatSync(path).isFile();
+    if (!lstatSync(path).isFile()) return false;
+    const relativeToRoot = relative(realpathSync(root), realpathSync(path));
+    return isSafeEvidenceRelativePath(relativeToRoot);
   } catch {
     return false;
   }
@@ -289,7 +291,7 @@ function bulletItems(text: string): string[] {
 
 export function readMissionSummary(root: string): Record<string, unknown> {
   const missionPath = join(root, 'MISSION.md');
-  if (!existsSync(missionPath)) return { defined: false, reason: 'MISSION.md not found', goals: [], non_goals: [], changelog: [] };
+  if (!existsSync(missionPath) || !isRegularMcpFile(missionPath, root)) return { defined: false, reason: 'MISSION.md not found or not a regular file under repository', goals: [], non_goals: [], changelog: [] };
   const raw = readFileSync(missionPath, 'utf8');
   const defined = !raw.includes('mission:unset') && !raw.includes('TODO: define mission');
   const sections = splitSections(raw);
@@ -315,7 +317,7 @@ function evidenceSlug(file: string): string {
 
 function listEvidence(root: string, slug?: string): Array<{ slug: string; file: string; path: string }> {
   const dir = join(root, '.osc', 'releases');
-  if (!existsSync(dir)) return [];
+  if (!existsSync(dir) || !isRegularEvidenceDirectory(dir, root)) return [];
   const normalizedSlug = slug ? safeSlug(slug) : undefined;
   return readdirSync(dir)
     .filter((file) => file.endsWith('.md') && file !== 'README.md')
@@ -333,8 +335,21 @@ function isRegularEvidenceFile(dir: string, file: string): boolean {
   }
 }
 
+function isRegularEvidenceDirectory(dir: string, root: string): boolean {
+  try {
+    if (!lstatSync(dir).isDirectory()) return false;
+    const relativeToRoot = relative(realpathSync(root), realpathSync(dir));
+    return isSafeEvidenceRelativePath(relativeToRoot);
+  } catch {
+    return false;
+  }
+}
+
 function safeEvidencePath(root: string, value: string): string {
   const releasesDir = resolve(root, '.osc', 'releases');
+  if (!existsSync(releasesDir)) throw new McpJsonRpcError(-32004, '.osc/releases not found');
+  if (!isRegularEvidenceDirectory(releasesDir, root)) throw new McpJsonRpcError(-32602, '.osc/releases must be a regular directory under the repository');
+  const canonicalReleasesDir = realpathSync(releasesDir);
   const candidate = value.includes('/') || value.includes(sep) ? resolve(root, value) : resolve(releasesDir, value);
   const relativeToReleases = relative(releasesDir, candidate);
   if (!isSafeEvidenceRelativePath(relativeToReleases)) {
@@ -343,6 +358,11 @@ function safeEvidencePath(root: string, value: string): string {
   if (!existsSync(candidate)) throw new McpJsonRpcError(-32004, `Evidence not found: ${value}`);
   const candidateStat = lstatSync(candidate);
   if (!candidateStat.isFile()) throw new McpJsonRpcError(-32602, `Evidence path must be a regular file under .osc/releases: ${value}`);
+  const canonicalCandidate = realpathSync(candidate);
+  const realRelativeToReleases = relative(canonicalReleasesDir, canonicalCandidate);
+  if (!isSafeEvidenceRelativePath(realRelativeToReleases)) {
+    throw new McpJsonRpcError(-32602, `Evidence path must stay under .osc/releases: ${value}`);
+  }
   return candidate;
 }
 

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path';
 import {
   closePlan,
@@ -323,7 +323,9 @@ function safeEvidencePath(root: string, value: string): string {
   if (!isSafeEvidenceRelativePath(relativeToReleases)) {
     throw new McpJsonRpcError(-32602, `Evidence path must stay under .osc/releases: ${value}`);
   }
-  if (!existsSync(candidate) || !statSync(candidate).isFile()) throw new McpJsonRpcError(-32004, `Evidence not found: ${value}`);
+  if (!existsSync(candidate)) throw new McpJsonRpcError(-32004, `Evidence not found: ${value}`);
+  const candidateStat = lstatSync(candidate);
+  if (!candidateStat.isFile()) throw new McpJsonRpcError(-32602, `Evidence path must be a regular file under .osc/releases: ${value}`);
   return candidate;
 }
 

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -311,9 +311,18 @@ function listEvidence(root: string, slug?: string): Array<{ slug: string; file: 
   const normalizedSlug = slug ? safeSlug(slug) : undefined;
   return readdirSync(dir)
     .filter((file) => file.endsWith('.md') && file !== 'README.md')
+    .filter((file) => isRegularEvidenceFile(dir, file))
     .sort()
     .filter((file) => !normalizedSlug || evidenceSlug(file) === normalizedSlug)
     .map((file) => ({ slug: evidenceSlug(file), file, path: relative(root, join(dir, file)) }));
+}
+
+function isRegularEvidenceFile(dir: string, file: string): boolean {
+  try {
+    return lstatSync(join(dir, file)).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function safeEvidencePath(root: string, value: string): string {
@@ -346,7 +355,8 @@ function getEvidence(root: string, pathArg?: string, slug?: string): Record<stri
   else if (slug) {
     const matches = listEvidence(root, slug);
     const latest = matches.at(-1);
-    if (latest) evidencePath = join(root, latest.path);
+    if (!latest) throw new McpJsonRpcError(-32004, `Evidence not found: ${slug}`);
+    evidencePath = safeEvidencePath(root, latest.path);
   }
   if (!evidencePath) throw new McpJsonRpcError(-32602, 'Provide either path or slug for get_evidence');
   const file = basename(evidencePath);

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { basename, join, relative, resolve, sep } from 'node:path';
+import { basename, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path';
 import {
   closePlan,
   createEvidenceNoteSkeleton,
@@ -320,11 +320,22 @@ function safeEvidencePath(root: string, value: string): string {
   const releasesDir = resolve(root, '.osc', 'releases');
   const candidate = value.includes('/') || value.includes(sep) ? resolve(root, value) : resolve(releasesDir, value);
   const relativeToReleases = relative(releasesDir, candidate);
-  if (relativeToReleases.startsWith('..') || relativeToReleases === '' || resolve(candidate) === releasesDir) {
+  if (!isSafeEvidenceRelativePath(relativeToReleases)) {
     throw new McpJsonRpcError(-32602, `Evidence path must stay under .osc/releases: ${value}`);
   }
   if (!existsSync(candidate) || !statSync(candidate).isFile()) throw new McpJsonRpcError(-32004, `Evidence not found: ${value}`);
   return candidate;
+}
+
+export function isSafeEvidenceRelativePath(relativePath: string): boolean {
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${sep}`) &&
+    !relativePath.startsWith(`..${win32.sep}`) &&
+    !isAbsolute(relativePath) &&
+    !win32.isAbsolute(relativePath)
+  );
 }
 
 function getEvidence(root: string, pathArg?: string, slug?: string): Record<string, unknown> {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -138,10 +138,12 @@ describe('Open Scaffold MCP tool handlers', () => {
 
     const outside = join(root, '..', 'outside-secret.md');
     const symlinkedEvidence = join(root, '.osc/releases/2999-evil.md');
+    const symlinkedSlugEvidence = join(root, '.osc/releases/2999-001-sample.md');
     writeFileSync(outside, 'do not expose this file');
     let symlinkCreated = false;
     try {
       symlinkSync(outside, symlinkedEvidence);
+      symlinkSync(outside, symlinkedSlugEvidence);
       symlinkCreated = true;
     } catch {
       // Some platforms disable file symlink creation. The path-shape guard above still covers
@@ -149,6 +151,11 @@ describe('Open Scaffold MCP tool handlers', () => {
     }
     if (symlinkCreated) {
       expect(() => callMcpTool('get_evidence', { path: '.osc/releases/2999-evil.md' }, { root, allowWrite: false })).toThrow(McpJsonRpcError);
+    if (symlinkCreated) {
+      expect(() => callMcpTool('get_evidence', { path: '.osc/releases/2999-evil.md' }, { root, allowWrite: false })).toThrow(McpJsonRpcError);
+      const evidenceBySlug = callMcpTool('get_evidence', { slug: '001-sample' }, { root, allowWrite: false });
+      expect((evidenceBySlug as { content: string }).content).toContain('Verified sample behavior.');
+      expect((evidenceBySlug as { content: string }).content).not.toContain('do not expose this file');
       const latestEvidence = readMcpResource('osc://releases/latest', { root });
       expect(latestEvidence.text).toContain('Verified sample behavior.');
       expect(latestEvidence.text).not.toContain('do not expose this file');

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -198,6 +198,21 @@ describe('Open Scaffold MCP JSON-RPC server', () => {
     expect(malformed).toMatchObject({ jsonrpc: '2.0', id: null, error: { code: -32700 } });
   });
 
+  it('suppresses responses for notifications and handles JSON-RPC batches', () => {
+    const root = scaffoldFixture();
+    const context = { root, allowWrite: false };
+
+    const notification = handleMcpJsonRpcLine('{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}', context);
+    expect(notification).toBeNull();
+
+    const batch = handleMcpJsonRpcLine('[{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}},{"jsonrpc":"2.0","method":"notifications/initialized","params":{}},{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}]', context);
+
+    expect(Array.isArray(batch)).toBe(true);
+    expect(batch).toHaveLength(2);
+    expect((batch as Array<{ id: number; result: unknown }>)[0].id).toBe(1);
+    expect((batch as Array<{ id: number; result: unknown }>)[1].id).toBe(2);
+  });
+
   it('wires osc mcp serve --validate and osc-mcp --validate to local scaffold status output', () => {
     const root = scaffoldFixture();
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { callMcpTool, isSafeEvidenceRelativePath, listMcpTools, McpJsonRpcError } from '../src/mcp-tools.js';
@@ -135,6 +135,24 @@ describe('Open Scaffold MCP tool handlers', () => {
     expect(isSafeEvidenceRelativePath('/tmp/secret.md')).toBe(false);
     expect(isSafeEvidenceRelativePath('D:\\secret.md')).toBe(false);
     expect(isSafeEvidenceRelativePath('\\\\server\\share\\secret.md')).toBe(false);
+
+    const outside = join(root, '..', 'outside-secret.md');
+    const symlinkedEvidence = join(root, '.osc/releases/2999-evil.md');
+    writeFileSync(outside, 'do not expose this file');
+    let symlinkCreated = false;
+    try {
+      symlinkSync(outside, symlinkedEvidence);
+      symlinkCreated = true;
+    } catch {
+      // Some platforms disable file symlink creation. The path-shape guard above still covers
+      // cross-root strings; symlink-specific assertions run when the fixture can create one.
+    }
+    if (symlinkCreated) {
+      expect(() => callMcpTool('get_evidence', { path: '.osc/releases/2999-evil.md' }, { root, allowWrite: false })).toThrow(McpJsonRpcError);
+      const latestEvidence = readMcpResource('osc://releases/latest', { root });
+      expect(latestEvidence.text).toContain('Verified sample behavior.');
+      expect(latestEvidence.text).not.toContain('do not expose this file');
+    }
 
     const search = callMcpTool('search_plans', { query: 'sample support' }, { root, allowWrite: false });
     expect(search).toMatchObject({ results: [{ slug: '001-sample', stage: 'active' }] });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -151,8 +151,8 @@ describe('Open Scaffold MCP tool handlers', () => {
     }
     if (symlinkCreated) {
       expect(() => callMcpTool('get_evidence', { path: '.osc/releases/2999-evil.md' }, { root, allowWrite: false })).toThrow(McpJsonRpcError);
-    if (symlinkCreated) {
-      expect(() => callMcpTool('get_evidence', { path: '.osc/releases/2999-evil.md' }, { root, allowWrite: false })).toThrow(McpJsonRpcError);
+      expect(callMcpTool('list_evidence', { slug: 'evil' }, { root, allowWrite: false })).toMatchObject({ evidence: [] });
+      expect(() => callMcpTool('get_evidence', { slug: 'evil' }, { root, allowWrite: false })).toThrow(McpJsonRpcError);
       const evidenceBySlug = callMcpTool('get_evidence', { slug: '001-sample' }, { root, allowWrite: false });
       expect((evidenceBySlug as { content: string }).content).toContain('Verified sample behavior.');
       expect((evidenceBySlug as { content: string }).content).not.toContain('do not expose this file');

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3,7 +3,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { callMcpTool, listMcpTools, McpJsonRpcError } from '../src/mcp-tools.js';
+import { callMcpTool, isSafeEvidenceRelativePath, listMcpTools, McpJsonRpcError } from '../src/mcp-tools.js';
 import { listMcpResources, readMcpResource } from '../src/mcp-resources.js';
 import { handleMcpJsonRpcLine } from '../src/mcp-server.js';
 
@@ -126,6 +126,15 @@ describe('Open Scaffold MCP tool handlers', () => {
 
     const evidence = callMcpTool('list_evidence', { slug: '001-sample' }, { root, allowWrite: false });
     expect(evidence).toMatchObject({ evidence: [{ slug: '001-sample', file: '2026-05-22-001-sample.md' }] });
+
+    const evidenceFile = callMcpTool('get_evidence', { path: '.osc/releases/2026-05-22-001-sample.md' }, { root, allowWrite: false });
+    expect(evidenceFile).toMatchObject({ slug: '001-sample', file: '2026-05-22-001-sample.md' });
+    expect(isSafeEvidenceRelativePath('2026-05-22-001-sample.md')).toBe(true);
+    expect(isSafeEvidenceRelativePath('../secret.md')).toBe(false);
+    expect(isSafeEvidenceRelativePath('..\\secret.md')).toBe(false);
+    expect(isSafeEvidenceRelativePath('/tmp/secret.md')).toBe(false);
+    expect(isSafeEvidenceRelativePath('D:\\secret.md')).toBe(false);
+    expect(isSafeEvidenceRelativePath('\\\\server\\share\\secret.md')).toBe(false);
 
     const search = callMcpTool('search_plans', { query: 'sample support' }, { root, allowWrite: false });
     expect(search).toMatchObject({ results: [{ slug: '001-sample', stage: 'active' }] });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { callMcpTool, isSafeEvidenceRelativePath, listMcpTools, McpJsonRpcError } from '../src/mcp-tools.js';
@@ -139,11 +139,13 @@ describe('Open Scaffold MCP tool handlers', () => {
     const outside = join(root, '..', 'outside-secret.md');
     const symlinkedEvidence = join(root, '.osc/releases/2999-evil.md');
     const symlinkedSlugEvidence = join(root, '.osc/releases/2999-001-sample.md');
+    const symlinkedPlan = join(root, '.osc/plans/done/999-evil.md');
     writeFileSync(outside, 'do not expose this file');
     let symlinkCreated = false;
     try {
       symlinkSync(outside, symlinkedEvidence);
       symlinkSync(outside, symlinkedSlugEvidence);
+      symlinkSync(outside, symlinkedPlan);
       symlinkCreated = true;
     } catch {
       // Some platforms disable file symlink creation. The path-shape guard above still covers
@@ -156,6 +158,9 @@ describe('Open Scaffold MCP tool handlers', () => {
       const evidenceBySlug = callMcpTool('get_evidence', { slug: '001-sample' }, { root, allowWrite: false });
       expect((evidenceBySlug as { content: string }).content).toContain('Verified sample behavior.');
       expect((evidenceBySlug as { content: string }).content).not.toContain('do not expose this file');
+      expect(() => callMcpTool('get_plan', { slug: '999-evil' }, { root, allowWrite: false })).toThrow(McpJsonRpcError);
+      expect(callMcpTool('list_plans', { stage: 'done' }, { root, allowWrite: false })).toMatchObject({ plans: [] });
+      expect(callMcpTool('search_plans', { query: 'do not expose' }, { root, allowWrite: false })).toMatchObject({ results: [] });
       const latestEvidence = readMcpResource('osc://releases/latest', { root });
       expect(latestEvidence.text).toContain('Verified sample behavior.');
       expect(latestEvidence.text).not.toContain('do not expose this file');
@@ -208,6 +213,28 @@ describe('Open Scaffold MCP tool handlers', () => {
 
     const rules = readMcpResource('osc://rules', { root });
     expect(rules.text).toContain('Mission first');
+  });
+
+  it('refuses symlinked fixed markdown resources', () => {
+    const root = scaffoldFixture();
+    const outside = join(root, '..', 'resource-secret.md');
+    writeFileSync(outside, 'do not expose this resource');
+
+    let symlinkCreated = false;
+    try {
+      rmSync(join(root, 'ROADMAP.md'));
+      rmSync(join(root, '.osc/RULES.md'));
+      symlinkSync(outside, join(root, 'ROADMAP.md'));
+      symlinkSync(outside, join(root, '.osc/RULES.md'));
+      symlinkCreated = true;
+    } catch {
+      // Some platforms disable file symlink creation.
+    }
+
+    if (symlinkCreated) {
+      expect(() => readMcpResource('osc://roadmap', { root })).toThrow(McpJsonRpcError);
+      expect(() => readMcpResource('osc://rules', { root })).toThrow(McpJsonRpcError);
+    }
   });
 });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -183,8 +183,11 @@ describe('Open Scaffold MCP JSON-RPC server', () => {
     const context = { root, allowWrite: false };
 
     const initialized = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}', context);
-    expect(initialized).toMatchObject({ jsonrpc: '2.0', id: 1, result: { serverInfo: { name: 'open-scaffold-mcp' } } });
+    expect(initialized).toMatchObject({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2024-11-05', serverInfo: { name: 'open-scaffold-mcp' } } });
     expect((initialized as { result: { serverInfo: { version: string } } }).result.serverInfo.version).toMatch(/^\d+\.\d+\.\d+/);
+
+    const unsupportedProtocol = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":5,"method":"initialize","params":{"protocolVersion":"2099-01-01","capabilities":{}}}', context);
+    expect(unsupportedProtocol).toMatchObject({ jsonrpc: '2.0', id: 5, result: { protocolVersion: '2024-11-05' } });
 
     const tools = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}', context);
     expect((tools as { result: { tools: Array<{ name: string }> } }).result.tools.map((tool) => tool.name)).toContain('get_plan');
@@ -200,6 +203,9 @@ describe('Open Scaffold MCP JSON-RPC server', () => {
 
     const invalidId = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":{},"method":"tools/list","params":{}}', context);
     expect(invalidId).toMatchObject({ jsonrpc: '2.0', id: null, error: { code: -32600 } });
+
+    const nullId = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":null,"method":"tools/list","params":{}}', context);
+    expect(nullId).toMatchObject({ jsonrpc: '2.0', id: null, error: { code: -32600 } });
   });
 
   it('suppresses responses for notifications and handles JSON-RPC batches', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -3,9 +3,10 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { Readable, Writable } from 'node:stream';
 import { callMcpTool, isSafeEvidenceRelativePath, listMcpTools, McpJsonRpcError } from '../src/mcp-tools.js';
 import { listMcpResources, readMcpResource } from '../src/mcp-resources.js';
-import { handleMcpJsonRpcLine } from '../src/mcp-server.js';
+import { handleMcpJsonRpcLine, runMcpStdioServer } from '../src/mcp-server.js';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const tsx = join(repoRoot, 'node_modules/.bin/tsx');
@@ -109,6 +110,18 @@ function parseFramedMessages(output: string): unknown[] {
     remaining = remaining.slice(bodyStart + length);
   }
   return messages;
+}
+
+async function runStdioChunks(root: string, chunks: string[]): Promise<string> {
+  let output = '';
+  const writable = new Writable({
+    write(chunk, _encoding, callback) {
+      output += chunk.toString();
+      callback();
+    },
+  });
+  await runMcpStdioServer({ root, allowWrite: false }, Readable.from(chunks), writable);
+  return output;
 }
 
 describe('Open Scaffold MCP tool handlers', () => {
@@ -374,4 +387,14 @@ describe('Open Scaffold MCP JSON-RPC server', () => {
     expect(messages[0]).toMatchObject({ id: 1, result: { serverInfo: { name: 'open-scaffold-mcp' } } });
     expect(messages[1].result.tools?.map((tool) => tool.name)).toContain('list_plans');
   }, 20_000);
+
+  it('keeps MCP frame detection pending across split content-length headers', async () => {
+    const root = scaffoldFixture();
+    const frame = framedMessage({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {} } });
+    const output = await runStdioChunks(root, [frame.slice(0, 4), frame.slice(4, 17), frame.slice(17)]);
+    const messages = parseFramedMessages(output) as Array<{ id: number; result: { serverInfo?: { name: string } } }>;
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ id: 1, result: { serverInfo: { name: 'open-scaffold-mcp' } } });
+  });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { callMcpTool, listMcpTools, McpJsonRpcError } from '../src/mcp-tools.js';
+import { listMcpResources, readMcpResource } from '../src/mcp-resources.js';
+import { handleMcpJsonRpcLine } from '../src/mcp-server.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+const mcpCli = join(repoRoot, 'src/mcp-cli.ts');
+
+function scaffoldFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'osc-mcp-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/backlog'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/blocked'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/done'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  writeFileSync(join(root, '.osc/RULES.md'), '# Rules\n\n- Mission first.\n');
+  writeFileSync(join(root, 'ROADMAP.md'), '# Roadmap\n\n- Build MCP visibility.\n');
+  writeFileSync(join(root, 'MISSION.md'), [
+    '# Mission',
+    '',
+    'Expose repo truth to tools.',
+    '',
+    '## Goals',
+    '',
+    '- Make plan state queryable.',
+    '- Keep data local.',
+    '',
+    '## Non-Goals',
+    '',
+    '- Do not spawn agents.',
+    '',
+    '## Changelog',
+    '',
+    '<!-- append YYYY-MM-DD entries below this line -->',
+    '- 2026-05-22: created fixture mission',
+    '',
+  ].join('\n'));
+  writeFileSync(join(root, '.osc/plans/active/001-sample.md'), samplePlan('001-sample', 'active', 'Ship MCP sample support.'));
+  writeFileSync(join(root, '.osc/plans/active/001-sample-amendment-1.md'), '# Amendment 1: 001-sample\n\n## Parent\n\n001-sample\n');
+  writeFileSync(join(root, '.osc/plans/backlog/002-next.md'), samplePlan('002-next', 'backlog', 'Backlog follow-up.'));
+  writeFileSync(join(root, '.osc/releases/2026-05-22-001-sample.md'), '# Evidence: 001-sample\n\nVerified sample behavior.\n');
+  return root;
+}
+
+function samplePlan(slug: string, status: string, goal: string) {
+  return [
+    `# Plan: ${slug}`,
+    '',
+    '## Status',
+    '',
+    status,
+    '',
+    '## Context',
+    '',
+    `Context for ${slug}.`,
+    '',
+    '## Goal',
+    '',
+    goal,
+    '',
+    '## Constraints / Out of scope',
+    '',
+    '- Do not execute runtimes.',
+    '',
+    '## Files to touch',
+    '',
+    '- `src/mcp-server.ts` — expose MCP surface.',
+    '',
+    '## Acceptance criteria',
+    '',
+    '- [ ] Agent can read the plan.',
+    '- [ ] Missing plans return structured errors.',
+    '',
+    '## Verification steps',
+    '',
+    '1. Run `npm test`.',
+    '',
+    '## Open questions',
+    '',
+    '- None.',
+    '',
+  ].join('\n');
+}
+
+describe('Open Scaffold MCP tool handlers', () => {
+  it('lists core tools and returns structured local scaffold state', () => {
+    const root = scaffoldFixture();
+    const toolNames = listMcpTools().map((tool) => tool.name);
+
+    expect(toolNames).toEqual(expect.arrayContaining([
+      'list_plans',
+      'get_plan',
+      'get_mission',
+      'list_evidence',
+      'get_evidence',
+      'get_status',
+      'search_plans',
+      'list_amendments',
+      'create_plan',
+      'amend_plan',
+      'close_plan',
+      'create_evidence',
+    ]));
+
+    const plans = callMcpTool('list_plans', { stage: 'active' }, { root, allowWrite: false });
+    expect(plans).toMatchObject({ plans: [{ slug: '001-sample', stage: 'active' }] });
+
+    const plan = callMcpTool('get_plan', { slug: '001-sample' }, { root, allowWrite: false });
+    expect(plan).toMatchObject({
+      slug: '001-sample',
+      stage: 'active',
+      status: 'active',
+      goal: 'Ship MCP sample support.',
+      sections: { Goal: 'Ship MCP sample support.' },
+    });
+    expect(String((plan as { raw_markdown: string }).raw_markdown)).toContain('# Plan: 001-sample');
+
+    const mission = callMcpTool('get_mission', {}, { root, allowWrite: false });
+    expect(mission).toMatchObject({ defined: true, goals: ['Make plan state queryable.', 'Keep data local.'] });
+
+    const evidence = callMcpTool('list_evidence', { slug: '001-sample' }, { root, allowWrite: false });
+    expect(evidence).toMatchObject({ evidence: [{ slug: '001-sample', file: '2026-05-22-001-sample.md' }] });
+
+    const search = callMcpTool('search_plans', { query: 'sample support' }, { root, allowWrite: false });
+    expect(search).toMatchObject({ results: [{ slug: '001-sample', stage: 'active' }] });
+
+    const amendments = callMcpTool('list_amendments', { slug: '001-sample' }, { root, allowWrite: false });
+    expect(amendments).toMatchObject({ amendments: [{ file: '001-sample-amendment-1.md' }] });
+
+    const status = callMcpTool('get_status', {}, { root, allowWrite: false });
+    expect(status).toMatchObject({ mission: { defined: true }, plan_counts: { active: 1, backlog: 1, blocked: 0, done: 0 } });
+  });
+
+  it('enforces read-only mode for write tools with the MCP JSON-RPC application error code', () => {
+    const root = scaffoldFixture();
+
+    try {
+      callMcpTool('create_plan', { slug: '003-write', stage: 'backlog' }, { root, allowWrite: false });
+      throw new Error('expected read-only gate to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(McpJsonRpcError);
+      expect((error as McpJsonRpcError).code).toBe(-32000);
+      expect((error as Error).message).toBe('Write operations require --allow-write flag');
+    }
+  });
+
+  it('lists and resolves osc:// resources without network access', () => {
+    const root = scaffoldFixture();
+    const resources = listMcpResources(root).map((resource) => resource.uri);
+
+    expect(resources).toEqual(expect.arrayContaining([
+      'osc://plans/active',
+      'osc://plans/backlog',
+      'osc://plans/done',
+      'osc://plans/blocked',
+      'osc://releases/latest',
+      'osc://mission/goals',
+      'osc://mission/changelog',
+      'osc://rules',
+      'osc://roadmap',
+    ]));
+
+    const activePlans = readMcpResource('osc://plans/active', { root });
+    expect(JSON.parse(activePlans.text)).toMatchObject({ plans: [{ slug: '001-sample' }] });
+
+    const latestEvidence = readMcpResource('osc://releases/latest', { root });
+    expect(latestEvidence.text).toContain('Verified sample behavior.');
+
+    const rules = readMcpResource('osc://rules', { root });
+    expect(rules.text).toContain('Mission first');
+  });
+});
+
+describe('Open Scaffold MCP JSON-RPC server', () => {
+  it('handles initialize, tools/list, tools/call, resources/list, and malformed JSON', () => {
+    const root = scaffoldFixture();
+    const context = { root, allowWrite: false };
+
+    const initialized = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}', context);
+    expect(initialized).toMatchObject({ jsonrpc: '2.0', id: 1, result: { serverInfo: { name: 'open-scaffold-mcp' } } });
+
+    const tools = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}', context);
+    expect((tools as { result: { tools: Array<{ name: string }> } }).result.tools.map((tool) => tool.name)).toContain('get_plan');
+
+    const writeDenied = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"create_plan","arguments":{"slug":"003-write","stage":"backlog"}}}', context);
+    expect(writeDenied).toMatchObject({ jsonrpc: '2.0', id: 3, error: { code: -32000, message: 'Write operations require --allow-write flag' } });
+
+    const resources = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":4,"method":"resources/list","params":{}}', context);
+    expect((resources as { result: { resources: Array<{ uri: string }> } }).result.resources.map((resource) => resource.uri)).toContain('osc://roadmap');
+
+    const malformed = handleMcpJsonRpcLine('{not json', context);
+    expect(malformed).toMatchObject({ jsonrpc: '2.0', id: null, error: { code: -32700 } });
+  });
+
+  it('wires osc mcp serve --validate and osc-mcp --validate to local scaffold status output', () => {
+    const root = scaffoldFixture();
+
+    const validate = spawnSync(tsx, [cli, 'mcp', 'serve', '--validate'], { cwd: root, encoding: 'utf8' });
+    expect(validate.status).toBe(0);
+    expect(JSON.parse(validate.stdout)).toMatchObject({ plan_counts: { active: 1, backlog: 1 }, mission: { defined: true } });
+
+    const aliasValidate = spawnSync(tsx, [mcpCli, '--validate'], { cwd: root, encoding: 'utf8' });
+    expect(aliasValidate.status).toBe(0);
+    expect(JSON.parse(aliasValidate.stdout)).toMatchObject({ plan_counts: { active: 1, backlog: 1 }, mission: { defined: true } });
+  }, 20_000);
+
+  it('responds over stdio with JSON-RPC envelopes', () => {
+    const root = scaffoldFixture();
+    const input = [
+      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}',
+      '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}',
+      '',
+    ].join('\n');
+
+    const run = execFileSync(tsx, [cli, 'mcp', 'serve'], { cwd: root, input, encoding: 'utf8' });
+    const lines = run.trim().split(/\r?\n/).map((line) => JSON.parse(line));
+
+    expect(lines[0]).toMatchObject({ id: 1, result: { serverInfo: { name: 'open-scaffold-mcp' } } });
+    expect(lines[1].result.tools.map((tool: { name: string }) => tool.name)).toContain('list_plans');
+  }, 20_000);
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -184,6 +184,7 @@ describe('Open Scaffold MCP JSON-RPC server', () => {
 
     const initialized = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}', context);
     expect(initialized).toMatchObject({ jsonrpc: '2.0', id: 1, result: { serverInfo: { name: 'open-scaffold-mcp' } } });
+    expect((initialized as { result: { serverInfo: { version: string } } }).result.serverInfo.version).toMatch(/^\d+\.\d+\.\d+/);
 
     const tools = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}', context);
     expect((tools as { result: { tools: Array<{ name: string }> } }).result.tools.map((tool) => tool.name)).toContain('get_plan');
@@ -196,6 +197,9 @@ describe('Open Scaffold MCP JSON-RPC server', () => {
 
     const malformed = handleMcpJsonRpcLine('{not json', context);
     expect(malformed).toMatchObject({ jsonrpc: '2.0', id: null, error: { code: -32700 } });
+
+    const invalidId = handleMcpJsonRpcLine('{"jsonrpc":"2.0","id":{},"method":"tools/list","params":{}}', context);
+    expect(invalidId).toMatchObject({ jsonrpc: '2.0', id: null, error: { code: -32600 } });
   });
 
   it('suppresses responses for notifications and handles JSON-RPC batches', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -88,6 +88,29 @@ function samplePlan(slug: string, status: string, goal: string) {
   ].join('\n');
 }
 
+function framedMessage(payload: unknown): string {
+  const json = JSON.stringify(payload);
+  return `Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`;
+}
+
+function parseFramedMessages(output: string): unknown[] {
+  const messages: unknown[] = [];
+  let remaining = output;
+  while (remaining.trim()) {
+    const headerEnd = remaining.indexOf('\r\n\r\n');
+    expect(headerEnd).toBeGreaterThanOrEqual(0);
+    const header = remaining.slice(0, headerEnd);
+    const lengthMatch = /^Content-Length:\s*(\d+)$/im.exec(header);
+    expect(lengthMatch).not.toBeNull();
+    const length = Number(lengthMatch?.[1] ?? 0);
+    const bodyStart = headerEnd + 4;
+    const body = remaining.slice(bodyStart, bodyStart + length);
+    messages.push(JSON.parse(body));
+    remaining = remaining.slice(bodyStart + length);
+  }
+  return messages;
+}
+
 describe('Open Scaffold MCP tool handlers', () => {
   it('lists core tools and returns structured local scaffold state', () => {
     const root = scaffoldFixture();
@@ -224,8 +247,10 @@ describe('Open Scaffold MCP tool handlers', () => {
     try {
       rmSync(join(root, 'ROADMAP.md'));
       rmSync(join(root, '.osc/RULES.md'));
+      rmSync(join(root, 'MISSION.md'));
       symlinkSync(outside, join(root, 'ROADMAP.md'));
       symlinkSync(outside, join(root, '.osc/RULES.md'));
+      symlinkSync(outside, join(root, 'MISSION.md'));
       symlinkCreated = true;
     } catch {
       // Some platforms disable file symlink creation.
@@ -234,6 +259,31 @@ describe('Open Scaffold MCP tool handlers', () => {
     if (symlinkCreated) {
       expect(() => readMcpResource('osc://roadmap', { root })).toThrow(McpJsonRpcError);
       expect(() => readMcpResource('osc://rules', { root })).toThrow(McpJsonRpcError);
+      const mission = callMcpTool('get_mission', {}, { root, allowWrite: false });
+      expect(mission).toMatchObject({ defined: false, goals: [], changelog: [] });
+      expect(JSON.stringify(mission)).not.toContain('do not expose this resource');
+    }
+  });
+
+  it('refuses evidence reads through a symlinked releases directory', () => {
+    const root = scaffoldFixture();
+    const outsideReleases = join(root, '..', 'outside-releases');
+    mkdirSync(outsideReleases, { recursive: true });
+    writeFileSync(join(outsideReleases, '2999-evil.md'), 'do not expose this release');
+
+    let symlinkCreated = false;
+    try {
+      rmSync(join(root, '.osc/releases'), { recursive: true, force: true });
+      symlinkSync(outsideReleases, join(root, '.osc/releases'));
+      symlinkCreated = true;
+    } catch {
+      // Some platforms disable directory symlink creation.
+    }
+
+    if (symlinkCreated) {
+      expect(callMcpTool('list_evidence', { slug: 'evil' }, { root, allowWrite: false })).toMatchObject({ evidence: [] });
+      expect(() => callMcpTool('get_evidence', { path: '.osc/releases/2999-evil.md' }, { root, allowWrite: false })).toThrow(McpJsonRpcError);
+      expect(() => readMcpResource('osc://releases/latest', { root })).toThrow(McpJsonRpcError);
     }
   });
 });
@@ -309,5 +359,19 @@ describe('Open Scaffold MCP JSON-RPC server', () => {
 
     expect(lines[0]).toMatchObject({ id: 1, result: { serverInfo: { name: 'open-scaffold-mcp' } } });
     expect(lines[1].result.tools.map((tool: { name: string }) => tool.name)).toContain('list_plans');
+  }, 20_000);
+
+  it('responds over stdio with MCP content-length frames', () => {
+    const root = scaffoldFixture();
+    const input = [
+      framedMessage({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {} } }),
+      framedMessage({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+    ].join('');
+
+    const run = execFileSync(tsx, [cli, 'mcp', 'serve'], { cwd: root, input, encoding: 'utf8' });
+    const messages = parseFramedMessages(run) as Array<{ id: number; result: { serverInfo?: { name: string }; tools?: Array<{ name: string }> } }>;
+
+    expect(messages[0]).toMatchObject({ id: 1, result: { serverInfo: { name: 'open-scaffold-mcp' } } });
+    expect(messages[1].result.tools?.map((tool) => tool.name)).toContain('list_plans');
   }, 20_000);
 });

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -28,6 +28,7 @@ describe('npm package payload', () => {
     expect(paths).toContain('.osc/plans/handoff-template.md');
     expect(paths).toContain('.osc/releases/README.md');
     expect(paths).toContain('dist/cli.js');
+    expect(paths).toContain('dist/mcp-cli.js');
     expect(paths).toContain('README.md');
 
     const forbidden = paths.filter((path) =>


### PR DESCRIPTION
## Summary

Opened/advanced by Open Scaffold runner automation.

Selected source: `open_pr` — PR #94 continuing `.osc/plans/done/060-mcp-server.md`.

- Adds optional stdio MCP server support via `osc mcp serve` and `osc-mcp`.
- Exposes read tools/resources for mission, plans, amendments, evidence, status, rules, and roadmap state.
- Keeps write helpers gated behind `--allow-write` with JSON-RPC error code `-32000` by default.
- Supports MCP content-length stdio framing while preserving newline-delimited JSON-RPC compatibility for local smokes.
- Hardens JSON-RPC notification suppression, batch handling, initialize protocol metadata, request-id validation, and evidence-path containment.
- Rejects symlinked MCP reads through evidence paths, evidence slug lookup/listing, releases-directory containment, plan read/list/search/status, and fixed markdown resources such as rules/roadmap.
- Adds `docs/MCP.md`, system ontology coverage, package bin metadata, package version `0.4.14`, and evidence note closure.

## Verification

- `npm test -- tests/mcp-server.test.ts --reporter=verbose` — 10 MCP tests passed.
- `npm test -- --reporter=verbose` — 33 files / 305 tests passed.
- `npm run build` — core and runtime OMX builds passed.
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
- `git diff --check` / `git diff --cached --check` — passed.
- `npm pack --dry-run --json` — confirmed local package payload includes `dist/mcp-cli.js`, `dist/mcp-server.js`, and `docs/MCP.md`.
- Built CLI smokes for `node dist/cli.js mcp serve --repo <repo-root> --validate`, `node dist/mcp-cli.js --repo <repo-root> --validate`, and JSON-RPC batch response handling passed in this PR's verification history.

## Owner gates

- Merge: owner-gated.
- npm publication: owner-gated; do not publish `open-scaffold@0.4.14` from automation.
- GitHub Release: owner-gated; do not create or move Latest from automation.
