### PR TITLE
docs: finalize MCP release evidence

### DIFF
--- a/.osc/releases/2026-05-22-060-mcp-server.md
+++ b/.osc/releases/2026-05-22-060-mcp-server.md
@@ -22,13 +22,20 @@ The server is read-only by default, keeps all data local, exposes write helpers 
 - `npm pack --dry-run --json` — pass; dry-run tarball `open-scaffold-0.4.14.tgz` includes `dist/mcp-cli.js`, `dist/mcp-server.js`, and `docs/MCP.md`.
 - `node dist/cli.js mcp serve --repo <repo-root> --validate` — pass; returned mission defined, active plan count, and local scaffold validation OK.
 - `node dist/mcp-cli.js --repo <repo-root> --validate` — pass; bin alias returned the same local scaffold validation status.
+- Post-merge `./verify.sh --strict` on `main` — pass; 10 pass, 0 fail, 0 warn.
+- Post-merge `npm test -- --reporter=verbose` on `main` — pass; 33 files / 306 tests passed.
+- Post-merge `npm run build` on `main` — pass.
+- Trusted publishing workflow run `26316316080` — pass; published from merge commit `8713d160ff7f9ced1e7755bef64487190d65584d`.
+- `npm view open-scaffold version dist-tags --json --prefer-online` — pass; `open-scaffold@latest` is `0.4.14`.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` — pass; help lists `osc mcp serve`.
+- Fresh isolated-cache `npx --yes open-scaffold@latest mcp --help` — pass.
+- Fresh isolated-cache `npx --yes open-scaffold@latest mcp serve --validate` — pass; returned local scaffold JSON validation.
+- GitHub Release: `v0.4.14 — Optional MCP server interface` created and marked Latest.
 
 ## Outcome
 
-The MCP server v1 surface is implemented as an optional local stdio interface. It exposes the accepted read tools/resources, blocks write tools without `--allow-write` using JSON-RPC error code `-32000`, adds `docs/MCP.md` client setup examples, documents the MCP layer in the system ontology, and prepares package version `0.4.14` for owner-gated publication.
+The MCP server v1 surface shipped as `open-scaffold@0.4.14` and GitHub Release `v0.4.14`. It exposes the accepted read tools/resources, blocks write tools without `--allow-write` using JSON-RPC error code `-32000`, adds `docs/MCP.md` client setup examples, documents the MCP layer in the system ontology, and preserves the core non-spawning runtime boundary.
 
 ## Follow-up
 
-- Owner gate: merge the PR if accepted.
-- Owner gate: publish `open-scaffold@0.4.14` and create/update the matching GitHub Release only after merge approval.
 - Future extension: HTTP/SSE transports, streaming, or broader write automation remain out of scope for this v1 slice.


### PR DESCRIPTION
## Summary
- Finalize the 060 MCP release evidence note after owner-approved merge, trusted npm publication, fresh npx smoke tests, and GitHub Release creation.
- Remove stale owner-gate follow-up wording now that `open-scaffold@0.4.14` is published and `v0.4.14` is Latest.

## Verification
- [x] `git diff --check`
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- [x] `npm run osc -- verify` — pass with 3 known pre-existing warnings

Codex review: skipped — evidence-only closeout; no code/package behavior changes.