### PR TITLE
Add local task database CLI

### DIFF
--- a/.osc/.gitignore
+++ b/.osc/.gitignore
@@ -1,0 +1,1 @@
+tasks.db*

--- a/.osc/plans/done/061-local-task-database.md
+++ b/.osc/plans/done/061-local-task-database.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-23-061-local-task-database.md
+++ b/.osc/releases/2026-05-23-061-local-task-database.md
@@ -24,6 +24,7 @@ The feature stays local-only: no network access, no daemon, no background sync, 
 - `./verify.sh --strict` — passed, 10 pass / 0 fail / 0 warn after plan close and evidence update.
 - Built CLI smoke in a temporary initialized scaffold — passed: empty `task list --json`, `task new`, `task list --json`, `task claim`, `task comment`, `task complete`, `task show`, and `status` task counts.
 - Codex round-1 hardening — fixed native SQLite install risk by moving `better-sqlite3` to `optionalDependencies`, and fixed `osc status` outside scaffold roots with a regression test; latest local gates after the fix: `npx vitest run tests/tasks.test.ts`, `npm run build:core`, `npm pack --dry-run --json`, `./verify.sh --strict`, `git diff --check`, and `npm test -- --run`.
+- Codex round-2 hardening — added `docs/TASKS.md` to the standard/max initialized scaffold file set so `docs/WORKFLOW.md` links resolve downstream; latest local gates after the fix: `npx vitest run tests/init.test.ts tests/tasks.test.ts tests/package-payload.test.ts` (23 tests), `npm test -- --run` (312 tests), `npm run build`, `npm pack --dry-run --json`, `./verify.sh --strict`, `git diff --check`, and a built-CLI standard/max init smoke.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-23-061-local-task-database.md
+++ b/.osc/releases/2026-05-23-061-local-task-database.md
@@ -23,6 +23,7 @@ The feature stays local-only: no network access, no daemon, no background sync, 
 - `npm pack --dry-run --json` — passed; package payload includes `.osc/.gitignore` and excludes dogfood plan/release history.
 - `./verify.sh --strict` — passed, 10 pass / 0 fail / 0 warn after plan close and evidence update.
 - Built CLI smoke in a temporary initialized scaffold — passed: empty `task list --json`, `task new`, `task list --json`, `task claim`, `task comment`, `task complete`, `task show`, and `status` task counts.
+- Codex round-1 hardening — fixed native SQLite install risk by moving `better-sqlite3` to `optionalDependencies`, and fixed `osc status` outside scaffold roots with a regression test; latest local gates after the fix: `npx vitest run tests/tasks.test.ts`, `npm run build:core`, `npm pack --dry-run --json`, `./verify.sh --strict`, `git diff --check`, and `npm test -- --run`.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-23-061-local-task-database.md
+++ b/.osc/releases/2026-05-23-061-local-task-database.md
@@ -16,15 +16,16 @@ The feature stays local-only: no network access, no daemon, no background sync, 
 ## Verification
 
 - `git diff --check` — passed.
-- `npx vitest run tests/tasks.test.ts` — passed, 6 tests.
-- `npx vitest run tests/tasks.test.ts tests/package-payload.test.ts` — passed, 7 tests across 2 files.
-- `npm test -- --run` — passed, 312 tests across 34 files.
+- `npx vitest run tests/tasks.test.ts` — passed, 7 tests.
+- `npx vitest run tests/init.test.ts tests/tasks.test.ts tests/package-payload.test.ts` — passed, 24 tests across 3 files.
+- `npm test -- --run` — passed, 313 tests across 34 files.
 - `npm run build` — passed, core and runtime-omx TypeScript builds.
 - `npm pack --dry-run --json` — passed; package `open-scaffold-0.4.14.tgz` includes `.osc/.gitignore` and `docs/TASKS.md`, and excludes dogfood plan/release history.
 - `./verify.sh --strict` — passed, 10 pass / 0 fail / 0 warn after plan close and evidence update.
 - Built CLI smoke in a temporary initialized scaffold — passed: empty `task list --json`, `task new`, `task list --json`, `task claim`, `task comment`, `task complete`, `task show`, and `status` task counts.
 - Codex round-1 hardening — fixed native SQLite install risk by moving `better-sqlite3` to `optionalDependencies`, and fixed `osc status` outside scaffold roots with a regression test; latest local gates after the fix: `npx vitest run tests/tasks.test.ts`, `npm run build:core`, `npm pack --dry-run --json`, `./verify.sh --strict`, `git diff --check`, and `npm test -- --run`.
 - Codex round-2 hardening — added `docs/TASKS.md` to the standard/max initialized scaffold file set so `docs/WORKFLOW.md` links resolve downstream; latest local gates after the fix: `npx vitest run tests/init.test.ts tests/tasks.test.ts tests/package-payload.test.ts` (23 tests), `npm test -- --run` (312 tests), `npm run build`, `npm pack --dry-run --json`, `./verify.sh --strict`, `git diff --check`, and a built-CLI standard/max init smoke.
+- Codex round-3 hardening — wrapped `createTask` insert and public-id assignment in a SQLite transaction, with a trigger-based regression test proving a failed id update leaves no `NULL` task id row; latest local gates after the fix: `npx vitest run tests/init.test.ts tests/tasks.test.ts tests/package-payload.test.ts` (24 tests), `npm test -- --run` (313 tests), `npm run build`, `npm pack --dry-run --json`, `./verify.sh --strict`, and `git diff --check`.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-23-061-local-task-database.md
+++ b/.osc/releases/2026-05-23-061-local-task-database.md
@@ -1,0 +1,42 @@
+# Release / Evidence Note: 061-local-task-database
+
+## Summary
+
+Added an optional local task database for Open Scaffold. `osc task` now supports creating, listing, filtering, showing, claiming/starting, completing, blocking, cancelling, commenting on, and plan-linking local tasks backed by `.osc/tasks.db`.
+
+The feature stays local-only: no network access, no daemon, no background sync, and no claim that it replaces shared task systems such as GitHub Issues, Linear, Jira, or coordinator-owned Kanban boards.
+
+## Traceability
+
+- Roadmap / issue / task: backlog plan selected by Open Scaffold runner automation.
+- Plan: `.osc/plans/done/061-local-task-database.md`
+- Run ID / run packet: N/A — direct runner implementation against selected backlog plan.
+- Branch / PR: `feat/061-local-task-database`; PR pending.
+
+## Verification
+
+- `git diff --check` — passed.
+- `npx vitest run tests/tasks.test.ts` — passed, 5 tests.
+- `npx vitest run tests/tasks.test.ts tests/package-payload.test.ts` — passed, 6 tests across 2 files.
+- `npm test -- --run` — passed, 311 tests across 34 files.
+- `npm run build` — passed, core and runtime-omx TypeScript builds.
+- `npm pack --dry-run --json` — passed; package payload includes `.osc/.gitignore` and excludes dogfood plan/release history.
+- `./verify.sh --strict` — passed, 10 pass / 0 fail / 0 warn after plan close and evidence update.
+- Built CLI smoke in a temporary initialized scaffold — passed: empty `task list --json`, `task new`, `task list --json`, `task claim`, `task comment`, `task complete`, `task show`, and `status` task counts.
+
+## Outcome
+
+The slice implements the local task bridge described in plan 061:
+
+- new `src/tasks.ts` SQLite-backed local task storage using `better-sqlite3`;
+- `src/cli.ts` `osc task` subcommands and task summary in `osc status`;
+- initialized scaffolds receive `.osc/.gitignore` with `tasks.db*`;
+- `docs/TASKS.md`, `docs/WORKFLOW.md`, and `docs/OPEN_SCAFFOLD_SYSTEM.md` explain the task DB boundary and usage;
+- tests cover graceful no-DB listing, CRUD/filtering, status transitions, comments, plan linking, persistence, status summary integration, invalid options, and scaffold ignore-rule shipping.
+
+Merge, npm publication, and GitHub Release changes remain owner-gated.
+
+## Follow-up
+
+- Open PR and run the standard latest-head Codex review loop.
+- If this merges, decide separately whether a package/release-train sync is needed for the new CLI surface.

--- a/.osc/releases/2026-05-23-061-local-task-database.md
+++ b/.osc/releases/2026-05-23-061-local-task-database.md
@@ -11,16 +11,16 @@ The feature stays local-only: no network access, no daemon, no background sync, 
 - Roadmap / issue / task: backlog plan selected by Open Scaffold runner automation.
 - Plan: `.osc/plans/done/061-local-task-database.md`
 - Run ID / run packet: N/A — direct runner implementation against selected backlog plan.
-- Branch / PR: `feat/061-local-task-database`; PR pending.
+- Branch / PR: `feat/061-local-task-database`; https://github.com/graphanov/open-scaffold/pull/96.
 
 ## Verification
 
 - `git diff --check` — passed.
-- `npx vitest run tests/tasks.test.ts` — passed, 5 tests.
-- `npx vitest run tests/tasks.test.ts tests/package-payload.test.ts` — passed, 6 tests across 2 files.
-- `npm test -- --run` — passed, 311 tests across 34 files.
+- `npx vitest run tests/tasks.test.ts` — passed, 6 tests.
+- `npx vitest run tests/tasks.test.ts tests/package-payload.test.ts` — passed, 7 tests across 2 files.
+- `npm test -- --run` — passed, 312 tests across 34 files.
 - `npm run build` — passed, core and runtime-omx TypeScript builds.
-- `npm pack --dry-run --json` — passed; package payload includes `.osc/.gitignore` and excludes dogfood plan/release history.
+- `npm pack --dry-run --json` — passed; package `open-scaffold-0.4.14.tgz` includes `.osc/.gitignore` and `docs/TASKS.md`, and excludes dogfood plan/release history.
 - `./verify.sh --strict` — passed, 10 pass / 0 fail / 0 warn after plan close and evidence update.
 - Built CLI smoke in a temporary initialized scaffold — passed: empty `task list --json`, `task new`, `task list --json`, `task claim`, `task comment`, `task complete`, `task show`, and `status` task counts.
 - Codex round-1 hardening — fixed native SQLite install risk by moving `better-sqlite3` to `optionalDependencies`, and fixed `osc status` outside scaffold roots with a regression test; latest local gates after the fix: `npx vitest run tests/tasks.test.ts`, `npm run build:core`, `npm pack --dry-run --json`, `./verify.sh --strict`, `git diff --check`, and `npm test -- --run`.
@@ -39,5 +39,5 @@ Merge, npm publication, and GitHub Release changes remain owner-gated.
 
 ## Follow-up
 
-- Open PR and run the standard latest-head Codex review loop.
+- Merge remains owner-gated.
 - If this merges, decide separately whether a package/release-train sync is needed for the new CLI surface.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-23: closed 061-local-task-database — added local task database CLI
 - 2026-05-22: closed 060-mcp-server — added optional read-only MCP server
 - 2026-05-22: closed 094-evolution-ledger-demo-proof — added reproducible evolution-ledger demo proof
 - 2026-05-22: closed 093-pr89-public-surface-sync — published 0.4.13 and aligned public package/release surfaces

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -12,6 +12,7 @@ This document is the full ontology. Most readers do not need every protocol page
 
 - New here? Read the [README](../README.md), then [`docs/EXAMPLES.md`](EXAMPLES.md) for the 60-second viewer demo.
 - Wiring task/run identity into a coordinator or task system: [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md).
+- Using repo-local tasks before an external tracker: [`docs/TASKS.md`](TASKS.md).
 - Understanding runtime handoff progressively: [`docs/RUNTIME_SELECTION.md`](RUNTIME_SELECTION.md) for choosing a lane, [`docs/RUNTIME_PROFILES.md`](RUNTIME_PROFILES.md) for profile metadata, then [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) and [`docs/SPAWNING_BOUNDARY.md`](SPAWNING_BOUNDARY.md) for adapter/runtime responsibilities.
 - Closing a slice and producing evidence: [`docs/SLICE_CLOSE_PROTOCOL.md`](SLICE_CLOSE_PROTOCOL.md).
 - Recording multi-attempt improvement loops and frontier promotion: [`docs/EVOLUTION_LOOP.md`](EVOLUTION_LOOP.md).
@@ -35,6 +36,7 @@ Open Scaffold core owns the portable project substrate:
 - `docs/SLICE_CLOSE_PROTOCOL.md` — evidence receipts, postflight decisions, approval strength, correction routing, and next-slice inheritance.
 - `docs/EVOLUTION_LOOP.md` — multi-attempt loop state, attempt journals, frontier promotion, and improvement routing.
 - `osc mcp serve` / `osc-mcp` — optional stdio MCP server that exposes local mission, plan, evidence, status, rules, and roadmap state to MCP-capable tools without requiring each agent to parse markdown directly.
+- `osc task` — optional local SQLite task bridge for day-one repo-local task tracking in `.osc/tasks.db`; see [`docs/TASKS.md`](TASKS.md).
 - `verify.sh` / `osc verify` — methodology compliance checks.
 - `.github/` templates — issue and PR traceability for GitHub-centered workflows.
 
@@ -104,7 +106,7 @@ Examples:
 - GitHub Issues
 - Linear
 - Jira
-- a local SQLite task queue
+- the optional local `.osc/tasks.db` task queue exposed by `osc task`
 - a custom orchestrator board
 
 Open Scaffold should define how roadmap items and plans link to these systems, but it should not assume one board is universal. The dispatch pattern is documented in [`docs/RUNTIME_HARNESS_DISPATCH.md`](RUNTIME_HARNESS_DISPATCH.md): core creates the package, coordinators/task bridges choose and launch the harness, and evidence returns to `.osc/runs`, GitHub, or release notes.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,61 @@
+# Local Tasks
+
+`osc task` is the optional local task bridge for solo developers and small teams that do not want to wire GitHub Issues, Linear, Jira, or an external Kanban board on day one.
+
+It is intentionally small:
+
+- task data lives in `.osc/tasks.db`;
+- the database is local and gitignored;
+- IDs are local short codes such as `T-001`;
+- statuses are `todo`, `in-progress`, `blocked`, `done`, and `cancelled`;
+- priorities are `high`, `medium`, and `low`;
+- tasks may link to an Open Scaffold plan with `--plan <slug>`, but tasks and plans stay independent.
+
+The task database is not a team project-management replacement. Use GitHub Issues, Linear, Jira, Hermes Kanban, or another shared coordinator when multiple people or automation lanes need shared live state.
+
+## First commands
+
+```bash
+osc task list
+osc task new "Fix login redirect bug" --priority high --plan 050-npm-publish
+osc task list --status todo
+osc task show T-001
+osc task claim T-001
+osc task comment T-001 "Investigated the redirect path"
+osc task block T-001 --reason "Waiting for npm access token"
+osc task complete T-001
+```
+
+`osc task list --json` prints a JSON array for scripts and local dashboards.
+
+## Tasks versus plans
+
+Use a task when you need a lightweight operational reminder or status marker:
+
+- something to pick up next;
+- a small blocker note;
+- a local checklist item that should survive shell history;
+- a work item that may later become a GitHub issue or plan.
+
+Use a plan when the work is non-trivial and needs acceptance criteria, files-to-touch, verification steps, and close evidence.
+
+A task can link to a plan:
+
+```bash
+osc task new "Implement local task DB" --plan 061-local-task-database
+osc task link T-001 --plan 061-local-task-database
+```
+
+The link is just traceability. Closing a plan does not automatically complete tasks, and completing a task does not close a plan.
+
+## Tasks versus GitHub Issues
+
+Use local tasks for private, repo-local, day-one operation. Use GitHub Issues when work should be public, shared, discussed, assigned, referenced from PRs, or managed across clones.
+
+Local task IDs such as `T-001` are only unique inside the repo's `.osc/tasks.db`. They are not global product IDs.
+
+## Storage and safety
+
+`.osc/tasks.db` is SQLite-backed and ignored by `.osc/.gitignore` via `tasks.db*`, which also covers local SQLite sidecar files if they appear.
+
+No task command uses the network, starts a daemon, syncs in the background, or stores secrets. The database is local operator state; promote durable product proof into plans, evidence notes, PRs, or GitHub issues when it needs to be reviewed or shared.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -70,6 +70,17 @@ Then fill every TODO before implementation. The helpers create and move structur
 
 Implement what the plan says. Independent tasks can run in parallel. Every change must trace back to a plan file or amendment.
 
+For day-one local task tracking without an external board, use `osc task` as a repo-local task bridge:
+
+```bash
+osc task new "Fix login redirect bug" --priority high --plan <plan-slug>
+osc task list --status todo
+osc task claim T-001
+osc task complete T-001
+```
+
+Tasks live in local `.osc/tasks.db` and can link to plans, but they do not replace plan acceptance criteria or GitHub Issues for public/shared work. See [`docs/TASKS.md`](TASKS.md).
+
 Before creating a durable run packet, preview what Open Scaffold would package:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "open-scaffold",
       "version": "0.4.14",
       "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^12.10.0"
+      },
       "bin": {
         "open-scaffold": "dist/cli.js",
         "osc": "dist/cli.js",
@@ -993,6 +996,84 @@
         "node": ">=12"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1003,6 +1084,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1010,14 +1097,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1079,6 +1198,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1107,6 +1235,18 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1134,6 +1274,44 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1418,6 +1596,33 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -1437,6 +1642,24 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1447,6 +1670,15 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1504,6 +1736,72 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1548,12 +1846,89 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1578,6 +1953,52 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1651,6 +2072,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1670,6 +2103,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -1856,6 +2295,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^12.10.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1014,7 +1017,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/better-sqlite3": {
       "version": "12.10.0",
@@ -1022,6 +1026,7 @@
       "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -1035,6 +1040,7 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -1044,6 +1050,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1069,6 +1076,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1088,7 +1096,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1102,6 +1111,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -1117,6 +1127,7 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1125,6 +1136,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1135,6 +1147,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1203,6 +1216,7 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1239,13 +1253,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1279,7 +1295,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -1299,19 +1316,22 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1601,6 +1621,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -1613,6 +1634,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1621,7 +1643,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -1646,13 +1669,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-abi": {
       "version": "3.92.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
       "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1676,6 +1701,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -1742,6 +1768,7 @@
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -1768,6 +1795,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -1778,6 +1806,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -1793,6 +1822,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1864,13 +1894,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/semver": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1903,7 +1935,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -1924,6 +1957,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -1959,6 +1993,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -1968,6 +2003,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1977,6 +2013,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -1989,6 +2026,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -2077,6 +2115,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -2109,7 +2148,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/vite": {
       "version": "8.0.12",
@@ -2300,7 +2340,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "files": [
     "dist",
+    ".osc/.gitignore",
     ".osc/RULES.md",
     ".osc/plans/WORKFLOW.md",
     ".osc/plans/README.md",
@@ -63,5 +64,8 @@
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^4.1.6"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "^5.7.2",
     "vitest": "^4.1.6"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "better-sqlite3": "^12.10.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -368,7 +368,13 @@ function init(args: string[]): void {
 
 function status(json: boolean): void {
   const state = inspectScaffold(process.cwd());
-  const taskSummary = getTaskSummary(process.cwd());
+  let taskSummary: ReturnType<typeof getTaskSummary> = null;
+  try {
+    taskSummary = getTaskSummary(process.cwd());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith('No Open Scaffold root found')) throw error;
+  }
   if (json) {
     console.log(JSON.stringify({ ...state, tasks: taskSummary }, null, 2));
     return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { computeMetrics, formatMetrics, parseSinceDate } from './metrics.js';
 import { runMcpCommand } from './mcp-server.js';
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
 import { closePlan, createEvidenceNoteSkeleton, createPlanAmendment, createPlanSkeleton, inspectScaffold, listPlanTemplates, movePlan, parsePlanFile, planToJson, PLAN_CREATION_STAGES, type PlanCreationStage } from './scaffold.js';
+import { addTaskComment, createTask, formatTaskDetails, formatTaskSummary, formatTaskTable, getTaskDetails, getTaskSummary, linkTaskPlan, listTasks, taskToJson, transitionTask, TASK_PRIORITIES, TASK_STATUSES, TaskUsageError, type TaskStatus } from './tasks.js';
 import { validateScaffold } from './validation.js';
 import { formatPlanValidationIssues, hasBlockingIssues, resolvePlanValidationPath, validatePlanFile } from './plan-validate.js';
 import { askInteractiveAnswers, assertWizardReady, createWizardPlan, loadAnswersFile, type PlanWizardAnswers } from './wizard.js';
@@ -24,6 +25,13 @@ Usage:
   osc init --from-existing --tier min --target <dir> [--force]
   osc init --min|--standard|--max --target <dir> [--force]
   osc status [--json]
+  osc task new <title> [--priority <high|medium|low>] [--plan <slug>]
+  osc task list [--status <status>] [--priority <priority>] [--plan <slug>] [--json]
+  osc task show <task-id>
+  osc task claim|start|complete|cancel <task-id>
+  osc task block <task-id> --reason <text>
+  osc task comment <task-id> <comment>
+  osc task link <task-id> --plan <slug>
   osc plan <plan-path>
   osc plan new <slug> --stage <active|backlog|blocked> [--from-template <name>]
   osc plan new --from-template list
@@ -360,8 +368,9 @@ function init(args: string[]): void {
 
 function status(json: boolean): void {
   const state = inspectScaffold(process.cwd());
+  const taskSummary = getTaskSummary(process.cwd());
   if (json) {
-    console.log(JSON.stringify(state, null, 2));
+    console.log(JSON.stringify({ ...state, tasks: taskSummary }, null, 2));
     return;
   }
   console.log('Open Scaffold status');
@@ -372,6 +381,7 @@ function status(json: boolean): void {
     console.log(`${stage}: ${plans.length}`);
     for (const plan of plans) console.log(`  - ${plan.slug}`);
   }
+  if (taskSummary) console.log(formatTaskSummary(taskSummary));
 }
 
 function exitForScaffoldHelperError(error: unknown): never {
@@ -1539,6 +1549,190 @@ function metricsCommand(args: string[]): void {
   }
 }
 
+function printTaskUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc task new <title> [--priority <${TASK_PRIORITIES.join('|')}>] [--plan <slug>]
+  osc task list [--status <${TASK_STATUSES.join('|')}>] [--priority <${TASK_PRIORITIES.join('|')}>] [--plan <slug>] [--json]
+  osc task show <task-id>
+  osc task claim|start|complete|cancel <task-id>
+  osc task block <task-id> --reason <text>
+  osc task comment <task-id> <comment>
+  osc task link <task-id> --plan <slug>`, stream);
+}
+
+function takeTaskValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    console.error(`Missing value for ${flag}`);
+    process.exit(2);
+  }
+  return value;
+}
+
+function exitForTaskError(error: unknown): never {
+  console.error(error instanceof Error ? error.message : String(error));
+  if (error instanceof TaskUsageError) process.exit(2);
+  process.exit(1);
+}
+
+function taskCommand(args: string[]): void {
+  const [subcommand, ...rest] = args;
+  if (subcommand === undefined || isHelpArg(subcommand)) {
+    printTaskUsage('stdout');
+    return;
+  }
+
+  try {
+    if (subcommand === 'new') {
+      const title = requireArg(rest, 'title');
+      let priority: string | undefined;
+      let plan: string | undefined;
+      for (let i = 1; i < rest.length; i += 1) {
+        const flag = rest[i];
+        switch (flag) {
+          case '--priority':
+            priority = takeTaskValue(rest, i, flag);
+            i += 1;
+            break;
+          case '--plan':
+            plan = takeTaskValue(rest, i, flag);
+            i += 1;
+            break;
+          default:
+            console.error(`Unknown option for task new: ${flag}`);
+            printTaskUsage();
+            process.exit(2);
+        }
+      }
+      const task = createTask(title, { priority, plan }, process.cwd());
+      console.log(`Created task ${task.id}: ${task.title}`);
+      return;
+    }
+
+    if (subcommand === 'list') {
+      let json = false;
+      let status: string | undefined;
+      let priority: string | undefined;
+      let plan: string | undefined;
+      for (let i = 0; i < rest.length; i += 1) {
+        const flag = rest[i];
+        switch (flag) {
+          case '--json':
+            json = true;
+            break;
+          case '--status':
+            status = takeTaskValue(rest, i, flag);
+            i += 1;
+            break;
+          case '--priority':
+            priority = takeTaskValue(rest, i, flag);
+            i += 1;
+            break;
+          case '--plan':
+            plan = takeTaskValue(rest, i, flag);
+            i += 1;
+            break;
+          default:
+            console.error(`Unknown option for task list: ${flag}`);
+            printTaskUsage();
+            process.exit(2);
+        }
+      }
+      const tasks = listTasks({ status, priority, plan }, process.cwd());
+      if (json) console.log(JSON.stringify(tasks.map(taskToJson), null, 2));
+      else process.stdout.write(formatTaskTable(tasks));
+      return;
+    }
+
+    if (subcommand === 'show') {
+      const id = requireArg(rest, 'task-id');
+      if (rest.length > 1) {
+        console.error(`Unknown option for task show: ${rest[1]}`);
+        printTaskUsage();
+        process.exit(2);
+      }
+      process.stdout.write(formatTaskDetails(getTaskDetails(id, process.cwd())));
+      return;
+    }
+
+    if (subcommand === 'claim' || subcommand === 'start' || subcommand === 'complete' || subcommand === 'cancel') {
+      const id = requireArg(rest, 'task-id');
+      if (rest.length > 1) {
+        console.error(`Unknown option for task ${subcommand}: ${rest[1]}`);
+        printTaskUsage();
+        process.exit(2);
+      }
+      const nextStatus: TaskStatus = subcommand === 'complete' ? 'done' : subcommand === 'cancel' ? 'cancelled' : 'in-progress';
+      const task = transitionTask(id, nextStatus, {}, process.cwd());
+      console.log(`${task.id} is now ${task.status}`);
+      return;
+    }
+
+    if (subcommand === 'block') {
+      const id = requireArg(rest, 'task-id');
+      let reason: string | undefined;
+      for (let i = 1; i < rest.length; i += 1) {
+        const flag = rest[i];
+        if (flag === '--reason') {
+          reason = takeTaskValue(rest, i, flag);
+          i += 1;
+        } else {
+          console.error(`Unknown option for task block: ${flag}`);
+          printTaskUsage();
+          process.exit(2);
+        }
+      }
+      if (!reason) {
+        console.error('Missing required option: --reason <text>');
+        process.exit(2);
+      }
+      const task = transitionTask(id, 'blocked', { reason }, process.cwd());
+      console.log(`${task.id} is now ${task.status}`);
+      return;
+    }
+
+    if (subcommand === 'comment') {
+      const id = requireArg(rest, 'task-id');
+      const body = rest.slice(1).join(' ').trim();
+      if (!body) {
+        console.error('Missing required argument: comment');
+        process.exit(2);
+      }
+      addTaskComment(id, body, process.cwd());
+      console.log(`Added comment to ${id.toUpperCase()}`);
+      return;
+    }
+
+    if (subcommand === 'link') {
+      const id = requireArg(rest, 'task-id');
+      let plan: string | undefined;
+      for (let i = 1; i < rest.length; i += 1) {
+        const flag = rest[i];
+        if (flag === '--plan') {
+          plan = takeTaskValue(rest, i, flag);
+          i += 1;
+        } else {
+          console.error(`Unknown option for task link: ${flag}`);
+          printTaskUsage();
+          process.exit(2);
+        }
+      }
+      if (!plan) {
+        console.error('Missing required option: --plan <slug>');
+        process.exit(2);
+      }
+      const task = linkTaskPlan(id, plan, process.cwd());
+      console.log(`Linked ${task.id} to plan ${task.plan}`);
+      return;
+    }
+  } catch (error) {
+    exitForTaskError(error);
+  }
+
+  console.error(`Unknown task subcommand: ${subcommand}`);
+  printTaskUsage();
+  process.exit(2);
+}
+
 function runtimes(args: string[]): void {
   const [subcommand, ...rest] = args;
   if (subcommand === 'list') {
@@ -1609,6 +1803,9 @@ async function main(): Promise<void> {
       return;
     case 'status':
       status(args.includes('--json'));
+      return;
+    case 'task':
+      taskCommand(args);
       return;
     case 'plan':
       await planCommand(args);

--- a/src/init.ts
+++ b/src/init.ts
@@ -8,6 +8,7 @@ export type ScaffoldTier = (typeof scaffoldTiers)[number];
 
 const minFiles = [
   'MISSION.md',
+  '.osc/.gitignore',
   '.osc/RULES.md',
   '.osc/plans/WORKFLOW.md',
   '.osc/plans/README.md',

--- a/src/init.ts
+++ b/src/init.ts
@@ -37,6 +37,7 @@ const standardOnlyFiles = [
   'CLAUDE.md',
   'amend.sh',
   'docs/WORKFLOW.md',
+  'docs/TASKS.md',
   'docs/MINIMUM_VIABLE_SCAFFOLD.md',
   'docs/SLICE_CLOSE_PROTOCOL.md',
 ] as const;

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,0 +1,448 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { findScaffoldRoot } from './scaffold.js';
+
+const require = createRequire(import.meta.url);
+
+export const TASK_STATUSES = ['todo', 'in-progress', 'done', 'blocked', 'cancelled'] as const;
+export type TaskStatus = typeof TASK_STATUSES[number];
+export const TASK_PRIORITIES = ['high', 'medium', 'low'] as const;
+export type TaskPriority = typeof TASK_PRIORITIES[number];
+
+type SqlValue = string | number | null;
+
+interface SqliteRunResult {
+  changes: number;
+  lastInsertRowid: number | bigint;
+}
+
+interface SqliteStatement<T = unknown> {
+  run(...values: SqlValue[]): SqliteRunResult;
+  get(...values: SqlValue[]): T | undefined;
+  all(...values: SqlValue[]): T[];
+}
+
+interface SqliteDatabase {
+  exec(sql: string): void;
+  prepare<T = unknown>(sql: string): SqliteStatement<T>;
+  pragma(sql: string): void;
+  close(): void;
+}
+
+interface TaskRow {
+  local_id: number;
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  plan_slug: string | null;
+  blocked_reason: string | null;
+  created_at: string;
+  updated_at: string;
+  claimed_at: string | null;
+  completed_at: string | null;
+  blocked_at: string | null;
+  cancelled_at: string | null;
+}
+
+interface CommentRow {
+  id: number;
+  task_id: string;
+  body: string;
+  created_at: string;
+}
+
+interface CountRow {
+  status: TaskStatus;
+  count: number;
+}
+
+export interface LocalTask {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  plan: string | null;
+  blockedReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+  claimedAt: string | null;
+  completedAt: string | null;
+  blockedAt: string | null;
+  cancelledAt: string | null;
+}
+
+export interface TaskComment {
+  id: number;
+  taskId: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface TaskDetails {
+  task: LocalTask;
+  comments: TaskComment[];
+}
+
+export interface TaskFilters {
+  status?: string;
+  priority?: string;
+  plan?: string;
+}
+
+export interface TaskSummary {
+  total: number;
+  counts: Partial<Record<TaskStatus, number>>;
+}
+
+export class TaskUsageError extends Error {}
+
+export function taskDbPath(root: string): string {
+  return join(root, '.osc', 'tasks.db');
+}
+
+function loadSqliteConstructor(): new (path: string) => SqliteDatabase {
+  try {
+    return require('better-sqlite3') as new (path: string) => SqliteDatabase;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Local task database requires the better-sqlite3 native dependency. Re-run npm install, try npm install --build-from-source, or use GitHub Issues for task tracking. (${detail})`);
+  }
+}
+
+function resolveRoot(start = process.cwd()): string {
+  const root = findScaffoldRoot(start);
+  if (!root) throw new Error(`No Open Scaffold root found from ${start}. Run this inside a repo with .osc/plans and .osc/releases.`);
+  return root;
+}
+
+function openDatabase(root: string, create: boolean): SqliteDatabase | null {
+  const dbPath = taskDbPath(root);
+  if (!create && !existsSync(dbPath)) return null;
+  mkdirSync(join(root, '.osc'), { recursive: true });
+  const Database = loadSqliteConstructor();
+  let db: SqliteDatabase;
+  try {
+    db = new Database(dbPath);
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not open local task database at .osc/tasks.db. Reinstall better-sqlite3 or remove the broken local DB file. (${detail})`);
+  }
+  return db;
+}
+
+function initializeSchema(db: SqliteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tasks (
+      local_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT UNIQUE,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('todo', 'in-progress', 'done', 'blocked', 'cancelled')),
+      priority TEXT NOT NULL CHECK (priority IN ('high', 'medium', 'low')),
+      plan_slug TEXT,
+      blocked_reason TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      claimed_at TEXT,
+      completed_at TEXT,
+      blocked_at TEXT,
+      cancelled_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS task_comments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL,
+      body TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+    CREATE INDEX IF NOT EXISTS idx_tasks_priority ON tasks(priority);
+    CREATE INDEX IF NOT EXISTS idx_tasks_plan_slug ON tasks(plan_slug);
+    CREATE INDEX IF NOT EXISTS idx_task_comments_task_id ON task_comments(task_id);
+  `);
+}
+
+function formatTaskId(localId: number): string {
+  return `T-${String(localId).padStart(3, '0')}`;
+}
+
+function normalizeTaskId(raw: string): string {
+  const trimmed = raw.trim().toUpperCase();
+  const match = trimmed.match(/^T-(\d+)$/);
+  if (!match) throw new TaskUsageError(`Invalid task id: ${raw}. Expected an id like T-001.`);
+  return `T-${match[1].padStart(3, '0')}`;
+}
+
+function parsePriority(raw: string | undefined): TaskPriority {
+  const value = raw ?? 'medium';
+  if ((TASK_PRIORITIES as readonly string[]).includes(value)) return value as TaskPriority;
+  throw new TaskUsageError(`Invalid priority: ${value}. Expected one of: ${TASK_PRIORITIES.join(', ')}`);
+}
+
+function parseStatus(raw: string | undefined): TaskStatus | undefined {
+  if (raw === undefined) return undefined;
+  if ((TASK_STATUSES as readonly string[]).includes(raw)) return raw as TaskStatus;
+  throw new TaskUsageError(`Invalid status: ${raw}. Expected one of: ${TASK_STATUSES.join(', ')}`);
+}
+
+function parsePlan(raw: string | undefined): string | undefined {
+  const value = raw?.trim();
+  return value ? value : undefined;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function mapTask(row: TaskRow): LocalTask {
+  return {
+    id: row.id,
+    title: row.title,
+    status: row.status,
+    priority: row.priority,
+    plan: row.plan_slug,
+    blockedReason: row.blocked_reason,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    claimedAt: row.claimed_at,
+    completedAt: row.completed_at,
+    blockedAt: row.blocked_at,
+    cancelledAt: row.cancelled_at,
+  };
+}
+
+function mapComment(row: CommentRow): TaskComment {
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    body: row.body,
+    createdAt: row.created_at,
+  };
+}
+
+function getTaskById(db: SqliteDatabase, taskId: string): LocalTask | null {
+  const row = db.prepare<TaskRow>('SELECT * FROM tasks WHERE id = ?').get(taskId);
+  return row ? mapTask(row) : null;
+}
+
+function requireTask(db: SqliteDatabase, taskId: string): LocalTask {
+  const task = getTaskById(db, taskId);
+  if (!task) throw new Error(`Task not found: ${taskId}`);
+  return task;
+}
+
+export function createTask(title: string, options: { priority?: string; plan?: string } = {}, start = process.cwd()): LocalTask {
+  const cleanTitle = title.trim();
+  if (!cleanTitle) throw new TaskUsageError('Missing required argument: title');
+  const priority = parsePriority(options.priority);
+  const plan = parsePlan(options.plan) ?? null;
+  const root = resolveRoot(start);
+  const db = openDatabase(root, true);
+  if (!db) throw new Error('Could not initialize local task database.');
+  try {
+    const stamp = nowIso();
+    const inserted = db.prepare('INSERT INTO tasks (title, status, priority, plan_slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(cleanTitle, 'todo', priority, plan, stamp, stamp);
+    const localId = Number(inserted.lastInsertRowid);
+    const id = formatTaskId(localId);
+    db.prepare('UPDATE tasks SET id = ? WHERE local_id = ?').run(id, localId);
+    const task = getTaskById(db, id);
+    if (!task) throw new Error(`Created task ${id} but could not read it back.`);
+    return task;
+  } finally {
+    db.close();
+  }
+}
+
+export function listTasks(filters: TaskFilters = {}, start = process.cwd()): LocalTask[] {
+  const status = parseStatus(filters.status);
+  const priority = filters.priority === undefined ? undefined : parsePriority(filters.priority);
+  const plan = parsePlan(filters.plan);
+  const root = resolveRoot(start);
+  const db = openDatabase(root, false);
+  if (!db) return [];
+  try {
+    const clauses: string[] = [];
+    const values: SqlValue[] = [];
+    if (status) {
+      clauses.push('status = ?');
+      values.push(status);
+    }
+    if (priority) {
+      clauses.push('priority = ?');
+      values.push(priority);
+    }
+    if (plan) {
+      clauses.push('plan_slug = ?');
+      values.push(plan);
+    }
+    const where = clauses.length ? ` WHERE ${clauses.join(' AND ')}` : '';
+    const rows = db.prepare<TaskRow>(`SELECT * FROM tasks${where} ORDER BY local_id ASC`).all(...values);
+    return rows.map(mapTask);
+  } finally {
+    db.close();
+  }
+}
+
+export function getTaskDetails(id: string, start = process.cwd()): TaskDetails {
+  const taskId = normalizeTaskId(id);
+  const root = resolveRoot(start);
+  const db = openDatabase(root, false);
+  if (!db) throw new Error(`Task not found: ${taskId}`);
+  try {
+    const task = requireTask(db, taskId);
+    const comments = db.prepare<CommentRow>('SELECT * FROM task_comments WHERE task_id = ? ORDER BY id ASC').all(taskId).map(mapComment);
+    return { task, comments };
+  } finally {
+    db.close();
+  }
+}
+
+export function transitionTask(id: string, status: TaskStatus, options: { reason?: string } = {}, start = process.cwd()): LocalTask {
+  const taskId = normalizeTaskId(id);
+  parseStatus(status);
+  const root = resolveRoot(start);
+  const db = openDatabase(root, false);
+  if (!db) throw new Error(`Task not found: ${taskId}`);
+  try {
+    requireTask(db, taskId);
+    const stamp = nowIso();
+    if (status === 'blocked') {
+      const reason = options.reason?.trim();
+      if (!reason) throw new TaskUsageError('Missing required option: --reason <text>');
+      db.prepare('UPDATE tasks SET status = ?, blocked_reason = ?, blocked_at = ?, updated_at = ? WHERE id = ?')
+        .run(status, reason, stamp, stamp, taskId);
+    } else if (status === 'in-progress') {
+      db.prepare('UPDATE tasks SET status = ?, blocked_reason = NULL, claimed_at = COALESCE(claimed_at, ?), updated_at = ? WHERE id = ?')
+        .run(status, stamp, stamp, taskId);
+    } else if (status === 'done') {
+      db.prepare('UPDATE tasks SET status = ?, blocked_reason = NULL, completed_at = ?, updated_at = ? WHERE id = ?')
+        .run(status, stamp, stamp, taskId);
+    } else if (status === 'cancelled') {
+      db.prepare('UPDATE tasks SET status = ?, blocked_reason = NULL, cancelled_at = ?, updated_at = ? WHERE id = ?')
+        .run(status, stamp, stamp, taskId);
+    } else {
+      db.prepare('UPDATE tasks SET status = ?, blocked_reason = NULL, updated_at = ? WHERE id = ?')
+        .run(status, stamp, taskId);
+    }
+    return requireTask(db, taskId);
+  } finally {
+    db.close();
+  }
+}
+
+export function addTaskComment(id: string, body: string, start = process.cwd()): TaskComment {
+  const taskId = normalizeTaskId(id);
+  const cleanBody = body.trim();
+  if (!cleanBody) throw new TaskUsageError('Missing required argument: comment');
+  const root = resolveRoot(start);
+  const db = openDatabase(root, false);
+  if (!db) throw new Error(`Task not found: ${taskId}`);
+  try {
+    requireTask(db, taskId);
+    const stamp = nowIso();
+    const inserted = db.prepare('INSERT INTO task_comments (task_id, body, created_at) VALUES (?, ?, ?)').run(taskId, cleanBody, stamp);
+    db.prepare('UPDATE tasks SET updated_at = ? WHERE id = ?').run(stamp, taskId);
+    const row = db.prepare<CommentRow>('SELECT * FROM task_comments WHERE id = ?').get(Number(inserted.lastInsertRowid));
+    if (!row) throw new Error(`Added comment to ${taskId} but could not read it back.`);
+    return mapComment(row);
+  } finally {
+    db.close();
+  }
+}
+
+export function linkTaskPlan(id: string, plan: string, start = process.cwd()): LocalTask {
+  const taskId = normalizeTaskId(id);
+  const cleanPlan = parsePlan(plan);
+  if (!cleanPlan) throw new TaskUsageError('Missing required option: --plan <slug>');
+  const root = resolveRoot(start);
+  const db = openDatabase(root, false);
+  if (!db) throw new Error(`Task not found: ${taskId}`);
+  try {
+    requireTask(db, taskId);
+    const stamp = nowIso();
+    db.prepare('UPDATE tasks SET plan_slug = ?, updated_at = ? WHERE id = ?').run(cleanPlan, stamp, taskId);
+    return requireTask(db, taskId);
+  } finally {
+    db.close();
+  }
+}
+
+export function getTaskSummary(start = process.cwd()): TaskSummary | null {
+  const root = resolveRoot(start);
+  const db = openDatabase(root, false);
+  if (!db) return null;
+  try {
+    const rows = db.prepare<CountRow>('SELECT status, COUNT(*) AS count FROM tasks GROUP BY status').all();
+    const counts: Partial<Record<TaskStatus, number>> = {};
+    let total = 0;
+    for (const row of rows) {
+      counts[row.status] = row.count;
+      total += row.count;
+    }
+    return { total, counts };
+  } finally {
+    db.close();
+  }
+}
+
+export function formatTaskTable(tasks: LocalTask[]): string {
+  if (tasks.length === 0) return 'No tasks yet. Create one with `osc task new <title>`\n';
+  const rows = tasks.map((task) => [task.id, task.status, task.priority, task.plan ?? '-', task.title]);
+  const headers = ['ID', 'Status', 'Priority', 'Plan', 'Title'];
+  const widths = headers.map((header, index) => Math.max(header.length, ...rows.map((row) => row[index].length)));
+  const render = (row: string[]) => row.map((cell, index) => cell.padEnd(widths[index])).join('  ').trimEnd();
+  return `${render(headers)}\n${render(widths.map((width) => '-'.repeat(width)))}\n${rows.map(render).join('\n')}\n`;
+}
+
+export function taskToJson(task: LocalTask): Record<string, string | null> {
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    priority: task.priority,
+    plan: task.plan,
+    blockedReason: task.blockedReason,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    claimedAt: task.claimedAt,
+    completedAt: task.completedAt,
+    blockedAt: task.blockedAt,
+    cancelledAt: task.cancelledAt,
+  };
+}
+
+export function formatTaskDetails(details: TaskDetails): string {
+  const { task, comments } = details;
+  const lines = [
+    `Task ${task.id}`,
+    `Title: ${task.title}`,
+    `Status: ${task.status}`,
+    `Priority: ${task.priority}`,
+    `Plan: ${task.plan ?? '-'}`,
+    `Created: ${task.createdAt}`,
+    `Updated: ${task.updatedAt}`,
+  ];
+  if (task.claimedAt) lines.push(`Claimed: ${task.claimedAt}`);
+  if (task.completedAt) lines.push(`Completed: ${task.completedAt}`);
+  if (task.blockedAt) lines.push(`Blocked: ${task.blockedAt}`);
+  if (task.cancelledAt) lines.push(`Cancelled: ${task.cancelledAt}`);
+  if (task.blockedReason) lines.push(`Blocked reason: ${task.blockedReason}`);
+  lines.push('');
+  lines.push('Comments:');
+  if (comments.length === 0) lines.push('- None.');
+  else for (const comment of comments) lines.push(`- ${comment.createdAt} — ${comment.body}`);
+  return `${lines.join('\n')}\n`;
+}
+
+export function formatTaskSummary(summary: TaskSummary): string {
+  if (summary.total === 0) return 'Tasks: 0';
+  const parts = TASK_STATUSES
+    .map((status) => ({ status, count: summary.counts[status] ?? 0 }))
+    .filter((entry) => entry.count > 0)
+    .map((entry) => `${entry.count} ${entry.status}`);
+  return `Tasks: ${parts.join(', ')}`;
+}

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -244,14 +244,25 @@ export function createTask(title: string, options: { priority?: string; plan?: s
   if (!db) throw new Error('Could not initialize local task database.');
   try {
     const stamp = nowIso();
-    const inserted = db.prepare('INSERT INTO tasks (title, status, priority, plan_slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
-      .run(cleanTitle, 'todo', priority, plan, stamp, stamp);
-    const localId = Number(inserted.lastInsertRowid);
-    const id = formatTaskId(localId);
-    db.prepare('UPDATE tasks SET id = ? WHERE local_id = ?').run(id, localId);
-    const task = getTaskById(db, id);
-    if (!task) throw new Error(`Created task ${id} but could not read it back.`);
-    return task;
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      const inserted = db.prepare('INSERT INTO tasks (title, status, priority, plan_slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run(cleanTitle, 'todo', priority, plan, stamp, stamp);
+      const localId = Number(inserted.lastInsertRowid);
+      const id = formatTaskId(localId);
+      db.prepare('UPDATE tasks SET id = ? WHERE local_id = ?').run(id, localId);
+      const task = getTaskById(db, id);
+      if (!task) throw new Error(`Created task ${id} but could not read it back.`);
+      db.exec('COMMIT');
+      return task;
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK');
+      } catch {
+        // Preserve the original task creation error if rollback itself fails.
+      }
+      throw error;
+    }
   } finally {
     db.close();
   }

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -40,6 +40,7 @@ describe('tiered scaffold initialization', () => {
     for (const file of tierFiles.min) expect(result.filesCreated).toContain(file);
     expect(readFileSync(join(target, 'README.md'), 'utf8')).toContain('Open Scaffold');
     expect(readFileSync(join(target, 'docs/MINIMUM_VIABLE_SCAFFOLD.md'), 'utf8')).toContain('minimum viable scaffold');
+    expect(readFileSync(join(target, 'docs/TASKS.md'), 'utf8')).toContain('Local Tasks');
   });
 
   it('generates the max scaffold as a superset of standard', () => {

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -22,6 +22,7 @@ describe('npm package payload', () => {
     const [pack] = JSON.parse(output) as PackResult[];
     const paths = pack.files.map((file) => file.path).sort();
 
+    expect(paths).toContain('.osc/.gitignore');
     expect(paths).toContain('.osc/RULES.md');
     expect(paths).toContain('.osc/plans/WORKFLOW.md');
     expect(paths).toContain('.osc/plans/README.md');

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -2,11 +2,28 @@ import { describe, expect, it } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const tsx = join(repoRoot, 'node_modules/.bin/tsx');
 const cli = join(repoRoot, 'src/cli.ts');
+const require = createRequire(import.meta.url);
+
+type SqliteStatement<T = unknown> = {
+  get(...values: unknown[]): T | undefined;
+};
+
+type SqliteDatabase = {
+  exec(sql: string): void;
+  prepare<T = unknown>(sql: string): SqliteStatement<T>;
+  close(): void;
+};
+
+function openTaskDb(target: string): SqliteDatabase {
+  const Database = require('better-sqlite3') as new (path: string) => SqliteDatabase;
+  return new Database(join(target, '.osc/tasks.db'));
+}
 
 function tempDir(prefix = 'osc-tasks-') {
   return mkdtempSync(join(tmpdir(), prefix));
@@ -75,6 +92,38 @@ describe('osc task local database', () => {
     const persisted = JSON.parse(runOsc(target, ['task', 'list', '--plan', '060-mcp-server', '--json'])) as Array<Record<string, unknown>>;
     expect(persisted).toHaveLength(1);
     expect(persisted[0].id).toBe('T-001');
+  }, 20_000);
+
+  it('rolls back task creation if public id assignment fails', () => {
+    const target = initializedScaffold();
+    runOsc(target, ['task', 'new', 'Seed task']);
+
+    const db = openTaskDb(target);
+    try {
+      db.exec(`
+        CREATE TRIGGER fail_task_id_update
+        BEFORE UPDATE OF id ON tasks
+        WHEN NEW.id IS NOT NULL
+        BEGIN
+          SELECT RAISE(ABORT, 'simulated id failure');
+        END;
+      `);
+    } finally {
+      db.close();
+    }
+
+    const failed = spawnSync(tsx, [cli, 'task', 'new', 'Should rollback'], { cwd: target, encoding: 'utf8' });
+    expect(failed.status).not.toBe(0);
+    expect(failed.stderr).toContain('simulated id failure');
+
+    const check = openTaskDb(target);
+    try {
+      const row = check.prepare<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE title = 'Should rollback' OR id IS NULL").get();
+      expect(row?.count).toBe(0);
+    } finally {
+      check.close();
+    }
+    expect(JSON.parse(runOsc(target, ['task', 'list', '--json']))).toHaveLength(1);
   }, 20_000);
 
   it('supports status transitions and status summary integration', () => {

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempDir(prefix = 'osc-tasks-') {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function initializedScaffold() {
+  const target = tempDir();
+  execFileSync(tsx, [cli, 'init', '--tier', 'min', '--target', target], { encoding: 'utf8' });
+  writeFileSync(join(target, 'MISSION.md'), '# Mission\n\nTest project mission.\n');
+  return target;
+}
+
+function runOsc(cwd: string, args: string[]): string {
+  return execFileSync(tsx, [cli, ...args], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+describe('osc task local database', () => {
+  it('lists gracefully before a task database exists', () => {
+    const target = initializedScaffold();
+
+    const human = runOsc(target, ['task', 'list']);
+    const json = runOsc(target, ['task', 'list', '--json']);
+
+    expect(human).toContain('No tasks yet. Create one with `osc task new <title>`');
+    expect(JSON.parse(json)).toEqual([]);
+    expect(existsSync(join(target, '.osc/tasks.db'))).toBe(false);
+  }, 20_000);
+
+  it('creates, filters, shows, comments, links, and persists tasks across CLI invocations', () => {
+    const target = initializedScaffold();
+
+    const created = runOsc(target, ['task', 'new', 'Fix login redirect bug', '--priority', 'high', '--plan', '050-npm-publish']);
+    expect(created).toContain('Created task T-001');
+    expect(existsSync(join(target, '.osc/tasks.db'))).toBe(true);
+
+    const all = JSON.parse(runOsc(target, ['task', 'list', '--json'])) as Array<Record<string, unknown>>;
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({
+      id: 'T-001',
+      title: 'Fix login redirect bug',
+      status: 'todo',
+      priority: 'high',
+      plan: '050-npm-publish',
+    });
+    expect(typeof all[0].createdAt).toBe('string');
+
+    expect(JSON.parse(runOsc(target, ['task', 'list', '--status', 'todo', '--json']))).toHaveLength(1);
+    expect(JSON.parse(runOsc(target, ['task', 'list', '--priority', 'high', '--json']))).toHaveLength(1);
+    expect(JSON.parse(runOsc(target, ['task', 'list', '--plan', '050-npm-publish', '--json']))).toHaveLength(1);
+    expect(JSON.parse(runOsc(target, ['task', 'list', '--status', 'done', '--json']))).toEqual([]);
+
+    const table = runOsc(target, ['task', 'list']);
+    expect(table).toContain('T-001');
+    expect(table).toContain('todo');
+    expect(table).toContain('high');
+    expect(table).toContain('Fix login redirect bug');
+    expect(table).toContain('050-npm-publish');
+
+    runOsc(target, ['task', 'comment', 'T-001', 'Investigated: the redirect uses window.location not router.push']);
+    runOsc(target, ['task', 'link', 'T-001', '--plan', '060-mcp-server']);
+    const shown = runOsc(target, ['task', 'show', 'T-001']);
+    expect(shown).toContain('Task T-001');
+    expect(shown).toContain('Plan: 060-mcp-server');
+    expect(shown).toContain('Investigated: the redirect uses window.location not router.push');
+
+    const persisted = JSON.parse(runOsc(target, ['task', 'list', '--plan', '060-mcp-server', '--json'])) as Array<Record<string, unknown>>;
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].id).toBe('T-001');
+  }, 20_000);
+
+  it('supports status transitions and status summary integration', () => {
+    const target = initializedScaffold();
+    runOsc(target, ['task', 'new', 'First task']);
+    runOsc(target, ['task', 'new', 'Second task', '--priority', 'low']);
+
+    expect(runOsc(target, ['task', 'claim', 'T-001'])).toContain('T-001 is now in-progress');
+    expect(runOsc(target, ['task', 'complete', 'T-001'])).toContain('T-001 is now done');
+    expect(runOsc(target, ['task', 'start', 'T-002'])).toContain('T-002 is now in-progress');
+    expect(runOsc(target, ['task', 'block', 'T-002', '--reason', 'Waiting for npm access token'])).toContain('T-002 is now blocked');
+
+    const blockedShow = runOsc(target, ['task', 'show', 'T-002']);
+    expect(blockedShow).toContain('Status: blocked');
+    expect(blockedShow).toContain('Blocked reason: Waiting for npm access token');
+
+    runOsc(target, ['task', 'new', 'Third task']);
+    expect(runOsc(target, ['task', 'cancel', 'T-003'])).toContain('T-003 is now cancelled');
+
+    const summary = runOsc(target, ['status']);
+    expect(summary).toContain('Tasks: 1 done, 1 blocked, 1 cancelled');
+
+    rmSync(join(target, '.osc/tasks.db'), { force: true });
+    expect(runOsc(target, ['status'])).not.toContain('Tasks:');
+  }, 20_000);
+
+  it('rejects invalid task options with clear errors', () => {
+    const target = initializedScaffold();
+
+    const badPriority = spawnSync(tsx, [cli, 'task', 'new', 'Bad priority', '--priority', 'urgent'], { cwd: target, encoding: 'utf8' });
+    expect(badPriority.status).toBe(2);
+    expect(badPriority.stderr).toContain('Invalid priority');
+
+    runOsc(target, ['task', 'new', 'Needs block']);
+    const missingReason = spawnSync(tsx, [cli, 'task', 'block', 'T-001'], { cwd: target, encoding: 'utf8' });
+    expect(missingReason.status).toBe(2);
+    expect(missingReason.stderr).toContain('Missing required option: --reason <text>');
+
+    const missingTask = spawnSync(tsx, [cli, 'task', 'show', 'T-999'], { cwd: target, encoding: 'utf8' });
+    expect(missingTask.status).toBe(1);
+    expect(missingTask.stderr).toContain('Task not found: T-999');
+  }, 20_000);
+
+  it('ships the task database ignore rule with initialized scaffolds', () => {
+    const target = initializedScaffold();
+
+    const ignore = readFileSync(join(target, '.osc/.gitignore'), 'utf8');
+
+    expect(ignore).toContain('tasks.db*');
+  }, 20_000);
+});

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -101,6 +101,17 @@ describe('osc task local database', () => {
     expect(runOsc(target, ['status'])).not.toContain('Tasks:');
   }, 20_000);
 
+  it('keeps status usable outside an Open Scaffold root', () => {
+    const target = tempDir('osc-no-scaffold-');
+
+    const result = spawnSync(tsx, [cli, 'status'], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Open Scaffold status');
+    expect(result.stdout).toContain('Mission: not defined');
+    expect(result.stdout).not.toContain('Tasks:');
+  }, 20_000);
+
   it('rejects invalid task options with clear errors', () => {
     const target = initializedScaffold();
 


### PR DESCRIPTION
## Summary

Opened/advanced by Open Scaffold runner automation.

Selected source: `backlog_plan` — `.osc/plans/backlog/061-local-task-database.md`.

This PR adds an optional local task database for day-one repo-local task tracking:

- adds `osc task new|list|show|claim|start|complete|block|cancel|comment|link` backed by local SQLite at `.osc/tasks.db`;
- shows task counts in `osc status` when a task DB exists;
- ships `.osc/.gitignore` with `tasks.db*` for initialized scaffolds;
- documents when to use local tasks versus plans, GitHub Issues, or shared coordinator boards;
- closes plan 061 with release/evidence notes.

## Traceability

- Selected source: `backlog_plan`
- Plan: `.osc/plans/done/061-local-task-database.md`
- Evidence: `.osc/releases/2026-05-23-061-local-task-database.md`
- Run packet: N/A — direct runner implementation for a selected repo backlog plan

## Verification

- `git diff --check`
- `npx vitest run tests/tasks.test.ts`
- `npx vitest run tests/tasks.test.ts tests/package-payload.test.ts`
- `npm test -- --run`
- `npm run build`
- `npm pack --dry-run --json`
- `./verify.sh --strict`
- Built CLI smoke in a temporary initialized scaffold: empty list, create, list JSON, claim, comment, complete, show, and status counts

## Owner gates

- Merge: owner-gated
- npm publication: owner-gated
- GitHub Release / latest movement: owner-gated
