### PR TITLE
Fix packaged init ignore template

### DIFF
--- a/.osc/plans/active/095-local-task-database-public-surface-sync-amendment-1.md
+++ b/.osc/plans/active/095-local-task-database-public-surface-sync-amendment-1.md
@@ -1,0 +1,23 @@
+# Amendment 1: 095-local-task-database-public-surface-sync
+
+## Parent
+
+095-local-task-database-public-surface-sync
+
+## Date
+
+2026-05-23
+
+## Learning
+
+Post-publish verification for `open-scaffold@0.4.15` proved the task CLI reached npm, but the fresh isolated-cache `npx open-scaffold@latest init --tier min` smoke failed before the release could be marked complete. The package extracted `.osc/.gitignore` as `.osc/.npmignore`, so the published CLI could not copy the scaffold ignore template even though local source and dry-run pack checks looked green.
+
+## New direction
+
+Prepare a patch hotfix release that keeps the local task database public surface and fixes packaged `osc init` by allowing the CLI to copy the packaged `.osc/.npmignore` fallback into downstream `.osc/.gitignore` when npm rewrites the template filename.
+
+## Impact on acceptance criteria
+
+- Public npm verification now requires a fresh isolated-cache `npx open-scaffold@latest init --tier min --target <tmp>` pass in addition to `task --help`.
+- The final public version may advance beyond `0.4.15` if a patch hotfix is required before GitHub Latest Release and plan closeout.
+- Package-payload verification must cover an extracted tarball / installed package behavior, not only `npm pack --dry-run --json` file names.

--- a/.osc/releases/2026-05-23-095-local-task-database-public-surface-sync.md
+++ b/.osc/releases/2026-05-23-095-local-task-database-public-surface-sync.md
@@ -2,13 +2,13 @@
 
 Date: 2026-05-23
 Plan: `.osc/plans/active/095-local-task-database-public-surface-sync.md`
-Branch: `release/local-task-database-public-surface-sync`
-Package version: `open-scaffold@0.4.15`
+Branch: `fix/packaged-init-gitignore-fallback`
+Package version: `open-scaffold@0.4.16`
 Release: pending owner-gated follow-through
 
 ## Summary
 
-PR #96 added the optional local SQLite task database CLI to repo `main`, but the public npm / `npx` surface is still `open-scaffold@0.4.14`, where `osc task` is not available. This candidate prepares `open-scaffold@0.4.15` so the local task database work can be published and represented by a GitHub Latest Release after owner approval.
+PR #96 added the optional local SQLite task database CLI to repo `main`. PR #97 published `open-scaffold@0.4.15`, which exposed `osc task`, but post-publish verification caught a packaged `osc init` regression before the GitHub Latest Release gate. This follow-up prepares `open-scaffold@0.4.16` so the local task database work and packaged init path can both be published and represented by a GitHub Latest Release after owner approval.
 
 ## Traceability
 
@@ -18,10 +18,12 @@ PR #96 added the optional local SQLite task database CLI to repo `main`, but the
 - Release-sync plan: `.osc/plans/active/095-local-task-database-public-surface-sync.md`
 - Release-sync branch: `release/local-task-database-public-surface-sync`
 - Release-sync PR: https://github.com/graphanov/open-scaffold/pull/97
+- Hotfix branch: `fix/packaged-init-gitignore-fallback`
+- Release-sync amendment: `.osc/plans/active/095-local-task-database-public-surface-sync-amendment-1.md`
 
-## Pre-release drift baseline
+## Pre-release and post-0.4.15 drift baseline
 
-Observed after PR #96 reached `main`:
+Observed after PR #96 reached `main` and before PR #97:
 
 ```text
 repo main package.json: 0.4.14
@@ -31,34 +33,57 @@ fresh npx open-scaffold@latest task --help: exit 2, Unknown command: task
 local repo npm run osc -- task --help: lists osc task subcommands
 ```
 
+Observed after PR #97 and trusted publishing run `26328214129`:
+
+```text
+npm latest: 0.4.15
+fresh npx open-scaffold@latest task --help: passed
+fresh npx open-scaffold@latest init --tier min --target <tmp>: failed
+failure: Template source missing for .osc/.gitignore because the extracted package had .osc/.npmignore
+GitHub Latest Release: still v0.4.14 because the 0.4.15 release gate was intentionally not completed after the init blocker
+```
+
 ## Candidate changes
 
 - `package.json`
-  - Candidate version: `0.4.15`.
+  - Candidate version: `0.4.16`.
 - `package-lock.json`
-  - Candidate root package version aligned to `0.4.15`.
-- `.osc/plans/active/095-local-task-database-public-surface-sync.md`
-  - Release-sync plan kept active until real npm / `npx` / GitHub Release proof exists.
+  - Candidate root package version aligned to `0.4.16`.
+- `src/init.ts`
+  - Copies packaged `.osc/.npmignore` as downstream `.osc/.gitignore` when npm rewrites the template filename during tarball extraction.
+- `tests/package-payload.test.ts`
+  - Adds an extracted-tarball `osc init` regression test instead of relying only on dry-run file names.
+- `.osc/plans/active/095-local-task-database-public-surface-sync-amendment-1.md`
+  - Records the public-package verification learning and hotfix direction.
 - `.osc/releases/2026-05-23-095-local-task-database-public-surface-sync.md`
-  - This candidate evidence note.
+  - This candidate evidence note, updated with the 0.4.15 blocker and 0.4.16 follow-through.
 
 ## Outcome
 
-This branch is a release-sync candidate only. It does not publish npm, create or update a GitHub Release, merge itself, resume Control Room runner autonomy, or change Open Scaffold's runtime boundary.
+This branch is a release-sync hotfix candidate. It does not publish npm, create or update a GitHub Release, merge itself, resume Control Room runner autonomy, or change Open Scaffold's runtime boundary.
 
 ## Verification
 
-Candidate verification from `release/local-task-database-public-surface-sync`:
+PR #97 / `0.4.15` verification reached npm but failed the final fresh-init smoke:
+
+```text
+trusted publishing run 26328214129 — success, published open-scaffold@0.4.15
+npm latest — 0.4.15
+fresh isolated-cache npx open-scaffold@latest task --help — passed
+fresh isolated-cache npx open-scaffold@latest init --tier min --target <tmp> — failed: Template source missing for .osc/.gitignore
+```
+
+Hotfix candidate verification from `fix/packaged-init-gitignore-fallback`:
 
 ```text
 git diff --check — passed
+git diff --cached --check — passed
 ./verify.sh --strict — 10 pass, 0 fail, 0 warn
-npm test -- tests/init.test.ts tests/tasks.test.ts tests/package-payload.test.ts --reporter=verbose — 3 files / 24 tests passed
-npm test -- --reporter=verbose — 34 files / 313 tests passed
+npm test -- tests/init.test.ts tests/tasks.test.ts tests/package-payload.test.ts --reporter=verbose — 3 files / 25 tests passed
+npm test -- --reporter=verbose — 34 files / 314 tests passed
 npm run build — passed, core and runtime-omx TypeScript builds
-npm pack --dry-run --json — open-scaffold-0.4.15.tgz, 120 files, unpackedSize 825953
-npm publish --dry-run — + open-scaffold@0.4.15
-fresh npx open-scaffold@latest task --help baseline — exit 2, Unknown command: task
+npm pack --dry-run --json — open-scaffold-0.4.16.tgz, 120 files, unpackedSize 826202
+npm publish --dry-run — + open-scaffold@0.4.16
 ```
 
 Package payload spot-check from `npm pack --dry-run --json`:
@@ -70,21 +95,21 @@ dist/tasks.d.ts YES
 dist/cli.js YES
 .osc/.gitignore YES
 forbidden .osc/plans/active 0
-forbidden .osc/plans/backlog 0
-forbidden .osc/plans/done 0
-forbidden .osc/runs 0
-forbidden .osc-dev 0
-forbidden .git 0
-forbidden node_modules 0
 .osc/releases payload .osc/releases/README.md only
+```
+
+Regression coverage added:
+
+```text
+npm package payload > runs init successfully from an extracted npm tarball — passed
 ```
 
 ## Remaining gates
 
-- Open release-sync PR.
+- Open hotfix PR.
 - CI and latest-head Codex review must pass with zero unresolved current review threads.
-- Owner approval is required before merge.
-- After merge, trusted npm publishing must be dispatched and verified.
-- Fresh isolated-cache `npx open-scaffold@latest task --help` must pass after publication.
-- GitHub Release `v0.4.15` must be created or updated and marked Latest after publication.
+- Owner-approved merge is already granted by the release-sync proceed instruction, but the PR must still be mechanically clean before merge.
+- After merge, trusted npm publishing must be dispatched and verified for `open-scaffold@0.4.16`.
+- Fresh isolated-cache `npx open-scaffold@latest task --help` and `init --tier min --target <tmp>` must pass after publication.
+- GitHub Release `v0.4.16` must be created or updated and marked Latest after publication.
 - Plan `095` should move to `done/` only after registry, fresh `npx`, and GitHub Latest Release proof exist.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-23: record packaged init hotfix after public npx verification — see .osc/plans/active/095-local-task-database-public-surface-sync-amendment-1.md
 - 2026-05-23: closed 061-local-task-database — added local task database CLI
 - 2026-05-22: closed 060-mcp-server — added optional read-only MCP server
 - 2026-05-22: closed 094-evolution-ledger-demo-proof — added reproducible evolution-ledger demo proof

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/src/init.ts
+++ b/src/init.ts
@@ -91,7 +91,14 @@ function isExecutableTemplate(file: string): boolean {
 function sourcePathFor(file: string): string | null {
   if (file === 'MISSION.md') return null;
   if (file.endsWith('/.gitkeep')) return null;
-  return join(packageRoot(), file);
+
+  const source = join(packageRoot(), file);
+  if (file === '.osc/.gitignore' && !existsSync(source)) {
+    const npmPackedFallback = join(packageRoot(), '.osc/.npmignore');
+    if (existsSync(npmPackedFallback)) return npmPackedFallback;
+  }
+
+  return source;
 }
 
 function missionTemplate(project?: ExistingProjectDetection): string {

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 
 interface PackedFile {
   path: string;
 }
 
 interface PackResult {
+  filename: string;
   files: PackedFile[];
 }
 
@@ -42,4 +45,40 @@ describe('npm package payload', () => {
 
     expect(forbidden).toEqual([]);
   }, 20_000);
+
+  it('runs init successfully from an extracted npm tarball', () => {
+    const packDir = mkdtempSync(join(tmpdir(), 'open-scaffold-pack-'));
+    const extractDir = mkdtempSync(join(tmpdir(), 'open-scaffold-extract-'));
+    const target = mkdtempSync(join(tmpdir(), 'open-scaffold-init-'));
+
+    try {
+      const output = execFileSync('npm', ['pack', '--json', '--pack-destination', packDir], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const [pack] = JSON.parse(output) as PackResult[];
+      const tarball = resolve(packDir, pack.filename);
+
+      execFileSync('tar', ['-xzf', tarball, '-C', extractDir], {
+        cwd: repoRoot,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const packageDir = join(extractDir, 'package');
+      expect(existsSync(join(packageDir, '.osc/.gitignore')) || existsSync(join(packageDir, '.osc/.npmignore'))).toBe(true);
+
+      execFileSync('node', [join(packageDir, 'dist/cli.js'), 'init', '--tier', 'min', '--target', target], {
+        cwd: packageDir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const ignore = readFileSync(join(target, '.osc/.gitignore'), 'utf8');
+      expect(ignore).toContain('tasks.db*');
+    } finally {
+      rmSync(packDir, { recursive: true, force: true });
+      rmSync(extractDir, { recursive: true, force: true });
+      rmSync(target, { recursive: true, force: true });
+    }
+  }, 40_000);
 });


### PR DESCRIPTION
## Summary
- Fix packaged `osc init` when npm extracts `.osc/.gitignore` as `.osc/.npmignore`.
- Add an extracted-tarball package regression test for `osc init --tier min`.
- Prepare the follow-up public package candidate `open-scaffold@0.4.16` after the `0.4.15` post-publish init smoke caught the blocker.

## Verification
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- [x] `npm test -- tests/init.test.ts tests/tasks.test.ts tests/package-payload.test.ts --reporter=verbose` — 3 files / 25 tests passed
- [x] `npm test -- --reporter=verbose` — 34 files / 314 tests passed
- [x] `npm run build`
- [x] `npm pack --dry-run --json` — `open-scaffold-0.4.16.tgz`, 120 files
- [x] `npm publish --dry-run` — `+ open-scaffold@0.4.16`

## Risk / gates
- No runtime spawning or runtime-boundary change.
- Actual npm trusted publishing and GitHub Latest Release follow after merge and public-surface verification.
- Plan `095` remains active until registry, fresh `npx`, and GitHub Release proof exist.
