### PR TITLE
Add glass cockpit webhooks

### DIFF
--- a/.osc/.gitignore
+++ b/.osc/.gitignore
@@ -1,1 +1,2 @@
 tasks.db*
+cockpit.json

--- a/.osc/cockpit.example.json
+++ b/.osc/cockpit.example.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Copy this file to .osc/cockpit.json and replace the placeholder webhook URLs. Never commit real webhook URLs.",
+  "targets": [
+    {
+      "name": "public-build-stream",
+      "platform": "discord",
+      "webhookUrl": "https://discord.com/api/webhooks/000000000000000000/replace-with-secret",
+      "events": ["status", "completion_report"]
+    },
+    {
+      "name": "review-room",
+      "platform": "slack",
+      "webhookUrl": "https://hooks.slack.com/services/T00000000/B00000000/replace-with-secret",
+      "events": ["blocker", "approval_request"]
+    }
+  ]
+}

--- a/.osc/plans/done/062-glass-cockpit-webhooks.md
+++ b/.osc/plans/done/062-glass-cockpit-webhooks.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
+++ b/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
@@ -1,0 +1,32 @@
+# Release / Evidence Note: 062-glass-cockpit-webhooks
+
+## Summary
+
+Added push-only glass-cockpit webhook support through `osc cockpit config`, `osc cockpit test`, and `osc cockpit post`. The slice sends structured Discord embed and Slack Block Kit payloads from `.osc/cockpit.json`, keeps webhook URLs masked in CLI output, and ships `.osc/cockpit.example.json` as the credential-safe template.
+
+## Traceability
+
+- Roadmap / issue / task: selector mode `backlog_plan`; no GitHub issue existed for this slice.
+- Plan: .osc/plans/done/062-glass-cockpit-webhooks.md
+- Run ID / run packet: N/A — direct runner implementation for the selected plan.
+- Branch / PR: feat/062-glass-cockpit-webhooks; PR pending.
+
+## Verification
+
+- `git diff --check` — passed.
+- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
+- `npm test -- --run` — 35 test files passed; 321 tests passed.
+- `npm run build` — passed for core and runtime-omx TypeScript builds.
+- `npm pack --dry-run --json` — passed; package payload includes `.osc/cockpit.example.json`.
+- `node dist/cli.js cockpit config`, `node dist/cli.js cockpit test --dry-run`, `node dist/cli.js cockpit post --event status --message "Test message" --dry-run`, `node dist/cli.js cockpit post --event blocker --message "should send" --dry-run`, and missing-config `node dist/cli.js cockpit test` — passed.
+
+## Outcome
+
+Local implementation and verification passed. This ships explicit one-shot webhook dispatch only: no daemon, no incoming webhooks, no slash commands, no background listener, and no chat surface as canonical project truth. Live Discord/Slack delivery with real webhooks remains credential-gated; the test suite proves the HTTP POST path against a local server and the CLI dry-runs prove Discord/Slack payload shape without exposing secrets.
+
+Owner gates remain: merge, npm publication, and GitHub Release latest/public-surface sync.
+
+## Follow-up
+
+- Optional owner-gated smoke with a real Discord or Slack webhook after review/merge.
+- Future slice, not part of v1: automatic cockpit posts from lifecycle commands such as `osc close` or `osc evidence new`.

--- a/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
+++ b/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
@@ -15,7 +15,7 @@ Added push-only glass-cockpit webhook support through `osc cockpit config`, `osc
 
 - `git diff --check` — passed.
 - `./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
-- `npm test -- --run` — 35 test files passed; 322 tests passed.
+- `npm test -- --run` — 35 test files passed; 323 tests passed.
 - `npm run build` — passed for core and runtime-omx TypeScript builds.
 - `npm pack --dry-run --json` — passed; package payload includes `.osc/cockpit.example.json`.
 - `node dist/cli.js cockpit config`, `node dist/cli.js cockpit test --dry-run`, `node dist/cli.js cockpit post --event status --message "Test message" --dry-run`, `node dist/cli.js cockpit post --event blocker --message "should send" --dry-run`, and missing-config `node dist/cli.js cockpit test` — passed.

--- a/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
+++ b/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
@@ -15,7 +15,7 @@ Added push-only glass-cockpit webhook support through `osc cockpit config`, `osc
 
 - `git diff --check` — passed.
 - `./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
-- `npm test -- --run` — 35 test files passed; 323 tests passed.
+- `npm test -- --run` — 35 test files passed; 324 tests passed.
 - `npm run build` — passed for core and runtime-omx TypeScript builds.
 - `npm pack --dry-run --json` — passed; package payload includes `.osc/cockpit.example.json`.
 - `node dist/cli.js cockpit config`, `node dist/cli.js cockpit test --dry-run`, `node dist/cli.js cockpit post --event status --message "Test message" --dry-run`, `node dist/cli.js cockpit post --event blocker --message "should send" --dry-run`, and missing-config `node dist/cli.js cockpit test` — passed.

--- a/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
+++ b/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
@@ -15,7 +15,7 @@ Added push-only glass-cockpit webhook support through `osc cockpit config`, `osc
 
 - `git diff --check` — passed.
 - `./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
-- `npm test -- --run` — 35 test files passed; 321 tests passed.
+- `npm test -- --run` — 35 test files passed; 322 tests passed.
 - `npm run build` — passed for core and runtime-omx TypeScript builds.
 - `npm pack --dry-run --json` — passed; package payload includes `.osc/cockpit.example.json`.
 - `node dist/cli.js cockpit config`, `node dist/cli.js cockpit test --dry-run`, `node dist/cli.js cockpit post --event status --message "Test message" --dry-run`, `node dist/cli.js cockpit post --event blocker --message "should send" --dry-run`, and missing-config `node dist/cli.js cockpit test` — passed.

--- a/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
+++ b/.osc/releases/2026-05-23-062-glass-cockpit-webhooks.md
@@ -9,7 +9,7 @@ Added push-only glass-cockpit webhook support through `osc cockpit config`, `osc
 - Roadmap / issue / task: selector mode `backlog_plan`; no GitHub issue existed for this slice.
 - Plan: .osc/plans/done/062-glass-cockpit-webhooks.md
 - Run ID / run packet: N/A — direct runner implementation for the selected plan.
-- Branch / PR: feat/062-glass-cockpit-webhooks; PR pending.
+- Branch / PR: feat/062-glass-cockpit-webhooks; https://github.com/graphanov/open-scaffold/pull/100
 
 ## Verification
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-23: closed 062-glass-cockpit-webhooks — added push-only Discord and Slack cockpit webhooks
 - 2026-05-23: closed 095-local-task-database-public-surface-sync — published 0.4.16 and aligned local task database public surfaces
 - 2026-05-23: record packaged init hotfix after public npx verification — see .osc/plans/done/095-local-task-database-public-surface-sync-amendment-1.md
 - 2026-05-23: closed 061-local-task-database — added local task database CLI

--- a/docs/GLASS_COCKPIT_PROTOCOL.md
+++ b/docs/GLASS_COCKPIT_PROTOCOL.md
@@ -404,6 +404,46 @@ Avoid:
 
 Glass cockpit events are the visible stream across those protocols. They do not replace any of them.
 
+## Implementation: `osc cockpit`
+
+Open Scaffold includes a minimal push-only webhook implementation for the protocol:
+
+```bash
+osc cockpit config
+osc cockpit test --dry-run
+osc cockpit test
+osc cockpit post --event status --message "Plan 062 in progress: implementing webhook dispatch" --dry-run
+osc cockpit post --event completion_report --run-id 20260518T120000Z-062 --plan 062-glass-cockpit-webhooks --pr "https://github.com/graphanov/open-scaffold/pull/56"
+osc cockpit post --event evidence_receipt --evidence-path ".osc/releases/2026-05-18-062-glass-cockpit-webhooks.md"
+osc cockpit post --event blocker --message "Blocked: waiting for webhook URL approval"
+osc cockpit post --event approval_request --message "Please review PR #56: 20 backlog items"
+```
+
+Configure webhook targets by copying `.osc/cockpit.example.json` to `.osc/cockpit.json` and replacing the placeholder URLs. `.osc/cockpit.json` is ignored by git because it contains credentials.
+
+```json
+{
+  "targets": [
+    {
+      "platform": "discord",
+      "webhookUrl": "https://discord.com/api/webhooks/...",
+      "events": ["status", "completion_report"]
+    },
+    {
+      "platform": "slack",
+      "webhookUrl": "https://hooks.slack.com/services/...",
+      "events": ["blocker", "approval_request"]
+    }
+  ]
+}
+```
+
+`osc cockpit config` prints configured targets with masked webhook URLs. `osc cockpit test --dry-run` and `osc cockpit post --dry-run` print the exact Discord embed or Slack Block Kit payload without sending anything. When no `.osc/cockpit.json` exists, cockpit commands exit successfully with `No cockpit targets configured. See .osc/cockpit.example.json`.
+
+Discord targets receive embed payloads with color-coded event types: green for completion/evidence/release, red for blockers, yellow for approval/questions, blue for status/session/PR updates, and gray for neutral events. Slack targets receive Block Kit messages with the same title, body, structured references, and footer.
+
+The v1 implementation is deliberately narrow: one-shot HTTP POST only. It does not receive messages, run a daemon, handle slash commands, store chat state, or make Discord/Slack canonical project truth.
+
 ## Product implication
 
 Open Scaffold should make semi-autonomous work visible without making visibility the truth:

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -116,7 +116,7 @@ Run `./verify.sh` for a zero-dependency methodology compliance report (mission d
 
 ### 5. Publish/review (when code or public docs change)
 
-Open a traceable GitHub PR for meaningful changes. The PR should link issue/task, plan/spec, `run.json` work package when delegated, verification, evidence, and review gates. If the Codex connector is enabled, trigger review by opening the PR for review, marking a draft ready, or commenting `@codex review`. See `docs/GITHUB_WORKFLOW.md`.
+Open a traceable GitHub PR for meaningful changes. The PR should link issue/task, plan/spec, `run.json` work package when delegated, verification, evidence, and review gates. If the Codex connector is enabled, trigger review by opening the PR for review, marking a draft ready, or commenting `@codex review`. When a configured Discord or Slack cockpit should see the update, use `osc cockpit post --event pr_link --pr <url>` or `osc cockpit post --event completion_report --run-id <id> --plan <slug> --pr <url>` after redaction review. See `docs/GITHUB_WORKFLOW.md`.
 
 ### 6. Capture amendments (when you "get smarter")
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "files": [
     "dist",
     ".osc/.gitignore",
+    ".osc/cockpit.example.json",
     ".osc/RULES.md",
     ".osc/plans/WORKFLOW.md",
     ".osc/plans/README.md",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { renderAuditManifest, validateAuditManifestFile, writeAuditManifest, type AuditArtifactInput } from './audit.js';
 import { createRunArtifacts, previewRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
+import { COCKPIT_EVENT_TYPES, CockpitConfigError, CockpitUsageError, formatCockpitConfig, formatCockpitDispatchSummary, hasCockpitDispatchFailures, loadCockpitConfig, postCockpitEvent, type CockpitEventType, type CockpitPostOptions } from './cockpit.js';
 import { doctorExitCode, formatDoctorReport, parseDoctorCheckName, runDoctor, type DoctorOptions, type DoctorSeverity } from './doctor.js';
 import { collectEvidence } from './evidence.js';
 import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
@@ -54,6 +55,9 @@ Usage:
   osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text>
   osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>]
   osc evolve check <loop-dir>
+  osc cockpit config
+  osc cockpit test [--dry-run]
+  osc cockpit post --event <event> [--message <text>] [--run-id <id>] [--plan <slug>] [--task-id <id>] [--pr <url>] [--evidence-path <path>] [--dry-run]
   osc mcp serve [--repo <path>] [--allow-write] [--validate]
   osc metrics [--json] [--since <date>] [--lookback <weeks>] [--table] [--verbose]
   osc verify
@@ -1795,6 +1799,129 @@ function runtimes(args: string[]): void {
   process.exit(2);
 }
 
+function printCockpitUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc cockpit config
+  osc cockpit test [--dry-run]
+  osc cockpit post --event <${COCKPIT_EVENT_TYPES.join('|')}> [--message <text>] [--run-id <id>] [--plan <slug>] [--task-id <id>] [--pr <url>] [--evidence-path <path>] [--dry-run]`, stream);
+}
+
+function takeCockpitValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new CockpitUsageError(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function parseCockpitPostOptions(args: string[]): CockpitPostOptions {
+  let event: CockpitEventType | undefined;
+  let message: string | undefined;
+  let runId: string | undefined;
+  let planSlug: string | undefined;
+  let taskId: string | undefined;
+  let pr: string | undefined;
+  let evidencePath: string | undefined;
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const flag = args[i];
+    switch (flag) {
+      case '--event':
+        event = parseChoice(takeCockpitValue(args, i, flag), COCKPIT_EVENT_TYPES, flag) as CockpitEventType;
+        i += 1;
+        break;
+      case '--message':
+        message = takeCockpitValue(args, i, flag);
+        i += 1;
+        break;
+      case '--run-id':
+        runId = takeCockpitValue(args, i, flag);
+        i += 1;
+        break;
+      case '--plan':
+        planSlug = takeCockpitValue(args, i, flag);
+        i += 1;
+        break;
+      case '--task-id':
+        taskId = takeCockpitValue(args, i, flag);
+        i += 1;
+        break;
+      case '--pr':
+        pr = takeCockpitValue(args, i, flag);
+        i += 1;
+        break;
+      case '--evidence-path':
+        evidencePath = takeCockpitValue(args, i, flag);
+        i += 1;
+        break;
+      case '--dry-run':
+        dryRun = true;
+        break;
+      default:
+        throw new CockpitUsageError(`Unknown option for cockpit post: ${flag}`);
+    }
+  }
+  if (!event) throw new CockpitUsageError(`Missing required option: --event <${COCKPIT_EVENT_TYPES.join('|')}>`);
+  return { event, message, runId, planSlug, taskId, pr, evidencePath, dryRun };
+}
+
+function parseCockpitTestOptions(args: string[]): { dryRun: boolean } {
+  let dryRun = false;
+  for (const arg of args) {
+    if (arg === '--dry-run') dryRun = true;
+    else throw new CockpitUsageError(`Unknown option for cockpit test: ${arg}`);
+  }
+  return { dryRun };
+}
+
+async function cockpitCommand(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args;
+  if (subcommand === undefined || isHelpArg(subcommand)) {
+    printCockpitUsage('stdout');
+    return;
+  }
+
+  try {
+    if (subcommand === 'config') {
+      if (rest.length > 0) throw new CockpitUsageError(`Unknown option for cockpit config: ${rest[0]}`);
+      process.stdout.write(formatCockpitConfig(loadCockpitConfig(process.cwd())));
+      return;
+    }
+
+    if (subcommand === 'test') {
+      const options = parseCockpitTestOptions(rest);
+      const summary = await postCockpitEvent({ event: 'status', message: 'Open Scaffold cockpit test message.', dryRun: options.dryRun, testMode: true }, process.cwd());
+      process.stdout.write(formatCockpitDispatchSummary(summary));
+      if (hasCockpitDispatchFailures(summary)) process.exit(1);
+      return;
+    }
+
+    if (subcommand === 'post') {
+      const options = parseCockpitPostOptions(rest);
+      const summary = await postCockpitEvent(options, process.cwd());
+      process.stdout.write(formatCockpitDispatchSummary(summary));
+      if (hasCockpitDispatchFailures(summary)) process.exit(1);
+      return;
+    }
+  } catch (error) {
+    if (error instanceof CockpitUsageError) {
+      console.error(error.message);
+      printCockpitUsage();
+      process.exit(2);
+    }
+    if (error instanceof CockpitConfigError) {
+      console.error(error.message);
+      process.exit(1);
+    }
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  console.error(`Unknown cockpit subcommand: ${subcommand}`);
+  printCockpitUsage();
+  process.exit(2);
+}
+
 async function main(): Promise<void> {
   const [command, ...args] = process.argv.slice(2);
   switch (command) {
@@ -1841,6 +1968,9 @@ async function main(): Promise<void> {
     }
     case 'metrics':
       metricsCommand(args);
+      return;
+    case 'cockpit':
+      await cockpitCommand(args);
       return;
     case 'evidence':
       evidenceCommand(args);

--- a/src/cockpit.ts
+++ b/src/cockpit.ts
@@ -306,14 +306,15 @@ export function buildDiscordPayload(options: CockpitPostOptions, root = resolveR
 
 export function buildSlackPayload(options: CockpitPostOptions, root = resolveRoot()): Record<string, unknown> {
   const envelope = buildCockpitEnvelope(options, root);
+  const body = truncate(envelope.body, 3000);
   const fields = refsToSlackFields(envelope.refs);
   const blocks: unknown[] = [
     { type: 'header', text: { type: 'plain_text', text: truncate(envelope.title, 150), emoji: true } },
-    { type: 'section', text: { type: 'mrkdwn', text: envelope.body } },
+    { type: 'section', text: { type: 'mrkdwn', text: body } },
   ];
   if (fields.length > 0) blocks.push({ type: 'section', fields });
   blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: footerText(root) }] });
-  return { text: `${envelope.title}: ${envelope.body}`, blocks };
+  return { text: truncate(`${envelope.title}: ${body}`, 3000), blocks };
 }
 
 export function buildCockpitPayload(platform: CockpitPlatform, options: CockpitPostOptions, root = resolveRoot()): Record<string, unknown> {

--- a/src/cockpit.ts
+++ b/src/cockpit.ts
@@ -293,11 +293,11 @@ export function buildDiscordPayload(options: CockpitPostOptions, root = resolveR
     username: 'Open Scaffold',
     embeds: [
       {
-        title: envelope.title,
-        description: envelope.body,
+        title: truncate(envelope.title, 256),
+        description: truncate(envelope.body, 4096),
         color: discordColors[envelope.event_type],
         fields: refsToDiscordFields(envelope.refs),
-        footer: { text: footerText(root) },
+        footer: { text: truncate(footerText(root), 2048) },
         timestamp: envelope.created_at,
       },
     ],

--- a/src/cockpit.ts
+++ b/src/cockpit.ts
@@ -276,7 +276,7 @@ function refsToDiscordFields(refs: Record<string, string>): Array<{ name: string
 }
 
 function refsToSlackFields(refs: Record<string, string>): Array<{ type: 'mrkdwn'; text: string }> {
-  return Object.entries(refs).map(([name, value]) => ({ type: 'mrkdwn', text: `*${name}*\n\`${truncate(value, 2800)}\`` }));
+  return Object.entries(refs).map(([name, value]) => ({ type: 'mrkdwn', text: `*${name}*\n\`${truncate(value, 1900)}\`` }));
 }
 
 function footerText(root: string): string {

--- a/src/cockpit.ts
+++ b/src/cockpit.ts
@@ -1,0 +1,411 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findScaffoldRoot } from './scaffold.js';
+
+export const COCKPIT_EVENT_TYPES = [
+  'nudge',
+  'session_start',
+  'status',
+  'blocker',
+  'question',
+  'answer',
+  'approval_request',
+  'completion_report',
+  'evidence_receipt',
+  'pr_link',
+  'release_link',
+  'cancellation',
+] as const;
+
+export const COCKPIT_PLATFORMS = ['discord', 'slack'] as const;
+
+export type CockpitEventType = (typeof COCKPIT_EVENT_TYPES)[number];
+export type CockpitPlatform = (typeof COCKPIT_PLATFORMS)[number];
+
+export interface CockpitTarget {
+  name?: string;
+  platform: CockpitPlatform;
+  webhookUrl: string;
+  events: CockpitEventType[];
+}
+
+export interface CockpitConfig {
+  exists: boolean;
+  path: string;
+  root: string;
+  targets: CockpitTarget[];
+}
+
+export interface CockpitPostOptions {
+  event: CockpitEventType;
+  message?: string;
+  title?: string;
+  taskId?: string;
+  runId?: string;
+  planSlug?: string;
+  pr?: string;
+  evidencePath?: string;
+  dryRun?: boolean;
+  testMode?: boolean;
+  now?: Date;
+}
+
+export interface CockpitTargetSummary {
+  name?: string;
+  platform: CockpitPlatform;
+  events: CockpitEventType[];
+}
+
+export interface CockpitDispatchResult {
+  target: CockpitTargetSummary;
+  status: 'sent' | 'dry_run' | 'skipped' | 'failed';
+  maskedUrl: string;
+  reason?: string;
+  httpStatus?: number;
+  responseSnippet?: string;
+  payload?: unknown;
+}
+
+export interface CockpitDispatchSummary {
+  configured: boolean;
+  configPath: string;
+  root: string;
+  results: CockpitDispatchResult[];
+}
+
+interface EventEnvelope {
+  schema: 'open-scaffold.cockpit_event.v1';
+  event_id: string;
+  created_at: string;
+  event_type: CockpitEventType;
+  visibility: 'private' | 'internal' | 'public' | 'stakeholder';
+  source: { kind: 'manual'; name: 'osc cockpit' };
+  refs: Record<string, string>;
+  title: string;
+  body: string;
+  requires_response: boolean;
+  redaction: 'public_safe' | 'internal_only' | 'private_sensitive';
+  next_action: string;
+}
+
+export class CockpitUsageError extends Error {}
+export class CockpitConfigError extends Error {}
+
+export const NO_COCKPIT_TARGETS_MESSAGE = 'No cockpit targets configured. See .osc/cockpit.example.json';
+
+const eventTitles: Record<CockpitEventType, string> = {
+  nudge: 'Nudge',
+  session_start: 'Session started',
+  status: 'Status update',
+  blocker: 'Blocker',
+  question: 'Question',
+  answer: 'Answer',
+  approval_request: 'Approval requested',
+  completion_report: 'Completion report',
+  evidence_receipt: 'Evidence receipt',
+  pr_link: 'Pull request ready',
+  release_link: 'Release link',
+  cancellation: 'Cancellation',
+};
+
+const nextActions: Record<CockpitEventType, string> = {
+  nudge: 'none',
+  session_start: 'none',
+  status: 'none',
+  blocker: 'unblock',
+  question: 'answer_question',
+  answer: 'none',
+  approval_request: 'approve',
+  completion_report: 'inspect_evidence',
+  evidence_receipt: 'inspect_evidence',
+  pr_link: 'review_pr',
+  release_link: 'none',
+  cancellation: 'none',
+};
+
+const discordColors: Record<CockpitEventType, number> = {
+  nudge: 0x95a5a6,
+  session_start: 0x3498db,
+  status: 0x3498db,
+  blocker: 0xe74c3c,
+  question: 0xf1c40f,
+  answer: 0x95a5a6,
+  approval_request: 0xf1c40f,
+  completion_report: 0x2ecc71,
+  evidence_receipt: 0x2ecc71,
+  pr_link: 0x3498db,
+  release_link: 0x2ecc71,
+  cancellation: 0x95a5a6,
+};
+
+function packageRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..');
+}
+
+function packageVersion(): string {
+  try {
+    const parsed = JSON.parse(readFileSync(join(packageRoot(), 'package.json'), 'utf8')) as { version?: unknown };
+    return typeof parsed.version === 'string' ? parsed.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function resolveRoot(start = process.cwd()): string {
+  return findScaffoldRoot(start) ?? resolve(start);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isCockpitPlatform(value: unknown): value is CockpitPlatform {
+  return typeof value === 'string' && (COCKPIT_PLATFORMS as readonly string[]).includes(value);
+}
+
+function isCockpitEventType(value: unknown): value is CockpitEventType {
+  return typeof value === 'string' && (COCKPIT_EVENT_TYPES as readonly string[]).includes(value);
+}
+
+export function cockpitConfigPath(root: string): string {
+  return join(root, '.osc', 'cockpit.json');
+}
+
+export function maskWebhookUrl(url: string): string {
+  return `${url.slice(0, 20)}...`;
+}
+
+function validateTarget(raw: unknown, index: number): CockpitTarget {
+  if (!isObject(raw)) throw new CockpitConfigError(`cockpit target ${index + 1} must be an object`);
+  const platform = raw.platform;
+  if (!isCockpitPlatform(platform)) {
+    throw new CockpitConfigError(`cockpit target ${index + 1} has unsupported platform: ${String(platform)}. Expected discord or slack.`);
+  }
+  if (typeof raw.webhookUrl !== 'string' || raw.webhookUrl.trim() === '') {
+    throw new CockpitConfigError(`cockpit target ${index + 1} must include webhookUrl`);
+  }
+  if (!Array.isArray(raw.events)) {
+    throw new CockpitConfigError(`cockpit target ${index + 1} must include events as an array`);
+  }
+  const events = raw.events.map((event, eventIndex) => {
+    if (!isCockpitEventType(event)) {
+      throw new CockpitConfigError(`cockpit target ${index + 1} has unsupported event at events[${eventIndex}]: ${String(event)}`);
+    }
+    return event;
+  });
+  const name = typeof raw.name === 'string' && raw.name.trim() ? raw.name.trim() : undefined;
+  return { name, platform, webhookUrl: raw.webhookUrl.trim(), events };
+}
+
+export function loadCockpitConfig(start = process.cwd()): CockpitConfig {
+  const root = resolveRoot(start);
+  const path = cockpitConfigPath(root);
+  if (!existsSync(path)) return { exists: false, path, root, targets: [] };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CockpitConfigError(`Failed to parse .osc/cockpit.json: ${message}`);
+  }
+  if (!isObject(parsed)) throw new CockpitConfigError('.osc/cockpit.json must contain a JSON object');
+  if (!Array.isArray(parsed.targets)) throw new CockpitConfigError('.osc/cockpit.json must include a targets array');
+  const targets = parsed.targets.map(validateTarget);
+  return { exists: true, path, root, targets };
+}
+
+export function formatCockpitConfig(config: CockpitConfig): string {
+  if (!config.exists || config.targets.length === 0) return `${NO_COCKPIT_TARGETS_MESSAGE}\n`;
+  const lines = ['Cockpit targets:'];
+  for (const target of config.targets) {
+    const label = target.name ? `${target.platform} (${target.name})` : target.platform;
+    lines.push(`- ${label} ${maskWebhookUrl(target.webhookUrl)} events: ${target.events.join(', ') || '(none)'}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function refsFromOptions(options: CockpitPostOptions): Record<string, string> {
+  const refs: Record<string, string> = {};
+  if (options.taskId) refs.task_id = options.taskId;
+  if (options.runId) refs.run_id = options.runId;
+  if (options.planSlug) refs.plan_slug = options.planSlug;
+  if (options.pr) refs.pr = options.pr;
+  if (options.evidencePath) refs.evidence_path = options.evidencePath;
+  return refs;
+}
+
+function defaultBody(options: CockpitPostOptions): string {
+  if (options.testMode) return 'Open Scaffold cockpit test message.';
+  if (options.message?.trim()) return options.message.trim();
+  if (options.event === 'completion_report') return 'Open Scaffold completion report.';
+  if (options.event === 'evidence_receipt') return 'Open Scaffold evidence receipt.';
+  if (options.event === 'pr_link') return 'Open Scaffold pull request link.';
+  if (options.event === 'approval_request') return 'Open Scaffold approval requested.';
+  if (options.event === 'blocker') return 'Open Scaffold blocker.';
+  return `Open Scaffold ${options.event.replace(/_/g, ' ')} event.`;
+}
+
+function eventIdFrom(date: Date, event: CockpitEventType): string {
+  const stamp = date.toISOString().replace(/[-:.]/g, '').slice(0, 15);
+  return `evt_${stamp}_${event}`;
+}
+
+export function buildCockpitEnvelope(options: CockpitPostOptions, root = resolveRoot()): EventEnvelope {
+  const createdAt = options.now ?? new Date();
+  const requiresResponse = options.event === 'question' || options.event === 'approval_request';
+  return {
+    schema: 'open-scaffold.cockpit_event.v1',
+    event_id: eventIdFrom(createdAt, options.event),
+    created_at: createdAt.toISOString(),
+    event_type: options.event,
+    visibility: 'internal',
+    source: { kind: 'manual', name: 'osc cockpit' },
+    refs: refsFromOptions(options),
+    title: options.title?.trim() || eventTitles[options.event],
+    body: defaultBody(options),
+    requires_response: requiresResponse,
+    redaction: 'internal_only',
+    next_action: nextActions[options.event],
+  };
+}
+
+function refsToDiscordFields(refs: Record<string, string>): Array<{ name: string; value: string; inline: boolean }> {
+  return Object.entries(refs).map(([name, value]) => ({ name, value: truncate(value, 1024), inline: true }));
+}
+
+function refsToSlackFields(refs: Record<string, string>): Array<{ type: 'mrkdwn'; text: string }> {
+  return Object.entries(refs).map(([name, value]) => ({ type: 'mrkdwn', text: `*${name}*\n\`${truncate(value, 2800)}\`` }));
+}
+
+function footerText(root: string): string {
+  return `osc cockpit v${packageVersion()} • repo: ${root}`;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 1))}…`;
+}
+
+export function buildDiscordPayload(options: CockpitPostOptions, root = resolveRoot()): Record<string, unknown> {
+  const envelope = buildCockpitEnvelope(options, root);
+  return {
+    username: 'Open Scaffold',
+    embeds: [
+      {
+        title: envelope.title,
+        description: envelope.body,
+        color: discordColors[envelope.event_type],
+        fields: refsToDiscordFields(envelope.refs),
+        footer: { text: footerText(root) },
+        timestamp: envelope.created_at,
+      },
+    ],
+  };
+}
+
+export function buildSlackPayload(options: CockpitPostOptions, root = resolveRoot()): Record<string, unknown> {
+  const envelope = buildCockpitEnvelope(options, root);
+  const fields = refsToSlackFields(envelope.refs);
+  const blocks: unknown[] = [
+    { type: 'header', text: { type: 'plain_text', text: truncate(envelope.title, 150), emoji: true } },
+    { type: 'section', text: { type: 'mrkdwn', text: envelope.body } },
+  ];
+  if (fields.length > 0) blocks.push({ type: 'section', fields });
+  blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: footerText(root) }] });
+  return { text: `${envelope.title}: ${envelope.body}`, blocks };
+}
+
+export function buildCockpitPayload(platform: CockpitPlatform, options: CockpitPostOptions, root = resolveRoot()): Record<string, unknown> {
+  if (platform === 'discord') return buildDiscordPayload(options, root);
+  return buildSlackPayload(options, root);
+}
+
+function targetAcceptsEvent(target: CockpitTarget, event: CockpitEventType): boolean {
+  return target.events.includes(event);
+}
+
+function summarizeTarget(target: CockpitTarget): CockpitTargetSummary {
+  return { name: target.name, platform: target.platform, events: target.events };
+}
+
+async function sendWebhook(target: CockpitTarget, payload: unknown): Promise<{ ok: true } | { ok: false; httpStatus?: number; responseSnippet: string }> {
+  try {
+    const response = await fetch(target.webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (response.ok) return { ok: true };
+    const body = await response.text().catch(() => '');
+    return { ok: false, httpStatus: response.status, responseSnippet: truncate(body, 300) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, responseSnippet: truncate(message, 300) };
+  }
+}
+
+export async function postCockpitEvent(options: CockpitPostOptions, start = process.cwd()): Promise<CockpitDispatchSummary> {
+  const config = loadCockpitConfig(start);
+  if (!config.exists || config.targets.length === 0) {
+    return { configured: false, configPath: config.path, root: config.root, results: [] };
+  }
+
+  const results: CockpitDispatchResult[] = [];
+  for (const target of config.targets) {
+    const targetSummary = summarizeTarget(target);
+    const maskedUrl = maskWebhookUrl(target.webhookUrl);
+    const shouldSend = options.testMode || targetAcceptsEvent(target, options.event);
+    const payload = buildCockpitPayload(target.platform, options, config.root);
+    if (!shouldSend) {
+      results.push({ target: targetSummary, status: 'skipped', maskedUrl, reason: `event ${options.event} not enabled for target`, payload });
+      continue;
+    }
+    if (options.dryRun) {
+      results.push({ target: targetSummary, status: 'dry_run', maskedUrl, payload });
+      continue;
+    }
+    const sent = await sendWebhook(target, payload);
+    if (sent.ok) {
+      results.push({ target: targetSummary, status: 'sent', maskedUrl });
+    } else {
+      results.push({
+        target: targetSummary,
+        status: 'failed',
+        maskedUrl,
+        httpStatus: sent.httpStatus,
+        responseSnippet: sent.responseSnippet,
+      });
+    }
+  }
+  return { configured: true, configPath: config.path, root: config.root, results };
+}
+
+function targetLabel(target: CockpitTargetSummary): string {
+  return target.name ? `${target.platform} (${target.name})` : target.platform;
+}
+
+export function formatCockpitDispatchSummary(summary: CockpitDispatchSummary): string {
+  if (!summary.configured) return `${NO_COCKPIT_TARGETS_MESSAGE}\n`;
+  const lines: string[] = [];
+  for (const result of summary.results) {
+    const label = targetLabel(result.target);
+    if (result.status === 'sent') {
+      lines.push(`sent ${label} ${result.maskedUrl}`);
+    } else if (result.status === 'skipped') {
+      lines.push(`skipped ${label} ${result.maskedUrl}: ${result.reason}`);
+    } else if (result.status === 'failed') {
+      const status = result.httpStatus ? `HTTP ${result.httpStatus}` : 'request failed';
+      const snippet = result.responseSnippet ? `: ${result.responseSnippet}` : '';
+      lines.push(`failed ${label} ${status}${snippet}`);
+    } else {
+      lines.push(`dry-run ${label} ${result.maskedUrl}`);
+      lines.push(JSON.stringify(result.payload, null, 2));
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function hasCockpitDispatchFailures(summary: CockpitDispatchSummary): boolean {
+  return summary.results.some((result) => result.status === 'failed');
+}

--- a/src/cockpit.ts
+++ b/src/cockpit.ts
@@ -139,6 +139,13 @@ const discordColors: Record<CockpitEventType, number> = {
   cancellation: 0x95a5a6,
 };
 
+const DISCORD_EMBED_TOTAL_LIMIT = 6000;
+const DISCORD_TITLE_LIMIT = 256;
+const DISCORD_DESCRIPTION_LIMIT = 4096;
+const DISCORD_FOOTER_SOFT_LIMIT = 512;
+const DISCORD_FIELD_VALUE_SOFT_LIMIT = 600;
+const WEBHOOK_TIMEOUT_MS = 10_000;
+
 function packageRoot(): string {
   return resolve(dirname(fileURLToPath(import.meta.url)), '..');
 }
@@ -272,7 +279,11 @@ export function buildCockpitEnvelope(options: CockpitPostOptions, root = resolve
 }
 
 function refsToDiscordFields(refs: Record<string, string>): Array<{ name: string; value: string; inline: boolean }> {
-  return Object.entries(refs).map(([name, value]) => ({ name, value: truncate(value, 1024), inline: true }));
+  return Object.entries(refs).map(([name, value]) => ({
+    name: truncate(name, DISCORD_TITLE_LIMIT),
+    value: truncate(value, DISCORD_FIELD_VALUE_SOFT_LIMIT),
+    inline: true,
+  }));
 }
 
 function refsToSlackFields(refs: Record<string, string>): Array<{ type: 'mrkdwn'; text: string }> {
@@ -287,17 +298,31 @@ function truncate(value: string, max: number): string {
   return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 1))}…`;
 }
 
+function discordFieldsLength(fields: Array<{ name: string; value: string }>): number {
+  return fields.reduce((total, field) => total + field.name.length + field.value.length, 0);
+}
+
+function fitDiscordDescription(body: string, title: string, fields: Array<{ name: string; value: string }>, footer: string): string {
+  const used = title.length + footer.length + discordFieldsLength(fields);
+  const availableForDescription = Math.max(0, DISCORD_EMBED_TOTAL_LIMIT - used);
+  return truncate(body, Math.min(DISCORD_DESCRIPTION_LIMIT, availableForDescription));
+}
+
 export function buildDiscordPayload(options: CockpitPostOptions, root = resolveRoot()): Record<string, unknown> {
   const envelope = buildCockpitEnvelope(options, root);
+  const title = truncate(envelope.title, DISCORD_TITLE_LIMIT);
+  const fields = refsToDiscordFields(envelope.refs);
+  const footer = truncate(footerText(root), DISCORD_FOOTER_SOFT_LIMIT);
+  const description = fitDiscordDescription(envelope.body, title, fields, footer);
   return {
     username: 'Open Scaffold',
     embeds: [
       {
-        title: truncate(envelope.title, 256),
-        description: truncate(envelope.body, 4096),
+        title,
+        description,
         color: discordColors[envelope.event_type],
-        fields: refsToDiscordFields(envelope.refs),
-        footer: { text: truncate(footerText(root), 2048) },
+        fields,
+        footer: { text: footer },
         timestamp: envelope.created_at,
       },
     ],
@@ -336,6 +361,7 @@ async function sendWebhook(target: CockpitTarget, payload: unknown): Promise<{ o
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
     });
     if (response.ok) return { ok: true };
     const body = await response.text().catch(() => '');

--- a/src/init.ts
+++ b/src/init.ts
@@ -9,6 +9,7 @@ export type ScaffoldTier = (typeof scaffoldTiers)[number];
 const minFiles = [
   'MISSION.md',
   '.osc/.gitignore',
+  '.osc/cockpit.example.json',
   '.osc/RULES.md',
   '.osc/plans/WORKFLOW.md',
   '.osc/plans/README.md',

--- a/tests/cockpit.test.ts
+++ b/tests/cockpit.test.ts
@@ -113,6 +113,20 @@ describe('osc cockpit webhooks', () => {
     expect(slack.text.length).toBeLessThanOrEqual(3_000);
   });
 
+  it('keeps Slack field text under the Block Kit field limit', () => {
+    const root = tempScaffold();
+    const longRef = `https://example.com/${'x'.repeat(3_000)}`;
+
+    const slack = buildSlackPayload({ event: 'completion_report', pr: longRef, evidencePath: longRef }, root) as { blocks: Array<{ type: string; fields?: Array<{ text: string }> }> };
+    const fields = slack.blocks.flatMap((block) => block.fields ?? []);
+
+    expect(fields).toHaveLength(2);
+    for (const field of fields) {
+      expect(field.text.length).toBeLessThanOrEqual(2_000);
+      expect(field.text.endsWith('…`')).toBe(true);
+    }
+  });
+
   it('dry-runs exact payloads and skips targets whose events list does not include the event', () => {
     const root = tempScaffold();
     writeConfig(root);

--- a/tests/cockpit.test.ts
+++ b/tests/cockpit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -46,6 +46,8 @@ function runOsc(root: string, args: string[]) {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
@@ -124,7 +126,31 @@ describe('osc cockpit webhooks', () => {
     expect(discord.embeds[0].title.endsWith('…')).toBe(true);
     expect(discord.embeds[0].description).toHaveLength(4_096);
     expect(discord.embeds[0].description.endsWith('…')).toBe(true);
-    expect(discord.embeds[0].footer.text.length).toBeLessThanOrEqual(2_048);
+    expect(discord.embeds[0].footer.text.length).toBeLessThanOrEqual(512);
+  });
+
+  it('keeps Discord embed text under the 6000-character aggregate limit', () => {
+    const root = tempScaffold();
+    const longBody = 'd'.repeat(5_000);
+    const longRef = `https://example.com/${'r'.repeat(3_000)}`;
+
+    const discord = buildDiscordPayload({
+      event: 'completion_report',
+      message: longBody,
+      runId: longRef,
+      planSlug: longRef,
+      taskId: longRef,
+      pr: longRef,
+      evidencePath: longRef,
+    }, root) as { embeds: Array<{ title: string; description: string; footer: { text: string }; fields: Array<{ name: string; value: string }> }> };
+    const embed = discord.embeds[0];
+    const totalLength = embed.title.length
+      + embed.description.length
+      + embed.footer.text.length
+      + embed.fields.reduce((sum, field) => sum + field.name.length + field.value.length, 0);
+
+    expect(totalLength).toBeLessThanOrEqual(6_000);
+    for (const field of embed.fields) expect(field.value.length).toBeLessThanOrEqual(600);
   });
 
   it('keeps Slack field text under the Block Kit field limit', () => {
@@ -194,6 +220,21 @@ describe('osc cockpit webhooks', () => {
     } finally {
       await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
     }
+  });
+
+  it('passes an abort signal to webhook POST requests', async () => {
+    const root = tempScaffold();
+    writeConfig(root, 'https://discord.com/api/webhooks/1234567890/test');
+    const fetchSpy = vi.fn(async () => ({ ok: true, text: async () => '' } as Response));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const summary = await postCockpitEvent({ event: 'status', message: 'timeout guarded' }, root);
+
+    expect(summary.results[0]).toMatchObject({ status: 'sent' });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://discord.com/api/webhooks/1234567890/test',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it('sends a real one-shot HTTP POST and reports success', async () => {

--- a/tests/cockpit.test.ts
+++ b/tests/cockpit.test.ts
@@ -113,6 +113,20 @@ describe('osc cockpit webhooks', () => {
     expect(slack.text.length).toBeLessThanOrEqual(3_000);
   });
 
+  it('truncates Discord embed title and description to Discord limits', () => {
+    const root = tempScaffold();
+    const longTitle = 't'.repeat(500);
+    const longBody = 'd'.repeat(5_000);
+
+    const discord = buildDiscordPayload({ event: 'status', title: longTitle, message: longBody }, root) as { embeds: Array<{ title: string; description: string; footer: { text: string } }> };
+
+    expect(discord.embeds[0].title).toHaveLength(256);
+    expect(discord.embeds[0].title.endsWith('…')).toBe(true);
+    expect(discord.embeds[0].description).toHaveLength(4_096);
+    expect(discord.embeds[0].description.endsWith('…')).toBe(true);
+    expect(discord.embeds[0].footer.text.length).toBeLessThanOrEqual(2_048);
+  });
+
   it('keeps Slack field text under the Block Kit field limit', () => {
     const root = tempScaffold();
     const longRef = `https://example.com/${'x'.repeat(3_000)}`;

--- a/tests/cockpit.test.ts
+++ b/tests/cockpit.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  buildDiscordPayload,
+  buildSlackPayload,
+  formatCockpitConfig,
+  hasCockpitDispatchFailures,
+  loadCockpitConfig,
+  maskWebhookUrl,
+  postCockpitEvent,
+} from '../src/cockpit.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+const roots: string[] = [];
+
+function tempScaffold(prefix = 'osc-cockpit-') {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/backlog'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/blocked'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/done'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nTest cockpit project.\n');
+  writeFileSync(join(root, '.osc/releases/README.md'), '# Releases\n');
+  return root;
+}
+
+function writeConfig(root: string, webhookUrl = 'https://discord.com/api/webhooks/1234567890/test') {
+  writeFileSync(join(root, '.osc/cockpit.json'), JSON.stringify({
+    targets: [
+      { name: 'build-stream', platform: 'discord', webhookUrl, events: ['status', 'completion_report', 'evidence_receipt'] },
+      { name: 'review-room', platform: 'slack', webhookUrl: 'https://hooks.slack.com/services/T000/B000/secret', events: ['blocker', 'approval_request'] },
+    ],
+  }, null, 2));
+}
+
+function runOsc(root: string, args: string[]) {
+  return spawnSync(tsx, [cli, ...args], { cwd: root, encoding: 'utf8' });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('osc cockpit webhooks', () => {
+  it('prints a graceful missing-config message with exit 0', () => {
+    const root = tempScaffold();
+
+    const config = runOsc(root, ['cockpit', 'config']);
+    const test = runOsc(root, ['cockpit', 'test']);
+
+    expect(config.status).toBe(0);
+    expect(config.stdout).toContain('No cockpit targets configured. See .osc/cockpit.example.json');
+    expect(test.status).toBe(0);
+    expect(test.stdout).toContain('No cockpit targets configured. See .osc/cockpit.example.json');
+  }, 20_000);
+
+  it('loads config and masks webhook URLs in config output', () => {
+    const root = tempScaffold();
+    writeConfig(root);
+
+    const config = loadCockpitConfig(root);
+    const rendered = formatCockpitConfig(config);
+    const cliConfig = runOsc(root, ['cockpit', 'config']);
+
+    expect(config.targets).toHaveLength(2);
+    expect(maskWebhookUrl(config.targets[0].webhookUrl)).toBe('https://discord.com/...');
+    expect(rendered).toContain('discord (build-stream) https://discord.com/... events: status, completion_report, evidence_receipt');
+    expect(cliConfig.status).toBe(0);
+    expect(cliConfig.stdout).toContain('slack (review-room) https://hooks.slack.... events: blocker, approval_request');
+    expect(cliConfig.stdout).not.toContain('/secret');
+  }, 20_000);
+
+  it('builds structured Discord embeds and Slack blocks with refs and footer', () => {
+    const root = tempScaffold();
+    const options = {
+      event: 'completion_report' as const,
+      runId: '20260518T120000Z-062',
+      planSlug: '062-glass-cockpit-webhooks',
+      taskId: 'issue:62',
+      pr: 'https://github.com/graphanov/open-scaffold/pull/100',
+      now: new Date('2026-05-23T18:00:00.000Z'),
+    };
+
+    const discord = buildDiscordPayload(options, root) as { embeds: Array<Record<string, unknown>> };
+    const slack = buildSlackPayload(options, root) as { blocks: Array<Record<string, unknown>> };
+
+    expect(discord.embeds[0].title).toBe('Completion report');
+    expect(discord.embeds[0].color).toBe(0x2ecc71);
+    expect(discord.embeds[0].fields).toContainEqual({ name: 'run_id', value: '20260518T120000Z-062', inline: true });
+    expect(discord.embeds[0].footer).toEqual({ text: expect.stringContaining(`repo: ${root}`) });
+    expect(slack.blocks[0]).toMatchObject({ type: 'header', text: { type: 'plain_text', text: 'Completion report', emoji: true } });
+    expect(JSON.stringify(slack.blocks)).toContain('*plan_slug*');
+    expect(JSON.stringify(slack.blocks)).toContain(`repo: ${root}`);
+  });
+
+  it('dry-runs exact payloads and skips targets whose events list does not include the event', () => {
+    const root = tempScaffold();
+    writeConfig(root);
+
+    const status = runOsc(root, ['cockpit', 'post', '--event', 'status', '--message', 'Plan 062 in progress: implementing webhook dispatch', '--dry-run']);
+    const blocker = runOsc(root, ['cockpit', 'post', '--event', 'blocker', '--message', 'Blocked: waiting for webhook URL approval', '--dry-run']);
+
+    expect(status.status).toBe(0);
+    expect(status.stdout).toContain('dry-run discord (build-stream) https://discord.com/...');
+    expect(status.stdout).toContain('Plan 062 in progress: implementing webhook dispatch');
+    expect(status.stdout).toContain('skipped slack (review-room) https://hooks.slack....: event status not enabled for target');
+
+    expect(blocker.status).toBe(0);
+    expect(blocker.stdout).toContain('skipped discord (build-stream) https://discord.com/...: event blocker not enabled for target');
+    expect(blocker.stdout).toContain('dry-run slack (review-room) https://hooks.slack....');
+    expect(blocker.stdout).toContain('Blocked: waiting for webhook URL approval');
+  }, 20_000);
+
+  it('test --dry-run sends the test message shape to every configured target regardless of event filter', () => {
+    const root = tempScaffold();
+    writeConfig(root);
+
+    const result = runOsc(root, ['cockpit', 'test', '--dry-run']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('dry-run discord (build-stream) https://discord.com/...');
+    expect(result.stdout).toContain('dry-run slack (review-room) https://hooks.slack....');
+    expect(result.stdout).toContain('Open Scaffold cockpit test message.');
+  }, 20_000);
+
+  it('reports webhook HTTP failures without printing the full webhook URL', async () => {
+    const root = tempScaffold();
+    const server = await new Promise<Server>((resolveServer) => {
+      const candidate = createServer((_, response) => {
+        response.writeHead(503, { 'content-type': 'text/plain' });
+        response.end('service unavailable for test target');
+      });
+      candidate.listen(0, '127.0.0.1', () => resolveServer(candidate));
+    });
+    const address = server.address();
+    if (typeof address !== 'object' || address === null) throw new Error('missing test server address');
+    const webhookUrl = `http://127.0.0.1:${address.port}/discord-webhook-secret-token`;
+    writeConfig(root, webhookUrl);
+
+    try {
+      const summary = await postCockpitEvent({ event: 'status', message: 'Should fail cleanly' }, root);
+
+      expect(hasCockpitDispatchFailures(summary)).toBe(true);
+      expect(summary.results[0]).toMatchObject({ status: 'failed', httpStatus: 503, responseSnippet: 'service unavailable for test target' });
+      expect(JSON.stringify(summary.results)).not.toContain('discord-webhook-secret-token');
+    } finally {
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    }
+  });
+
+  it('sends a real one-shot HTTP POST and reports success', async () => {
+    const root = tempScaffold();
+    let received = '';
+    const server = await new Promise<Server>((resolveServer) => {
+      const candidate = createServer((request, response) => {
+        request.setEncoding('utf8');
+        request.on('data', (chunk) => { received += chunk; });
+        request.on('end', () => {
+          response.writeHead(204);
+          response.end();
+        });
+      });
+      candidate.listen(0, '127.0.0.1', () => resolveServer(candidate));
+    });
+    const address = server.address();
+    if (typeof address !== 'object' || address === null) throw new Error('missing test server address');
+    const webhookUrl = `http://127.0.0.1:${address.port}/discord-webhook-test`;
+    writeFileSync(join(root, '.osc/cockpit.json'), JSON.stringify({
+      targets: [{ platform: 'discord', webhookUrl, events: ['status'] }],
+    }, null, 2));
+
+    try {
+      const summary = await postCockpitEvent({ event: 'status', message: 'Successful local send' }, root);
+
+      expect(summary.results).toHaveLength(1);
+      expect(summary.results[0]).toMatchObject({ status: 'sent' });
+      expect(received).toContain('Open Scaffold');
+      expect(received).toContain('Successful local send');
+    } finally {
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    }
+  });
+});

--- a/tests/cockpit.test.ts
+++ b/tests/cockpit.test.ts
@@ -101,6 +101,18 @@ describe('osc cockpit webhooks', () => {
     expect(JSON.stringify(slack.blocks)).toContain(`repo: ${root}`);
   });
 
+  it('truncates Slack section text to the Block Kit limit', () => {
+    const root = tempScaffold();
+    const longBody = 'x'.repeat(3_500);
+
+    const slack = buildSlackPayload({ event: 'status', message: longBody }, root) as { blocks: Array<{ type: string; text?: { text: string } }>; text: string };
+    const section = slack.blocks.find((block) => block.type === 'section' && block.text);
+
+    expect(section?.text?.text).toHaveLength(3_000);
+    expect(section?.text?.text.endsWith('…')).toBe(true);
+    expect(slack.text.length).toBeLessThanOrEqual(3_000);
+  });
+
   it('dry-runs exact payloads and skips targets whose events list does not include the event', () => {
     const root = tempScaffold();
     writeConfig(root);

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -17,6 +17,7 @@ describe('tiered scaffold initialization', () => {
     expect(result.tier).toBe('min');
     expect(result.filesCreated.sort()).toEqual([...tierFiles.min].sort());
     expect(readFileSync(join(target, 'MISSION.md'), 'utf8')).toContain('<!-- mission:unset -->');
+    expect(readFileSync(join(target, '.osc/cockpit.example.json'), 'utf8')).toContain('discord');
     expect(readFileSync(join(target, '.osc/plans/WORKFLOW.md'), 'utf8')).toContain('Plan Workflow');
     expect(readFileSync(join(target, '.osc/plans/README.md'), 'utf8')).toContain('Amendments');
     expect(readFileSync(join(target, '.osc/plans/README.md'), 'utf8')).not.toContain('amend.sh');

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -26,6 +26,7 @@ describe('npm package payload', () => {
     const paths = pack.files.map((file) => file.path).sort();
 
     expect(paths).toContain('.osc/.gitignore');
+    expect(paths).toContain('.osc/cockpit.example.json');
     expect(paths).toContain('.osc/RULES.md');
     expect(paths).toContain('.osc/plans/WORKFLOW.md');
     expect(paths).toContain('.osc/plans/README.md');
@@ -75,6 +76,8 @@ describe('npm package payload', () => {
 
       const ignore = readFileSync(join(target, '.osc/.gitignore'), 'utf8');
       expect(ignore).toContain('tasks.db*');
+      expect(ignore).toContain('cockpit.json');
+      expect(existsSync(join(target, '.osc/cockpit.example.json'))).toBe(true);
     } finally {
       rmSync(packDir, { recursive: true, force: true });
       rmSync(extractDir, { recursive: true, force: true });

--- a/tests/tasks.test.ts
+++ b/tests/tasks.test.ts
@@ -184,5 +184,6 @@ describe('osc task local database', () => {
     const ignore = readFileSync(join(target, '.osc/.gitignore'), 'utf8');
 
     expect(ignore).toContain('tasks.db*');
+    expect(ignore).toContain('cockpit.json');
   }, 20_000);
 });


### PR DESCRIPTION
Opened/advanced by Open Scaffold runner automation.

Selected source: `backlog_plan` — `.osc/plans/backlog/062-glass-cockpit-webhooks.md`.

Owner gates: merge, npm publication, GitHub Release latest/public-surface sync.

## Summary
- Adds `osc cockpit config`, `osc cockpit test`, and `osc cockpit post` for push-only Discord/Slack webhook dispatch.
- Adds credential-safe `.osc/cockpit.example.json`, ignores `.osc/cockpit.json`, and ships the example in initialized scaffolds/package payloads.
- Documents the `osc cockpit` implementation path and closes plan 062 with release/evidence notes.
- Addresses Codex latest-head feedback by capping Discord embed text and Slack Block Kit section/field text to platform-safe limits.

## Verification
- `git diff --check`
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- `npm test -- --run` — 35 test files passed; 324 tests passed
- `npm run build`
- `npm pack --dry-run --json`
- Built CLI smoke: `node dist/cli.js cockpit config`, `cockpit test --dry-run`, `cockpit post --event status --message "Test message" --dry-run`, `cockpit post --event blocker --message "should send" --dry-run`, and missing-config `cockpit test`

## Notes
- Live Discord/Slack delivery with real webhooks was not run because webhook URLs are credentials. The test suite covers the one-shot HTTP POST path against a local server and validates Discord/Slack payload shape through dry-runs.
- No daemon, incoming webhook handler, slash command, background listener, lifecycle auto-posting, merge, publish, or release mutation is included.
