### PR TITLE
fix: harden release security posture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+      optional-dependencies:
+        dependency-type: "production"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/runtime-omx"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,7 +34,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.14.1
 
       - name: Install dependencies
         run: npm ci

--- a/.osc/plans/done/097-omo-security-hardening.md
+++ b/.osc/plans/done/097-omo-security-hardening.md
@@ -1,0 +1,57 @@
+# Plan: 097-omo-security-hardening
+
+## Status
+
+active
+
+## Context
+
+A read-only OmO `/security-research` run, followed by Hermes verification, found several actionable release-path and supply-chain hygiene improvements. The high-severity `actions@v6` claim was verified as a false positive and is intentionally excluded from this patch.
+
+## Goal
+
+Harden Open Scaffold's release and dependency maintenance posture without changing runtime behavior or promoting OmO into core.
+
+## Constraints / Out of scope
+
+- Do not implement runtime spawning or new adapter behavior.
+- Do not act on the rejected `actions/checkout@v6` / `actions/setup-node@v6` false positive.
+- Do not publish npm, create a GitHub Release, or merge without owner approval.
+- Keep fixes narrow: release workflow pinning, dependency update scanning, and documented security posture.
+
+## Files to touch
+
+- `.github/workflows/publish-npm.yml` — remove publish-time `npm@latest` drift by pinning the npm CLI used in the trusted publishing job.
+- `.github/dependabot.yml` — add automated update scanning for npm manifests and GitHub Actions.
+- `SECURITY.md` — document reporting, trusted publishing posture, optional native dependency posture, runtime command trust boundary, and cockpit config trust boundary.
+- `package.json` — include `SECURITY.md` in the published npm package surface.
+- `src/tasks.ts` — clarify that the local task database uses an optional native dependency and core workflows can avoid it.
+- `packages/runtime-omx/README.md` — document `--omx-command` as trusted-operator-only when explicit spawning is allowed.
+
+## Implementation Architecture Coverage
+
+- Strengthens: release-path supply-chain hygiene, dependency maintenance, adoption trust, runtime authority disclosure.
+- Audit envelope: OmO evidence in `.osc/runs/omo-security-research-20260523T205502Z/`, this plan, the patch diff, and verification output.
+- Evaluation envelope: `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, and targeted checks that the new Dependabot config and SECURITY posture exist.
+- Feedback routing: rejected or low-confidence OmO findings remain in the verified report; only verified findings become tracked code/docs changes.
+- Boundary: no npm publish, GitHub Release, runtime spawn behavior, credential handling, or security certification.
+
+## Acceptance criteria
+
+- [ ] Trusted publishing workflow no longer installs unbounded `npm@latest` in the privileged publish job.
+- [ ] Dependabot covers npm and GitHub Actions update surfaces.
+- [ ] Public security posture documents reporting path, optional native dependency posture, trusted publishing, runtime command override boundary, and cockpit webhook config trust boundary.
+- [ ] Runtime OMX docs make clear `--omx-command` is trusted-operator-only and only relevant with explicit `--allow-spawn`.
+- [ ] Open Scaffold verification and Node test/build gates pass.
+
+## Verification steps
+
+1. `git diff --check`
+2. `./verify.sh --strict`
+3. `npm test -- --run`
+4. `npm run build`
+5. Inspect `.github/workflows/publish-npm.yml`, `.github/dependabot.yml`, `SECURITY.md`, `src/tasks.ts`, and `packages/runtime-omx/README.md` for the acceptance criteria.
+
+## Open questions
+
+- None for this immediate hardening patch. Actual npm publication and GitHub Release alignment remain separate owner-gated public-surface steps if a package release is desired.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-23: closed 097-omo-security-hardening — hardened release-path and dependency security posture
 - 2026-05-23: closed 096-glass-cockpit-webhooks-public-surface-sync — Publish open-scaffold@0.4.17 and align GitHub Latest Release for cockpit webhooks.
 - 2026-05-23: closed 062-glass-cockpit-webhooks — added push-only Discord and Slack cockpit webhooks
 - 2026-05-23: closed 095-local-task-database-public-surface-sync — published 0.4.16 and aligned local task database public surfaces

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+Open Scaffold is a repo-native workflow substrate. It helps humans and agents plan, execute, verify, and hand off software work, but it is not a security scanner, sandbox, or runtime supervisor by itself.
+
+## Reporting a vulnerability
+
+Please report security issues through GitHub Security Advisories for this repository when available, or open a minimal public issue that asks for a private contact path without disclosing exploit details.
+
+Include:
+
+- affected version or commit;
+- affected command, workflow, or package surface;
+- reproduction steps using non-sensitive test data;
+- expected impact and any required attacker capability.
+
+Do not include real tokens, webhook URLs, private repo content, customer data, or other secrets in public issues.
+
+## Release and publishing posture
+
+The npm publishing workflow uses GitHub Actions trusted publishing with least-privilege job permissions:
+
+- `contents: read`
+- `id-token: write`
+
+The workflow pins the npm CLI used by the privileged publish job instead of installing `npm@latest` at publish time. Version bumps, actual npm publication, GitHub Release updates, and merge/publish decisions remain owner-gated.
+
+## Dependency maintenance
+
+Dependabot monitors:
+
+- GitHub Actions workflow dependencies;
+- the root npm package;
+- the private `packages/runtime-omx` npm manifest.
+
+Security or dependency bot output is review input, not automatic truth. Changes still need local verification and owner review before merge/publish.
+
+## Optional native dependency posture
+
+The local task database uses `better-sqlite3` as an optional native dependency. npm installs optional dependencies by default, which means downstream installs may fetch prebuilt/native artifacts for that feature.
+
+This dependency is not required for the core scaffold files, plan workflow, run packets, evidence notes, or GitHub-based task tracking. If an environment wants to avoid optional native installs, install with npm's optional-dependency omission mode and use GitHub Issues or another task bridge instead of `osc task` local database commands.
+
+When the optional dependency is unavailable, Open Scaffold should fail only the local task database command path with an explicit error rather than making the whole scaffold unusable.
+
+## Runtime command boundaries
+
+Open Scaffold core does not spawn agents by default. Runtime packages and adapters must keep launch authority explicit and auditable.
+
+For `@open-scaffold/runtime-omx`:
+
+- default behavior validates a run packet and writes receipt/evidence artifacts;
+- real OMX launch requires explicit `--allow-spawn`;
+- `--omx-command` is a trusted-operator override for local/manual use, not a value that should come from untrusted files or remote input;
+- commit, push, merge, publish, credential management, destructive filesystem operations, and runtime certification remain outside the adapter's authority.
+
+## Cockpit webhook configuration
+
+`.osc/cockpit.json` is trusted local/operator configuration. Webhook URLs can send messages to external Discord or Slack endpoints, so keep this file out of git, avoid pasting real URLs into public artifacts, and rotate any webhook that may have been exposed.
+
+Open Scaffold masks webhook URLs in summaries, but masking is not a substitute for treating the config file as sensitive local configuration.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     ".osc/specs/.gitkeep",
     "docs",
     "README.md",
+    "SECURITY.md",
     "LICENSE",
     "amend.sh",
     "bootstrap.sh",

--- a/packages/runtime-omx/README.md
+++ b/packages/runtime-omx/README.md
@@ -64,6 +64,7 @@ open-scaffold-runtime-omx .osc/runs/<run_id>/run.json --allow-spawn
 Launch safety checks:
 
 - `--allow-spawn` must be present;
+- `--omx-command` is a trusted-operator override for local/manual use only; do not populate it from untrusted files, remote input, or generated run-packet content;
 - `omx --version` must report `oh-my-codex >= 0.17.3`;
 - `runtime.branch` must be a non-main disposable branch such as `runtime/<slug>`;
 - `runtime.worktreePath` must exist and resolve inside `runtime.repoPath`;

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -107,7 +107,7 @@ function loadSqliteConstructor(): new (path: string) => SqliteDatabase {
     return require('better-sqlite3') as new (path: string) => SqliteDatabase;
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    throw new Error(`Local task database requires the better-sqlite3 native dependency. Re-run npm install, try npm install --build-from-source, or use GitHub Issues for task tracking. (${detail})`);
+    throw new Error(`Local task database commands require the optional better-sqlite3 native dependency. Re-run npm install with optional dependencies enabled, try npm install --build-from-source, or use GitHub Issues / another task bridge for task tracking. Core Open Scaffold workflows do not require the local task database. (${detail})`);
   }
 }
 
@@ -129,7 +129,7 @@ function openDatabase(root: string, create: boolean): SqliteDatabase | null {
     initializeSchema(db);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    throw new Error(`Could not open local task database at .osc/tasks.db. Reinstall better-sqlite3 or remove the broken local DB file. (${detail})`);
+    throw new Error(`Could not open local task database at .osc/tasks.db. Reinstall the optional better-sqlite3 dependency with optional dependencies enabled, try npm install --build-from-source, or remove the broken local DB file. Core Open Scaffold workflows can continue without local task database commands. (${detail})`);
   }
   return db;
 }


### PR DESCRIPTION
## Summary
- Pins the privileged npm trusted-publishing workflow to `npm@11.14.1` instead of `npm@latest`.
- Adds Dependabot coverage for GitHub Actions, root npm dependencies, and the runtime-omx package manifest.
- Adds `SECURITY.md` and includes it in the npm package surface.
- Documents optional native dependency posture plus runtime/cockpit trust boundaries.

## Verification
- `git diff --check`
- `./verify.sh --strict`
- `npm test -- --run`
- `npm run build`
- `npm pack --dry-run --json` confirms `SECURITY.md` is included
- Independent pre-commit review passed with no blockers

## Traceability
- Plan: `.osc/plans/done/097-omo-security-hardening.md`
- Evidence source: `.osc/runs/omo-security-research-20260523T205502Z/hermes-verified-report.md`

## Risk / gates
- Does not publish npm, create a GitHub Release, spawn runtimes, or change runtime behavior.
- Merge, npm publication, and GitHub Release decisions remain owner-gated.
