### PR TITLE
ci: add GitHub Actions scaffold templates

### DIFF
--- a/.github/workflows/evidence-validate.yml
+++ b/.github/workflows/evidence-validate.yml
@@ -1,0 +1,74 @@
+name: Evidence validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".osc/releases/**/*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-evidence:
+    name: Validate evidence notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Find changed evidence notes
+        id: changed-evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="origin/${{ github.base_ref || 'main' }}"
+          git diff --name-only --diff-filter=ACMRT "$base"...HEAD -- '.osc/releases/**/*.md' | sort > changed-evidence.txt
+          count="$(wc -l < changed-evidence.txt | tr -d ' ')"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [[ "$count" == "0" ]]; then
+            echo "No changed evidence notes to validate."
+          else
+            echo "Changed evidence notes:"
+            cat changed-evidence.txt
+          fi
+
+      - name: Run scaffold strict verifier
+        if: steps.changed-evidence.outputs.count != '0'
+        run: ./verify.sh --strict
+
+      - name: Validate changed evidence-note sections and freshness
+        if: steps.changed-evidence.outputs.count != '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          required_sections = ('Summary', 'Traceability', 'Verification', 'Outcome')
+          stale_pattern = re.compile(r'(PR #[0-9]+ merged|issue #[0-9]+ closed|Tag:\s*v[0-9]|GitHub Release:\s*https?://)', re.I)
+          failures = []
+
+          for line in pathlib.Path('changed-evidence.txt').read_text().splitlines():
+              if not line or line.endswith('/README.md'):
+                  continue
+              path = pathlib.Path(line)
+              if not path.exists():
+                  continue
+              text = path.read_text()
+              for section in required_sections:
+                  if not re.search(rf'^## .*{re.escape(section)}\b', text, re.M | re.I):
+                      failures.append(f'{line}: missing ## {section}')
+              if re.search(r'pending', text, re.I) and stale_pattern.search(text):
+                  failures.append(f'{line}: says pending while citing merged/closed/released evidence')
+
+          if failures:
+              print('\n'.join(failures), file=sys.stderr)
+              sys.exit(1)
+          print('Changed evidence notes passed section/freshness checks.')
+          PY

--- a/.github/workflows/evidence-validate.yml
+++ b/.github/workflows/evidence-validate.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".osc/releases/*.md"
       - ".osc/releases/**/*.md"
   workflow_dispatch:
 
@@ -26,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           base="origin/${{ github.base_ref || 'main' }}"
-          git diff --name-only --diff-filter=ACMRT "$base"...HEAD -- '.osc/releases/**/*.md' | sort > changed-evidence.txt
+          git diff --name-only --diff-filter=ACMRT "$base"...HEAD -- '.osc/releases/*.md' '.osc/releases/**/*.md' | sort > changed-evidence.txt
           count="$(wc -l < changed-evidence.txt | tr -d ' ')"
           echo "count=$count" >> "$GITHUB_OUTPUT"
           if [[ "$count" == "0" ]]; then

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,8 +47,9 @@ jobs:
             echo "Tag $tag does not match package.json version $version. Expected v$version." >&2
             exit 1
           fi
-          if npm view "open-scaffold@$version" version >/dev/null 2>&1; then
-            echo "open-scaffold@$version is already published." >&2
+          name="$(node -p "require('./package.json').name")"
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version is already published." >&2
             exit 1
           fi
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,58 @@
+name: Publish npm on version tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build, test, and publish package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test -- --run
+
+      - name: Verify scaffold
+        run: ./verify.sh --strict
+
+      - name: Validate tag matches package version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="$(node -p "require('./package.json').version")"
+          if [[ "$tag" != "v$version" ]]; then
+            echo "Tag $tag does not match package.json version $version. Expected v$version." >&2
+            exit 1
+          fi
+          if npm view "open-scaffold@$version" version >/dev/null 2>&1; then
+            echo "open-scaffold@$version is already published." >&2
+            exit 1
+          fi
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/.github/workflows/plan-validate.yml
+++ b/.github/workflows/plan-validate.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - ".osc/plans/**/*.md"
+      - ".osc/plans/active/**/*.md"
+      - ".osc/plans/backlog/**/*.md"
+      - ".osc/plans/blocked/**/*.md"
+      - ".osc/plans/done/**/*.md"
   workflow_dispatch:
 
 permissions:
@@ -38,7 +41,11 @@ jobs:
         run: |
           set -euo pipefail
           base="origin/${{ github.base_ref || 'main' }}"
-          git diff --name-only --diff-filter=ACMRT "$base"...HEAD -- '.osc/plans/**/*.md' | sort > changed-plans.txt
+          git diff --name-only --diff-filter=ACMRT "$base"...HEAD -- \
+            '.osc/plans/active/**/*.md' \
+            '.osc/plans/backlog/**/*.md' \
+            '.osc/plans/blocked/**/*.md' \
+            '.osc/plans/done/**/*.md' | sort > changed-plans.txt
           count="$(wc -l < changed-plans.txt | tr -d ' ')"
           echo "count=$count" >> "$GITHUB_OUTPUT"
           if [[ "$count" == "0" ]]; then

--- a/.github/workflows/plan-validate.yml
+++ b/.github/workflows/plan-validate.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".osc/plans/active/*.md"
       - ".osc/plans/active/**/*.md"
+      - ".osc/plans/backlog/*.md"
       - ".osc/plans/backlog/**/*.md"
+      - ".osc/plans/blocked/*.md"
       - ".osc/plans/blocked/**/*.md"
+      - ".osc/plans/done/*.md"
       - ".osc/plans/done/**/*.md"
   workflow_dispatch:
 
@@ -42,9 +46,13 @@ jobs:
           set -euo pipefail
           base="origin/${{ github.base_ref || 'main' }}"
           git diff --name-only --diff-filter=ACMRT "$base"...HEAD -- \
+            '.osc/plans/active/*.md' \
             '.osc/plans/active/**/*.md' \
+            '.osc/plans/backlog/*.md' \
             '.osc/plans/backlog/**/*.md' \
+            '.osc/plans/blocked/*.md' \
             '.osc/plans/blocked/**/*.md' \
+            '.osc/plans/done/*.md' \
             '.osc/plans/done/**/*.md' | sort > changed-plans.txt
           count="$(wc -l < changed-plans.txt | tr -d ' ')"
           echo "count=$count" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/plan-validate.yml
+++ b/.github/workflows/plan-validate.yml
@@ -1,0 +1,61 @@
+name: Plan validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".osc/plans/**/*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-plans:
+    name: Validate changed plans
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build
+
+      - name: Find changed plan files
+        id: changed-plans
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="origin/${{ github.base_ref || 'main' }}"
+          git diff --name-only --diff-filter=ACMRT "$base"...HEAD -- '.osc/plans/**/*.md' | sort > changed-plans.txt
+          count="$(wc -l < changed-plans.txt | tr -d ' ')"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [[ "$count" == "0" ]]; then
+            echo "No changed plan files to validate."
+          else
+            echo "Changed plan files:"
+            cat changed-plans.txt
+          fi
+
+      - name: Validate changed plans
+        if: steps.changed-plans.outputs.count != '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r plan; do
+            [[ -n "$plan" ]] || continue
+            echo "::group::osc plan validate $plan"
+            node dist/cli.js plan validate "$plan"
+            echo "::endgroup::"
+          done < changed-plans.txt

--- a/.github/workflows/stale-plans.yml
+++ b/.github/workflows/stale-plans.yml
@@ -1,0 +1,128 @@
+name: Stale active plans
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      stale-days:
+        description: "Active-plan age threshold in days"
+        required: false
+        default: "30"
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  stale-plans:
+    name: Open issue for stale active plans
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build
+
+      - name: Capture scaffold metrics
+        run: node dist/cli.js metrics --json --verbose > scaffold-metrics.json
+
+      - name: Detect stale active plans
+        id: stale
+        shell: bash
+        env:
+          STALE_DAYS: ${{ github.event.inputs['stale-days'] || '30' }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import datetime as dt
+          import json
+          import os
+          import pathlib
+          import re
+          import subprocess
+
+          threshold = int(os.environ.get('STALE_DAYS', '30'))
+          now = dt.datetime.now(dt.timezone.utc)
+          active_dir = pathlib.Path('.osc/plans/active')
+          stale = []
+
+          for path in sorted(active_dir.glob('*.md')):
+              if re.search(r'-amendment-\d+\.md$', path.name):
+                  continue
+              completed = subprocess.run(
+                  ['git', 'log', '-1', '--format=%ct', '--', str(path)],
+                  text=True,
+                  capture_output=True,
+                  check=False,
+              )
+              if completed.returncode == 0 and completed.stdout.strip():
+                  modified = dt.datetime.fromtimestamp(int(completed.stdout.strip()), tz=dt.timezone.utc)
+              else:
+                  modified = dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.timezone.utc)
+              age_days = (now - modified).days
+              if age_days > threshold:
+                  stale.append({
+                      'path': str(path),
+                      'name': path.name,
+                      'last_modified': modified.date().isoformat(),
+                      'age_days': age_days,
+                  })
+
+          pathlib.Path('stale-plans.json').write_text(json.dumps(stale, indent=2) + '\n')
+          if stale:
+              rows = '\n'.join(
+                  f"- `{item['path']}` — last modified {item['last_modified']} ({item['age_days']} days old)"
+                  for item in stale
+              )
+              body = '\n'.join([
+                  'Stale active plans were detected by the weekly Open Scaffold CI check.',
+                  '',
+                  f'Threshold: active plan older than {threshold} days since last git modification.',
+                  '',
+                  rows,
+                  '',
+                  'Suggested action: review each plan and either continue it, move it to `blocked/`, or close it to `done/` with evidence.',
+                  '',
+              ])
+              pathlib.Path('stale-issue.md').write_text(body)
+          PY
+
+          count="$(python3 -c 'import json; print(len(json.load(open("stale-plans.json"))))')"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          week="$(date -u +%F)"
+          echo "week=$week" >> "$GITHUB_OUTPUT"
+          if [[ "$count" == "0" ]]; then
+            echo "No stale active plans found."
+          else
+            cat stale-plans.json
+          fi
+
+      - name: Open or reuse stale-plan issue
+        if: steps.stale.outputs.count != '0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: Stale active plans — week of ${{ steps.stale.outputs.week }}
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')"
+          if [[ -n "$existing" ]]; then
+            echo "Stale-plan issue already exists: #$existing"
+            gh issue comment "$existing" --body-file stale-issue.md
+          else
+            gh issue create --title "$TITLE" --body-file stale-issue.md
+          fi

--- a/.github/workflows/stale-plans.yml
+++ b/.github/workflows/stale-plans.yml
@@ -60,9 +60,7 @@ jobs:
           active_dir = pathlib.Path('.osc/plans/active')
           stale = []
 
-          for path in sorted(active_dir.glob('*.md')):
-              if re.search(r'-amendment-\d+\.md$', path.name):
-                  continue
+          def git_or_stat_modified(path: pathlib.Path) -> dt.datetime:
               completed = subprocess.run(
                   ['git', 'log', '-1', '--format=%ct', '--', str(path)],
                   text=True,
@@ -70,9 +68,15 @@ jobs:
                   check=False,
               )
               if completed.returncode == 0 and completed.stdout.strip():
-                  modified = dt.datetime.fromtimestamp(int(completed.stdout.strip()), tz=dt.timezone.utc)
-              else:
-                  modified = dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.timezone.utc)
+                  return dt.datetime.fromtimestamp(int(completed.stdout.strip()), tz=dt.timezone.utc)
+              return dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.timezone.utc)
+
+          for path in sorted(active_dir.glob('*.md')):
+              if re.search(r'-amendment-\d+\.md$', path.name):
+                  continue
+              plan_stem = path.stem
+              related_files = [path, *sorted(active_dir.glob(f'{plan_stem}-amendment-*.md'))]
+              modified = max(git_or_stat_modified(related) for related in related_files)
               age_days = (now - modified).days
               if age_days > threshold:
                   stale.append({

--- a/.osc/plans/done/063-github-actions-ci-templates.md
+++ b/.osc/plans/done/063-github-actions-ci-templates.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-24-063-github-actions-ci-templates.md
+++ b/.osc/releases/2026-05-24-063-github-actions-ci-templates.md
@@ -1,0 +1,30 @@
+# Release / Evidence Note: 063-github-actions-ci-templates
+
+## Summary
+
+Added GitHub Actions guardrail templates for changed plan validation, evidence note validation, weekly stale active-plan issue creation, and version-tag npm publishing. Added a CI strategy guide and linked the workflow set from the GitHub workflow guide.
+
+## Traceability
+
+- Roadmap / issue / task: selected backlog plan `063-github-actions-ci-templates`.
+- Plan: `.osc/plans/done/063-github-actions-ci-templates.md`.
+- Run ID / run packet: N/A — direct repository automation slice, no external runtime packet.
+- Branch / PR: `ci/063-github-actions-ci-templates`; PR pending.
+
+## Verification
+
+- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].sort.each { |p| YAML.load_file(p); puts "valid yaml: #{p}" }'` — passed for all workflow YAML files.
+- `git diff --check` — passed.
+- `npm run build` — passed.
+- `node dist/cli.js plan validate 063-github-actions-ci-templates` — completed with one non-blocking warning inherited from a resolved open-question line.
+- `./verify.sh --strict` — passed with 9 pass, 0 fail, 1 warning while the plan was active.
+- `npm test -- --run` — passed, 35 files / 326 tests.
+
+## Outcome
+
+The CI template slice is implemented and the plan is closed. The new workflows are not a merge, publication, GitHub Release, deployment, or npm publish approval; those remain owner gates.
+
+## Follow-up
+
+- Owner gate: review/merge the PR.
+- Owner gate: decide separately before using any npm publication or GitHub Release action.

--- a/.osc/releases/2026-05-24-063-github-actions-ci-templates.md
+++ b/.osc/releases/2026-05-24-063-github-actions-ci-templates.md
@@ -9,7 +9,7 @@ Added GitHub Actions guardrail templates for changed plan validation, evidence n
 - Roadmap / issue / task: selected backlog plan `063-github-actions-ci-templates`.
 - Plan: `.osc/plans/done/063-github-actions-ci-templates.md`.
 - Run ID / run packet: N/A — direct repository automation slice, no external runtime packet.
-- Branch / PR: `ci/063-github-actions-ci-templates`; PR pending.
+- Branch / PR: `ci/063-github-actions-ci-templates`; https://github.com/graphanov/open-scaffold/pull/107.
 
 ## Verification
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-24: closed 063-github-actions-ci-templates — added GitHub Actions CI templates
 - 2026-05-24: closed 098-omo-security-hardening-package-sync — published open-scaffold@0.4.18 and aligned GitHub Latest Release
 - 2026-05-23: closed 097-omo-security-hardening — hardened release-path and dependency security posture
 - 2026-05-23: closed 096-glass-cockpit-webhooks-public-surface-sync — Publish open-scaffold@0.4.17 and align GitHub Latest Release for cockpit webhooks.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -38,7 +38,7 @@ This keeps release/evidence notes from becoming stale proof claims.
 
 ## Stale active plans
 
-`stale-plans.yml` runs weekly and can also be started manually from the Actions tab. It scans `.osc/plans/active/*.md`, computes the last git modification date, and opens an issue titled:
+`stale-plans.yml` runs weekly and can also be started manually from the Actions tab. It scans `.osc/plans/active/*.md`, computes the latest git modification date across each parent plan and its amendment files, and opens an issue titled:
 
 ```text
 Stale active plans — week of YYYY-MM-DD

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,97 @@
+# CI templates
+
+Open Scaffold keeps work reviewable by making the repo record testable. The workflows in `.github/workflows/` turn the same local checks into GitHub gates for pull requests, scheduled hygiene, evidence notes, and version-tag publishing.
+
+These workflows are active in this repository and can also be copied into downstream Open Scaffold projects.
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | PRs and pushes to `main` | Full build, test, strict verifier, and CLI verifier. |
+| `.github/workflows/plan-validate.yml` | PRs touching `.osc/plans/**/*.md` | Validates changed plan files with `osc plan validate`. Errors fail the PR; warnings remain visible but non-blocking. |
+| `.github/workflows/evidence-validate.yml` | PRs touching `.osc/releases/**/*.md` | Runs `./verify.sh --strict` and checks changed evidence notes for required sections and stale `pending` claims. |
+| `.github/workflows/stale-plans.yml` | Weekly Monday 09:00 UTC and manual dispatch | Detects active plans older than the configured threshold and opens or updates a GitHub Issue. |
+| `.github/workflows/npm-publish.yml` | Version tag pushes matching `v*` | Builds, tests, verifies, checks the tag against `package.json`, then publishes to npm using `NPM_TOKEN`. |
+
+## Plan validation
+
+`plan-validate.yml` checks out full history, builds the local CLI, finds changed plan files against the PR base branch, and runs:
+
+```bash
+node dist/cli.js plan validate <changed-plan>
+```
+
+The command fails on structural errors such as missing required sections, TODO markers, or status/folder drift. Non-strict warnings are printed but do not block the PR.
+
+## Evidence validation
+
+`evidence-validate.yml` is scoped to `.osc/releases/**/*.md`. It runs the repository strict verifier and then checks each changed evidence note for:
+
+- `## Summary`
+- `## Traceability`
+- `## Verification`
+- `## Outcome`
+- no `pending` wording while also citing merged PRs, closed issues, tags, or GitHub Releases
+
+This keeps release/evidence notes from becoming stale proof claims.
+
+## Stale active plans
+
+`stale-plans.yml` runs weekly and can also be started manually from the Actions tab. It scans `.osc/plans/active/*.md`, computes the last git modification date, and opens an issue titled:
+
+```text
+Stale active plans — week of YYYY-MM-DD
+```
+
+The workflow does not move plans automatically. A human or coordinator still decides whether to continue, move to `blocked/`, or close to `done/` with evidence.
+
+To customize the threshold:
+
+- Manual run: set the `stale-days` input.
+- Permanent change: edit the workflow input default from `30` to the desired number.
+- Private fork: keep the same workflow, but adjust labels, issue wording, or schedule to match the team cadence.
+
+## npm publishing
+
+`npm-publish.yml` is intentionally tag-gated. It does not run on regular pushes or pull requests.
+
+Required setup:
+
+1. Add an npm automation token as the repository secret `NPM_TOKEN`.
+2. Ensure `package.json` has the version that should be released.
+3. Push a matching tag such as `v0.4.19`.
+
+The workflow refuses to publish if the tag does not match `package.json` or if that package version is already on npm.
+
+Projects using npm trusted publishing can keep a separate manual trusted-publishing workflow instead. Do not run both publish paths for the same release without an owner decision.
+
+## Enabling, disabling, and adapting
+
+- To disable a workflow, rename the file extension away from `.yml` or remove its trigger block.
+- To keep workflows as templates only, move them out of `.github/workflows/` before committing.
+- For private npm registries, change `registry-url` and the publish token secret name in `npm-publish.yml`.
+- For non-Node projects, keep plan/evidence/stale-plan workflows and replace only the build/test steps in `ci.yml` and `npm-publish.yml`.
+
+## Local testing
+
+Manual syntax check without extra tools:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+for path in Path('.github/workflows').glob('*.yml'):
+    yaml.safe_load(path.read_text())
+    print(f'valid yaml: {path}')
+PY
+```
+
+With `act`, run one workflow locally when Docker is available:
+
+```bash
+act pull_request -W .github/workflows/plan-validate.yml
+act workflow_dispatch -W .github/workflows/stale-plans.yml
+```
+
+`act` does not perfectly emulate GitHub tokens, issue creation, or npm publication. Treat local `act` runs as syntax and shell-flow checks, then rely on GitHub Actions for the final integration proof.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -9,14 +9,14 @@ These workflows are active in this repository and can also be copied into downst
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
 | `.github/workflows/ci.yml` | PRs and pushes to `main` | Full build, test, strict verifier, and CLI verifier. |
-| `.github/workflows/plan-validate.yml` | PRs touching `.osc/plans/**/*.md` | Validates changed plan files with `osc plan validate`. Errors fail the PR; warnings remain visible but non-blocking. |
+| `.github/workflows/plan-validate.yml` | PRs touching staged plan files under `.osc/plans/{active,backlog,blocked,done}/` | Validates changed plan files with `osc plan validate`. Errors fail the PR; warnings remain visible but non-blocking. |
 | `.github/workflows/evidence-validate.yml` | PRs touching `.osc/releases/**/*.md` | Runs `./verify.sh --strict` and checks changed evidence notes for required sections and stale `pending` claims. |
 | `.github/workflows/stale-plans.yml` | Weekly Monday 09:00 UTC and manual dispatch | Detects active plans older than the configured threshold and opens or updates a GitHub Issue. |
 | `.github/workflows/npm-publish.yml` | Version tag pushes matching `v*` | Builds, tests, verifies, checks the tag against `package.json`, then publishes to npm using `NPM_TOKEN`. |
 
 ## Plan validation
 
-`plan-validate.yml` checks out full history, builds the local CLI, finds changed plan files against the PR base branch, and runs:
+`plan-validate.yml` checks out full history, builds the local CLI, finds changed stage plan files against the PR base branch, and runs:
 
 ```bash
 node dist/cli.js plan validate <changed-plan>

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -91,6 +91,18 @@ Open the PR with traceability back to the task/run chain. The PR body should inc
 - Evidence paths.
 - Review gates: CI, Codex review, human approval.
 
+## CI guardrails
+
+Open Scaffold projects should keep repository truth mechanically checked in GitHub, not only in local agent sessions. The default workflow set is documented in [`docs/CI.md`](CI.md):
+
+- `ci.yml` runs build, tests, strict scaffold verification, and CLI verification.
+- `plan-validate.yml` validates changed `.osc/plans/**/*.md` files on PRs.
+- `evidence-validate.yml` runs strict evidence checks for `.osc/releases/**/*.md` changes.
+- `stale-plans.yml` runs weekly and opens a GitHub Issue for stale active plans instead of mutating plan state automatically.
+- `npm-publish.yml` is tag-gated and uses `NPM_TOKEN`; publish, release, and deployment remain owner gates.
+
+CI failures should be resolved before merge unless the failure is explicitly classified as external infrastructure. CI does not replace Codex review or human approval.
+
 ## Codex review connector
 
 If the ChatGPT/Codex GitHub connector is enabled for the repository, Codex review is triggered by the connector, not necessarily by assigning a normal GitHub user as a reviewer. If the connector is not installed for the repo, mark Codex review as intentionally skipped in the PR and record the rationale.


### PR DESCRIPTION
## Summary

Opened/advanced by Open Scaffold runner automation.

Selected source: `backlog_plan` — `.osc/plans/done/063-github-actions-ci-templates.md`.

- Adds plan validation, evidence validation, stale active-plan issue creation, and version-tag npm publish workflows.
- Adds `docs/CI.md` as the CI strategy guide.
- Links the workflow set from `docs/GITHUB_WORKFLOW.md`.
- Closes plan `063-github-actions-ci-templates` with an evidence note.

## Traceability

- Plan: `.osc/plans/done/063-github-actions-ci-templates.md`
- Evidence: `.osc/releases/2026-05-24-063-github-actions-ci-templates.md`
- Source mode: `backlog_plan`

## Verification

- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].sort.each { |p| YAML.load_file(p); puts "valid yaml: #{p}" }'` — passed.
- `git diff --check` — passed.
- `npm run build` — passed.
- `node dist/cli.js plan validate 063-github-actions-ci-templates` — completed with one non-blocking warning inherited from a resolved open-question line.
- `./verify.sh --strict` — passed, 10 pass / 0 fail / 0 warn.
- `npm test -- --run` — passed, 35 files / 326 tests.

## Owner gates

- Merge: owner approval required.
- npm publication: not performed; owner approval required.
- GitHub Release / Latest: not performed; owner approval required.

## Notes

- `npm-publish.yml` is tag-gated and uses `NPM_TOKEN`; it does not run on normal pushes or PRs.
- `stale-plans.yml` opens or updates a GitHub Issue; it does not mutate plan state automatically.
