### PR TITLE
feat: add terminal dashboard

### DIFF
--- a/.osc/plans/done/065-tui-dashboard.md
+++ b/.osc/plans/done/065-tui-dashboard.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-25-065-tui-dashboard.md
+++ b/.osc/releases/2026-05-25-065-tui-dashboard.md
@@ -1,0 +1,31 @@
+# Release / Evidence Note: 065-tui-dashboard
+
+## Summary
+
+Added a read-only terminal dashboard for Open Scaffold. The new `osc dashboard` command and `osc status --dashboard` alias show mission state, plan counts, active-plan freshness, recent evidence, validation health, and optional task summary data in a keyboard-driven terminal view without adding a daemon or browser surface.
+
+## Traceability
+
+- Roadmap / issue / task: backlog plan 065 terminal dashboard.
+- Plan: .osc/plans/done/065-tui-dashboard.md
+- Run ID / run packet: N/A — implemented directly by runner automation for a selected backlog plan.
+- Branch / PR: Branch `feat/065-tui-dashboard`; PR pending owner review.
+
+## Verification
+
+- `npm test -- tests/dashboard.test.ts` — 5 dashboard tests passed after the RED failure for the missing dashboard module.
+- `npm test -- tests/dashboard.test.ts packages/runtime-omx/tests/no-spawn-boundary.test.ts && npm run build` — dashboard tests, no-spawn boundary tests, and TypeScript build passed after replacing process spawning with in-process validation.
+- `npm test` — full suite passed: 38 test files, 337 tests.
+- `git diff --check` and `./verify.sh --strict` — whitespace and strict scaffold checks passed: 10 pass, 0 fail, 0 warn.
+- `npm pack --dry-run --json` — package dry-run succeeded and included `dist/dashboard.js` plus `dist/dashboard.d.ts`.
+- `node dist/cli.js dashboard` and `node dist/cli.js status --dashboard` — static non-interactive dashboard output showed mission, plan counts, active plans, recent evidence, and footer shortcuts.
+- PTY smoke: `node dist/cli.js dashboard`, send `q` — interactive dashboard exited with code 0 and restored the terminal.
+
+## Outcome
+
+Terminal dashboard v1 is ready for owner review. It is intentionally read-only, uses ANSI/raw terminal handling instead of a new TUI dependency, preserves the core no-spawn boundary, and keeps publication, merge, npm publication, and GitHub Release changes behind owner gates.
+
+## Follow-up
+
+- Owner review and merge gate remain open.
+- Publication gate remains batched with the release train; no `npm publish` or GitHub Latest Release move was performed.

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-25: closed 065-tui-dashboard — added terminal dashboard CLI
 - 2026-05-24: align devcontainer image with published package and workspace post-create install — see .osc/plans/active/064-devcontainer-profile-amendment-1.md
 - 2026-05-24: closed 063-github-actions-ci-templates — added GitHub Actions CI templates
 - 2026-05-24: closed 098-omo-security-hardening-package-sync — published open-scaffold@0.4.18 and aligned GitHub Latest Release

--- a/docs/GLASS_COCKPIT_PROTOCOL.md
+++ b/docs/GLASS_COCKPIT_PROTOCOL.md
@@ -84,6 +84,19 @@ Use for:
 
 Default visibility: curated.
 
+### Terminal dashboard
+
+`osc dashboard` is the simplest local glass cockpit: a read-only terminal view over the repo-owned state. It shows mission status, plan counts, active-plan freshness, recent evidence notes, verification health, and optional task summary data without becoming a second source of truth.
+
+Use for:
+
+- quick local orientation before starting or resuming a slice;
+- checking active-plan staleness and evidence recency;
+- watching repo state with `osc dashboard --watch` during manual work;
+- sharing a human-readable state view without opening a browser or running a daemon.
+
+The dashboard must point back to durable paths such as `.osc/plans/*` and `.osc/releases/*`. It must remain read-only in v1: plan edits, approvals, publication, and task transitions still happen through the existing CLI, GitHub, or task bridge surfaces.
+
 ## Event envelope
 
 Every cockpit event should be able to fit this shape:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from 'node:path';
 import { renderAuditManifest, validateAuditManifestFile, writeAuditManifest, type AuditArtifactInput } from './audit.js';
 import { createRunArtifacts, previewRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
 import { COCKPIT_EVENT_TYPES, CockpitConfigError, CockpitUsageError, formatCockpitConfig, formatCockpitDispatchSummary, hasCockpitDispatchFailures, loadCockpitConfig, postCockpitEvent, type CockpitEventType, type CockpitPostOptions } from './cockpit.js';
+import { runDashboard, type DashboardRunOptions } from './dashboard.js';
 import { doctorExitCode, formatDoctorReport, parseDoctorCheckName, runDoctor, type DoctorOptions, type DoctorSeverity } from './doctor.js';
 import { collectEvidence } from './evidence.js';
 import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
@@ -25,7 +26,8 @@ Usage:
   osc init --tier <min|standard|max> --target <dir> [--force]
   osc init --from-existing --tier min --target <dir> [--force]
   osc init --min|--standard|--max --target <dir> [--force]
-  osc status [--json]
+  osc status [--json|--dashboard]
+  osc dashboard [--watch] [--interval <seconds>]
   osc task new <title> [--priority <high|medium|low>] [--plan <slug>]
   osc task list [--status <status>] [--priority <priority>] [--plan <slug>] [--json]
   osc task show <task-id>
@@ -379,7 +381,62 @@ function init(args: string[]): void {
   }
 }
 
-function status(json: boolean): void {
+function printDashboardUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc dashboard [--watch] [--interval <seconds>]', stream);
+}
+
+function parseDashboardOptions(args: string[]): DashboardRunOptions {
+  const options: DashboardRunOptions = {};
+  for (let i = 0; i < args.length; i += 1) {
+    const flag = args[i];
+    switch (flag) {
+      case '--watch':
+        options.watch = true;
+        break;
+      case '--interval': {
+        const value = args[i + 1];
+        if (!value || value.startsWith('--')) {
+          console.error('Missing value for --interval');
+          process.exit(2);
+        }
+        const intervalSeconds = Number.parseInt(value, 10);
+        if (!Number.isFinite(intervalSeconds) || intervalSeconds < 1) {
+          console.error(`Invalid value for --interval: ${value}. Expected a positive number of seconds.`);
+          process.exit(2);
+        }
+        options.intervalSeconds = intervalSeconds;
+        i += 1;
+        break;
+      }
+      default:
+        console.error(`Unknown option for dashboard: ${flag}`);
+        printDashboardUsage();
+        process.exit(2);
+    }
+  }
+  return options;
+}
+
+async function dashboardCommand(args: string[]): Promise<void> {
+  if (isHelpArg(args[0])) {
+    printDashboardUsage('stdout');
+    return;
+  }
+  await runDashboard(parseDashboardOptions(args));
+}
+
+async function status(args: string[]): Promise<void> {
+  if (args.includes('--dashboard')) {
+    await dashboardCommand(args.filter((arg) => arg !== '--dashboard'));
+    return;
+  }
+  const unknown = args.filter((arg) => arg !== '--json');
+  if (unknown.length > 0) {
+    console.error(`Unknown option for status: ${unknown[0]}`);
+    printUsage('Usage: osc status [--json|--dashboard]');
+    process.exit(2);
+  }
+  const json = args.includes('--json');
   const state = inspectScaffold(process.cwd());
   let taskSummary: ReturnType<typeof getTaskSummary> = null;
   try {
@@ -1949,7 +2006,10 @@ async function main(): Promise<void> {
       init(args);
       return;
     case 'status':
-      status(args.includes('--json'));
+      await status(args);
+      return;
+    case 'dashboard':
+      await dashboardCommand(args);
       return;
     case 'task':
       taskCommand(args);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -313,14 +313,58 @@ export function formatDashboardText(data: DashboardData, options: DashboardForma
   return fitted.join('\n');
 }
 
-function parseKey(buffer: Buffer): 'up' | 'down' | 'enter' | 'refresh' | 'quit' | 'none' {
-  const value = buffer.toString('utf8');
-  if (value === '\u0003' || value === 'q' || value === 'Q' || value === '\x1b') return 'quit';
+export type DashboardKey = 'up' | 'down' | 'enter' | 'refresh' | 'quit' | 'none';
+export type DashboardKeyResult = DashboardKey | 'pending';
+
+function parseCompleteKey(value: string): DashboardKey {
+  if (value === '\u0003' || value === 'q' || value === 'Q') return 'quit';
   if (value === 'r' || value === 'R') return 'refresh';
   if (value === '\r' || value === '\n') return 'enter';
   if (value === '\x1b[A') return 'up';
   if (value === '\x1b[B') return 'down';
   return 'none';
+}
+
+function isPartialEscapeSequence(value: string): boolean {
+  return value === '\x1b' || value === '\x1b[';
+}
+
+export class DashboardKeyParser {
+  private pendingEscapeSequence: string | null = null;
+
+  push(buffer: Buffer): DashboardKeyResult {
+    const value = buffer.toString('utf8');
+    if (!value) return 'none';
+
+    if (this.pendingEscapeSequence) {
+      const combined = `${this.pendingEscapeSequence}${value}`;
+      const parsed = parseCompleteKey(combined);
+      if (parsed !== 'none') {
+        this.pendingEscapeSequence = null;
+        return parsed;
+      }
+      if (isPartialEscapeSequence(combined)) {
+        this.pendingEscapeSequence = combined;
+        return 'pending';
+      }
+      this.pendingEscapeSequence = null;
+      return parseCompleteKey(value);
+    }
+
+    if (isPartialEscapeSequence(value)) {
+      this.pendingEscapeSequence = value;
+      return 'pending';
+    }
+
+    return parseCompleteKey(value);
+  }
+
+  flushPendingEscape(): DashboardKey {
+    const pending = this.pendingEscapeSequence;
+    this.pendingEscapeSequence = null;
+    if (pending === '\x1b') return 'quit';
+    return 'none';
+  }
 }
 
 export async function runDashboard(options: DashboardRunOptions = {}): Promise<void> {
@@ -355,18 +399,36 @@ export async function runDashboard(options: DashboardRunOptions = {}): Promise<v
     render();
   };
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
     const stdin = process.stdin;
-    const cleanup = () => {
-      if (timer) clearInterval(timer);
-      stdin.off('data', onData);
+    const keyParser = new DashboardKeyParser();
+    let pendingEscapeTimer: NodeJS.Timeout | null = null;
+    let onData: ((buffer: Buffer) => void) | null = null;
+    let settled = false;
+
+    const clearPendingEscapeTimer = () => {
+      if (pendingEscapeTimer) clearTimeout(pendingEscapeTimer);
+      pendingEscapeTimer = null;
+    };
+
+    const cleanup = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      clearPendingEscapeTimer();
+      if (onData) stdin.off('data', onData);
       if (typeof stdin.setRawMode === 'function') stdin.setRawMode(false);
       stdin.pause();
       process.stdout.write('\x1b[?25h\x1b[?1049l');
-      resolve();
+      if (error) reject(error);
+      else resolve();
     };
-    const onData = (buffer: Buffer) => {
-      const key = parseKey(buffer);
+
+    const handleKey = (key: DashboardKey) => {
+      if (key === 'none') return;
       if (key === 'quit') {
         cleanup();
         return;
@@ -386,11 +448,51 @@ export async function runDashboard(options: DashboardRunOptions = {}): Promise<v
       }
     };
 
+    const flushPendingEscape = () => {
+      pendingEscapeTimer = null;
+      try {
+        handleKey(keyParser.flushPendingEscape());
+      } catch (error) {
+        cleanup(error);
+      }
+    };
+
+    const schedulePendingEscapeFlush = () => {
+      clearPendingEscapeTimer();
+      pendingEscapeTimer = setTimeout(flushPendingEscape, 25);
+    };
+
+    onData = (buffer: Buffer) => {
+      try {
+        clearPendingEscapeTimer();
+        const key = keyParser.push(buffer);
+        if (key === 'pending') {
+          schedulePendingEscapeFlush();
+          return;
+        }
+        handleKey(key);
+      } catch (error) {
+        cleanup(error);
+      }
+    };
+
     process.stdout.write('\x1b[?1049h\x1b[?25l');
     if (typeof stdin.setRawMode === 'function') stdin.setRawMode(true);
     stdin.resume();
     stdin.on('data', onData);
-    if (options.watch) timer = setInterval(refresh, Math.max(1, intervalSeconds) * 1000);
-    render();
+    if (options.watch) {
+      timer = setInterval(() => {
+        try {
+          refresh();
+        } catch (error) {
+          cleanup(error);
+        }
+      }, Math.max(1, intervalSeconds) * 1000);
+    }
+    try {
+      render();
+    } catch (error) {
+      cleanup(error);
+    }
   });
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,0 +1,396 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+import { inspectScaffold, parsePlanFile, type MissionState, type PlanStage } from './scaffold.js';
+import { formatTaskSummary, getTaskSummary, type TaskSummary } from './tasks.js';
+import { validateScaffold } from './validation.js';
+
+export type StalenessLevel = 'green' | 'yellow' | 'red';
+export type VerifyLevel = 'green' | 'yellow' | 'red' | 'unknown';
+
+export interface DashboardPlan {
+  slug: string;
+  path: string;
+  modifiedAt: string;
+  ageDays: number;
+  staleness: StalenessLevel;
+  goal: string;
+  acceptanceSummary: string[];
+}
+
+export interface DashboardEvidenceNote {
+  path: string;
+  title: string;
+  modifiedAt: string;
+}
+
+export interface DashboardVerifyStatus {
+  level: VerifyLevel;
+  label: string;
+  command: string;
+  exitCode: number | null;
+  detail: string;
+}
+
+export interface DashboardData {
+  root: string;
+  projectName: string;
+  mission: MissionState;
+  counts: Record<PlanStage, number>;
+  activePlans: DashboardPlan[];
+  recentEvidence: DashboardEvidenceNote[];
+  verify: DashboardVerifyStatus;
+  taskSummary: TaskSummary | null;
+  loadedAt: string;
+}
+
+export interface DashboardLoadOptions {
+  now?: Date;
+  runVerify?: boolean;
+}
+
+export interface DashboardFormatOptions {
+  selectedIndex?: number;
+  expanded?: boolean;
+  color?: boolean;
+  rows?: number;
+  columns?: number;
+}
+
+export interface DashboardRunOptions {
+  root?: string;
+  watch?: boolean;
+  intervalSeconds?: number;
+}
+
+const ANSI = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+};
+
+function colorize(text: string, color: keyof typeof ANSI, enabled: boolean): string {
+  if (!enabled) return text;
+  return `${ANSI[color]}${text}${ANSI.reset}`;
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '');
+}
+
+function truncateAnsi(text: string, columns: number): string {
+  if (!Number.isFinite(columns) || columns <= 0) return text;
+  const visible = stripAnsi(text);
+  if (visible.length <= columns) return text;
+  const suffix = '…';
+  const limit = Math.max(0, columns - suffix.length);
+  if (text === visible) return `${visible.slice(0, limit)}${suffix}`;
+
+  let output = '';
+  let count = 0;
+  for (let i = 0; i < text.length && count < limit; i += 1) {
+    if (text[i] === '\x1b') {
+      const match = text.slice(i).match(/^\x1b\[[0-9;?]*[A-Za-z]/);
+      if (match) {
+        output += match[0];
+        i += match[0].length - 1;
+        continue;
+      }
+    }
+    output += text[i];
+    count += 1;
+  }
+  return `${output}${suffix}`;
+}
+
+function daysBetween(from: Date, to: Date): number {
+  return Math.max(0, (to.getTime() - from.getTime()) / 86_400_000);
+}
+
+function roundOne(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+export function stalenessLevel(ageDays: number): StalenessLevel {
+  if (ageDays < 7) return 'green';
+  if (ageDays <= 30) return 'yellow';
+  return 'red';
+}
+
+function projectName(root: string): string {
+  const packagePath = join(root, 'package.json');
+  if (existsSync(packagePath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(packagePath, 'utf8')) as { name?: unknown };
+      if (typeof parsed.name === 'string' && parsed.name.trim()) return parsed.name.trim();
+    } catch {
+      // Fall through to directory name.
+    }
+  }
+  return basename(root);
+}
+
+function evidenceTitle(text: string, file: string): string {
+  const heading = text.match(/^#\s+(.+)$/m)?.[1]?.trim();
+  if (heading) return heading.replace(/^Release \/ Evidence Note:\s*/i, '').trim();
+  return basename(file, '.md');
+}
+
+function recentEvidence(root: string): DashboardEvidenceNote[] {
+  const releasesDir = join(root, '.osc', 'releases');
+  if (!existsSync(releasesDir)) return [];
+  return readdirSync(releasesDir)
+    .filter((file) => file.endsWith('.md') && file !== 'README.md')
+    .map((file) => {
+      const path = join(releasesDir, file);
+      const stat = statSync(path);
+      const text = readFileSync(path, 'utf8');
+      return {
+        path: relative(root, path),
+        title: evidenceTitle(text, file),
+        modifiedAt: stat.mtime.toISOString(),
+        modifiedTime: stat.mtime.getTime(),
+      };
+    })
+    .sort((a, b) => b.modifiedTime - a.modifiedTime || a.path.localeCompare(b.path))
+    .slice(0, 3)
+    .map(({ modifiedTime: _modifiedTime, ...note }) => note);
+}
+
+function runVerify(root: string, enabled: boolean): DashboardVerifyStatus {
+  const command = 'osc verify';
+  if (!enabled) {
+    return { level: 'unknown', label: 'not run', command, exitCode: null, detail: 'verification skipped by caller' };
+  }
+  const result = validateScaffold(root);
+  if (!result.ok) {
+    const firstFailure = result.failures[0];
+    return {
+      level: 'red',
+      label: 'failing',
+      command,
+      exitCode: 1,
+      detail: firstFailure ? `${firstFailure.code}: ${firstFailure.message}` : 'validation failed',
+    };
+  }
+  if (result.warnings.length > 0) {
+    const firstWarning = result.warnings[0];
+    return {
+      level: 'yellow',
+      label: 'warnings',
+      command,
+      exitCode: 0,
+      detail: firstWarning ? `${firstWarning.code}: ${firstWarning.message}` : 'validation warnings present',
+    };
+  }
+  return {
+    level: 'green',
+    label: 'passing',
+    command,
+    exitCode: 0,
+    detail: 'validation passed',
+  };
+}
+
+function loadTaskSummary(root: string): TaskSummary | null {
+  if (!existsSync(join(root, '.osc', 'tasks.db'))) return null;
+  try {
+    return getTaskSummary(root);
+  } catch {
+    return null;
+  }
+}
+
+export function loadDashboardData(root = process.cwd(), options: DashboardLoadOptions = {}): DashboardData {
+  const now = options.now ?? new Date();
+  const state = inspectScaffold(root);
+  const counts = Object.fromEntries(
+    (['active', 'backlog', 'blocked', 'done'] as const).map((stage) => [stage, state.plans[stage].length]),
+  ) as Record<PlanStage, number>;
+  const activePlans = state.plans.active.map((summary) => {
+    const fullPath = join(root, summary.path);
+    const stat = statSync(fullPath);
+    const parsed = parsePlanFile(fullPath);
+    const ageDays = roundOne(daysBetween(stat.mtime, now));
+    return {
+      slug: summary.slug,
+      path: summary.path,
+      modifiedAt: stat.mtime.toISOString(),
+      ageDays,
+      staleness: stalenessLevel(ageDays),
+      goal: parsed.goal,
+      acceptanceSummary: parsed.acceptanceCriteria.slice(0, 3),
+    };
+  });
+
+  return {
+    root,
+    projectName: projectName(root),
+    mission: state.mission,
+    counts,
+    activePlans,
+    recentEvidence: recentEvidence(root),
+    verify: runVerify(root, options.runVerify ?? true),
+    taskSummary: loadTaskSummary(root),
+    loadedAt: now.toISOString(),
+  };
+}
+
+function stalenessLabel(plan: DashboardPlan): string {
+  if (plan.staleness === 'green') return `green ${plan.ageDays}d`;
+  if (plan.staleness === 'yellow') return `yellow ${plan.ageDays}d`;
+  return `red ${plan.ageDays}d`;
+}
+
+function levelColor(level: StalenessLevel | VerifyLevel): keyof typeof ANSI {
+  if (level === 'green') return 'green';
+  if (level === 'yellow') return 'yellow';
+  if (level === 'red') return 'red';
+  return 'dim';
+}
+
+function renderPlanLine(plan: DashboardPlan, index: number, selectedIndex: number, color: boolean): string {
+  const marker = index === selectedIndex ? '›' : ' ';
+  const status = colorize(stalenessLabel(plan), levelColor(plan.staleness), color);
+  return `${marker} ${plan.slug}  ${status}  ${plan.path}`;
+}
+
+function renderExpandedPlan(plan: DashboardPlan, verify: DashboardVerifyStatus, color: boolean): string[] {
+  const lines = [`  Goal: ${plan.goal || '(none)'}`];
+  const criteria = plan.acceptanceSummary.length > 0 ? plan.acceptanceSummary : ['(no acceptance criteria found)'];
+  for (const item of criteria) lines.push(`  AC: ${item}`);
+  lines.push(`  Last verification: ${colorize(verify.label, levelColor(verify.level), color)} (${verify.command})`);
+  return lines;
+}
+
+function taskSummaryLine(summary: TaskSummary | null): string | null {
+  if (!summary) return null;
+  return formatTaskSummary(summary);
+}
+
+export function formatDashboardText(data: DashboardData, options: DashboardFormatOptions = {}): string {
+  const color = options.color ?? false;
+  const selectedIndex = Math.min(Math.max(options.selectedIndex ?? 0, 0), Math.max(data.activePlans.length - 1, 0));
+  const expanded = options.expanded ?? false;
+  const columns = options.columns ?? 100;
+  const rows = options.rows ?? Number.POSITIVE_INFINITY;
+  const mission = data.mission.defined ? colorize('defined', 'green', color) : colorize(`not defined (${data.mission.reason ?? 'unknown'})`, 'red', color);
+  const verify = colorize(data.verify.label, levelColor(data.verify.level), color);
+  const lines: string[] = [];
+
+  lines.push(colorize('Open Scaffold dashboard', 'bold', color));
+  lines.push(`${data.projectName}  |  Mission: ${mission}  |  Verify: ${verify}  |  ${new Date(data.loadedAt).toISOString()}`);
+  lines.push('');
+  lines.push(`Plans: active ${data.counts.active} · backlog ${data.counts.backlog} · blocked ${data.counts.blocked} · done ${data.counts.done}`);
+  const tasks = taskSummaryLine(data.taskSummary);
+  if (tasks) lines.push(tasks);
+  lines.push('');
+  lines.push(colorize('Active plans', 'blue', color));
+  if (data.activePlans.length === 0) {
+    lines.push('No active plans. Create one with `osc plan new <slug> --stage active`');
+  } else {
+    data.activePlans.forEach((plan, index) => {
+      lines.push(renderPlanLine(plan, index, selectedIndex, color));
+      if (expanded && index === selectedIndex) lines.push(...renderExpandedPlan(plan, data.verify, color));
+    });
+  }
+  lines.push('');
+  lines.push(colorize('Recent evidence', 'cyan', color));
+  if (data.recentEvidence.length === 0) {
+    lines.push('No evidence notes yet. Create one with `osc evidence new <slug>`.');
+  } else {
+    for (const note of data.recentEvidence) lines.push(`- ${note.title}  ${note.path}`);
+  }
+  lines.push('');
+  lines.push(`Footer: ↑/↓ select · Enter expand · r refresh · q quit · verify ${data.verify.label}`);
+
+  const fitted = lines.map((line) => truncateAnsi(line, columns));
+  if (Number.isFinite(rows) && rows > 0 && fitted.length > rows) return fitted.slice(0, rows).join('\n');
+  return fitted.join('\n');
+}
+
+function parseKey(buffer: Buffer): 'up' | 'down' | 'enter' | 'refresh' | 'quit' | 'none' {
+  const value = buffer.toString('utf8');
+  if (value === '\u0003' || value === 'q' || value === 'Q' || value === '\x1b') return 'quit';
+  if (value === 'r' || value === 'R') return 'refresh';
+  if (value === '\r' || value === '\n') return 'enter';
+  if (value === '\x1b[A') return 'up';
+  if (value === '\x1b[B') return 'down';
+  return 'none';
+}
+
+export async function runDashboard(options: DashboardRunOptions = {}): Promise<void> {
+  const root = options.root ?? process.cwd();
+  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!interactive) {
+    const data = loadDashboardData(root);
+    console.log(formatDashboardText(data, { color: false, columns: process.stdout.columns ?? 100 }));
+    return;
+  }
+
+  let data = loadDashboardData(root);
+  let selectedIndex = 0;
+  let expanded = false;
+  const intervalSeconds = options.intervalSeconds ?? 30;
+  let timer: NodeJS.Timeout | null = null;
+
+  const render = () => {
+    process.stdout.write('\x1b[H\x1b[2J');
+    process.stdout.write(formatDashboardText(data, {
+      selectedIndex,
+      expanded,
+      color: true,
+      rows: process.stdout.rows ?? 24,
+      columns: process.stdout.columns ?? 80,
+    }));
+  };
+
+  const refresh = () => {
+    data = loadDashboardData(root);
+    selectedIndex = Math.min(selectedIndex, Math.max(data.activePlans.length - 1, 0));
+    render();
+  };
+
+  await new Promise<void>((resolve) => {
+    const stdin = process.stdin;
+    const cleanup = () => {
+      if (timer) clearInterval(timer);
+      stdin.off('data', onData);
+      if (typeof stdin.setRawMode === 'function') stdin.setRawMode(false);
+      stdin.pause();
+      process.stdout.write('\x1b[?25h\x1b[?1049l');
+      resolve();
+    };
+    const onData = (buffer: Buffer) => {
+      const key = parseKey(buffer);
+      if (key === 'quit') {
+        cleanup();
+        return;
+      }
+      if (key === 'refresh') refresh();
+      if (key === 'enter') {
+        expanded = !expanded;
+        render();
+      }
+      if (key === 'up') {
+        selectedIndex = Math.max(0, selectedIndex - 1);
+        render();
+      }
+      if (key === 'down') {
+        selectedIndex = Math.min(Math.max(data.activePlans.length - 1, 0), selectedIndex + 1);
+        render();
+      }
+    };
+
+    process.stdout.write('\x1b[?1049h\x1b[?25l');
+    if (typeof stdin.setRawMode === 'function') stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on('data', onData);
+    if (options.watch) timer = setInterval(refresh, Math.max(1, intervalSeconds) * 1000);
+    render();
+  });
+}

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { formatDashboardText, loadDashboardData, stalenessLevel } from '../src/dashboard.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempScaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'osc-dashboard-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/backlog'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/blocked'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/done'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nKeep AI work reviewable.\n');
+  writeFileSync(join(root, 'package.json'), '{"name":"dashboard-project"}\n');
+  return root;
+}
+
+function writePlan(root: string, stage: 'active' | 'backlog' | 'blocked' | 'done', slug: string, goal = 'Show project state.'): string {
+  const path = join(root, `.osc/plans/${stage}/${slug}.md`);
+  writeFileSync(path, `# Plan: ${slug}
+
+## Status
+
+${stage}
+
+## Context
+
+Dashboard test plan.
+
+## Goal
+
+${goal}
+
+## Constraints / Out of scope
+
+- Read only.
+
+## Files to touch
+
+- src/dashboard.ts
+
+## Acceptance criteria
+
+- [ ] Dashboard shows active plans.
+- [ ] Dashboard shows evidence.
+
+## Verification steps
+
+1. Run the dashboard test.
+
+## Open questions
+
+None.
+`);
+  return path;
+}
+
+describe('dashboard data and formatting', () => {
+  it('classifies active plan staleness by modified age', () => {
+    expect(stalenessLevel(0)).toBe('green');
+    expect(stalenessLevel(6.9)).toBe('green');
+    expect(stalenessLevel(7)).toBe('yellow');
+    expect(stalenessLevel(30)).toBe('yellow');
+    expect(stalenessLevel(30.1)).toBe('red');
+  });
+
+  it('loads active plans, counts, recent evidence, goal, and acceptance summary', () => {
+    const root = tempScaffold();
+    const activePath = writePlan(root, 'active', '001-dashboard', 'Make terminal state visible.');
+    writePlan(root, 'backlog', '002-next');
+    writePlan(root, 'blocked', '003-blocked');
+    writePlan(root, 'done', '004-done');
+    writeFileSync(join(root, '.osc/releases/2026-05-25-dashboard.md'), '# Dashboard evidence\n\nVerified.\n');
+    const now = new Date('2026-05-25T12:00:00Z');
+    const modified = new Date('2026-05-20T12:00:00Z');
+    utimesSync(activePath, modified, modified);
+
+    const data = loadDashboardData(root, { runVerify: false, now });
+
+    expect(data.projectName).toBe('dashboard-project');
+    expect(data.mission.defined).toBe(true);
+    expect(data.counts).toMatchObject({ active: 1, backlog: 1, blocked: 1, done: 1 });
+    expect(data.activePlans[0]).toMatchObject({ slug: '001-dashboard', staleness: 'green', goal: 'Make terminal state visible.' });
+    expect(data.activePlans[0].acceptanceSummary).toContain('Dashboard shows active plans.');
+    expect(data.recentEvidence[0]).toMatchObject({ title: 'Dashboard evidence' });
+  });
+
+  it('formats an empty active-plan state with dashboard shortcuts', () => {
+    const root = tempScaffold();
+    const data = loadDashboardData(root, { runVerify: false, now: new Date('2026-05-25T12:00:00Z') });
+
+    const text = formatDashboardText(data, { selectedIndex: 0, expanded: false, color: false, rows: 24, columns: 80 });
+
+    expect(text).toContain('Open Scaffold dashboard');
+    expect(text).toContain('Mission: defined');
+    expect(text).toContain('No active plans. Create one with `osc plan new <slug> --stage active`');
+    expect(text).toContain('q quit');
+    expect(text).toContain('r refresh');
+  });
+
+  it('prints a static dashboard in non-interactive CLI mode and aliases status --dashboard', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '001-dashboard', 'Show cockpit state.');
+
+    const dashboardOutput = execFileSync(tsx, [cli, 'dashboard'], { cwd: root, encoding: 'utf8' });
+    const aliasOutput = execFileSync(tsx, [cli, 'status', '--dashboard'], { cwd: root, encoding: 'utf8' });
+
+    expect(dashboardOutput).toContain('Open Scaffold dashboard');
+    expect(dashboardOutput).toContain('001-dashboard');
+    expect(aliasOutput).toContain('Open Scaffold dashboard');
+  });
+
+  it('mentions dashboard commands in help', () => {
+    const output = execFileSync(tsx, [cli, '--help'], { encoding: 'utf8' });
+
+    expect(output).toContain('osc dashboard [--watch] [--interval <seconds>]');
+    expect(output).toContain('osc status [--json|--dashboard]');
+  });
+});

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { Buffer } from 'node:buffer';
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { formatDashboardText, loadDashboardData, stalenessLevel } from '../src/dashboard.js';
+import { DashboardKeyParser, formatDashboardText, loadDashboardData, stalenessLevel } from '../src/dashboard.js';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const tsx = join(repoRoot, 'node_modules/.bin/tsx');
@@ -102,6 +103,22 @@ describe('dashboard data and formatting', () => {
     expect(text).toContain('No active plans. Create one with `osc plan new <slug> --stage active`');
     expect(text).toContain('q quit');
     expect(text).toContain('r refresh');
+  });
+
+  it('keeps split arrow-key escape sequences from being treated as quit', () => {
+    const parser = new DashboardKeyParser();
+
+    expect(parser.push(Buffer.from('\x1b'))).toBe('pending');
+    expect(parser.push(Buffer.from('['))).toBe('pending');
+    expect(parser.push(Buffer.from('A'))).toBe('up');
+    expect(parser.flushPendingEscape()).toBe('none');
+  });
+
+  it('flushes a standalone Escape key as quit after the split-sequence window', () => {
+    const parser = new DashboardKeyParser();
+
+    expect(parser.push(Buffer.from('\x1b'))).toBe('pending');
+    expect(parser.flushPendingEscape()).toBe('quit');
   });
 
   it('prints a static dashboard in non-interactive CLI mode and aliases status --dashboard', () => {


### PR DESCRIPTION
## Summary

Opened/advanced by Open Scaffold runner automation.

Selected source: `wip_branch` — `feat/065-tui-dashboard` for plan `065-tui-dashboard`.

- Adds `osc dashboard` as a read-only terminal glass cockpit for mission state, plan counts, active-plan freshness, recent evidence, validation health, and optional task summary data.
- Adds `osc status --dashboard` as an alias for the same dashboard.
- Documents the terminal dashboard as the simplest local glass cockpit implementation.
- Closes plan `065-tui-dashboard` and records a repo-native evidence note.
- Addresses latest-head review feedback by parsing split escape-key sequences safely and restoring terminal state when refresh/watch reloads fail.

## Verification

- `git diff --check` — passed.
- `./verify.sh --strict` — passed: 10 pass, 0 fail, 0 warn.
- `npm test -- tests/dashboard.test.ts --run` — passed: 7 tests.
- `npm test -- --run` — passed: 38 test files, 339 tests.
- `npm run build` — passed.
- `npm pack --dry-run --json` — passed; package contains dashboard build artifacts.
- `node dist/cli.js dashboard` and `node dist/cli.js status --dashboard` — static dashboard smoke passed.

## Owner gates

- Merge gate: owner review required.
- npm publication gate: not performed; keep batched with the release train.
- GitHub Release gate: not performed; keep batched with the release train.

## Scope notes

- No daemon, browser, Electron, or web server.
- No package publication or GitHub Latest Release movement.
- No runtime spawning; dashboard validation uses in-process scaffold validation rather than process launch.
