### PR TITLE
docs: polish v1 launch docs and release truth

### DIFF
--- a/.osc/plans/done/074-v1-launch-docs-polish.md
+++ b/.osc/plans/done/074-v1-launch-docs-polish.md
@@ -1,0 +1,62 @@
+# Plan: v1-launch-docs-polish
+
+## Status
+
+done
+
+## Context
+
+The v1.0.0 release-candidate branch has merged into `main`, but the launch-facing docs still contain small bits of pre-merge wording, stale publishing guidance, a broken README quickstart anchor, and a few overclaim/meme FAQ lines that weaken the first serious public read.
+
+This slice is the final docs-only launch polish before the owner decides whether to publish `open-scaffold@1.0.0` and mark the GitHub Release latest.
+
+## Goal
+
+Make the README and key public docs accurately describe the current release truth: repo `main` is a v1.0.0 candidate, npm/GitHub Latest still show the previous public release until publication, runtime/native-spawn material is clearly experimental or historical, and first-time readers get a sharper adoption path.
+
+## Constraints / Out of scope
+
+- Do not change product behavior, package code, schemas, workflow YAML behavior, or runtime implementation.
+- Do not publish to npm, create or move GitHub Releases, deploy a website, or announce launch.
+- Do not broaden the v1 stable contract.
+- Do not rewrite historical research into current product promises.
+- Keep public wording owner-neutral; do not mention private operator names.
+
+## Files to touch
+
+- `README.md` — sharpen first-read flow, add the missing quickstart anchor, promote minimum viable scaffold guidance, and update release-state wording.
+- `docs/STABILITY.md` — remove stale merge gate language and state the remaining external publication gates.
+- `docs/CHANGELOG.md` — align v1 candidate wording with the already-merged repository state.
+- `ROADMAP.md` — align Milestone 18 release status with the merged repo candidate.
+- `docs/CI.md` — document both trusted publishing and legacy token/tag publishing accurately.
+- `docs/GITHUB_WORKFLOW.md` — align CI/publishing bullet with current workflow reality.
+- `docs/examples/README.md` — fix the broken README quickstart anchor.
+- `docs/FAQ.md` — tighten launch-risky tone and unsupported claims without removing personality.
+- `docs/RUNTIME_HARNESS_DISPATCH.md` and `docs/RUNTIME_STRATEGY_RESEARCH_SYNTHESIS.md` — label historical/research scope clearly where needed.
+- `docs/index.html` — align the landing-page owner gate footer.
+- `AGENTS.md` and `CLAUDE.md` — keep paired first-read product wording aligned with launch docs if changed.
+- `.osc/releases/2026-05-25-074-v1-launch-docs-polish.md` — record evidence for this docs slice.
+
+## Acceptance criteria
+
+- [x] README has a working `#quickstart` anchor and explains install/adoption before deep release-candidate detail.
+- [x] README key docs point fresh users to `docs/MINIMUM_VIABLE_SCAFFOLD.md`.
+- [x] Release-state wording says merge is done and remaining gates are npm publication, GitHub Release latest movement, and launch/deploy choices.
+- [x] CI/publishing docs describe trusted publishing as the preferred v1 path and legacy token/tag publishing as an alternative.
+- [x] Runtime strategy/research pages are clearly framed as historical/research or private-deployment examples, not v1 promises.
+- [x] FAQ removes unsupported/meme launch-path claims such as "over 9000" and "zero re-explanation cost forever".
+- [x] No product behavior, package code, workflow behavior, npm publication, GitHub Release mutation, or deploy occurs.
+
+## Verification steps
+
+1. `git diff --check` — no whitespace errors.
+2. `./verify.sh --standard` — scaffold methodology passes for this docs slice.
+3. `npm run osc -- verify` — CLI verification path passes.
+4. `npm test -- --run` — docs-linked tests and package tests pass.
+5. `npm run build` — TypeScript/package build passes.
+6. Targeted grep checks — stale launch blockers and risky FAQ lines are absent from launch-facing docs.
+7. `npm pack --dry-run --json` — package payload remains valid after docs changes.
+
+## Open questions
+
+None for this docs-only polish. Merge, npm publication, GitHub Release latest movement, deployment, and launch announcement remain owner gates after the PR is reviewed.

--- a/.osc/releases/2026-05-25-074-v1-launch-docs-polish.md
+++ b/.osc/releases/2026-05-25-074-v1-launch-docs-polish.md
@@ -9,7 +9,7 @@ Polished launch-facing documentation for the v1.0.0 release candidate. The READM
 - Roadmap / issue / task: Milestone 18 v1.0.0 stability launch docs polish.
 - Plan: `.osc/plans/done/074-v1-launch-docs-polish.md`
 - Run ID / run packet: N/A — docs-only branch, no runtime handoff package.
-- Branch / PR: `docs/v1-launch-polish`; PR URL is recorded in GitHub once the branch is pushed.
+- Branch / PR: `docs/v1-launch-polish`; https://github.com/graphanov/open-scaffold/pull/115.
 
 ## Verification
 

--- a/.osc/releases/2026-05-25-074-v1-launch-docs-polish.md
+++ b/.osc/releases/2026-05-25-074-v1-launch-docs-polish.md
@@ -1,0 +1,31 @@
+# Release / Evidence Note: 074-v1-launch-docs-polish
+
+## Summary
+
+Polished launch-facing documentation for the v1.0.0 release candidate. The README now exposes a working Quickstart anchor before release-candidate detail, key docs point to the Minimum Viable Scaffold guide, release-state wording reflects that the repo candidate is merged while npm/GitHub Release publication remains external, and FAQ/runtime pages avoid launch-risky overclaims.
+
+## Traceability
+
+- Roadmap / issue / task: Milestone 18 v1.0.0 stability launch docs polish.
+- Plan: `.osc/plans/done/074-v1-launch-docs-polish.md`
+- Run ID / run packet: N/A — docs-only branch, no runtime handoff package.
+- Branch / PR: `docs/v1-launch-polish`; PR URL is recorded in GitHub once the branch is pushed.
+
+## Verification
+
+- `git diff --check` — passed.
+- `npm test -- --run` — passed, 356 tests.
+- `npm run build` — passed.
+- Targeted launch-doc hygiene checks — passed: stale merge-gate wording, stale `v0.4.19`, risky FAQ claims, and broken Quickstart anchor were absent or fixed.
+- `npm pack --dry-run --json` — passed, `open-scaffold@1.0.0`, 145 files, `open-scaffold-1.0.0.tgz`.
+- `./verify.sh --standard` — passed after plan closure: 6 pass, 0 fail, 0 warn.
+- `./verify.sh --strict` — passed after plan closure: 10 pass, 0 fail, 0 warn.
+- `npm run osc -- verify` — passed after plan closure with 5 pre-existing warnings from older artifacts, no new failure.
+
+## Outcome
+
+The docs now present Open Scaffold as a clear repo-native work record for AI-assisted software while keeping advanced runtime/native-spawn material outside the v1 stable promise. No product behavior, package code, workflow behavior, npm publication, GitHub Release mutation, deployment, or launch announcement happened in this slice.
+
+## Follow-up
+
+Owner gates remain: review/merge this docs PR, publish `open-scaffold@1.0.0` to npm if approved, create or mark GitHub Release `v1.0.0` as Latest if approved, then decide whether to launch publicly.

--- a/.osc/releases/2026-05-25-074-v1-launch-docs-polish.md
+++ b/.osc/releases/2026-05-25-074-v1-launch-docs-polish.md
@@ -24,7 +24,7 @@ Polished launch-facing documentation for the v1.0.0 release candidate. The READM
 
 ## Outcome
 
-The docs now present Open Scaffold as a clear repo-native work record for AI-assisted software while keeping advanced runtime/native-spawn material outside the v1 stable promise. No product behavior, package code, workflow behavior, npm publication, GitHub Release mutation, deployment, or launch announcement happened in this slice.
+The docs now present Open Scaffold as a clear repo-native work record for AI-assisted software while keeping advanced runtime/native-spawn material outside the v1 stable promise. Codex's first review pass found one valid README wording issue where npm package truth and GitHub Release truth were coupled; the follow-up patch separates those public surfaces. No product behavior, package code, workflow behavior, npm publication, GitHub Release mutation, deployment, or launch announcement happened in this slice.
 
 ## Follow-up
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 # Agent Instructions
 
-This project is [open-scaffold](https://github.com/graphanov/open-scaffold), a runtime-neutral repo-native operating system for agent-orchestrated development. It ships with a persistent project structure — mission, roadmap, immutable plans, amendment protocols, decisions, evidence, run packets, and session handover practices — so that any agent or orchestrator (Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, or similar) can operate in the repository from commit #1 without re-explanation.
+This project is [open-scaffold](https://github.com/graphanov/open-scaffold), a repo-native work record for AI-assisted software. It keeps mission, roadmap, plans, amendments, evidence, run packets, and session handover practices in git-tracked files so any capable agent or orchestrator (Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, or similar) can enter the repository without relying on vanished chat context.
 
 ## Layered architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 # Project Context
 
-This project is [open-scaffold](https://github.com/graphanov/open-scaffold), a runtime-neutral repo-native operating system for agent-orchestrated development. It ships with a persistent project structure — mission, roadmap, immutable plans, amendment protocols, decisions, evidence, run packets, and session handover practices — so that any agent or orchestrator can operate in this repository from commit #1 without re-explanation. Read this file first, then consult `MISSION.md` for what the project actually is.
+This project is [open-scaffold](https://github.com/graphanov/open-scaffold), a repo-native work record for AI-assisted software. It keeps mission, roadmap, plans, amendments, evidence, run packets, and session handover practices in git-tracked files so any capable agent or orchestrator can enter this repository without relying on vanished chat context. Read this file first, then consult `MISSION.md` for what the project actually is.
 
 ## Layered architecture
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-26: closed 074-v1-launch-docs-polish — polished v1 launch docs and release truth
 - 2026-05-25: closed 064-devcontainer-profile — devcontainer profile shipped in PR #108
 - 2026-05-25: closed 069-v1-launch — prepared v1.0.0 release candidate with stability docs and owner publication gates
 - 2026-05-25: limit automation to v1 release-candidate preparation; publication remains owner-gated — see .osc/plans/done/069-v1-launch-amendment-1.md

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Use cases the stable contract supports today:
 - teams that want PRs to carry intent, evidence, and approval state;
 - consulting or audit-sensitive delivery where later readers need to reconstruct what happened.
 
-Publication truth lives outside git. This repository can carry the `1.0.0` candidate before npm and GitHub Releases do. Check `npm view open-scaffold version dist-tags --json` and the GitHub Release marked **Latest**; until those show v1.0.0, the live public package is still the previous release. See [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
+Publication truth lives outside git, and the two public surfaces move separately. Check `npm view open-scaffold version dist-tags --json` to see which package `npx open-scaffold@latest` installs. Check the GitHub Release marked **Latest** to see which release note GitHub highlights. Until npm shows `1.0.0`, the install path is still the previous package; until GitHub Releases shows `v1.0.0` as **Latest**, the release page is still on the previous release. See [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ For the one-screen version, see [`docs/examples/evolution-loop-compare.md`](docs
 
 ---
 
-## Recommended default flow
+## Quickstart
+
+This is the smallest useful path: add the scaffold, define the mission, create one active plan, verify, record evidence, and close the slice.
 
 ### 1. Add Open Scaffold to a repo
 
@@ -146,35 +148,6 @@ node dist/cli.js init --tier standard --target <your-project>
 ```
 
 Optional container path: clone the repo, open it with VS Code Dev Containers or GitHub Codespaces, and the bundled `.devcontainer/` provides Node.js 22, npm, git, and `osc`. See [`docs/DEV_CONTAINER.md`](docs/DEV_CONTAINER.md) for Docker-only use and customization.
-
-## v1.0.0 Stable release candidate
-
-Open Scaffold v1.0.0 means the repo protocol and day-two CLI are stable enough to adopt with semver expectations. It does **not** mean every experimental integration is frozen.
-
-Stable:
-
-- CLI: `osc init`, `osc status`, `osc plan new`, `osc plan validate`, `osc plan move`, `osc amend`, `osc close`, `osc evidence new`, `osc evidence collect`, and `osc verify`.
-- Protocol: `MISSION.md`, `ROADMAP.md`, `.osc/plans/`, the 7-section plan schema, folder-as-status workflow, amendments, evidence notes, and run-packet records.
-- Verification floor: `verify.sh` plus package tests/builds for this repository.
-
-Experimental:
-
-- Runtime profiles and runtime-selection helpers beyond no-spawn run-packet metadata.
-- MCP, glass cockpit webhooks, local task database helpers, TUI/web dashboards, runtime packages, and Python parser packaging.
-
-Future / not included:
-
-- Native autonomous spawning in core.
-- Compliance certification.
-- Provider/model benchmarking or ranking.
-
-Use cases the stable contract supports today:
-
-- solo developers who need multi-session AI work to be resumable;
-- teams that want PRs to carry intent, evidence, and approval state;
-- consulting or audit-sensitive delivery where later readers need to reconstruct what happened.
-
-The live public release is true only after the owner approves merge, npm publication, and GitHub Release latest movement. See [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
 
 ### 2. Define the mission
 
@@ -253,6 +226,37 @@ That creates a `run.json` work package. The outside tool executes. Evidence come
 
 ---
 
+## v1.0.0 stable release candidate
+
+Open Scaffold v1.0.0 means the repo protocol and day-two CLI are stable enough to adopt with semver expectations. It does **not** mean every experimental integration is frozen.
+
+Stable:
+
+- CLI: `osc init`, `osc status`, `osc plan new`, `osc plan validate`, `osc plan move`, `osc amend`, `osc close`, `osc evidence new`, `osc evidence collect`, and `osc verify`.
+- Protocol: `MISSION.md`, `ROADMAP.md`, `.osc/plans/`, the 7-section plan schema, folder-as-status workflow, amendments, evidence notes, and run-packet records.
+- Verification floor: `verify.sh` plus package tests/builds for this repository.
+
+Experimental:
+
+- Runtime profiles and runtime-selection helpers beyond no-spawn run-packet metadata.
+- MCP, glass cockpit webhooks, local task database helpers, TUI/web dashboards, runtime packages, and Python parser packaging.
+
+Future / not included:
+
+- Native autonomous spawning in core.
+- Compliance certification.
+- Provider/model benchmarking or ranking.
+
+Use cases the stable contract supports today:
+
+- solo developers who need multi-session AI work to be resumable;
+- teams that want PRs to carry intent, evidence, and approval state;
+- consulting or audit-sensitive delivery where later readers need to reconstruct what happened.
+
+Publication truth lives outside git. This repository can carry the `1.0.0` candidate before npm and GitHub Releases do. Check `npm view open-scaffold version dist-tags --json` and the GitHub Release marked **Latest**; until those show v1.0.0, the live public package is still the previous release. See [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
+
+---
+
 ## Simple mental model
 
 - **You** decide the goal, taste, risk, merge, and publish gates.
@@ -307,6 +311,7 @@ Skip it for:
 
 - [`docs/WHY_OPEN_SCAFFOLD.md`](docs/WHY_OPEN_SCAFFOLD.md) — visual story and fit.
 - [`docs/index.html`](docs/index.html) — one-page landing page for the 30-second explanation.
+- [`docs/MINIMUM_VIABLE_SCAFFOLD.md`](docs/MINIMUM_VIABLE_SCAFFOLD.md) — smallest practical day-one adoption path.
 - [`docs/STABILITY.md`](docs/STABILITY.md) — v1.0.0 stable, experimental, and future surfaces.
 - [`docs/CHANGELOG.md`](docs/CHANGELOG.md) — curated release history.
 - [`docs/DEV_CONTAINER.md`](docs/DEV_CONTAINER.md) — optional container setup for consistent team onboarding.
@@ -315,7 +320,7 @@ Skip it for:
 - [`docs/OPEN_SCAFFOLD_SYSTEM.md`](docs/OPEN_SCAFFOLD_SYSTEM.md) — full system map and boundaries.
 - [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — choosing runtime lanes and profiles.
 - [`docs/RUNTIME_BINDING_CONTRACT.md`](docs/RUNTIME_BINDING_CONTRACT.md) — adapter responsibilities after `run.json` exists.
-- [`docs/FAQ.md`](docs/FAQ.md) — deeper docs.
+- [`docs/FAQ.md`](docs/FAQ.md) — deeper questions.
 
 Translations for agent entry files: Chinese, Japanese, Korean, Spanish, Portuguese. See [`docs/TRANSLATIONS.md`](docs/TRANSLATIONS.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -393,7 +393,7 @@ Acceptance criteria:
 
 ### Milestone 18 — v1.0.0 stability launch
 
-Status: repository-side v1.0.0 release candidate prepared by `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, and PR #113. Owner-gated merge, npm publication, and GitHub Release latest movement remain required before v1.0.0 is live.
+Status: repository-side v1.0.0 release candidate prepared by `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, and merged PR #113. Owner-gated npm publication and GitHub Release latest movement remain required before v1.0.0 is live.
 
 Goal: make the stable adoption contract explicit before the first major release.
 
@@ -407,7 +407,6 @@ Deliverables:
 
 Owner gates:
 
-- Merge the release-candidate PR.
 - Publish `open-scaffold@1.0.0` to npm.
 - Create or mark the `v1.0.0` GitHub Release as **Latest**.
 - Decide whether to launch publicly through a blog, social channel, GitHub Pages, or another site.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 This is a curated human-readable changelog. It compresses the detailed `MISSION.md` changelog, `.osc/releases/` evidence notes, GitHub PR history, and GitHub Releases into adoption-facing release groups.
 
-For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared; publication still depends on owner-gated merge, npm, and GitHub Release actions.
+For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared; publication still depends on owner-gated npm and GitHub Release actions.
 
 ## v1.0.0 — Stable protocol release candidate
 
-Status: repository candidate prepared; npm publication and GitHub Release latest movement are owner-gated external actions.
+Status: repository candidate merged; npm publication and GitHub Release latest movement are owner-gated external actions.
 
 Highlights:
 
@@ -14,7 +14,7 @@ Highlights:
 - Adds a landing page at `docs/index.html` for the 30-second explanation: problem, audience, first command.
 - Promotes the stable surface: scaffold state folders, 7-section plans, mission/roadmap/evidence files, `verify.sh`, and day-two CLI commands.
 - Separates experimental surfaces: runtime profiles, MCP, cockpit webhooks, task database helpers, dashboards, runtime packages, and future native spawning.
-- Keeps merge, npm publication, GitHub Release latest movement, and any launch announcement as owner gates.
+- Keeps npm publication, GitHub Release latest movement, and any launch announcement as owner gates.
 
 Evidence:
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -12,7 +12,8 @@ These workflows are active in this repository and can also be copied into downst
 | `.github/workflows/plan-validate.yml` | PRs touching staged plan files under `.osc/plans/{active,backlog,blocked,done}/` | Validates changed plan files with `osc plan validate`. Errors fail the PR; warnings remain visible but non-blocking. |
 | `.github/workflows/evidence-validate.yml` | PRs touching `.osc/releases/**/*.md` | Runs `./verify.sh --strict` and checks changed evidence notes for required sections and stale `pending` claims. |
 | `.github/workflows/stale-plans.yml` | Weekly Monday 09:00 UTC and manual dispatch | Detects active plans older than the configured threshold and opens or updates a GitHub Issue. |
-| `.github/workflows/npm-publish.yml` | Version tag pushes matching `v*` | Builds, tests, verifies, checks the tag against `package.json`, then publishes to npm using `NPM_TOKEN`. |
+| `.github/workflows/publish-npm.yml` | Manual dispatch | Preferred v1 publish path: builds, tests, verifies, checks the requested version, then publishes with npm trusted publishing and provenance. |
+| `.github/workflows/npm-publish.yml` | Version tag pushes matching `v*` | Legacy/token publish path: builds, tests, verifies, checks the tag against `package.json`, then publishes with `NPM_TOKEN` when that path is intentionally enabled. |
 
 ## Plan validation
 
@@ -54,24 +55,44 @@ To customize the threshold:
 
 ## npm publishing
 
+Open Scaffold currently documents two publish paths. Do not run both for the same release.
+
+### Preferred v1 path: trusted publishing
+
+`publish-npm.yml` is manually dispatched by the owner. It uses GitHub Actions OIDC / npm trusted publishing with least-privilege permissions:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+Required setup:
+
+1. Configure npm trusted publishing for this repository and workflow filename.
+2. Ensure `package.json` has the version that should be released.
+3. Run the workflow manually with `expected-version` and `npm-tag` inputs.
+
+The workflow refuses to publish if `package.json` does not match the requested version or if that package version is already on npm.
+
+### Legacy path: token + version tag
+
 `npm-publish.yml` is intentionally tag-gated. It does not run on regular pushes or pull requests.
 
 Required setup:
 
 1. Add an npm automation token as the repository secret `NPM_TOKEN`.
 2. Ensure `package.json` has the version that should be released.
-3. Push a matching tag such as `v0.4.19`.
+3. Push a matching tag such as `v1.0.0`.
 
 The workflow refuses to publish if the tag does not match `package.json` or if that package version is already on npm.
-
-Projects using npm trusted publishing can keep a separate manual trusted-publishing workflow instead. Do not run both publish paths for the same release without an owner decision.
 
 ## Enabling, disabling, and adapting
 
 - To disable a workflow, rename the file extension away from `.yml` or remove its trigger block.
 - To keep workflows as templates only, move them out of `.github/workflows/` before committing.
-- For private npm registries, change `registry-url` and the publish token secret name in `npm-publish.yml`.
-- For non-Node projects, keep plan/evidence/stale-plan workflows and replace only the build/test steps in `ci.yml` and `npm-publish.yml`.
+- For private npm registries, change `registry-url` and the publish token or trusted-publishing setup in the selected publish workflow.
+- For non-Node projects, keep plan/evidence/stale-plan workflows and replace only the build/test steps in `ci.yml` and the selected publish workflow.
 
 ## Local testing
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,15 +14,15 @@ Questions that did not fit in the main README but are still worth answering.
 
 ### Can I run this for 5 hours straight and come back to a finished product?
 
-> No. Anyone who says their framework does that is selling you something. What you *can* do: write a plan, give it to an outside tool or runner, and come back to work that still traces back to your acceptance criteria. Examples include a private coordinator deployment such as Hermes/Claw, OMC with `/autopilot`/`/ralph` for Claude Code, or OMX with `$team`/`$ralph`/`$ultrawork` for Codex. These are runtime lanes or private deployment examples, not Open Scaffold dependencies; see [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md). The difference the scaffold makes is **recoverability** — because the plan is on disk, you can read what the agent did, compare against the ACs, and know exactly where to resume. Without it, a 5-hour run is a 5-hour black box.
+> Not by Open Scaffold itself. Open Scaffold is not a hands-off product factory. What you *can* do: write a plan, give it to an outside tool or runner, and come back to work that still traces back to your acceptance criteria. Examples include a private coordinator deployment such as Hermes/Claw, OMC with `/autopilot`/`/ralph` for Claude Code, or OMX with `$team`/`$ralph`/`$ultrawork` for Codex. These are runtime lanes or private deployment examples, not Open Scaffold dependencies; see [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md). The difference the scaffold makes is **recoverability** — because the plan is on disk, you can read what the agent did, compare against the ACs, and know exactly where to resume. Without it, a long run is hard to audit.
 
 ### Does this reduce token usage / cost?
 
-> Usually, yes — indirectly. Plans mean less context-stuffing ("remember yesterday when..."). Immutability means no back-and-forth about what was already decided. `verify.sh` catches methodology drift mechanically instead of via a review round. Not benchmarked, so treat it as a hypothesis — but the "wait, we already decided this" loops are the expensive ones, and the scaffold is designed to eliminate them.
+> Often, indirectly — but this is not benchmarked yet. Plans mean less context-stuffing ("remember yesterday when..."). Immutability means fewer loops about what was already decided. `verify.sh` catches methodology drift mechanically instead of relying only on another review round. Treat cost reduction as a workflow hypothesis to measure in your own repo, not as a guaranteed benchmark.
 
 ### Will my agent actually follow the protocol, or will it just ignore the files?
 
-> Depends on the agent and how you prompt it. Claude Code and Codex read [CLAUDE.md](../CLAUDE.md) and [AGENTS.md](../AGENTS.md) automatically. Cursor, Aider, and most others will too if you tell them to once. Compliance holds up because the instructions are direct and `verify.sh` is mechanical — not a judgment call. If your agent is the type that routinely ignores explicit instructions, no scaffold will save you.
+> Depends on the agent and how you prompt it. Claude Code and Codex read [CLAUDE.md](../CLAUDE.md) and [AGENTS.md](../AGENTS.md) automatically. Cursor, Aider, and most others will too if you tell them to once. The protocol holds up better because the instructions are direct and `verify.sh` is mechanical — not only a judgment call. If your agent routinely ignores explicit instructions, no scaffold can fully solve that.
 
 ### Why are CLAUDE.md and AGENTS.md hand-duplicated instead of generated from one source?
 
@@ -38,11 +38,11 @@ Questions that did not fit in the main README but are still worth answering.
 
 ### What if I'm bad at writing plans? Does this fall apart?
 
-> No. The [handoff template](../.osc/plans/handoff-template.md) is a fill-in-the-blanks form with 7 sections. If you can answer "what am I trying to do, how will I know it worked, what's out of scope," you can write a plan. If you can't answer those, you probably shouldn't be coding yet — which is exactly the point.
+> No. The [handoff template](../.osc/plans/handoff-template.md) is a fill-in-the-blanks form with 7 sections. If you can answer "what am I trying to do, how will I know it worked, what's out of scope," you can write a plan. If you can't answer those yet, pause before coding — that uncertainty is exactly what the plan is supposed to expose.
 
 ### Is this just going to slow me down? I'm used to vibing.
 
-> Yes — by about 15 minutes on day one. That's the tax. After that, it speeds you up because session two doesn't start with "OK so where were we..." You trade 15 upfront minutes for zero re-explanation cost forever. For anything you'll work on more than once, the trade is obvious.
+> A little on day one. That is the tax. After that, it should speed you up because session two does not start with "OK so where were we..." You trade a short setup step for lower re-explanation cost on future sessions. For anything you will work on more than once, the trade is usually worth it.
 
 ### Can I adopt this mid-project, or is it only for new repos?
 
@@ -64,11 +64,9 @@ Questions that did not fit in the main README but are still worth answering.
 
 > You have to commit them. Immutability means "committed to version control." An uncommitted plan is a draft; a committed plan is a record. Uncommitted plans can be edited silently, which is exactly what the protocol exists to prevent.
 
-### What power level will I achieve when using this?
+### What changes after I adopt it?
 
-> Over 9000, obviously.
->
-> More usefully: you'll stop losing context between sessions, stop re-explaining constraints, and stop waking up to "what did I decide last Tuesday?" For a multi-session project, that's a bigger deal than it sounds.
+> You stop losing as much context between sessions, stop re-explaining the same constraints, and stop waking up to "what did I decide last Tuesday?" For a multi-session project, that is a bigger deal than it sounds.
 
 ### Who built this?
 

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -99,7 +99,7 @@ Open Scaffold projects should keep repository truth mechanically checked in GitH
 - `plan-validate.yml` validates changed `.osc/plans/**/*.md` files on PRs.
 - `evidence-validate.yml` runs strict evidence checks for `.osc/releases/**/*.md` changes.
 - `stale-plans.yml` runs weekly and opens a GitHub Issue for stale active plans instead of mutating plan state automatically.
-- `npm-publish.yml` is tag-gated and uses `NPM_TOKEN`; publish, release, and deployment remain owner gates.
+- `publish-npm.yml` is the preferred manual trusted-publishing path; `npm-publish.yml` remains a legacy tag/token path. Publication, release, and deployment remain owner gates.
 
 CI failures should be resolved before merge unless the failure is explicitly classified as external infrastructure. CI does not replace Codex review or human approval.
 

--- a/docs/RUNTIME_HARNESS_DISPATCH.md
+++ b/docs/RUNTIME_HARNESS_DISPATCH.md
@@ -1,5 +1,7 @@
 # Runtime Harness Dispatch Pattern
 
+> Status: historical dispatch-pattern evidence and adapter-boundary guidance. This is not a v1 promise that Open Scaffold core launches agents.
+
 Open Scaffold core defines the portable contract for semi-autonomous work. It does **not** own the local launcher/controller that starts agents. A coordinator or runtime-specific binding — external launch glue — consumes `.osc/runs/<run_id>/run.json` and dispatches the selected harness, meaning the workflow wrapper around the chosen agent.
 
 This page captures a **private deployment example**: an owner-local Command Center used Hermes Kanban -> OMX `$ralplan` to prove the dispatch shape. It translates that private dogfood pattern into the public Open Scaffold model; the private deployment is not required to adopt Open Scaffold. The detailed adapter/binding responsibilities live in [`docs/RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md), and reference labels live in [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md).

--- a/docs/RUNTIME_STRATEGY_RESEARCH_SYNTHESIS.md
+++ b/docs/RUNTIME_STRATEGY_RESEARCH_SYNTHESIS.md
@@ -1,5 +1,7 @@
 # Runtime Strategy Research Synthesis
 
+> Status: research synthesis, not the v1 stable contract. The v1 product keeps runtime launch outside Open Scaffold core; native spawning remains future research unless promoted by a separate plan, safety review, and owner approval.
+
 This synthesis consolidates the Milestone 16 framework research lanes produced from `docs/RUNTIME_STRATEGY_RESEARCH_CRITERIA.md`. Named runtimes and coordinators in this research are evidence sources, runtime lanes, private deployment examples, or adapter candidates as labeled in [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md); they are not Open Scaffold core dependencies.
 
 Raw worker reports are local evidence, not yet public project truth. The report inventory and evidence-quality caveats are summarized in `docs/RUNTIME_STRATEGY_RESEARCH_EVIDENCE.md`.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -6,11 +6,11 @@ The short version: the repo protocol, folder state machine, core plan schema, ev
 
 ## Release status
 
-- Repository release candidate: `1.0.0`.
+- Repository candidate on `main`: `1.0.0`.
 - Live npm package truth: check `npm view open-scaffold version dist-tags --json`.
 - Live GitHub release truth: check the GitHub Releases page and the release marked **Latest**.
 
-A branch or PR may set `package.json` to `1.0.0` before the owner completes the external publication gates. Do not treat repo version alone as proof that npm publication or GitHub Release latest movement has happened.
+The repository may carry `package.json` version `1.0.0` before the owner completes the external publication gates. Do not treat repo version alone as proof that npm publication or GitHub Release latest movement has happened.
 
 ## Stable in v1.0.0
 
@@ -134,7 +134,6 @@ Future breaking changes must provide:
 
 The owner must explicitly approve and perform or authorize these external side effects:
 
-- Merge of the v1.0.0 PR.
 - `npm publish` for `open-scaffold@1.0.0`.
 - GitHub Release creation or marking `v1.0.0` as **Latest**.
 - Any website deployment or public launch announcement.

--- a/docs/index.html
+++ b/docs/index.html
@@ -170,7 +170,7 @@
       </section>
 
       <footer class="muted">
-        <p><strong class="accent">Owner gates stay human.</strong> Merge, npm publication, GitHub Release latest movement, deployment, and launch announcements require explicit approval.</p>
+        <p><strong class="accent">Owner gates stay human.</strong> npm publication, GitHub Release latest movement, deployment, and launch announcements require explicit approval.</p>
       </footer>
     </main>
   </body>


### PR DESCRIPTION
## Summary
- Polishes v1 launch-facing docs after the release-candidate PR merged.
- Moves README release-candidate detail below the quickstart, adds a working `#quickstart` anchor, and promotes the Minimum Viable Scaffold guide.
- Aligns release truth across README, stability/changelog/roadmap, CI/publishing docs, FAQ, runtime research docs, agent entry files, and the landing page.
- Closes `.osc/plans/done/074-v1-launch-docs-polish.md` with evidence in `.osc/releases/2026-05-25-074-v1-launch-docs-polish.md`.

## Verification
- `git diff --check`
- `npm test -- --run` — 356 passed
- `npm run build`
- targeted launch-doc hygiene checks for stale merge gates, stale `v0.4.19`, risky FAQ claims, and the README quickstart anchor
- `npm pack --dry-run --json` — `open-scaffold@1.0.0`, 145 files
- `./verify.sh --standard` — 6 pass, 0 fail, 0 warn
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- `npm run osc -- verify` — exit 0 with 5 pre-existing warnings from older artifacts

## Risk / gates
- Docs-only: no product behavior, package code, workflow behavior, npm publication, GitHub Release mutation, deploy, or launch announcement.
- Remaining owner gates after this PR: merge, npm publication for `open-scaffold@1.0.0`, GitHub Release `v1.0.0` latest movement, and any public launch/deployment decision.
