### PR TITLE
docs: capture Codex-first runtime adoption target

### DIFF
--- a/.osc/plans/backlog/100-verify-strict-filename-quoting.md
+++ b/.osc/plans/backlog/100-verify-strict-filename-quoting.md
@@ -1,0 +1,52 @@
+# Plan: 100-verify-strict-filename-quoting
+
+## Status
+
+backlog
+
+## Context
+
+The post-v1 security audit found a low-likelihood but real shell-quoting issue in `verify.sh --strict`: a malicious plan filename containing quotes can be interpolated into a Python `-c` command. This is not an adoption feature, but it is the fastest trust fix before broadening the runtime/dispatch surface.
+
+## Goal
+
+Make `verify.sh --strict` handle unusual plan filenames without shell-interpolating filenames into executable Python source.
+
+## Constraints / Out of scope
+
+- Do not redesign `verify.sh`.
+- Do not change the plan filename slug policy or `osc plan new` behavior unless a regression test proves it is necessary.
+- Do not add new security tooling, signing, or runtime sandbox features in this slice.
+
+## Files to touch
+
+- `verify.sh` — pass filenames to Python through `sys.argv` instead of interpolating into `python3 -c` source.
+- `tests/` or shell verification fixture if practical — regression coverage for quote-containing filenames.
+- `.osc/releases/` — evidence note if the fix ships in a PR.
+
+## Implementation Architecture Coverage
+
+- Strengthens: verification trust and safe handling of adversarial repository content.
+- Audit envelope: verification command output plus regression fixture/test output.
+- Evaluation envelope: malicious-looking filename fixture must not execute and strict verification must complete safely.
+- Feedback routing: any broader audit-signing or prompt-injection findings become separate plans.
+- Boundary: this is not runtime security, adapter sandboxing, compliance certification, or supply-chain redesign.
+
+## Acceptance criteria
+
+- [ ] `verify.sh` no longer interpolates untrusted filenames into Python source strings.
+- [ ] A plan filename containing a single quote is handled safely by the strict verification path or rejected before execution.
+- [ ] Existing `./verify.sh --strict` behavior remains otherwise unchanged.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run the new regression fixture/test for quote-containing plan filenames.
+2. Run `./verify.sh --strict`.
+3. Run `npm test`.
+4. Run `npm run build`.
+5. Run `git diff --check`.
+
+## Open questions
+
+- None.

--- a/.osc/plans/backlog/101-osc-start-codex-agent-entry.md
+++ b/.osc/plans/backlog/101-osc-start-codex-agent-entry.md
@@ -1,0 +1,59 @@
+# Plan: 101-osc-start-codex-agent-entry
+
+## Status
+
+backlog
+
+## Context
+
+The post-v1 product audit found that the largest workflow gap is not native runtime spawning; it is the missing first-party bridge from an Open Scaffold plan to a usable agent prompt. The owner wants the next runtime-adoption path to be Codex-first, not Claude Code-first.
+
+## Goal
+
+Add a no-spawn `osc start` agent-entry command that turns a plan into a paste-ready Codex/OMX handoff prompt with acceptance criteria, verification, evidence expectations, and authority boundaries.
+
+## Constraints / Out of scope
+
+- Do not spawn Codex, OMX, Claude Code, OpenHands, or any other process.
+- Do not create commits, pushes, PRs, or runtime sessions.
+- Do not require `omx` or `codex` to be installed.
+- Do not replace `osc run`; this is a lighter agent-entry affordance for users sitting in an agent terminal/chat.
+- Do not add a Claude Code-specific adapter in this slice.
+
+## Files to touch
+
+- `src/cli.ts` or future CLI command module — command parsing and help text for `osc start`.
+- `src/` prompt/artifact helper if needed — shared prompt generation.
+- `tests/` — command output fixtures for Codex/OMX and generic modes.
+- `README.md` / `docs/RUNTIME_ADOPTION_WORKFLOW.md` — usage docs if the command ships.
+- `.osc/releases/` — evidence note if the command ships in a PR.
+
+## Implementation Architecture Coverage
+
+- Strengthens: workflow design, adoption trust, and runtime boundary clarity.
+- Audit envelope: command output fixture plus plan path/acceptance criteria/verification command trace.
+- Evaluation envelope: tests assert no files/processes are spawned and output includes required boundary language.
+- Feedback routing: missing adapter execution remains a follow-up for `osc dispatch` / runtime package work.
+- Boundary: this command prints a handoff; it does not execute work.
+
+## Acceptance criteria
+
+- [ ] `osc start PLAN_OR_SLUG --runtime codex` prints a paste-ready prompt for a Codex/OMX worker.
+- [ ] Output includes plan path, goal, acceptance criteria, verification commands, evidence expectations, and commit/push/PR/publish approval boundaries.
+- [ ] The command works without `omx`, `codex`, network access, or credentials.
+- [ ] Tests prove the command does not spawn a process or mutate source files.
+- [ ] README/docs explain this as no-spawn agent entry, not runtime execution.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run the focused `osc start` tests.
+2. Run a CLI smoke against a real backlog or fixture plan.
+3. Run `./verify.sh --strict`.
+4. Run `npm test`.
+5. Run `npm run build`.
+6. Run `git diff --check`.
+
+## Open questions
+
+- Should `osc start` accept a slug, a path, or both in v1? Prefer both only if existing plan lookup utilities make it low-risk.

--- a/.osc/plans/backlog/102-codex-runtime-adapter-package-hardening.md
+++ b/.osc/plans/backlog/102-codex-runtime-adapter-package-hardening.md
@@ -1,0 +1,62 @@
+# Plan: 102-codex-runtime-adapter-package-hardening
+
+## Status
+
+backlog
+
+## Context
+
+`packages/runtime-omx/` is the first optional runtime package proof for Open Scaffold. It targets OMX / oh-my-codex `$ralplan`, writes no-spawn dispatch receipts/evidence by default, and has an explicit `--allow-spawn` launch path behind safety checks. The post-v1 strategy now prioritizes Codex-first runtime adoption rather than a Claude Code adapter.
+
+## Goal
+
+Harden the Codex-first runtime adapter path and decide whether the public adapter surface should graduate `@open-scaffold/runtime-omx`, introduce `@open-scaffold/runtime-codex`, or support both with a shared dispatch receipt contract.
+
+## Constraints / Out of scope
+
+- Do not add provider-specific spawning to Open Scaffold core.
+- Do not publish an npm package without explicit owner approval and a package safety gate.
+- Do not claim full Codex/OMX workflow support beyond the tested adapter lane.
+- Do not add auto-install behavior or a remote marketplace.
+- Do not broaden into Claude Code adapter work in this slice.
+
+## Files to touch
+
+- `packages/runtime-omx/` — safety, packaging, docs, tests, and launch/no-spawn behavior as needed.
+- Potential `packages/runtime-codex/` — only if direct Codex support is chosen after source inspection.
+- `tests/runtime-binding-conformance*` — adapter conformance coverage if needed.
+- `docs/RUNTIME_ADOPTION_WORKFLOW.md`, `docs/RUNTIME_BINDING_CONTRACT.md`, or `docs/RUNTIME_SELECTION.md` — adapter naming and usage docs.
+- `package.json` / workspace packaging files — only if package publication or package inclusion is explicitly scoped.
+- `.osc/releases/` — evidence note if the hardening ships in a PR.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adapter proof, runtime boundary, dispatch receipt portability, and Codex-first adoption.
+- Audit envelope: adapter tests, no-spawn smoke, optional launch safety checks, package dry-run output if publication is prepared.
+- Evaluation envelope: conformance tests and local smoke must prove receipts/evidence are written under the selected `.osc/runs/RUN_ID/` directory.
+- Feedback routing: direct Codex-vs-OMX naming/shape decision should be recorded in docs or a decision note before code expands.
+- Boundary: runtime package may launch only by explicit operator flag; core remains non-spawning.
+
+## Acceptance criteria
+
+- [ ] The adapter naming decision is documented: `runtime-omx`, `runtime-codex`, or both.
+- [ ] No-spawn adapter receipt/evidence behavior is covered by tests and a local smoke.
+- [ ] If explicit launch remains supported, safety checks cover branch, worktree, version, path, command redaction, and sandbox posture.
+- [ ] Adapter docs state current support limits and do not imply core runtime ownership.
+- [ ] Package publication remains owner-gated unless explicitly approved.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, runtime adapter tests, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run `npm run build:runtime-omx`.
+2. Run `npm run test:runtime-omx`.
+3. Run a no-spawn adapter smoke from a scratch run packet.
+4. If package changes are included, run `npm pack --dry-run --json` or the relevant package dry-run.
+5. Run `./verify.sh --strict`.
+6. Run `npm test`.
+7. Run `npm run build`.
+8. Run `git diff --check`.
+
+## Open questions
+
+- Should broad users see `--runtime codex` as a direct adapter or `--runtime omx` as the Codex harness profile? Resolve through source inspection and a small UX decision before implementation.

--- a/.osc/plans/backlog/103-osc-dispatch-adapter-glue.md
+++ b/.osc/plans/backlog/103-osc-dispatch-adapter-glue.md
@@ -1,0 +1,59 @@
+# Plan: 103-osc-dispatch-adapter-glue
+
+## Status
+
+backlog
+
+## Context
+
+`osc run` creates run packets, and optional runtime packages can consume them, but users still have to manually bridge the packet to the adapter. The post-v1 target needs a single adapter invocation command that records receipts and evidence without making core a hidden runtime.
+
+## Goal
+
+Add an explicit `osc dispatch RUN_JSON --adapter ADAPTER_ID` glue command that invokes a selected adapter package, captures its receipt/evidence paths, and prints the next verification/approval step.
+
+## Constraints / Out of scope
+
+- Do not add default-on spawning to core.
+- Do not auto-install adapters from a registry.
+- Do not supervise long-running runtime sessions, tmux, credentials, or provider auth.
+- Do not support unknown third-party adapter execution without a local trust decision.
+- Do not merge this with `osc work`; dispatch acts on an existing run packet.
+
+## Files to touch
+
+- `src/cli.ts` or CLI command modules — `osc dispatch` parsing/help.
+- `src/` adapter resolution helpers — trusted local adapter lookup and refusal behavior.
+- `tests/` — fake adapter fixture, receipt/evidence capture tests, unsafe adapter refusal tests.
+- `docs/RUNTIME_ADOPTION_WORKFLOW.md` / runtime docs — command semantics and boundaries.
+- `.osc/releases/` — evidence note if shipped.
+
+## Implementation Architecture Coverage
+
+- Strengthens: runtime boundary, adapter portability, and receipt/evidence recovery.
+- Audit envelope: run packet path, adapter id, dispatch receipt, adapter evidence, exit status/refusal code.
+- Evaluation envelope: fake/local adapter tests prove command behavior without real provider execution.
+- Feedback routing: adapter resolution and registry questions feed into the existing runtime adapter registry backlog after at least two adapters exist.
+- Boundary: dispatch invokes a trusted adapter; the adapter owns launch policy, and core records outputs.
+
+## Acceptance criteria
+
+- [ ] `osc dispatch RUN_JSON --adapter ADAPTER_ID` works with a fake/local adapter fixture.
+- [ ] The command refuses missing, unknown, auto-installing, or unsafe adapters by default.
+- [ ] Receipt/evidence/log paths remain under the run directory or a documented safe output path.
+- [ ] The command prints clear next steps for verification and human approval.
+- [ ] Tests prove core does not import provider SDKs or hardcode Codex/OMX launch behavior.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run focused `osc dispatch` tests with fake/local adapters.
+2. Run a scratch `osc run` -> `osc dispatch` no-spawn smoke.
+3. Run `./verify.sh --strict`.
+4. Run `npm test`.
+5. Run `npm run build`.
+6. Run `git diff --check`.
+
+## Open questions
+
+- Should adapter discovery start as explicit `--adapter-command PATH` only, or use a repo-local registry file after the fake/local fixture passes?

--- a/.osc/plans/backlog/104-osc-work-dry-run-target.md
+++ b/.osc/plans/backlog/104-osc-work-dry-run-target.md
@@ -1,0 +1,59 @@
+# Plan: 104-osc-work-dry-run-target
+
+## Status
+
+backlog
+
+## Context
+
+The north-star workflow is `osc work "Add a /health endpoint with tests" --runtime codex`: a user starts from intent, Open Scaffold drafts a plan, confirms scope, creates a run packet, dispatches to the selected adapter, captures evidence, verifies, and asks before commit/push/PR. That target should be approached only after the smaller no-spawn pieces exist.
+
+## Goal
+
+Add the first `osc work` composition as a dry-run intake command that drafts the plan/run/dispatch preview for a natural-language task without launching a runtime.
+
+## Constraints / Out of scope
+
+- Do not launch Codex, OMX, Claude Code, OpenHands, or any other runtime.
+- Do not auto-commit, push, open PRs, merge, publish, or modify source files outside the drafted scaffold artifacts.
+- Do not replace project/product judgment; the operator must confirm scope before execution.
+- Do not require network access or model calls in the first dry-run version unless a separate design proves it safe and useful.
+
+## Files to touch
+
+- `src/cli.ts` or CLI command modules — `osc work` parsing/help.
+- `src/` plan/run preview helpers — natural-language intent to scaffolded candidate artifacts.
+- `tests/` — dry-run output, no-spawn/no-source-mutation tests.
+- `docs/RUNTIME_ADOPTION_WORKFLOW.md`, `README.md`, or quickstart docs — target workflow docs.
+- `.osc/releases/` — evidence note if shipped.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adoption UX, scope confirmation, and staged runtime boundaries.
+- Audit envelope: candidate plan preview, run packet preview, dispatch command preview, and operator confirmation status.
+- Evaluation envelope: tests assert no runtime spawn and no source mutation; manual UX read checks that the command is understandable.
+- Feedback routing: if users need automatic plan drafting via an LLM, route that as a later adapter/model-assisted planning slice.
+- Boundary: `osc work --dry-run` composes existing primitives; it is not a native runtime.
+
+## Acceptance criteria
+
+- [ ] `osc work "TASK DESCRIPTION" --runtime codex --dry-run` produces a readable plan/run/dispatch preview.
+- [ ] The command clearly asks for scope confirmation before any execution path.
+- [ ] The command does not spawn runtime processes, call provider APIs, mutate source files, commit, push, or create PRs.
+- [ ] Output points to the next staged command (`osc start`, `osc run`, or `osc dispatch`) rather than hiding execution.
+- [ ] Tests cover no-spawn/no-source-mutation behavior.
+- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+
+## Verification steps
+
+1. Run focused `osc work --dry-run` tests.
+2. Run a scratch CLI smoke with a simple task string.
+3. Inspect generated preview artifacts for no private owner context.
+4. Run `./verify.sh --strict`.
+5. Run `npm test`.
+6. Run `npm run build`.
+7. Run `git diff --check`.
+
+## Open questions
+
+- Should the first version write a draft plan file immediately, or only print a preview until the operator confirms? Prefer preview-first unless user testing shows too much friction.

--- a/.osc/plans/done/099-runtime-adoption-ux-reset.md
+++ b/.osc/plans/done/099-runtime-adoption-ux-reset.md
@@ -1,0 +1,64 @@
+# Plan: 099-runtime-adoption-ux-reset
+
+## Status
+
+done
+
+## Context
+
+A post-v1 eight-lane Claude Code audit found that Open Scaffold v1 is a credible protocol release, but the adoption path is still too manual: users can create plans and run packets, yet the bridge from "I have a task" to "my agent is working with durable evidence" is not legible enough. The owner accepted the recommendation to capture a future `osc work "..."` target, but corrected the next runtime-adapter direction from Claude Code to Codex-first.
+
+## Goal
+
+Capture the post-v1 Codex-first `osc work` target workflow and staged improvement chain in public repo truth without adding runtime spawning or provider coupling to core.
+
+## Constraints / Out of scope
+
+- Do not implement `osc work`, `osc start`, `osc dispatch`, adapter registry behavior, or runtime spawning in this slice.
+- Do not add Claude Code-specific runtime work as the next default adapter path.
+- Do not claim Open Scaffold core executes tasks today; it packages work and records evidence.
+- Do not publish runtime packages, npm packages, or GitHub Releases in this slice.
+- Do not resume autonomous PR runner/product automation as part of this strategy capture.
+
+## Files to touch
+
+- `docs/RUNTIME_ADOPTION_WORKFLOW.md` — new canonical target workflow and staged chain.
+- `README.md` — link the target workflow and describe it as future direction, not current execution.
+- `MISSION.md` — align the mission goals with Codex-first adapter/dispatch UX while keeping core non-spawning.
+- `ROADMAP.md` — add the post-v1 adoption workflow target milestone.
+- `.osc/plans/backlog/100-verify-strict-filename-quoting.md` — immediate security/trust follow-up.
+- `.osc/plans/backlog/101-osc-start-codex-agent-entry.md` — no-spawn agent-entry command follow-up.
+- `.osc/plans/backlog/102-codex-runtime-adapter-package-hardening.md` — Codex/OMX adapter package follow-up.
+- `.osc/plans/backlog/103-osc-dispatch-adapter-glue.md` — adapter invocation glue follow-up.
+- `.osc/plans/backlog/104-osc-work-dry-run-target.md` — future natural-language workflow command follow-up.
+- `.osc/releases/2026-05-26-099-runtime-adoption-ux-reset.md` — evidence note for this strategy capture.
+
+## Implementation Architecture Coverage
+
+- Strengthens: workflow design, authority, adoption trust, runtime boundary clarity.
+- Audit envelope: this plan, the new target workflow doc, roadmap/mission diffs, and follow-up backlog plans define the post-v1 improvement chain.
+- Evaluation envelope: verification is documentation/source-truth consistency plus repo verification; implementation follow-ups remain separate plans.
+- Feedback routing: if the owner changes the runtime target again, create a new plan or amendment rather than silently editing this chain.
+- Boundary: runtime enforcement, adapter publication, provider auth, real process spawning, Codex/OMX session correctness, merge, publish, and compliance certification remain outside this slice.
+
+## Acceptance criteria
+
+- [x] The repo contains a public doc explaining the future `osc work "..." --runtime codex` target flow.
+- [x] The doc separates current implemented truth from staged future work.
+- [x] The staged chain starts with no-spawn UX (`osc start`) before adapter dispatch and optional gated execution.
+- [x] The chain is Codex-first and does not promote a Claude Code adapter as the next default path.
+- [x] The roadmap and mission reflect the adapter/dispatch target while preserving core no-spawn boundaries.
+- [x] Follow-up backlog plans exist for security hotfix, no-spawn agent entry, Codex adapter hardening, dispatch glue, and future `osc work` dry-run.
+- [x] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass before PR.
+
+## Verification steps
+
+1. Run `./verify.sh --strict` and confirm it passes.
+2. Run `npm test` and confirm the test suite passes.
+3. Run `npm run build` and confirm TypeScript builds.
+4. Run `git diff --check` and confirm no whitespace errors.
+5. Manually read `docs/RUNTIME_ADOPTION_WORKFLOW.md` and confirm it does not claim current autonomous execution in core.
+
+## Open questions
+
+- Should the public package name for the Codex-first adapter remain `@open-scaffold/runtime-omx`, become `@open-scaffold/runtime-codex`, or support both as separate adapter packages? This plan captures the decision point but leaves implementation to the adapter-hardening slice.

--- a/.osc/releases/2026-05-26-099-runtime-adoption-ux-reset.md
+++ b/.osc/releases/2026-05-26-099-runtime-adoption-ux-reset.md
@@ -10,7 +10,7 @@ Captured the post-v1 adoption workflow target as a Codex-first, adapter/dispatch
 - Plan: `.osc/plans/done/099-runtime-adoption-ux-reset.md`
 - Source audit: post-v1 architecture/product/runtime/security audit synthesis; public-safe conclusions are promoted into this plan, roadmap milestone, and target workflow doc.
 - Run packet: N/A — strategy/docs/backlog slice, no runtime handoff package.
-- Branch / PR: `strategy/runtime-adoption-ux-reset`; PR pending at evidence-note creation time.
+- Branch / PR: `strategy/runtime-adoption-ux-reset`; https://github.com/graphanov/open-scaffold/pull/117.
 
 ## Verification
 

--- a/.osc/releases/2026-05-26-099-runtime-adoption-ux-reset.md
+++ b/.osc/releases/2026-05-26-099-runtime-adoption-ux-reset.md
@@ -1,0 +1,45 @@
+# Release / Evidence Note: 099-runtime-adoption-ux-reset
+
+## Summary
+
+Captured the post-v1 adoption workflow target as a Codex-first, adapter/dispatch path rather than a native runtime-in-core pivot. The repo now has a canonical target document for `osc work "TASK DESCRIPTION" --runtime codex`, mission/roadmap wording that preserves the core no-spawn boundary, and follow-up backlog plans for the staged implementation chain.
+
+## Traceability
+
+- Roadmap / issue / task: Milestone 19 — Post-v1 adoption workflow target.
+- Plan: `.osc/plans/done/099-runtime-adoption-ux-reset.md`
+- Source audit: post-v1 architecture/product/runtime/security audit synthesis; public-safe conclusions are promoted into this plan, roadmap milestone, and target workflow doc.
+- Run packet: N/A — strategy/docs/backlog slice, no runtime handoff package.
+- Branch / PR: `strategy/runtime-adoption-ux-reset`; PR pending at evidence-note creation time.
+
+## Verification
+
+- `npm run osc -- plan validate .osc/plans/done/099-runtime-adoption-ux-reset.md` — passed.
+- `npm run osc -- plan validate .osc/plans/backlog/100-verify-strict-filename-quoting.md` — passed.
+- `npm run osc -- plan validate .osc/plans/backlog/101-osc-start-codex-agent-entry.md` — passed.
+- `npm run osc -- plan validate .osc/plans/backlog/102-codex-runtime-adapter-package-hardening.md` — passed.
+- `npm run osc -- plan validate .osc/plans/backlog/103-osc-dispatch-adapter-glue.md` — passed.
+- `npm run osc -- plan validate .osc/plans/backlog/104-osc-work-dry-run-target.md` — passed.
+- `./verify.sh --strict` — passed after plan closure: 10 pass, 0 fail, 0 warn.
+- `npm test` — passed after docs/backlog changes: 40 files, 356 tests.
+- `npm run build` — passed after docs/backlog changes.
+- `git diff --check` — passed after docs/backlog changes.
+
+Final PR readiness is determined after the last pushed commit and review loop, not by this note alone.
+
+## Outcome
+
+The target direction is now explicit: Open Scaffold should evolve toward a smooth `osc work` control loop while keeping core as the work record, policy, evidence, and verification layer. The next runtime-adoption work is Codex-first. The existing `packages/runtime-omx/` is treated as the current experimental Codex/OMX proof, not as a finished broad runtime platform.
+
+## Follow-up
+
+Recommended sequence:
+
+1. `.osc/plans/backlog/100-verify-strict-filename-quoting.md`
+2. `.osc/plans/backlog/101-osc-start-codex-agent-entry.md`
+3. `.osc/plans/backlog/102-codex-runtime-adapter-package-hardening.md`
+4. `.osc/plans/backlog/103-osc-dispatch-adapter-glue.md`
+5. `.osc/plans/backlog/104-osc-work-dry-run-target.md`
+6. Existing evidence-chain verifier and adapter-registry backlog after the above clarifies the adapter path.
+
+Out of scope remains unchanged: no native runtime in core, no default-on spawning, no runtime package publication, no npm release, no GitHub Release update, and no automation-runner product PR resume in this slice.

--- a/MISSION.md
+++ b/MISSION.md
@@ -9,7 +9,8 @@ Open Scaffold is a runtime-neutral, repo-native operating system for agent-orche
 - Define clear integration boundaries between orchestrators, runtime harnesses, operator surfaces, repository truth, and GitHub issue/PR workflows.
 - Productize the closed evolutionary loop: slice work, capture feedback, amend plans, verify against acceptance criteria, and feed learnings into the next slice.
 - Ship a Discord glass-cockpit pattern for private control rooms, team control rooms, and build-in-public workflows while keeping durable truth in the repo/GitHub/task system.
-- Investigate whether Open Scaffold should remain a runtime-neutral launch checklist/dispatch contract/black-box recorder, add a thin opt-in spawner, or eventually grow a native runtime as a separate explicitly-governed product layer.
+- Make the post-v1 adoption target explicit: `osc work "TASK DESCRIPTION" --runtime codex` should draft/confirm a plan, create a run packet, dispatch through an explicit adapter, capture receipt/evidence, run verification, and stop at human approval gates.
+- Keep Open Scaffold core as the runtime-neutral work record; runtime execution belongs in paste-ready handoffs, optional adapter packages, or future explicitly approved runtime layers — not hidden core spawning by drift.
 - Dogfood Open Scaffold on Open Scaffold itself: use the framework to grow the framework.
 
 ## Non-Goals
@@ -28,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-26: closed 099-runtime-adoption-ux-reset — captured post-v1 Codex-first runtime adoption workflow target
 - 2026-05-26: closed 074-v1-launch-docs-polish — polished v1 launch docs and release truth
 - 2026-05-25: closed 064-devcontainer-profile — devcontainer profile shipped in PR #108
 - 2026-05-25: closed 069-v1-launch — prepared v1.0.0 release candidate with stability docs and owner publication gates

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ MISSION.md                         why this repo exists
 
 Chat, Discord, terminals, GitHub comments, and agent transcripts can help operate the work. They are not the source of truth. The repo record is.
 
+### Target workflow
+
+The post-v1 target is a smoother Codex-first path that starts from plain intent while preserving the same record:
+
+```bash
+osc work "Add a /health endpoint with tests" --runtime codex
+```
+
+That command is future direction, not a current v1 promise. The staged path is: `osc start` no-spawn prompt → Codex/OMX adapter package hardening → `osc dispatch` adapter glue → `osc work --dry-run` → optional gated execution after a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
+
 ---
 
 ## When one attempt is not enough
@@ -311,6 +321,7 @@ Skip it for:
 
 - [`docs/WHY_OPEN_SCAFFOLD.md`](docs/WHY_OPEN_SCAFFOLD.md) — visual story and fit.
 - [`docs/index.html`](docs/index.html) — one-page landing page for the 30-second explanation.
+- [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md) — post-v1 Codex-first `osc work` target and staged adapter path.
 - [`docs/MINIMUM_VIABLE_SCAFFOLD.md`](docs/MINIMUM_VIABLE_SCAFFOLD.md) — smallest practical day-one adoption path.
 - [`docs/STABILITY.md`](docs/STABILITY.md) — v1.0.0 stable, experimental, and future surfaces.
 - [`docs/CHANGELOG.md`](docs/CHANGELOG.md) — curated release history.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -411,6 +411,47 @@ Owner gates:
 - Create or mark the `v1.0.0` GitHub Release as **Latest**.
 - Decide whether to launch publicly through a blog, social channel, GitHub Pages, or another site.
 
+### Milestone 19 — Post-v1 adoption workflow target
+
+Status: planned through `.osc/plans/done/099-runtime-adoption-ux-reset.md` and `docs/RUNTIME_ADOPTION_WORKFLOW.md`.
+
+Goal: turn the credible v1 work-record protocol into a smoother adoption path without collapsing Open Scaffold core into a provider-specific runtime.
+
+Target workflow:
+
+```bash
+osc work "Add a /health endpoint with tests" --runtime codex
+```
+
+The target control loop is:
+
+```text
+intent
+  -> plan draft / scope confirmation
+  -> run packet
+  -> explicit Codex/OMX adapter dispatch
+  -> dispatch receipt + evidence
+  -> verification
+  -> human gate before commit/push/PR/merge/publish
+```
+
+Implementation sequence:
+
+1. Fix immediate verification trust issues such as unsafe strict-mode filename quoting.
+2. Add `osc start` as a no-spawn, paste-ready Codex/OMX agent-entry command.
+3. Harden the Codex-first adapter package path: graduate `runtime-omx`, add direct `runtime-codex`, or support both after source-grounded UX review.
+4. Add `osc dispatch <run.json> --adapter <id>` as explicit adapter invocation glue.
+5. Add `osc work --dry-run` as the first natural-language composition layer.
+6. Reconsider optional gated execution only after receipt/evidence, conformance, worktree isolation, authority budgets, approval queues, and user evidence exist.
+
+Acceptance direction:
+
+- Core stays the work record, policy, verification, and evidence layer.
+- Runtime execution stays adapter-owned and explicit.
+- The next adapter path is Codex-first; Claude Code-specific runtime work is not the default follow-up from this milestone.
+- Current `packages/runtime-omx/` is treated as an experimental Codex/OMX proof, not as a broad finished runtime platform.
+- Adapter registry work follows at least two credible adapter entries or a clear Codex/OMX package graduation; a registry with only one experimental adapter is not the adoption bottleneck.
+
 ## Parking lot
 
 - Deferred compliance-grade agentic OS / hashgraph-style regulated-SDLC exploration; reopen only through an explicit ADR/plan.

--- a/docs/RUNTIME_ADOPTION_WORKFLOW.md
+++ b/docs/RUNTIME_ADOPTION_WORKFLOW.md
@@ -1,0 +1,197 @@
+# Runtime Adoption Workflow Target
+
+Open Scaffold's post-v1 target is a workflow that feels executable without turning core into an autonomous agent runtime.
+
+The north-star command is intentionally simple:
+
+```bash
+osc work "Add a /health endpoint with tests" --runtime codex
+```
+
+That command does **not** mean Open Scaffold core becomes Codex, Claude Code, OpenHands, a daemon, or a hosted agent. It means Open Scaffold should own the durable control loop around work: plan, package, dispatch, evidence, verification, and approval gates.
+
+## Target flow
+
+A good future `osc work` flow should:
+
+1. Draft or locate a plan for the requested work.
+2. Ask the operator to confirm scope, acceptance criteria, and risk before execution.
+3. Create an `open-scaffold.run.v1` run packet.
+4. Dispatch the run packet to an explicitly selected adapter.
+5. Capture a dispatch receipt, logs, and adapter evidence under `.osc/runs/RUN_ID/`.
+6. Run the scaffold and project verification commands.
+7. Ask before commit, push, PR creation, merge, publish, or any other live side effect.
+8. Promote durable results into evidence notes, PR bodies, release notes, amendments, or next plans.
+
+The intended user experience is:
+
+```text
+User: osc work "Add a /health endpoint with tests" --runtime codex
+Open Scaffold: I drafted plan 101. These are the acceptance criteria. Proceed?
+User: yes
+Open Scaffold: run packet created; dispatching through the selected Codex adapter.
+Open Scaffold: receipt and evidence captured; verification passed.
+Open Scaffold: open a PR? commit first? amend scope? stop here?
+```
+
+## Product boundary
+
+Open Scaffold core should stay the durable record and policy layer:
+
+```text
+Open Scaffold core   = mission + plan + run packet + evidence expectations + verification + gates
+Runtime adapter      = translate/dispatch to a selected runtime and return receipt/evidence
+Runtime harness      = Codex/OMX/Claude/OpenHands/etc. execution while alive
+Human/operator       = approve, reject, redirect, commit, push, PR, merge, publish
+```
+
+Core must not silently spawn or supervise provider-specific agents. Runtime execution is always either:
+
+- a paste-ready handoff the operator runs in their chosen agent;
+- a separately installed adapter package invoked explicitly; or
+- a future gated execution mode approved through a dedicated architecture/security decision.
+
+## Codex-first adapter direction
+
+The post-v1 implementation chain is Codex-first.
+
+That means the next runtime-adoption work should prioritize Codex and OMX / oh-my-codex paths before a Claude Code-specific adapter.
+
+Current truth:
+
+- `osc run` can create `run.json` packets with `--runtime omx`, `--workflow plan`, `--executor omx-codex`, and `--harness-skill '$ralplan'`.
+- `packages/runtime-omx/` exists as the first optional runtime package proof.
+- `@open-scaffold/runtime-omx` validates OMX `$ralplan` run packets and writes dispatch receipts/evidence by default without spawning.
+- `@open-scaffold/runtime-omx --allow-spawn` has an explicit opt-in launch path guarded by branch, worktree, version, path, and read-only Codex sandbox checks.
+- The package is still experimental/private and does not make Open Scaffold core a runtime.
+
+The next adapter work should therefore harden the Codex path rather than starting a Claude Code adapter by default. The naming can be resolved by evidence:
+
+- If OMX remains the intended Codex harness, graduate `@open-scaffold/runtime-omx` as the Codex-first adapter.
+- If direct Codex CLI support is cleaner for broad users, add `@open-scaffold/runtime-codex` as a sibling that shares the same dispatch receipt contract.
+- In either case, core stays runtime-neutral and adapter-owned launch stays explicit.
+
+## Staged implementation chain
+
+Do this in stages. Do not jump straight to a native runtime.
+
+### Stage 0 — Safety and clarity
+
+Fix immediate trust issues and make the target workflow public:
+
+- patch the known `verify.sh --strict` filename quoting issue;
+- document this target flow;
+- make the README and roadmap say what is implemented today versus what is future;
+- keep runner automation paused for product PRs until this direction is explicit.
+
+### Stage 1 — `osc start` no-spawn agent entry
+
+Add a command such as:
+
+```bash
+osc start .osc/plans/active/my-task.md --runtime codex
+```
+
+or:
+
+```bash
+osc start my-task --runtime codex
+```
+
+It prints a paste-ready agent prompt with:
+
+- plan path;
+- goal;
+- acceptance criteria;
+- verification commands;
+- evidence expectations;
+- authority boundaries;
+- post-work instructions.
+
+It does not create a process, mutate source files, commit, push, or create a PR.
+
+### Stage 2 — Codex adapter package hardening
+
+Make the Codex adapter path credible:
+
+- validate the existing `runtime-omx` launch and no-spawn behavior against fresh fixtures;
+- decide whether the public adapter should be `runtime-omx`, `runtime-codex`, or both;
+- keep receipts/evidence compatible with `open-scaffold.dispatch-receipt.v1`;
+- document safety boundaries;
+- publish only after safety review and owner approval.
+
+### Stage 3 — `osc dispatch` adapter glue
+
+Add a command such as:
+
+```bash
+osc dispatch .osc/runs/RUN_ID/run.json --adapter omx
+```
+
+It should:
+
+- locate or validate the adapter;
+- call the selected adapter with the run packet;
+- capture receipt/evidence/log paths;
+- print the next verification and approval step;
+- refuse unknown, unsafe, or auto-installing adapters by default.
+
+`osc dispatch` is adapter invocation glue, not a hidden provider runtime.
+
+### Stage 4 — `osc work --dry-run`
+
+Add the first version of `osc work` as a no-spawn composition:
+
+```bash
+osc work "Add a /health endpoint with tests" --runtime codex --dry-run
+```
+
+It should draft or scaffold:
+
+- a candidate plan;
+- acceptance criteria;
+- a run packet preview;
+- the `osc start` / `osc dispatch` command the operator can approve.
+
+It should stop before runtime execution.
+
+### Stage 5 — Optional gated execution
+
+Only after Stages 0-4 have real evidence, consider:
+
+```bash
+osc work "Add a /health endpoint with tests" --runtime codex --execute --allow-spawn
+```
+
+This requires a separate decision record and security design:
+
+- typed authority budget;
+- environment allowlist / secret scrubbing;
+- per-run worktree isolation;
+- explicit approval queue;
+- resource/time limits;
+- kill switch;
+- receipt/evidence chain;
+- clear commit/push/PR/merge/publish gates.
+
+## What not to do
+
+- Do not add a default-on `osc spawn` to core.
+- Do not make Claude Code the next default adapter if the product direction is Codex-first.
+- Do not claim Open Scaffold executes work today when it only packages handoffs.
+- Do not auto-install runtime packages from a registry.
+- Do not treat dispatch receipts as proof that task implementation is correct.
+- Do not market compliance certification; Open Scaffold provides evidence substrate, not legal certification.
+
+## Success criteria for the chain
+
+The chain is succeeding when a new user can answer, without private context:
+
+1. What does Open Scaffold record?
+2. What does my agent/runtime do?
+3. What command starts from a natural-language task?
+4. Where do receipts and evidence land?
+5. What needs human approval?
+6. How do I resume or review the work later?
+
+Until then, optimize for a clearer work loop before adding more experimental surfaces.


### PR DESCRIPTION
## Summary
- Captures the post-v1 `osc work "TASK DESCRIPTION" --runtime codex` target workflow as an adapter/dispatch path, not a native runtime-in-core pivot.
- Adds a canonical runtime adoption workflow doc and aligns README, MISSION, and ROADMAP around the Codex-first staged chain.
- Adds follow-up backlog plans for the security hotfix, `osc start`, Codex adapter hardening, `osc dispatch`, and `osc work --dry-run`.

## Verification
- `npm run osc -- plan validate .osc/plans/done/099-runtime-adoption-ux-reset.md`
- `npm run osc -- plan validate .osc/plans/backlog/100-verify-strict-filename-quoting.md`
- `npm run osc -- plan validate .osc/plans/backlog/101-osc-start-codex-agent-entry.md`
- `npm run osc -- plan validate .osc/plans/backlog/102-codex-runtime-adapter-package-hardening.md`
- `npm run osc -- plan validate .osc/plans/backlog/103-osc-dispatch-adapter-glue.md`
- `npm run osc -- plan validate .osc/plans/backlog/104-osc-work-dry-run-target.md`
- `./verify.sh --strict`
- `npm test`
- `npm run build`
- `git diff --check`

## Risk / Gates
- Docs/planning only: no runtime spawning, no package publish, no GitHub Release update, no provider SDK dependency.
- Merge remains owner-gated.
