### PR TITLE
fix: harden strict verifier filename handling

### DIFF
--- a/.osc/plans/done/100-verify-strict-filename-quoting.md
+++ b/.osc/plans/done/100-verify-strict-filename-quoting.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-26-100-verify-strict-filename-quoting.md
+++ b/.osc/releases/2026-05-26-100-verify-strict-filename-quoting.md
@@ -9,7 +9,7 @@ Hardened `verify.sh --strict` so plan filenames are passed to Python as argument
 - Roadmap / issue / task: Milestone 19 trust/security hotfix before runtime-adoption UX work.
 - Plan: `.osc/plans/done/100-verify-strict-filename-quoting.md`
 - Branch: `fix/verify-strict-filename-quoting`
-- Pull Request: to be created for owner review.
+- Pull Request: https://github.com/graphanov/open-scaffold/pull/118.
 
 ## Verification
 

--- a/.osc/releases/2026-05-26-100-verify-strict-filename-quoting.md
+++ b/.osc/releases/2026-05-26-100-verify-strict-filename-quoting.md
@@ -1,0 +1,29 @@
+# Release / Evidence Note: 100-verify-strict-filename-quoting
+
+## Summary
+
+Hardened `verify.sh --strict` so plan filenames are passed to Python as arguments instead of interpolated into Python source. This closes the audit finding where a quote-containing plan filename could execute embedded Python while the verifier computed relative plan paths.
+
+## Traceability
+
+- Roadmap / issue / task: Milestone 19 trust/security hotfix before runtime-adoption UX work.
+- Plan: `.osc/plans/done/100-verify-strict-filename-quoting.md`
+- Branch: `fix/verify-strict-filename-quoting`
+- Pull Request: to be created for owner review.
+
+## Verification
+
+- `npm test -- tests/verify-help.test.ts` — passed, 4 tests including the malicious filename regression.
+- `npm run osc -- plan validate .osc/plans/done/100-verify-strict-filename-quoting.md` — passed, 0 issues.
+- `./verify.sh --strict` — passed: 10 pass, 0 fail, 0 warn.
+- `npm test` — passed: 40 files, 357 tests.
+- `npm run build` — passed.
+- `git diff --check` — passed.
+
+## Outcome
+
+The verifier keeps its existing behavior and output shape while avoiding untrusted filename interpolation in the strict immutability check. The regression fixture creates a minimal git-backed scaffold with a plan filename containing a single quote and embedded Python expression; strict verification must complete without creating the `PWNED` marker file.
+
+## Follow-up
+
+Continue with `101-osc-start-codex-agent-entry` after this PR is reviewed and merged. Broader runtime security, adapter sandboxing, signing, and supply-chain controls remain out of scope for this hotfix.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-26: closed 100-verify-strict-filename-quoting — hardened strict verifier filename handling
 - 2026-05-26: closed 099-runtime-adoption-ux-reset — captured post-v1 Codex-first runtime adoption workflow target
 - 2026-05-26: closed 074-v1-launch-docs-polish — polished v1 launch docs and release truth
 - 2026-05-25: closed 064-devcontainer-profile — devcontainer profile shipped in PR #108

--- a/tests/verify-help.test.ts
+++ b/tests/verify-help.test.ts
@@ -1,10 +1,59 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const tsx = join(repoRoot, 'node_modules/.bin/tsx');
 const cli = join(repoRoot, 'src/cli.ts');
+
+function makeMinimalScaffold(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(root, '.osc/plans/backlog'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nDefined.\n');
+  writeFileSync(join(root, '.osc/releases/README.md'), '# Evidence notes\n');
+  writeFileSync(join(root, 'verify.sh'), readFileSync(join(repoRoot, 'verify.sh')));
+  const git = spawnSync('git', ['init'], { cwd: root, encoding: 'utf8' });
+  expect(git.status).toBe(0);
+  return root;
+}
+
+const validPlanBody = `# Plan: malicious filename fixture
+
+## Status
+
+backlog
+
+## Context
+
+Fixture for verifier path handling.
+
+## Goal
+
+Exercise strict verification path handling.
+
+## Constraints / Out of scope
+
+- Fixture only.
+
+## Files to touch
+
+- None.
+
+## Acceptance criteria
+
+- Strict verification completes without executing filename content.
+
+## Verification steps
+
+1. Run verify.
+
+## Open questions
+
+- None.
+`;
 
 describe('verification help flags', () => {
   it('prints shell verifier help without running checks', () => {
@@ -36,5 +85,21 @@ describe('verification help flags', () => {
     expect(result.stderr).toContain('Unknown option for verify: --json');
     expect(result.stderr).toContain('Usage: osc verify');
     expect(result.stderr).not.toContain('PASS mission defined');
+  });
+
+  it('does not execute Python source injected through strict plan filenames', () => {
+    const root = makeMinimalScaffold('open-scaffold-verify-quoting-');
+    try {
+      const maliciousName = "001-a',open('PWNED','w').write('x'),'b.md";
+      writeFileSync(join(root, '.osc/plans/backlog', maliciousName), validPlanBody);
+
+      const result = spawnSync('bash', ['verify.sh', '--strict'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Plan immutability intact');
+      expect(existsSync(join(root, 'PWNED'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/verify.sh
+++ b/verify.sh
@@ -217,7 +217,7 @@ if [ "$TIER" = "--strict" ]; then
         case "$basename" in
           *-amendment-*) continue ;;
         esac
-        relpath=$(python3 -c "import os; print(os.path.relpath('$f', '$ROOT'))" 2>/dev/null || printf '%s' "$f" | sed "s|$ROOT/||")
+        relpath=$(python3 -c 'import os, sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))' "$f" "$ROOT" 2>/dev/null || printf '%s' "${f#"$ROOT"/}")
         # Count commits that modified this file's content (renames/moves during close are allowed)
         commit_count=$(git -C "$ROOT" log --oneline --diff-filter=M --follow -- "$relpath" 2>/dev/null | wc -l | tr -d ' ')
         if [ "$commit_count" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- Hardens `verify.sh --strict` so plan filenames are passed to Python through `sys.argv`, not interpolated into Python source.
- Adds a regression test with a malicious quote-containing plan filename that previously created a `PWNED` marker through Python expression injection.
- Closes plan `100-verify-strict-filename-quoting` with release/evidence notes.

## Verification
- `npm test -- tests/verify-help.test.ts`
- `npm run osc -- plan validate .osc/plans/done/100-verify-strict-filename-quoting.md`
- `./verify.sh --strict`
- `npm test`
- `npm run build`
- `git diff --check`

## Risk / Gates
- Narrow verifier hardening only.
- No runtime spawning, adapter sandboxing, signing, package publish, or GitHub Release update.
- Merge remains owner-gated.
