### PR TITLE
feat: add no-spawn osc start handoff

### DIFF
--- a/.osc/plans/done/101-osc-start-codex-agent-entry.md
+++ b/.osc/plans/done/101-osc-start-codex-agent-entry.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md
+++ b/.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md
@@ -9,7 +9,7 @@ This slice adds `osc start <plan> --runtime codex` as a no-spawn agent-entry com
 - Roadmap / issue / task: Open Scaffold backlog plan 101 from the post-v1 Codex-first runtime adoption chain.
 - Plan: `.osc/plans/done/101-osc-start-codex-agent-entry.md`
 - Run ID / run packet: N/A — `osc start` explicitly renders text and does not create run packets.
-- Branch / PR: branch `cli/osc-start-codex-entry`; PR pending owner review.
+- Branch / PR: branch `cli/osc-start-codex-entry`; PR https://github.com/graphanov/open-scaffold/pull/119.
 
 ## Verification
 

--- a/.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md
+++ b/.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md
@@ -14,20 +14,20 @@ This slice adds `osc start <plan> --runtime codex` as a no-spawn agent-entry com
 ## Verification
 
 - RED check: `npm test -- tests/cli-start.test.ts` failed before implementation because `osc start` was an unknown command; 2 tests failed as expected.
-- `npm test -- tests/cli-start.test.ts` — pass; 1 file / 2 tests, including Codex/OMX prompt content, no fake `codex`/`omx` process spawn, no `.osc/runs` creation, no source-file mutation, and direct path support for a runtime-neutral prompt.
+- `npm test -- tests/cli-start.test.ts` — pass; 1 file / 3 tests, including Codex/OMX prompt content, no fake `codex`/`omx` process spawn, no `.osc/runs` creation, no source-file mutation, direct path support for real plan files, and rejection of direct markdown paths outside `.osc/plans/{active,backlog,blocked,done}`.
 - CLI smoke: `npm run osc -- start 101-osc-start-codex-agent-entry --runtime codex` — pass; printed a no-spawn Codex/OMX handoff for the real active plan.
 - `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn.
-- `npm test` — pass; 41 files / 359 tests.
+- `npm test` — pass; 41 files / 360 tests.
 - `npm run build` — pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
 - `git diff --check` — pass.
-- `npm pack --dry-run --json` — pass; produced package candidate `open-scaffold-1.0.1.tgz`, 148 files, unpacked size 999.7 kB.
+- `npm pack --dry-run --json` — pass; produced package candidate `open-scaffold-1.0.1.tgz`, 148 files, unpacked size 1.0 MB.
 - `npm publish --dry-run` — pass; dry-run only, reported `+ open-scaffold@1.0.1`.
 
 ## Outcome
 
 `osc start` now accepts a plan slug or direct plan path plus an explicit runtime (`codex`, `omx`, `plain`, `human`, or `custom`). The Codex path is intentionally framed as a Codex/OMX handoff while the direct adapter naming decision remains a follow-up. The command reads plan content, prints a prompt, and stops; it does not spawn agents, install runtimes, create `.osc/runs`, commit, push, open PRs, merge, publish, release, or deploy.
 
-The public CLI surface changed, so this branch prepares package candidate version `1.0.1`. Merge, npm publish, and GitHub Release creation remain owner-gated.
+The public CLI surface changed, so this branch prepares package candidate version `1.0.1`. A Codex P2 review finding on PR #119 tightened direct-path handling so `osc start` rejects markdown files outside the scaffold plan directories before parsing them. Merge, npm publish, and GitHub Release creation remain owner-gated.
 
 ## Follow-up
 

--- a/.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md
+++ b/.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md
@@ -1,0 +1,36 @@
+# Release / Evidence Note: 101-osc-start-codex-agent-entry
+
+## Summary
+
+This slice adds `osc start <plan> --runtime codex` as a no-spawn agent-entry command. It renders an existing Open Scaffold plan into a paste-ready Codex/OMX handoff prompt with acceptance criteria, verification commands, evidence expectations, and approval boundaries, without launching a runtime or writing `.osc/runs` artifacts.
+
+## Traceability
+
+- Roadmap / issue / task: Open Scaffold backlog plan 101 from the post-v1 Codex-first runtime adoption chain.
+- Plan: `.osc/plans/done/101-osc-start-codex-agent-entry.md`
+- Run ID / run packet: N/A — `osc start` explicitly renders text and does not create run packets.
+- Branch / PR: branch `cli/osc-start-codex-entry`; PR pending owner review.
+
+## Verification
+
+- RED check: `npm test -- tests/cli-start.test.ts` failed before implementation because `osc start` was an unknown command; 2 tests failed as expected.
+- `npm test -- tests/cli-start.test.ts` — pass; 1 file / 2 tests, including Codex/OMX prompt content, no fake `codex`/`omx` process spawn, no `.osc/runs` creation, no source-file mutation, and direct path support for a runtime-neutral prompt.
+- CLI smoke: `npm run osc -- start 101-osc-start-codex-agent-entry --runtime codex` — pass; printed a no-spawn Codex/OMX handoff for the real active plan.
+- `./verify.sh --strict` — pass; 10 pass / 0 fail / 0 warn.
+- `npm test` — pass; 41 files / 359 tests.
+- `npm run build` — pass; core TypeScript and `packages/runtime-omx` TypeScript builds succeeded.
+- `git diff --check` — pass.
+- `npm pack --dry-run --json` — pass; produced package candidate `open-scaffold-1.0.1.tgz`, 148 files, unpacked size 999.7 kB.
+- `npm publish --dry-run` — pass; dry-run only, reported `+ open-scaffold@1.0.1`.
+
+## Outcome
+
+`osc start` now accepts a plan slug or direct plan path plus an explicit runtime (`codex`, `omx`, `plain`, `human`, or `custom`). The Codex path is intentionally framed as a Codex/OMX handoff while the direct adapter naming decision remains a follow-up. The command reads plan content, prints a prompt, and stops; it does not spawn agents, install runtimes, create `.osc/runs`, commit, push, open PRs, merge, publish, release, or deploy.
+
+The public CLI surface changed, so this branch prepares package candidate version `1.0.1`. Merge, npm publish, and GitHub Release creation remain owner-gated.
+
+## Follow-up
+
+- Owner review/merge gate for the PR.
+- If merged, verify npm/latest drift and publish `open-scaffold@1.0.1` only with explicit owner approval.
+- Continue the staged runtime-adoption chain with plan 102: Codex/OMX adapter package hardening.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-26: closed 101-osc-start-codex-agent-entry — added no-spawn osc start Codex handoff
 - 2026-05-26: closed 100-verify-strict-filename-quoting — hardened strict verifier filename handling
 - 2026-05-26: closed 099-runtime-adoption-ux-reset — captured post-v1 Codex-first runtime adoption workflow target
 - 2026-05-26: closed 074-v1-launch-docs-polish — polished v1 launch docs and release truth

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The post-v1 target is a smoother Codex-first path that starts from plain intent 
 osc work "Add a /health endpoint with tests" --runtime codex
 ```
 
-That command is future direction, not a current v1 promise. The staged path is: `osc start` no-spawn prompt → Codex/OMX adapter package hardening → `osc dispatch` adapter glue → `osc work --dry-run` → optional gated execution after a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
+That command is future direction, not a current v1 promise. The first no-spawn step is `osc start`, which prints a paste-ready Codex/OMX handoff prompt from an existing plan without launching a runtime. The remaining staged path is: Codex/OMX adapter package hardening → `osc dispatch` adapter glue → `osc work --dry-run` → optional gated execution after a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
 
 ---
 
@@ -219,9 +219,17 @@ Shell fallbacks remain available:
 ./close.sh my-first-task --message "verified first task"
 ```
 
-### 5. Optional: package work for another tool
+### 5. Optional: hand off to another tool
 
-Open Scaffold can write a handoff file for an agent, runtime, teammate, or future session:
+To print a paste-ready prompt for a Codex/OMX worker without writing run artifacts or launching anything:
+
+```bash
+osc start .osc/plans/active/my-first-task.md --runtime codex
+# or without local install:
+npx open-scaffold start .osc/plans/active/my-first-task.md --runtime codex
+```
+
+Open Scaffold can also write a durable handoff file for an agent, runtime, teammate, or future session:
 
 ```bash
 npx open-scaffold run .osc/plans/active/my-first-task.md \
@@ -236,9 +244,9 @@ That creates a `run.json` work package. The outside tool executes. Evidence come
 
 ---
 
-## v1.0.0 stable release candidate
+## v1.0.x stable release line
 
-Open Scaffold v1.0.0 means the repo protocol and day-two CLI are stable enough to adopt with semver expectations. It does **not** mean every experimental integration is frozen.
+Open Scaffold v1.0.x means the repo protocol and day-two CLI are stable enough to adopt with semver expectations. It does **not** mean every experimental integration is frozen.
 
 Stable:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,22 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared; publication still depends on owner-gated npm and GitHub Release actions.
 
+## v1.0.1 — No-spawn Codex handoff entry
+
+Status: repository candidate prepared; npm publication and GitHub Release latest movement are owner-gated external actions.
+
+Highlights:
+
+- Adds `osc start <plan> --runtime codex` as a no-spawn prompt renderer for Codex/OMX workers.
+- Keeps runtime execution outside Open Scaffold core: no process spawn, no `.osc/runs` write, no commit/push/PR/publish side effects.
+- Documents the first shipped step in the post-v1 Codex-first runtime adoption chain.
+
+Evidence:
+
+- Plan: `.osc/plans/done/101-osc-start-codex-agent-entry.md`
+- Evidence note: `.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md`
+- PR: pending owner review
+
 ## v1.0.0 — Stable protocol release candidate
 
 Status: repository candidate merged; npm publication and GitHub Release latest movement are owner-gated external actions.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ Evidence:
 
 - Plan: `.osc/plans/done/101-osc-start-codex-agent-entry.md`
 - Evidence note: `.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md`
-- PR: pending owner review
+- PR: https://github.com/graphanov/open-scaffold/pull/119
 
 ## v1.0.0 — Stable protocol release candidate
 

--- a/docs/RUNTIME_ADOPTION_WORKFLOW.md
+++ b/docs/RUNTIME_ADOPTION_WORKFLOW.md
@@ -86,7 +86,7 @@ Fix immediate trust issues and make the target workflow public:
 
 ### Stage 1 — `osc start` no-spawn agent entry
 
-Add a command such as:
+Current repo support begins with:
 
 ```bash
 osc start .osc/plans/active/my-task.md --runtime codex
@@ -108,7 +108,7 @@ It prints a paste-ready agent prompt with:
 - authority boundaries;
 - post-work instructions.
 
-It does not create a process, mutate source files, commit, push, or create a PR.
+It does not create a process, mutate source files, commit, push, or create a PR. It also does not require Codex, OMX, network access, or runtime credentials to be installed because it only renders text.
 
 ### Stage 2 — Codex adapter package hardening
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
+import { renderStartPrompt, parseStartRuntime, START_RUNTIMES } from './start.js';
 import { renderAuditManifest, validateAuditManifestFile, writeAuditManifest, type AuditArtifactInput } from './audit.js';
 import { createRunArtifacts, previewRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
 import { COCKPIT_EVENT_TYPES, CockpitConfigError, CockpitUsageError, formatCockpitConfig, formatCockpitDispatchSummary, hasCockpitDispatchFailures, loadCockpitConfig, postCockpitEvent, type CockpitEventType, type CockpitPostOptions } from './cockpit.js';
@@ -48,6 +49,7 @@ Usage:
   osc evidence new <slug>
   osc evidence collect <slug> [--ci] [--dry-run] [--verbose]
   osc close <plan-slug> [--message <text>]
+  osc start <plan-slug-or-path> --runtime <codex|omx|plain|human|custom>
   osc delegate <plan-path> [run binding options]
   osc run <plan-path> [--dry-run] [--json] [run binding options]
   osc review <plan-path> [run binding options]
@@ -1080,6 +1082,60 @@ function closeCommand(args: string[]): void {
     if (result.changelogStamped) console.log('Stamped: MISSION.md changelog');
   } catch (error) {
     exitForScaffoldHelperError(error);
+  }
+}
+
+function printStartUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc start <plan-slug-or-path> --runtime <${START_RUNTIMES.join('|')}>
+
+Prints a paste-ready agent handoff prompt. It does not spawn a runtime, create .osc/runs artifacts, commit, push, or open a PR.`, stream);
+}
+
+function takeStartValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    console.error(`Missing value for ${flag}`);
+    printStartUsage();
+    process.exit(2);
+  }
+  return value;
+}
+
+function startCommand(args: string[]): void {
+  if (isHelpArg(args[0])) {
+    printStartUsage('stdout');
+    return;
+  }
+  const planReference = requireArg(args, 'plan-slug-or-path');
+  let runtime: ReturnType<typeof parseStartRuntime> = null;
+  const rest = args.slice(1);
+  for (let i = 0; i < rest.length; i += 1) {
+    const flag = rest[i];
+    switch (flag) {
+      case '--runtime':
+        runtime = parseStartRuntime(takeStartValue(rest, i, flag));
+        if (!runtime) {
+          console.error(`Invalid value for --runtime. Expected one of: ${START_RUNTIMES.join(', ')}`);
+          process.exit(2);
+        }
+        i += 1;
+        break;
+      default:
+        console.error(`Unknown option for start: ${flag}`);
+        printStartUsage();
+        process.exit(2);
+    }
+  }
+  if (!runtime) {
+    console.error(`Missing required option: --runtime <${START_RUNTIMES.join('|')}>`);
+    printStartUsage();
+    process.exit(2);
+  }
+  try {
+    process.stdout.write(renderStartPrompt(planReference, { runtime, cwd: process.cwd() }).prompt);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
   }
 }
 
@@ -2284,6 +2340,9 @@ async function main(): Promise<void> {
       return;
     case 'close':
       closeCommand(args);
+      return;
+    case 'start':
+      startCommand(args);
       return;
     case 'verify': {
       if (isHelpArg(args[0])) {

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,5 +1,6 @@
+import { realpathSync } from 'node:fs';
 import { relative } from 'node:path';
-import { findScaffoldRoot, parsePlanFile, type ParsedPlan } from './scaffold.js';
+import { findScaffoldRoot, parsePlanFile, PLAN_STAGES, type ParsedPlan } from './scaffold.js';
 import { resolvePlanValidationPath } from './plan-validate.js';
 
 export const START_RUNTIMES = ['codex', 'omx', 'plain', 'human', 'custom'] as const;
@@ -60,11 +61,15 @@ function workerInstruction(runtime: StartRuntime): string {
 
 export function renderStartPrompt(planReference: string, options: { runtime: StartRuntime; cwd?: string }): StartPromptResult {
   const cwd = options.cwd ?? process.cwd();
-  const planPath = resolvePlanValidationPath(planReference, cwd);
+  const planPath = realpathSync(resolvePlanValidationPath(planReference, cwd));
   const root = findScaffoldRoot(planPath) ?? findScaffoldRoot(cwd);
   if (!root) throw new Error(`No Open Scaffold root found from ${cwd}. Run this inside a repo with .osc/plans and .osc/releases.`);
-  const plan = parsePlanFile(planPath);
   const relativePlanPath = relative(root, planPath).replace(/\\/g, '/');
+  const allowedPlanPath = PLAN_STAGES.some((stage) => relativePlanPath.startsWith(`.osc/plans/${stage}/`));
+  if (!allowedPlanPath) {
+    throw new Error(`Plan path must be under .osc/plans/{active,backlog,blocked,done}: ${relativePlanPath}`);
+  }
+  const plan = parsePlanFile(planPath);
   const context = firstSectionParagraph(plan, 'Context', 'Use the plan context as the source of truth.');
   const constraints = plan.sections.get('Constraints / Out of scope')?.trim() || 'Respect all plan constraints and stop before out-of-scope work.';
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,132 @@
+import { relative } from 'node:path';
+import { findScaffoldRoot, parsePlanFile, type ParsedPlan } from './scaffold.js';
+import { resolvePlanValidationPath } from './plan-validate.js';
+
+export const START_RUNTIMES = ['codex', 'omx', 'plain', 'human', 'custom'] as const;
+export type StartRuntime = typeof START_RUNTIMES[number];
+
+export interface StartPromptResult {
+  root: string;
+  planPath: string;
+  relativePlanPath: string;
+  runtime: StartRuntime;
+  prompt: string;
+}
+
+function list(items: string[], fallback: string): string {
+  const values = items.length > 0 ? items : [fallback];
+  return values.map((item) => `- ${item}`).join('\n');
+}
+
+function commandList(items: string[]): string {
+  const values = items.length > 0 ? items : ['Run the verification commands listed in the plan or ask the operator before inventing new gates.'];
+  return values.map((item) => `- ${item}`).join('\n');
+}
+
+function firstSectionParagraph(plan: ParsedPlan, section: string, fallback: string): string {
+  const body = plan.sections.get(section) ?? '';
+  return body.split(/\n\s*\n/).map((part) => part.trim()).find(Boolean) ?? fallback;
+}
+
+function runtimeLabel(runtime: StartRuntime): string {
+  switch (runtime) {
+    case 'codex':
+      return 'codex (Codex / OMX handoff)';
+    case 'omx':
+      return 'omx (OMX / oh-my-codex handoff)';
+    case 'plain':
+      return 'plain (Runtime-neutral manual handoff)';
+    case 'human':
+      return 'human (Human/manual handoff)';
+    case 'custom':
+      return 'custom (Custom adapter handoff)';
+  }
+}
+
+function workerInstruction(runtime: StartRuntime): string {
+  switch (runtime) {
+    case 'codex':
+      return 'You are a Codex or OMX / oh-my-codex worker receiving an Open Scaffold plan. Follow the plan exactly and return evidence; do not assume you may execute privileged side effects.';
+    case 'omx':
+      return 'You are an OMX / oh-my-codex worker receiving an Open Scaffold plan. Use the appropriate OMX skill only if the operator runs it; this prompt itself is not a launch command.';
+    case 'plain':
+      return 'You are an agent, runtime, or human collaborator receiving an Open Scaffold plan. Follow the plan exactly and return evidence.';
+    case 'human':
+      return 'You are a human/manual executor receiving an Open Scaffold plan. Follow the plan exactly and record evidence for later review.';
+    case 'custom':
+      return 'You are a custom runtime adapter or worker receiving an Open Scaffold plan. Preserve the Open Scaffold evidence and approval boundaries.';
+  }
+}
+
+export function renderStartPrompt(planReference: string, options: { runtime: StartRuntime; cwd?: string }): StartPromptResult {
+  const cwd = options.cwd ?? process.cwd();
+  const planPath = resolvePlanValidationPath(planReference, cwd);
+  const root = findScaffoldRoot(planPath) ?? findScaffoldRoot(cwd);
+  if (!root) throw new Error(`No Open Scaffold root found from ${cwd}. Run this inside a repo with .osc/plans and .osc/releases.`);
+  const plan = parsePlanFile(planPath);
+  const relativePlanPath = relative(root, planPath).replace(/\\/g, '/');
+  const context = firstSectionParagraph(plan, 'Context', 'Use the plan context as the source of truth.');
+  const constraints = plan.sections.get('Constraints / Out of scope')?.trim() || 'Respect all plan constraints and stop before out-of-scope work.';
+
+  const prompt = `Open Scaffold no-spawn agent handoff
+Runtime: ${runtimeLabel(options.runtime)}
+Plan path: ${relativePlanPath}
+Goal: ${plan.goal || 'See plan file.'}
+
+No process was started by Open Scaffold.
+Paste the prompt below into your selected agent/runtime.
+
+--- BEGIN AGENT PROMPT ---
+${workerInstruction(options.runtime)}
+
+Project root:
+${root}
+
+Plan path:
+${relativePlanPath}
+
+Goal:
+${plan.goal || 'See plan file.'}
+
+Context:
+${context}
+
+Constraints / out of scope:
+${constraints}
+
+Files to touch:
+${list(plan.filesToTouch, 'Only touch files required by the plan. If the plan is unclear, stop and ask the operator.')}
+
+Acceptance criteria:
+${list(plan.acceptanceCriteria, 'No explicit acceptance criteria were parsed; stop and ask the operator to clarify before implementation.')}
+
+Verification commands:
+${commandList(plan.verificationSteps)}
+
+Evidence expectations:
+- Report changed files and why each changed.
+- Report every verification command run, with pass/fail result.
+- Report any skipped verification with the reason.
+- Return enough evidence for a reviewer to update .osc/releases, PR body, and postflight notes.
+- Do not rewrite committed plan history; use an amendment if scope changes.
+
+Authority boundaries:
+- Do not commit, push, open a PR, merge, publish, create a release, or deploy without explicit operator approval.
+- Do not spawn additional autonomous runtimes, install dependencies, or use network access unless the operator explicitly allows it.
+- Do not access secrets or credentials; stop and ask if a secret is required.
+- If acceptance criteria conflict with constraints, stop and ask before changing scope.
+
+Post-work instructions:
+- Summarize outcome against each acceptance criterion.
+- Provide exact verification output or concise excerpts.
+- List follow-up risks, blockers, and unresolved questions.
+- Stop at the operator approval gate for any live side effect.
+--- END AGENT PROMPT ---
+`;
+
+  return { root, planPath, relativePlanPath, runtime: options.runtime, prompt };
+}
+
+export function parseStartRuntime(value: string): StartRuntime | null {
+  return (START_RUNTIMES as readonly string[]).includes(value) ? value as StartRuntime : null;
+}

--- a/tests/cli-start.test.ts
+++ b/tests/cli-start.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'osc-start-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/backlog'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild a small service.\n');
+  writeFileSync(join(root, '.osc/releases/README.md'), '# Evidence notes\n');
+  return root;
+}
+
+function writePlan(root: string, stage = 'active', slug = '123-health-endpoint'): string {
+  const planPath = join(root, `.osc/plans/${stage}/${slug}.md`);
+  writeFileSync(planPath, `# Plan: ${slug}
+
+## Status
+
+${stage}
+
+## Context
+
+A user needs a simple health check.
+
+## Goal
+
+Add a health endpoint with tests.
+
+## Constraints / Out of scope
+
+- Do not change deployment infrastructure.
+
+## Files to touch
+
+- \`src/server.ts\` — route implementation.
+- \`tests/server.test.ts\` — health endpoint coverage.
+
+## Acceptance criteria
+
+- [ ] Health endpoint returns 200.
+- [ ] Test suite covers the route.
+
+## Verification steps
+
+1. Run \`npm test\`.
+2. Run \`npm run build\`.
+
+## Open questions
+
+- None.
+`);
+  return planPath;
+}
+
+function fileSnapshot(root: string): string[] {
+  const result: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) walk(full);
+      else result.push(`${relative(root, full)}:${stat.size}:${stat.mtimeMs}`);
+    }
+  };
+  walk(root);
+  return result.sort();
+}
+
+describe('osc start', () => {
+  it('prints a Codex/OMX paste-ready no-spawn handoff from a plan slug', () => {
+    const root = tempRepo();
+    try {
+      writePlan(root);
+      const fakeBin = join(root, 'fake-bin');
+      mkdirSync(fakeBin);
+      for (const name of ['omx', 'codex']) {
+        const fake = join(fakeBin, name);
+        writeFileSync(fake, `#!/usr/bin/env bash\ntouch ${JSON.stringify(join(root, 'SPAWNED'))}\n`);
+        chmodSync(fake, 0o755);
+      }
+      const before = fileSnapshot(root);
+
+      const result = spawnSync(tsx, [cli, 'start', '123-health-endpoint', '--runtime', 'codex'], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH ?? ''}` },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('Open Scaffold no-spawn agent handoff');
+      expect(result.stdout).toContain('Runtime: codex (Codex / OMX handoff)');
+      expect(result.stdout).toContain('Plan path: .osc/plans/active/123-health-endpoint.md');
+      expect(result.stdout).toContain('Goal: Add a health endpoint with tests.');
+      expect(result.stdout).toContain('Acceptance criteria');
+      expect(result.stdout).toContain('Health endpoint returns 200.');
+      expect(result.stdout).toContain('Verification commands');
+      expect(result.stdout).toContain('npm test');
+      expect(result.stdout).toContain('Evidence expectations');
+      expect(result.stdout).toContain('Authority boundaries');
+      expect(result.stdout).toContain('Do not commit, push, open a PR, merge, publish, create a release, or deploy without explicit operator approval.');
+      expect(result.stdout).toContain('No process was started by Open Scaffold.');
+      expect(existsSync(join(root, 'SPAWNED'))).toBe(false);
+      expect(existsSync(join(root, '.osc/runs'))).toBe(false);
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a direct plan path and can print a runtime-neutral handoff', () => {
+    const root = tempRepo();
+    try {
+      const planPath = writePlan(root, 'backlog', '124-backlog-task');
+
+      const result = spawnSync(tsx, [cli, 'start', planPath, '--runtime', 'plain'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('Runtime: plain (Runtime-neutral manual handoff)');
+      expect(result.stdout).toContain('Plan path: .osc/plans/backlog/124-backlog-task.md');
+      expect(result.stdout).toContain('Paste the prompt below into your selected agent/runtime.');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-start.test.ts
+++ b/tests/cli-start.test.ts
@@ -135,4 +135,23 @@ describe('osc start', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('rejects direct markdown paths outside .osc/plans', () => {
+    const root = tempRepo();
+    try {
+      const outsidePath = join(root, 'outside-plan.md');
+      writeFileSync(outsidePath, '# Outside\n\n## Goal\n\nLeak me.\n');
+
+      const result = spawnSync(tsx, [cli, 'start', outsidePath, '--runtime', 'plain'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Plan path must be under .osc/plans/{active,backlog,blocked,done}');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Add `osc start <plan> --runtime codex` as a no-spawn agent-entry command that renders a paste-ready Codex/OMX handoff prompt.
- Support plan slug and direct plan path inputs, with runtime labels for `codex`, `omx`, `plain`, `human`, and `custom`.
- Document the Stage 1 runtime-adoption step, close plan 101, add evidence, and prepare package candidate `1.0.1`.

## Verification
- RED check: `npm test -- tests/cli-start.test.ts` failed before implementation because `osc start` was unknown.
- `npm test -- tests/cli-start.test.ts`
- `npm run osc -- start 101-osc-start-codex-agent-entry --runtime codex`
- `npm run osc -- plan validate .osc/plans/done/101-osc-start-codex-agent-entry.md`
- `npm test`
- `npm run build`
- `./verify.sh --strict`
- `git diff --check`
- `npm pack --dry-run --json`
- `npm publish --dry-run`

## Boundaries
- No runtime is spawned.
- No `.osc/runs` artifacts are created by `osc start`.
- npm publish and GitHub Release creation remain owner-gated after merge.
