### PR TITLE
docs: record v1.0.1 release evidence

### DIFF
--- a/.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md
+++ b/.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md
@@ -22,15 +22,17 @@ This slice adds `osc start <plan> --runtime codex` as a no-spawn agent-entry com
 - `git diff --check` — pass.
 - `npm pack --dry-run --json` — pass; produced package candidate `open-scaffold-1.0.1.tgz`, 148 files, unpacked size 1.0 MB.
 - `npm publish --dry-run` — pass; dry-run only, reported `+ open-scaffold@1.0.1`.
+- Trusted publishing run https://github.com/graphanov/open-scaffold/actions/runs/26444343837 — success; published from `main` commit `60d6c19de6ab352b6c284a0f88573a5032dd9b0d`.
+- `npm view open-scaffold version dist-tags --json --prefer-online` — `1.0.1` with `latest` -> `1.0.1`.
+- Registry tarball smoke from `open-scaffold@latest` — package version `1.0.1`; packaged CLI help contains `osc start <plan-slug-or-path>`; packaged `start` command is recognized.
+- GitHub Release https://github.com/graphanov/open-scaffold/releases/tag/v1.0.1 — created and marked Latest.
 
 ## Outcome
 
 `osc start` now accepts a plan slug or direct plan path plus an explicit runtime (`codex`, `omx`, `plain`, `human`, or `custom`). The Codex path is intentionally framed as a Codex/OMX handoff while the direct adapter naming decision remains a follow-up. The command reads plan content, prints a prompt, and stops; it does not spawn agents, install runtimes, create `.osc/runs`, commit, push, open PRs, merge, publish, release, or deploy.
 
-The public CLI surface changed, so this branch prepares package candidate version `1.0.1`. A Codex P2 review finding on PR #119 tightened direct-path handling so `osc start` rejects markdown files outside the scaffold plan directories before parsing them. Merge, npm publish, and GitHub Release creation remain owner-gated.
+The public CLI surface changed, so version `1.0.1` was published through GitHub Actions trusted publishing and GitHub Release `v1.0.1` is the current Latest release. A Codex P2 review finding on PR #119 tightened direct-path handling so `osc start` rejects markdown files outside the scaffold plan directories before parsing them.
 
 ## Follow-up
 
-- Owner review/merge gate for the PR.
-- If merged, verify npm/latest drift and publish `open-scaffold@1.0.1` only with explicit owner approval.
 - Continue the staged runtime-adoption chain with plan 102: Codex/OMX adapter package hardening.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 This is a curated human-readable changelog. It compresses the detailed `MISSION.md` changelog, `.osc/releases/` evidence notes, GitHub PR history, and GitHub Releases into adoption-facing release groups.
 
-For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared; publication still depends on owner-gated npm and GitHub Release actions.
+For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
 ## v1.0.1 — No-spawn Codex handoff entry
 
-Status: repository candidate prepared; npm publication and GitHub Release latest movement are owner-gated external actions.
+Status: published to npm as `open-scaffold@1.0.1`; GitHub Release `v1.0.1` is Latest.
 
 Highlights:
 
@@ -19,10 +19,12 @@ Evidence:
 - Plan: `.osc/plans/done/101-osc-start-codex-agent-entry.md`
 - Evidence note: `.osc/releases/2026-05-26-101-osc-start-codex-agent-entry.md`
 - PR: https://github.com/graphanov/open-scaffold/pull/119
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v1.0.1
+- npm: `open-scaffold@1.0.1` / `latest`
 
 ## v1.0.0 — Stable protocol release candidate
 
-Status: repository candidate merged; npm publication and GitHub Release latest movement are owner-gated external actions.
+Status: published to npm as `open-scaffold@1.0.0`; GitHub Release `v1.0.0` was the initial stable Latest release before `v1.0.1`.
 
 Highlights:
 


### PR DESCRIPTION
## Summary
- Record post-publish proof for `open-scaffold@1.0.1` after trusted publishing completed.
- Update the v1.0.1 evidence note and changelog so they no longer describe npm/GitHub Release as pending owner gates.

## Verification
- `git diff --check`
- `./verify.sh --strict`
- `npm run osc -- verify`
- npm registry shows `open-scaffold@latest` -> `1.0.1`
- GitHub Release `v1.0.1` is Latest

## Boundary
- Docs/evidence only; no package/code/runtime behavior changes.
