### PR TITLE
chore: prepare 1.0.2 Codex runtime sync

### DIFF
--- a/.osc/plans/active/105-codex-runtime-adapter-package-release-sync.md
+++ b/.osc/plans/active/105-codex-runtime-adapter-package-release-sync.md
@@ -1,0 +1,54 @@
+# Plan: 105-codex-runtime-adapter-package-release-sync
+
+## Status
+
+active
+
+## Context
+
+PR #121 put the Codex-first runtime adapter hardening slice onto `main`. That changed package-visible CLI/runtime-profile behavior and public docs: `osc runtimes list` on `main` now includes the broad user-facing `codex` preset, and README/docs now recommend `--runtime codex`. The published npm `latest` package is still `open-scaffold@1.0.1`, whose fresh `npx` runtime list does not include `codex`, so GitHub/main and npm/latest are temporarily out of sync.
+
+## Goal
+
+Publish and verify `open-scaffold@1.0.2` so npm `latest`, fresh `npx`, and the GitHub Latest Release include the Codex runtime preset and the `runtime-omx` adapter naming decision from PR #121.
+
+## Constraints / Out of scope
+
+- Do not add new runtime behavior beyond the PR #121 package-visible changes.
+- Do not publish `@open-scaffold/runtime-omx`; it remains private/repo-source only.
+- Do not add core spawning, auto-install, credential handling, or direct `runtime-codex` implementation.
+- Do not change the Codex/OMX adapter decision in this release-sync slice.
+
+## Files to touch
+
+- `package.json` — bump root package version to `1.0.2`.
+- `package-lock.json` — keep the root package-lock version in sync.
+- `docs/CHANGELOG.md` — record the v1.0.2 public package surface.
+- `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md` — durable release-sync evidence.
+- This plan file and `MISSION.md` — closeout only after package/release proof is complete.
+
+## Acceptance criteria
+
+- [ ] Root package version is bumped to `1.0.2` and lockfile metadata matches.
+- [ ] Changelog documents v1.0.2 as a package-surface sync for the Codex runtime preset / `runtime-omx` adapter decision.
+- [ ] Local gates pass before PR: `./verify.sh --strict`, `npm test`, `npm run build`, `npm pack --dry-run --json`, `git diff --check`.
+- [ ] PR CI and latest-head Codex review are clean before PR integration.
+- [ ] Trusted publishing succeeds for `open-scaffold@1.0.2` after PR integration.
+- [ ] `npm view open-scaffold version dist-tags` shows `1.0.2` / `latest: 1.0.2`.
+- [ ] Fresh isolated-cache `npx open-scaffold@latest runtimes list` includes `codex`.
+- [ ] GitHub Release `v1.0.2` exists, targets the integrated main commit, and is marked Latest.
+
+## Verification steps
+
+1. Run `./verify.sh --strict`.
+2. Run `npm test`.
+3. Run `npm run build`.
+4. Run `npm pack --dry-run --json`.
+5. Run `git diff --check`.
+6. After PR integration/publication, run `npm view open-scaffold version dist-tags --json`.
+7. After publish, run fresh isolated-cache `npx --yes open-scaffold@latest runtimes list` and verify `codex` appears.
+8. Check `gh release list --repo graphanov/open-scaffold --limit 5` for `v1.0.2` as Latest.
+
+## Open questions
+
+- None.

--- a/.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md
+++ b/.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md
@@ -1,0 +1,32 @@
+# Release / Evidence Note: 105-codex-runtime-adapter-package-release-sync
+
+## Summary
+
+Prepared the patch release-sync candidate for `open-scaffold@1.0.2` so npm/latest can catch up with PR #121's package-visible Codex runtime preset and `runtime-omx` adapter naming decision.
+
+## Traceability
+
+- Roadmap / issue / task: Milestone 16 / post-v1 Codex-first runtime adoption chain; release-sync follow-through after PR #121.
+- Plan: `.osc/plans/active/105-codex-runtime-adapter-package-release-sync.md` until publication proof is complete.
+- Run ID / run packet: N/A for release-sync candidate.
+- Branch / Pull Request: pending.
+
+## Verification
+
+- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
+- `npm test` — PASS, 362 tests.
+- `npm run build` — PASS.
+- `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.2` (149 files, unpacked 1008030 bytes).
+- `git diff --check` — PASS.
+- Pending PR gates: CI green and latest-head Codex review clean.
+- Pending publication gates: trusted publishing workflow success, npm registry verification, fresh isolated-cache `npx open-scaffold@latest runtimes list` includes `codex`, and GitHub Release `v1.0.2` marked Latest.
+
+## Outcome
+
+Release-sync candidate is prepared but not yet published. No runtime behavior beyond PR #121 is added here; `@open-scaffold/runtime-omx` remains private/repo-source only.
+
+## Follow-up
+
+- Open PR for version/changelog/evidence candidate.
+- After merge, dispatch trusted publishing for `1.0.2`, verify npm/latest and fresh `npx`, then create/update GitHub Release `v1.0.2` as Latest.
+- Close this plan only after public package and release surfaces are verified.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,22 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v1.0.2 — Codex runtime preset package sync
+
+Status: release-sync candidate for npm `open-scaffold@1.0.2`; publication proof belongs in `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md` after trusted publishing and GitHub Release follow-through.
+
+Highlights:
+
+- Publishes the PR #121 package-visible runtime surface: built-in `codex` runtime preset, mapped to `omx-codex` and the current `runtime-omx` adapter path.
+- Keeps `--runtime omx` as the explicit harness-name preset while docs/examples prefer `--runtime codex` for broad users.
+- Preserves the no-spawn boundary: core records run packets, while runtime launch remains adapter-owned and explicitly gated.
+
+Evidence:
+
+- Plan: `.osc/plans/active/105-codex-runtime-adapter-package-release-sync.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/121
+- Evidence note: `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md`
+
 ## v1.0.1 — No-spawn Codex handoff entry
 
 Status: published to npm as `open-scaffold@1.0.1`; GitHub Release `v1.0.1` is Latest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Bumps the root package candidate to `open-scaffold@1.0.2` after PR #121 changed package-visible runtime behavior.
- Adds changelog and release-sync evidence for publishing the `codex` runtime preset / `runtime-omx` adapter naming decision to npm latest.
- Keeps `@open-scaffold/runtime-omx` private/repo-source only; this is a root package surface sync, not a runtime package publication.

## Task / Run Trace

- Task ID / issue: Milestone 16 / post-v1 Codex-first runtime adoption chain; release-sync follow-through after PR #121.
- Run ID: N/A for release-sync candidate.
- Plan/spec: `.osc/plans/active/105-codex-runtime-adapter-package-release-sync.md`
- Source refs: PR #121, `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md`

## Execution

- Executor lane: human / release sync
- Harness skill: none
- Branch/worktree: `release/codex-runtime-preset-sync` / local feature worktree
- Operator surface: Discord + GitHub PR

## Verification

- [x] `npm run osc -- verify` — PASS with pre-existing warnings plus expected active-release-sync warnings while plan 105 remains active pending publication.
- [x] `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
- [x] `npm test` — PASS, 362 tests.
- [x] `npm run build` — PASS.
- [x] `git diff --check` — PASS.
- [x] `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.2`.

## Evidence

- Run packet: N/A.
- Logs/artifacts: `/tmp/open-scaffold-pack-dry-run-105.json` local pack dry-run output.
- Screenshots/demo: N/A.
- Release/evidence note: `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md`

## Review Gates

- [x] Codex review requested via `@codex review`.
- [ ] CI green, or failures classified as external/infrastructure.
- [ ] Human approval captured where required.
- [x] No commit/push/merge policy violations.

## Notes for reviewers

This PR intentionally does not publish npm by itself. After merge, trusted publishing must produce `open-scaffold@1.0.2`; then fresh isolated-cache `npx open-scaffold@latest runtimes list` must show `codex`, and GitHub Release `v1.0.2` should become Latest.
