### PR TITLE
docs: close 1.0.2 release sync evidence

### DIFF
--- a/.osc/plans/done/105-codex-runtime-adapter-package-release-sync.md
+++ b/.osc/plans/done/105-codex-runtime-adapter-package-release-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 

--- a/.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md
+++ b/.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md
@@ -2,14 +2,16 @@
 
 ## Summary
 
-Prepared the patch release-sync candidate for `open-scaffold@1.0.2` so npm/latest can catch up with PR #121's package-visible Codex runtime preset and `runtime-omx` adapter naming decision.
+Published `open-scaffold@1.0.2` so npm/latest, fresh `npx`, and GitHub Latest Release now include PR #121's package-visible Codex runtime preset and `runtime-omx` adapter naming decision.
 
 ## Traceability
 
 - Roadmap / issue / task: Milestone 16 / post-v1 Codex-first runtime adoption chain; release-sync follow-through after PR #121.
-- Plan: `.osc/plans/active/105-codex-runtime-adapter-package-release-sync.md` until publication proof is complete.
-- Run ID / run packet: N/A for release-sync candidate.
-- Branch / Pull Request: pending.
+- Plan: `.osc/plans/done/105-codex-runtime-adapter-package-release-sync.md`.
+- Run ID / run packet: N/A for release-sync.
+- Branch / Pull Request: https://github.com/graphanov/open-scaffold/pull/122.
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/26447284708.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v1.0.2.
 
 ## Verification
 
@@ -18,15 +20,17 @@ Prepared the patch release-sync candidate for `open-scaffold@1.0.2` so npm/lates
 - `npm run build` — PASS.
 - `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.2` (149 files, unpacked 1008030 bytes).
 - `git diff --check` — PASS.
-- Pending PR gates: CI green and latest-head Codex review clean.
-- Pending publication gates: trusted publishing workflow success, npm registry verification, fresh isolated-cache `npx open-scaffold@latest runtimes list` includes `codex`, and GitHub Release `v1.0.2` marked Latest.
+- PR #122 CI — PASS.
+- PR #122 latest-head Codex review — PASS, no major issues and zero unresolved current review threads.
+- Trusted publishing workflow — PASS for `open-scaffold@1.0.2`.
+- `npm view open-scaffold version dist-tags --json` — PASS: `version = 1.0.2`, `latest = 1.0.2`.
+- Fresh isolated-cache `npx --yes open-scaffold@latest runtimes list` — PASS; output includes `codex\tbuiltin\tomx-codex\tadapter-candidate\tCodex via OMX / oh-my-codex`.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS; `v1.0.2 — Codex runtime preset package sync` is Latest.
 
 ## Outcome
 
-Release-sync candidate is prepared but not yet published. No runtime behavior beyond PR #121 is added here; `@open-scaffold/runtime-omx` remains private/repo-source only.
+`open-scaffold@1.0.2` is published and GitHub Release `v1.0.2` is Latest. npm/latest now matches `main` for the Codex runtime preset surface. No runtime behavior beyond PR #121 was added; `@open-scaffold/runtime-omx` remains private/repo-source only.
 
 ## Follow-up
 
-- Open PR for version/changelog/evidence candidate.
-- After merge, dispatch trusted publishing for `1.0.2`, verify npm/latest and fresh `npx`, then create/update GitHub Release `v1.0.2` as Latest.
-- Close this plan only after public package and release surfaces are verified.
+- Continue the Codex-first runtime adoption chain with the next scoped slice: `103-osc-dispatch-adapter-glue` or `104-osc-work-dry-run-target`, based on whether adapter glue or user-facing dry-run UX should come first.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-26: closed 105-codex-runtime-adapter-package-release-sync — published 1.0.2 Codex runtime preset package sync
 - 2026-05-26: closed 102-codex-runtime-adapter-package-hardening — hardened Codex runtime adapter path
 - 2026-05-26: closed 101-osc-start-codex-agent-entry — added no-spawn osc start Codex handoff
 - 2026-05-26: closed 100-verify-strict-filename-quoting — hardened strict verifier filename handling

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v1.0.2 — Codex runtime preset package sync
 
-Status: release-sync candidate for npm `open-scaffold@1.0.2`; publication proof belongs in `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md` after trusted publishing and GitHub Release follow-through.
+Status: published to npm as `open-scaffold@1.0.2`; GitHub Release `v1.0.2` is Latest.
 
 Highlights:
 
@@ -16,9 +16,12 @@ Highlights:
 
 Evidence:
 
-- Plan: `.osc/plans/active/105-codex-runtime-adapter-package-release-sync.md`
+- Plan: `.osc/plans/done/105-codex-runtime-adapter-package-release-sync.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/121
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/122
 - Evidence note: `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md`
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v1.0.2
+- npm: `open-scaffold@1.0.2` / `latest`
 
 ## v1.0.1 — No-spawn Codex handoff entry
 


### PR DESCRIPTION
## Summary

- Closes plan 105 after `open-scaffold@1.0.2` was published and verified.
- Updates the v1.0.2 evidence note with trusted publishing, npm/latest, fresh `npx`, and GitHub Latest Release proof.
- Updates the changelog status from release candidate to published/latest.

## Task / Run Trace

- Task ID / issue: Milestone 16 / post-v1 Codex-first runtime adoption chain; release-sync closeout.
- Run ID: N/A.
- Plan/spec: `.osc/plans/done/105-codex-runtime-adapter-package-release-sync.md`
- Source refs: PR #121, PR #122, trusted publishing run 26447284708, GitHub Release v1.0.2.

## Execution

- Executor lane: human / release evidence closeout
- Harness skill: none
- Branch/worktree: `release/codex-runtime-preset-sync-closeout` / local feature worktree
- Operator surface: Discord + GitHub PR

## Verification

- [x] `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
- [x] `npm test -- tests/cli-plan-evidence.test.ts tests/cli-lifecycle-parity.test.ts` — PASS, 9 tests.
- [x] `git diff --check` — PASS.
- [x] Public proof: `npm view open-scaffold version dist-tags --json` shows `1.0.2` / `latest: 1.0.2`.
- [x] Public proof: fresh isolated-cache `npx open-scaffold@latest runtimes list` includes `codex`.
- [x] Public proof: `gh release list --repo graphanov/open-scaffold --limit 5` shows `v1.0.2` as Latest.

## Evidence

- Run packet: N/A.
- Logs/artifacts: npm/fresh-npx/GitHub Release proof recorded in `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md`.
- Screenshots/demo: N/A.
- Release/evidence note: `.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md`

## Review Gates

- [x] Codex review skipped as evidence-only closeout.
- [x] CI green, or failures classified as external/infrastructure — no GitHub checks reported for this docs/evidence-only branch; local strict and targeted tests passed.
- [x] Human approval captured where required.
- [x] No commit/push/merge policy violations.

## Notes for reviewers

Evidence-only closeout: no package code, workflow, security-sensitive runtime behavior, or npm version changes are introduced here. The package publication already happened through trusted publishing from PR #122's merged main commit.
