### PR TITLE
feat: add explicit dispatch adapter glue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,20 @@ jobs:
     name: ci
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Check out repository without workflow token
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+          else
+            git checkout --force "$GITHUB_SHA"
+          fi
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/evidence-validate.yml
+++ b/.github/workflows/evidence-validate.yml
@@ -16,10 +16,20 @@ jobs:
     name: Validate evidence notes
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Check out repository without workflow token
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+          else
+            git checkout --force "$GITHUB_SHA"
+          fi
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Find changed evidence notes
         id: changed-evidence

--- a/.github/workflows/plan-validate.yml
+++ b/.github/workflows/plan-validate.yml
@@ -22,10 +22,20 @@ jobs:
     name: Validate changed plans
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Check out repository without workflow token
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+          else
+            git checkout --force "$GITHUB_SHA"
+          fi
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.osc/plans/done/103-osc-dispatch-adapter-glue.md
+++ b/.osc/plans/done/103-osc-dispatch-adapter-glue.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 

--- a/.osc/releases/2026-05-26-103-osc-dispatch-adapter-glue.md
+++ b/.osc/releases/2026-05-26-103-osc-dispatch-adapter-glue.md
@@ -1,0 +1,33 @@
+# Release / Evidence Note: 103-osc-dispatch-adapter-glue
+
+## Summary
+
+Added explicit `osc dispatch <run.json> --adapter <id>` glue for existing Open Scaffold run packets. The command invokes a reviewed project-local adapter config, captures adapter stdout/stderr logs plus explicitly reported receipt/evidence paths under the run directory, preserves multiple evidence artifacts, avoids stale artifact inference, and keeps runtime launch policy outside Open Scaffold core. PR validation workflows also use public unauthenticated Git fetches so required checks can run without repository-token checkout credentials.
+
+## Traceability
+
+- Roadmap / issue / task: Milestone 19 — Post-v1 adoption workflow target.
+- Plan: `.osc/plans/done/103-osc-dispatch-adapter-glue.md`.
+- Run ID / run packet: local scratch `osc run` -> `osc dispatch` smoke used temporary `.osc/runs/<run_id>/run.json` artifacts that were removed after verification.
+- Branch / PR: branch `runtime/osc-dispatch-adapter-glue`; Pull Request pending owner review.
+
+## Verification
+
+- `npm test -- tests/cli-dispatch.test.ts` — PASS, 9 dispatch tests.
+- Scratch `osc run .osc/plans/active/123-health-endpoint.md --runtime codex --repo <tmp>` followed by `osc dispatch <run.json> --adapter fake-smoke` — PASS, wrote dispatch receipt, adapter evidence, stdout log, and stderr log under `.osc/runs/<run_id>/`.
+- `npm test -- tests/github-actions-workflows.test.ts tests/cli-dispatch.test.ts packages/runtime-omx/tests/no-spawn-boundary.test.ts` — PASS, 14 focused tests.
+- `npm test` — PASS, 42 files / 372 tests.
+- `npm run build` — PASS, core and runtime-omx TypeScript builds.
+- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
+- Manual unauthenticated public Git fetch smoke for `refs/pull/125/merge` and `origin/main` — PASS, checked out the PR merge ref without using stored GitHub credentials.
+- `git diff --check` — PASS.
+- Independent pre-commit review — PASS after symlink/output-path, adapter-executable denylist, stale-output, multi-evidence, and workflow-checkout hardening; no blocking security or logic issues remained.
+
+## Outcome
+
+The repo now has an explicit dispatch bridge between generated run packets and local adapter packages without turning core into a hidden provider runtime. Missing, unknown, unsafe, URL-based, shell-wrapper, platform-shim, network-fetching, auto-installing, unsafe-output, and symlinked-run-directory adapter cases are refused by default. Commit, push, PR, merge, publish, credential, and provider-runtime authority remain out of scope and human-gated. Required PR validation jobs also avoid authenticated checkout so public CI can still validate the merge ref when repository-token Git fetches are unavailable.
+
+## Follow-up
+
+- Next product slice: `104-osc-work-dry-run-target` for the first natural-language composition layer.
+- Package/public-surface sync remains a separate owner-gated follow-through after this PR merges because the root CLI surface changes.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-26: closed 103-osc-dispatch-adapter-glue — added explicit dispatch adapter glue
 - 2026-05-26: closed 105-codex-runtime-adapter-package-release-sync — published 1.0.2 Codex runtime preset package sync
 - 2026-05-26: closed 102-codex-runtime-adapter-package-hardening — hardened Codex runtime adapter path
 - 2026-05-26: closed 101-osc-start-codex-agent-entry — added no-spawn osc start Codex handoff

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The post-v1 target is a smoother Codex-first path that starts from plain intent 
 osc work "Add a /health endpoint with tests" --runtime codex
 ```
 
-That command is future direction, not a current v1 promise. The first no-spawn step is `osc start`, which prints a paste-ready Codex/OMX handoff prompt from an existing plan without launching a runtime. The remaining staged path is: Codex/OMX adapter package hardening → `osc dispatch` adapter glue → `osc work --dry-run` → optional gated execution after a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
+That command is future direction, not a current v1 promise. The first no-spawn step is `osc start`, which prints a paste-ready Codex/OMX handoff prompt from an existing plan without launching a runtime. The next explicit bridge is `osc dispatch .osc/runs/RUN_ID/run.json --adapter <id>`, which invokes a reviewed local adapter config and captures receipt/evidence/log paths without auto-installing providers or granting commit/push/PR/merge/publish authority. The remaining staged path is: `osc work --dry-run` → optional gated execution after a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -413,7 +413,7 @@ Owner gates:
 
 ### Milestone 19 — Post-v1 adoption workflow target
 
-Status: planned through `.osc/plans/done/099-runtime-adoption-ux-reset.md` and `docs/RUNTIME_ADOPTION_WORKFLOW.md`.
+Status: staged implementation through `.osc/plans/done/099-runtime-adoption-ux-reset.md`, `docs/RUNTIME_ADOPTION_WORKFLOW.md`, and follow-up Codex-first adoption slices through `103-osc-dispatch-adapter-glue`. The next planned composition layer is `osc work --dry-run`.
 
 Goal: turn the credible v1 work-record protocol into a smoother adoption path without collapsing Open Scaffold core into a provider-specific runtime.
 
@@ -437,12 +437,12 @@ intent
 
 Implementation sequence:
 
-1. Fix immediate verification trust issues such as unsafe strict-mode filename quoting.
-2. Add `osc start` as a no-spawn, paste-ready Codex/OMX agent-entry command.
-3. Harden the Codex-first adapter package path: graduate `runtime-omx`, add direct `runtime-codex`, or support both after source-grounded UX review.
-4. Add `osc dispatch <run.json> --adapter <id>` as explicit adapter invocation glue.
-5. Add `osc work --dry-run` as the first natural-language composition layer.
-6. Reconsider optional gated execution only after receipt/evidence, conformance, worktree isolation, authority budgets, approval queues, and user evidence exist.
+1. Done — verification trust issue: unsafe strict-mode filename quoting fixed.
+2. Done — `osc start` added as a no-spawn, paste-ready Codex/OMX agent-entry command.
+3. Done — Codex-first adapter package path hardened around `runtime-omx` and the broad `codex` preset.
+4. Done in repo — `osc dispatch <run.json> --adapter <id>` added as explicit local-adapter invocation glue.
+5. Next — add `osc work --dry-run` as the first natural-language composition layer.
+6. Later — reconsider optional gated execution only after receipt/evidence, conformance, worktree isolation, authority budgets, approval queues, and user evidence exist.
 
 Acceptance direction:
 

--- a/docs/RUNTIME_ADOPTION_WORKFLOW.md
+++ b/docs/RUNTIME_ADOPTION_WORKFLOW.md
@@ -127,21 +127,32 @@ Make the Codex adapter path credible:
 
 ### Stage 3 — `osc dispatch` adapter glue
 
-Add a command such as:
+Current repo support adds:
 
 ```bash
 osc dispatch .osc/runs/RUN_ID/run.json --adapter omx
 ```
 
-It should:
+`--adapter` resolves a reviewed project-local adapter config at `.osc/adapters/<adapter-id>.json`, for example:
 
-- locate or validate the adapter;
-- call the selected adapter with the run packet;
-- capture receipt/evidence/log paths;
-- print the next verification and approval step;
-- refuse unknown, unsafe, or auto-installing adapters by default.
+```json
+{
+  "schemaVersion": "open-scaffold.adapter.v1",
+  "id": "omx",
+  "command": ["open-scaffold-runtime-omx"]
+}
+```
 
-`osc dispatch` is adapter invocation glue, not a hidden provider runtime.
+The command:
+
+- requires an existing `open-scaffold.run.v1` packet under `.osc/runs/`;
+- invokes only the explicitly selected local adapter command;
+- refuses missing, unknown, unsafe, URL-based, shell-wrapper, platform-shim, network-fetching, or auto-installing adapter commands by default;
+- captures adapter stdout/stderr logs under `.osc/runs/RUN_ID/dispatch/`;
+- reads adapter-reported receipt/evidence paths only when they remain under the run directory;
+- prints the next verification and human-approval step.
+
+`osc dispatch` is adapter invocation glue, not a hidden provider runtime. Core does not import provider SDKs, auto-install adapters, own credentials, supervise tmux/processes, or grant commit/push/PR/merge/publish authority. Adapter packages own their launch policy and must return receipts/evidence that the operator can inspect.
 
 ### Stage 4 — `osc work --dry-run`
 

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -61,6 +61,7 @@ These surfaces are usable but not promised as final API shape. They may change i
 
 - Runtime profiles and runtime selection beyond run-packet metadata.
 - `osc run`, `osc delegate`, `osc review`, and `osc ultrareview` beyond their current no-spawn artifact-generation role.
+- `osc dispatch` as explicit local-adapter invocation glue; adapter commands, receipts, and launch policy remain experimental and adapter-owned.
 - Evaluation and audit envelope helpers.
 - Optional MCP server interface.
 - Glass cockpit webhook examples for Discord and Slack.

--- a/packages/runtime-omx/tests/no-spawn-boundary.test.ts
+++ b/packages/runtime-omx/tests/no-spawn-boundary.test.ts
@@ -17,6 +17,8 @@ const coreProcessAllowedFiles = new Set([
   join(coreSrcRoot, 'evidence.ts'),
   // Metrics may shell out to local `git log` for commit-date timestamps; it must not spawn runtimes or use network commands.
   join(coreSrcRoot, 'metrics.ts'),
+  // Dispatch may invoke an explicitly reviewed local adapter command for an existing run packet; adapter launch policy remains outside core.
+  join(coreSrcRoot, 'dispatch.ts'),
 ]);
 
 const runtimeForbiddenPatterns = [
@@ -45,11 +47,13 @@ function isCoreProcessAllowedFile(file: string): boolean {
 }
 
 describe('runtime-omx source boundary', () => {
-  it('only allowlists the intended core evidence and local metrics collector files', () => {
+  it('only allowlists the intended core evidence, dispatch, and local metrics collector files', () => {
     expect(isCoreProcessAllowedFile(join(coreSrcRoot, 'evidence.ts'))).toBe(true);
     expect(isCoreProcessAllowedFile(join(coreSrcRoot, 'metrics.ts'))).toBe(true);
+    expect(isCoreProcessAllowedFile(join(coreSrcRoot, 'dispatch.ts'))).toBe(true);
     expect(isCoreProcessAllowedFile(join(coreSrcRoot, 'nested', 'evidence.ts'))).toBe(false);
     expect(isCoreProcessAllowedFile(join(coreSrcRoot, 'nested', 'metrics.ts'))).toBe(false);
+    expect(isCoreProcessAllowedFile(join(coreSrcRoot, 'nested', 'dispatch.ts'))).toBe(false);
   });
 
   it('Open Scaffold core source remains free of runtime process launching code', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { renderAuditManifest, validateAuditManifestFile, writeAuditManifest, typ
 import { createRunArtifacts, previewRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
 import { COCKPIT_EVENT_TYPES, CockpitConfigError, CockpitUsageError, formatCockpitConfig, formatCockpitDispatchSummary, hasCockpitDispatchFailures, loadCockpitConfig, postCockpitEvent, type CockpitEventType, type CockpitPostOptions } from './cockpit.js';
 import { runDashboard, type DashboardRunOptions } from './dashboard.js';
+import { DispatchUsageError, formatDispatchSummary, runDispatch } from './dispatch.js';
 import { doctorExitCode, formatDoctorReport, parseDoctorCheckName, runDoctor, type DoctorOptions, type DoctorSeverity } from './doctor.js';
 import { openDashboardUrl, serveDashboard, writeWebDashboard } from './dashboard-web.js';
 import { collectEvidence } from './evidence.js';
@@ -52,6 +53,7 @@ Usage:
   osc start <plan-slug-or-path> --runtime <codex|omx|plain|human|custom>
   osc delegate <plan-path> [run binding options]
   osc run <plan-path> [--dry-run] [--json] [run binding options]
+  osc dispatch <run-json> --adapter <adapter-id>
   osc review <plan-path> [run binding options]
   osc ultrareview <plan-path> [run binding options]
   osc eval init <run-or-plan> [--out <path>]
@@ -1135,6 +1137,60 @@ function startCommand(args: string[]): void {
     process.stdout.write(renderStartPrompt(planReference, { runtime, cwd: process.cwd() }).prompt);
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+function printDispatchUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc dispatch <run-json> --adapter <adapter-id>
+
+Invokes an explicit trusted adapter for an existing run packet, captures adapter stdout/stderr logs, and prints receipt/evidence paths. Open Scaffold core does not auto-install adapters or grant commit/push/merge/publish authority.`, stream);
+}
+
+function takeDispatchValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    console.error(`Missing value for ${flag}`);
+    printDispatchUsage();
+    process.exit(2);
+  }
+  return value;
+}
+
+function dispatchCommand(args: string[]): void {
+  if (isHelpArg(args[0])) {
+    printDispatchUsage('stdout');
+    return;
+  }
+  const runJson = requireArg(args, 'run-json');
+  let adapterId: string | undefined;
+  const rest = args.slice(1);
+  for (let i = 0; i < rest.length; i += 1) {
+    const flag = rest[i];
+    switch (flag) {
+      case '--adapter':
+        adapterId = takeDispatchValue(rest, i, flag);
+        i += 1;
+        break;
+      default:
+        console.error(`Unknown option for dispatch: ${flag}`);
+        printDispatchUsage();
+        process.exit(2);
+    }
+  }
+  if (!adapterId) {
+    console.error('Missing required option: --adapter <adapter-id>');
+    printDispatchUsage();
+    process.exit(2);
+  }
+  try {
+    const result = runDispatch(runJson, { adapterId }, process.cwd());
+    const root = findScaffoldRoot(dirname(result.runPacketPath)) ?? process.cwd();
+    process.stdout.write(formatDispatchSummary(result, root));
+    if (result.exitStatus !== 0) process.exit(1);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    if (error instanceof DispatchUsageError) process.exit(2);
     process.exit(1);
   }
 }
@@ -2311,6 +2367,11 @@ async function main(): Promise<void> {
       return;
     case 'delegate':
     case 'run':
+      createArtifacts(args, command);
+      return;
+    case 'dispatch':
+      dispatchCommand(args);
+      return;
     case 'review':
     case 'ultrareview':
       createArtifacts(args, command);

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -1,0 +1,252 @@
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { findScaffoldRoot } from './scaffold.js';
+
+export class DispatchUsageError extends Error {}
+
+interface AdapterConfigFile {
+  schemaVersion?: unknown;
+  id?: unknown;
+  command?: unknown;
+}
+
+export interface DispatchOptions {
+  adapterId: string;
+}
+
+export interface DispatchResult {
+  adapterId: string;
+  runId: string;
+  runPacketPath: string;
+  receiptPath: string | null;
+  evidencePaths: string[];
+  stdoutLogPath: string;
+  stderrLogPath: string;
+  exitStatus: number | null;
+  signal: string | null;
+}
+
+interface AdapterDefinition {
+  id: string;
+  command: string[];
+}
+
+const forbiddenAdapterExecutables = new Set([
+  'npx',
+  'npm',
+  'pnpm',
+  'pnpx',
+  'yarn',
+  'bun',
+  'bunx',
+  'curl',
+  'wget',
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  'cmd',
+  'cmd.exe',
+  'powershell',
+  'powershell.exe',
+  'pwsh',
+  'env',
+  'corepack',
+]);
+
+function normalizeAdapterExecutableName(command: string): string {
+  let name = basename(command.replace(/\\/g, '/')).toLowerCase();
+  for (const extension of ['.cmd', '.exe', '.bat', '.com']) {
+    if (name.endsWith(extension)) {
+      name = name.slice(0, -extension.length);
+      break;
+    }
+  }
+  return name;
+}
+
+function isSafeId(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value) && !value.includes('..');
+}
+
+function ensureInside(parent: string, child: string, message: string): void {
+  const rel = relative(parent, child);
+  if (rel === '' || rel === '.') return;
+  if (rel.startsWith('..') || isAbsolute(rel)) throw new DispatchUsageError(message);
+}
+
+function toRelative(root: string, path: string | null): string | null {
+  if (!path) return null;
+  return relative(root, path).split('\\').join('/');
+}
+
+function resolveRunPacket(start: string, runPacketArg: string): { root: string; runPacketPath: string; runDir: string; runId: string } {
+  const candidate = isAbsolute(runPacketArg) ? resolve(runPacketArg) : resolve(start, runPacketArg);
+  if (!existsSync(candidate)) throw new DispatchUsageError(`Run packet does not exist: ${runPacketArg}`);
+  const runPacketPath = realpathSync.native(candidate);
+  if (basename(runPacketPath) !== 'run.json') throw new DispatchUsageError('Dispatch input must be a run.json file.');
+  const root = findScaffoldRoot(dirname(runPacketPath)) ?? findScaffoldRoot(start);
+  if (!root) throw new DispatchUsageError(`No Open Scaffold root found for run packet: ${runPacketArg}`);
+  const realRoot = realpathSync.native(root);
+  ensureInside(join(realRoot, '.osc', 'runs'), runPacketPath, 'Run packet must live under .osc/runs.');
+  const runDir = dirname(runPacketPath);
+  const raw = JSON.parse(readFileSync(runPacketPath, 'utf8')) as { runId?: unknown; schemaVersion?: unknown };
+  if (raw.schemaVersion !== 'open-scaffold.run.v1') throw new DispatchUsageError('Dispatch input must use schemaVersion open-scaffold.run.v1.');
+  if (typeof raw.runId !== 'string' || !raw.runId.trim()) throw new DispatchUsageError('Dispatch input is missing runId.');
+  return { root: realRoot, runPacketPath, runDir, runId: raw.runId };
+}
+
+function adapterConfigPath(root: string, adapterId: string): string {
+  return join(root, '.osc', 'adapters', `${adapterId}.json`);
+}
+
+function loadProjectAdapter(root: string, adapterId: string): AdapterDefinition | null {
+  const path = adapterConfigPath(root, adapterId);
+  if (!existsSync(path)) return null;
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as AdapterConfigFile;
+  if (parsed.schemaVersion !== 'open-scaffold.adapter.v1') {
+    throw new DispatchUsageError(`Adapter ${adapterId} has unsupported schemaVersion; expected open-scaffold.adapter.v1.`);
+  }
+  if (parsed.id !== adapterId) throw new DispatchUsageError(`Adapter config id mismatch: expected ${adapterId}.`);
+  if (!Array.isArray(parsed.command) || parsed.command.length === 0 || parsed.command.some((part) => typeof part !== 'string' || !part.trim())) {
+    throw new DispatchUsageError(`Adapter ${adapterId} command must be a non-empty string array.`);
+  }
+  return { id: adapterId, command: parsed.command };
+}
+
+function resolveAdapter(root: string, adapterId: string): AdapterDefinition {
+  if (!isSafeId(adapterId)) throw new DispatchUsageError(`Unsafe adapter id: ${adapterId}`);
+  const adapter = loadProjectAdapter(root, adapterId);
+  if (!adapter) throw new DispatchUsageError(`Unknown adapter: ${adapterId}`);
+  const first = adapter.command[0];
+  if (!first) throw new DispatchUsageError(`Adapter ${adapter.id} command is empty.`);
+  const executableName = normalizeAdapterExecutableName(first);
+  if (forbiddenAdapterExecutables.has(executableName)) {
+    throw new DispatchUsageError(`Adapter ${adapter.id} uses forbidden adapter executable: ${executableName}`);
+  }
+  if (/^https?:/i.test(first)) throw new DispatchUsageError(`Adapter ${adapter.id} command must be local, not a URL.`);
+  return adapter;
+}
+
+function assertNoSymlinksUnder(path: string, message: string): void {
+  let stat: ReturnType<typeof lstatSync>;
+  try {
+    stat = lstatSync(path);
+  } catch {
+    return;
+  }
+  if (stat.isSymbolicLink()) throw new DispatchUsageError(message);
+  if (!stat.isDirectory()) return;
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    assertNoSymlinksUnder(join(path, entry.name), message);
+  }
+}
+
+function assertSafeExistingOutput(root: string, runDir: string, outputPath: string, message: string): string {
+  const candidate = resolve(outputPath);
+  ensureInside(runDir, candidate, message);
+  ensureInside(root, candidate, 'Adapter output path must stay under the scaffold root.');
+  let stat: ReturnType<typeof lstatSync>;
+  try {
+    stat = lstatSync(candidate);
+  } catch {
+    throw new DispatchUsageError('Adapter-reported output path does not exist.');
+  }
+  if (stat.isSymbolicLink()) throw new DispatchUsageError('Adapter output path must not be a symlink.');
+  const realCandidate = realpathSync.native(candidate);
+  ensureInside(runDir, realCandidate, message);
+  ensureInside(root, realCandidate, 'Adapter output path must stay under the scaffold root.');
+  return realCandidate;
+}
+
+function resolveOutputPath(root: string, runDir: string, value: string): string {
+  const candidate = isAbsolute(value) ? resolve(value) : resolve(root, value);
+  return assertSafeExistingOutput(root, runDir, candidate, 'Adapter-reported output path must stay under the run directory.');
+}
+
+function extractReportedPaths(output: string, kind: 'receipt' | 'evidence'): string[] {
+  const pattern = kind === 'receipt' ? /receipt written:\s*(.+)$/gim : /evidence written:\s*(.+)$/gim;
+  return Array.from(output.matchAll(pattern), (match) => match[1]?.trim()).filter((value): value is string => Boolean(value));
+}
+
+function extractReportedPath(output: string, kind: 'receipt' | 'evidence'): string | null {
+  return extractReportedPaths(output, kind).at(-1) ?? null;
+}
+
+function discoverReceipt(root: string, runDir: string, stdout: string): string | null {
+  const reported = extractReportedPath(stdout, 'receipt');
+  return reported ? resolveOutputPath(root, runDir, reported) : null;
+}
+
+function discoverEvidence(root: string, runDir: string, stdout: string): string[] {
+  return extractReportedPaths(stdout, 'evidence').map((reported) => resolveOutputPath(root, runDir, reported));
+}
+
+function prepareDispatchDir(runDir: string): string {
+  const dispatchDir = join(runDir, 'dispatch');
+  if (existsSync(dispatchDir) && lstatSync(dispatchDir).isSymbolicLink()) throw new DispatchUsageError('Dispatch log directory must not be a symlink.');
+  mkdirSync(dispatchDir, { recursive: true });
+  const realDispatchDir = realpathSync.native(dispatchDir);
+  ensureInside(runDir, realDispatchDir, 'Dispatch log directory must stay under the run directory.');
+  return realDispatchDir;
+}
+
+function writeLogFile(dispatchDir: string, adapterId: string, kind: 'stdout' | 'stderr', content: string): string {
+  const path = join(dispatchDir, `${adapterId}-${kind}.log`);
+  if (existsSync(path) && lstatSync(path).isSymbolicLink()) throw new DispatchUsageError('Dispatch log path must not be a symlink.');
+  writeFileSync(path, content, 'utf8');
+  return path;
+}
+
+export function runDispatch(runPacketArg: string, options: DispatchOptions, start = process.cwd()): DispatchResult {
+  if (!runPacketArg) throw new DispatchUsageError('Missing required argument: run-json');
+  const run = resolveRunPacket(start, runPacketArg);
+  assertNoSymlinksUnder(run.runDir, 'Run directory must not contain symlinks before adapter dispatch.');
+  const adapter = resolveAdapter(run.root, options.adapterId);
+  prepareDispatchDir(run.runDir);
+
+  const result = spawnSync(adapter.command[0]!, [...adapter.command.slice(1), run.runPacketPath], {
+    cwd: run.root,
+    encoding: 'utf8',
+    env: process.env,
+  });
+  const stdout = String(result.stdout ?? '');
+  const stderr = result.error ? String(result.error.message) : String(result.stderr ?? '');
+  const finalDispatchDir = prepareDispatchDir(run.runDir);
+  const stdoutLogPath = writeLogFile(finalDispatchDir, adapter.id, 'stdout', stdout);
+  const stderrLogPath = writeLogFile(finalDispatchDir, adapter.id, 'stderr', stderr);
+
+  const receiptPath = discoverReceipt(run.root, run.runDir, stdout);
+  const evidencePaths = discoverEvidence(run.root, run.runDir, stdout);
+
+  return {
+    adapterId: adapter.id,
+    runId: run.runId,
+    runPacketPath: run.runPacketPath,
+    receiptPath,
+    evidencePaths,
+    stdoutLogPath,
+    stderrLogPath,
+    exitStatus: result.status,
+    signal: result.signal,
+  };
+}
+
+export function formatDispatchSummary(result: DispatchResult, root: string): string {
+  const evidence = result.evidencePaths.length ? result.evidencePaths.map((path) => `Evidence: ${toRelative(root, path)}`).join('\n') : 'Evidence: (none reported)';
+  return [
+    'Open Scaffold dispatch complete',
+    `Adapter: ${result.adapterId}`,
+    `Run ID: ${result.runId}`,
+    `Run packet: ${toRelative(root, result.runPacketPath)}`,
+    `Dispatch receipt: ${toRelative(root, result.receiptPath) ?? '(none reported)'}`,
+    evidence,
+    `Stdout log: ${toRelative(root, result.stdoutLogPath)}`,
+    `Stderr log: ${toRelative(root, result.stderrLogPath)}`,
+    `Exit status: ${result.exitStatus ?? '(none)'}`,
+    result.signal ? `Signal: ${result.signal}` : null,
+    'Next: inspect the adapter evidence, run verification, then ask before commit/push/PR/merge/publish.',
+    '',
+  ].filter((line): line is string => line !== null).join('\n');
+}

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'osc-dispatch-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/backlog'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild a small service.\n');
+  writeFileSync(join(root, '.osc/releases/README.md'), '# Evidence notes\n');
+  writePlan(root);
+  return root;
+}
+
+function writePlan(root: string, slug = '123-health-endpoint'): string {
+  const planPath = join(root, `.osc/plans/active/${slug}.md`);
+  writeFileSync(planPath, `# Plan: ${slug}
+
+## Status
+
+active
+
+## Context
+
+A user needs a simple health check.
+
+## Goal
+
+Add a health endpoint with tests.
+
+## Constraints / Out of scope
+
+- Do not change deployment infrastructure.
+
+## Files to touch
+
+- \`src/server.ts\` — route implementation.
+- \`tests/server.test.ts\` — health endpoint coverage.
+
+## Acceptance criteria
+
+- [ ] Health endpoint returns 200.
+- [ ] Test suite covers the route.
+
+## Verification steps
+
+1. Run \`npm test\`.
+2. Run \`npm run build\`.
+
+## Open questions
+
+- None.
+`);
+  return planPath;
+}
+
+function latestRunJson(root: string): string {
+  const runsDir = join(root, '.osc/runs');
+  const runId = readdirSync(runsDir).sort().at(-1);
+  expect(runId).toBeTruthy();
+  return join(runsDir, runId!, 'run.json');
+}
+
+function createRunPacket(root: string): string {
+  const result = spawnSync(tsx, [cli, 'run', '.osc/plans/active/123-health-endpoint.md', '--runtime', 'codex', '--repo', root], { cwd: root, encoding: 'utf8' });
+  expect(result.status).toBe(0);
+  return latestRunJson(root);
+}
+
+function writeFakeAdapter(root: string): void {
+  const adapterDir = join(root, '.osc/adapters');
+  mkdirSync(adapterDir, { recursive: true });
+  const adapterScript = join(adapterDir, 'fake-adapter.mjs');
+  writeFileSync(adapterScript, `import { dirname, join, relative } from 'node:path';
+import { readFileSync, writeFileSync } from 'node:fs';
+const runPath = process.argv[2];
+const packet = JSON.parse(readFileSync(runPath, 'utf8'));
+const runDir = dirname(runPath);
+const receiptPath = join(runDir, 'dispatch-receipt.json');
+const evidencePath = join(runDir, 'fake-adapter-evidence.md');
+writeFileSync(receiptPath, JSON.stringify({
+  schema_version: 'open-scaffold.dispatch-receipt.v1',
+  adapter_id: 'fake',
+  run_id: packet.runId,
+  status: 'dry_run',
+  spawned: false,
+  artifacts: [relative(packet.runtime.repoPath, evidencePath)]
+}, null, 2) + '\\n');
+writeFileSync(evidencePath, '# Fake adapter evidence\\n');
+console.log('fake adapter receipt written: ' + receiptPath);
+console.log('fake adapter evidence written: ' + evidencePath);
+`);
+  writeFileSync(join(adapterDir, 'fake.json'), JSON.stringify({
+    schemaVersion: 'open-scaffold.adapter.v1',
+    id: 'fake',
+    command: ['node', '.osc/adapters/fake-adapter.mjs']
+  }, null, 2) + '\n');
+}
+
+function writeAdapterConfig(root: string, id: string, command: string[]): void {
+  const adapterDir = join(root, '.osc/adapters');
+  mkdirSync(adapterDir, { recursive: true });
+  writeFileSync(join(adapterDir, `${id}.json`), JSON.stringify({ schemaVersion: 'open-scaffold.adapter.v1', id, command }, null, 2) + '\n');
+}
+
+function fileSnapshot(root: string): string[] {
+  const result: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) walk(full);
+      else result.push(`${relative(root, full)}:${stat.size}:${stat.mtimeMs}`);
+    }
+  };
+  walk(root);
+  return result.sort();
+}
+
+describe('osc dispatch', () => {
+  it('invokes a trusted local adapter fixture and captures receipt, evidence, and logs under the run directory', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      writeFakeAdapter(root);
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'fake'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('Open Scaffold dispatch complete');
+      expect(result.stdout).toContain('Adapter: fake');
+      expect(result.stdout).toContain('Dispatch receipt: .osc/runs/');
+      expect(result.stdout).toContain('Evidence: .osc/runs/');
+      expect(result.stdout).toContain('Next: inspect the adapter evidence, run verification, then ask before commit/push/PR/merge/publish.');
+
+      const runDir = dirname(runJson);
+      const receiptPath = join(runDir, 'dispatch-receipt.json');
+      const evidencePath = join(runDir, 'fake-adapter-evidence.md');
+      const stdoutLog = join(runDir, 'dispatch', 'fake-stdout.log');
+      expect(JSON.parse(readFileSync(receiptPath, 'utf8'))).toMatchObject({ adapter_id: 'fake', status: 'dry_run', spawned: false });
+      expect(readFileSync(evidencePath, 'utf8')).toContain('Fake adapter evidence');
+      expect(readFileSync(stdoutLog, 'utf8')).toContain('fake adapter receipt written:');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses an unknown adapter without creating dispatch logs', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const before = fileSnapshot(root);
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'missing'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('Unknown adapter: missing');
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses missing and unsafe adapter selections before execution', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const before = fileSnapshot(root);
+      const missing = spawnSync(tsx, [cli, 'dispatch', runJson], { cwd: root, encoding: 'utf8' });
+      const unsafe = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', '../evil'], { cwd: root, encoding: 'utf8' });
+
+      expect(missing.status).toBe(2);
+      expect(missing.stderr).toContain('Missing required option: --adapter <adapter-id>');
+      expect(unsafe.status).toBe(2);
+      expect(unsafe.stderr).toContain('Unsafe adapter id: ../evil');
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses auto-installing adapter commands and shell wrappers before execution', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      writeAdapterConfig(root, 'installer', ['npx', 'some-adapter']);
+      writeAdapterConfig(root, 'shell-installer', ['sh', '-c', 'npx some-adapter']);
+      writeAdapterConfig(root, 'case-installer', ['NPX', 'some-adapter']);
+      writeAdapterConfig(root, 'shim-installer', ['npx.cmd', 'some-adapter']);
+      const before = fileSnapshot(root);
+      const installer = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'installer'], { cwd: root, encoding: 'utf8' });
+      const shellInstaller = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'shell-installer'], { cwd: root, encoding: 'utf8' });
+      const caseInstaller = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'case-installer'], { cwd: root, encoding: 'utf8' });
+      const shimInstaller = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'shim-installer'], { cwd: root, encoding: 'utf8' });
+
+      expect(installer.status).toBe(2);
+      expect(installer.stderr).toContain('Adapter installer uses forbidden adapter executable: npx');
+      expect(shellInstaller.status).toBe(2);
+      expect(shellInstaller.stderr).toContain('Adapter shell-installer uses forbidden adapter executable: sh');
+      expect(caseInstaller.status).toBe(2);
+      expect(caseInstaller.stderr).toContain('Adapter case-installer uses forbidden adapter executable: npx');
+      expect(shimInstaller.status).toBe(2);
+      expect(shimInstaller.stderr).toContain('Adapter shim-installer uses forbidden adapter executable: npx');
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses adapter-reported receipt paths outside the run directory', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'escape.mjs'), "console.log('escape adapter receipt written: /tmp/outside-dispatch-receipt.json');\n");
+      writeAdapterConfig(root, 'escape', ['node', '.osc/adapters/escape.mjs']);
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'escape'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('Adapter-reported output path must stay under the run directory.');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses symlinks inside the run directory before adapter execution', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      writeFakeAdapter(root);
+      const runDir = dirname(runJson);
+      const outsideTarget = join(root, 'outside-receipt.json');
+      symlinkSync(outsideTarget, join(runDir, 'dispatch-receipt.json'));
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'fake'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('Run directory must not contain symlinks before adapter dispatch.');
+      expect(existsSync(outsideTarget)).toBe(false);
+      expect(existsSync(join(runDir, 'dispatch', 'fake-stdout.log'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves multiple adapter-reported evidence paths', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'multi-evidence.mjs'), `import { dirname, join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+const runDir = dirname(process.argv[2]);
+const first = join(runDir, 'first-evidence.md');
+const second = join(runDir, 'second-evidence.md');
+writeFileSync(first, '# First evidence\\n');
+writeFileSync(second, '# Second evidence\\n');
+console.log('multi adapter evidence written: ' + first);
+console.log('multi adapter evidence written: ' + second);
+`);
+      writeAdapterConfig(root, 'multi-evidence', ['node', '.osc/adapters/multi-evidence.mjs']);
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'multi-evidence'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Evidence: .osc/runs/');
+      expect(result.stdout).toContain('first-evidence.md');
+      expect(result.stdout).toContain('second-evidence.md');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not report stale receipt or evidence files when an adapter is silent', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      writeFakeAdapter(root);
+      const first = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'fake'], { cwd: root, encoding: 'utf8' });
+      expect(first.status).toBe(0);
+      expect(first.stdout).toContain('Dispatch receipt: .osc/runs/');
+
+      const adapterDir = join(root, '.osc/adapters');
+      writeFileSync(join(adapterDir, 'silent.mjs'), "// intentionally silent adapter\n");
+      writeAdapterConfig(root, 'silent', ['node', '.osc/adapters/silent.mjs']);
+      const second = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'silent'], { cwd: root, encoding: 'utf8' });
+
+      expect(second.status).toBe(0);
+      expect(second.stdout).toContain('Dispatch receipt: (none reported)');
+      expect(second.stdout).toContain('Evidence: (none reported)');
+      expect(second.stdout).not.toContain('fake-adapter-evidence.md');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps dispatch core free of provider SDK imports and fixed Codex/OMX launch commands', () => {
+    const dispatchSource = readFileSync(join(repoRoot, 'src/dispatch.ts'), 'utf8');
+    expect(dispatchSource).not.toMatch(/from ['\"](?:openai|@anthropic-ai|anthropic|codex|omx)['\"]/i);
+    expect(dispatchSource).not.toContain('open-scaffold-runtime-omx');
+    expect(dispatchSource).not.toContain('codex exec');
+    expect(dispatchSource).not.toContain('omx exec');
+  });
+});

--- a/tests/github-actions-workflows.test.ts
+++ b/tests/github-actions-workflows.test.ts
@@ -13,4 +13,15 @@ describe('GitHub Actions workflow templates', () => {
     expect(workflow).toContain('*-amendment-[0-9]*.md) continue ;;');
     expect(workflow).toContain('node dist/cli.js plan validate "$plan"');
   });
+
+  it('checks out pull request validation workflows without repository token credentials', () => {
+    for (const workflowPath of ['.github/workflows/ci.yml', '.github/workflows/plan-validate.yml', '.github/workflows/evidence-validate.yml']) {
+      const workflow = read(workflowPath);
+
+      expect(workflow).not.toContain('actions/checkout');
+      expect(workflow).toContain('GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin');
+      expect(workflow).toContain('refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge');
+      expect(workflow).toContain('git checkout --force "$GITHUB_SHA"');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Add `osc dispatch <run-json> --adapter <adapter-id>` for explicit local adapter invocation from existing `open-scaffold.run.v1` packets.
- Add project-local `.osc/adapters/<id>.json` adapter resolution with default refusals for missing/unknown/unsafe adapters, auto-install/network/shell/platform-shim executables, symlinks, out-of-run-dir receipt/evidence paths, stale inferred outputs, and dropped multi-evidence outputs.
- Document the Stage 3 dispatch boundary, record release/evidence note 103, and move plan 103 to done.
- Harden required PR validation workflows to checkout the public merge ref without repository-token Git credentials after token-backed checkout failed before repo code ran.

## Verification

- `npm test -- tests/cli-dispatch.test.ts`
- scratch `osc run` -> `osc dispatch` fake-adapter smoke
- manual unauthenticated public Git fetch smoke for `refs/pull/125/merge` + `origin/main`
- YAML parse for all workflows
- `npm test -- tests/github-actions-workflows.test.ts tests/cli-dispatch.test.ts packages/runtime-omx/tests/no-spawn-boundary.test.ts`
- `npm test`
- `./verify.sh --strict`
- `npm run build`
- `git diff --check`

## Risk / Gates

- Core now invokes explicit reviewed local adapter commands, but it still does not auto-install providers, manage credentials, supervise long-running runtimes, or grant commit/push/PR/merge/publish authority.
- Root CLI behavior changes, so npm/GitHub release public-surface sync remains a separate follow-up after this PR merges.
