### PR TITLE
chore: prepare dispatch adapter package sync

### DIFF
--- a/.osc/plans/active/106-dispatch-adapter-glue-package-sync.md
+++ b/.osc/plans/active/106-dispatch-adapter-glue-package-sync.md
@@ -1,0 +1,54 @@
+# Plan: 106-dispatch-adapter-glue-package-sync
+
+## Status
+
+active
+
+## Context
+
+PR #125 put explicit `osc dispatch <run.json> --adapter <id>` glue on `main`. That changed package-visible CLI/help behavior and runtime-adoption docs: local `main` now exposes `osc dispatch`, while the published npm `latest` package is still `open-scaffold@1.0.2` and fresh `npx open-scaffold@latest --help` does not show `osc dispatch`.
+
+## Goal
+
+Prepare and verify `open-scaffold@1.0.3` as the package/public-surface sync for dispatch adapter glue so npm `latest`, fresh `npx`, and the GitHub Latest Release can match `main` after the publish/release gate.
+
+## Constraints / Out of scope
+
+- Do not add new dispatch behavior beyond PR #125.
+- Do not implement `osc work`, native runtime spawning, provider SDK imports, credential management, or auto-install behavior.
+- Do not publish adapter packages in this slice.
+- Keep npm publishing and GitHub Release creation as explicit public-surface follow-through after PR integration.
+
+## Files to touch
+
+- `package.json` — bump root package version to `1.0.3`.
+- `package-lock.json` — keep root lockfile version metadata in sync.
+- `docs/CHANGELOG.md` — record the v1.0.3 package surface.
+- `.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md` — durable release-sync evidence.
+- This plan file and `MISSION.md` — closeout only after package/release proof exists.
+
+## Acceptance criteria
+
+- [ ] Root package version is bumped to `1.0.3` and lockfile metadata matches.
+- [ ] Changelog documents v1.0.3 as the package-surface sync for `osc dispatch` adapter glue and PR validation checkout resilience.
+- [ ] Local gates pass before PR: `./verify.sh --strict`, `npm test`, `npm run build`, `npm pack --dry-run --json`, `git diff --check`.
+- [ ] PR CI and latest-head Codex review are clean before PR integration.
+- [ ] Trusted publishing succeeds for `open-scaffold@1.0.3` after PR integration.
+- [ ] `npm view open-scaffold version dist-tags --json` shows `1.0.3` / `latest: 1.0.3`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc dispatch <run-json> --adapter <adapter-id>`.
+- [ ] GitHub Release `v1.0.3` exists, targets the integrated main commit, and is marked Latest.
+
+## Verification steps
+
+1. Run `./verify.sh --strict`.
+2. Run `npm test`.
+3. Run `npm run build`.
+4. Run `npm pack --dry-run --json`.
+5. Run `git diff --check`.
+6. After PR integration/publication, run `npm view open-scaffold version dist-tags --json`.
+7. After publish, run fresh isolated-cache `npx --yes open-scaffold@latest --help` and verify `osc dispatch` appears.
+8. Check `gh release list --repo graphanov/open-scaffold --limit 5` for `v1.0.3` as Latest.
+
+## Open questions
+
+- None.

--- a/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
+++ b/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
@@ -1,0 +1,39 @@
+# Release / Evidence Note: 106-dispatch-adapter-glue-package-sync
+
+## Summary
+
+Prepared `open-scaffold@1.0.3` as the package/public-surface sync candidate for PR #125's `osc dispatch` adapter glue and PR validation checkout resilience. npm/latest and GitHub Latest Release publication are pending trusted-publishing follow-through after this candidate is integrated.
+
+## Traceability
+
+- Roadmap / issue / task: Milestone 19 — Post-v1 Codex-first runtime adoption chain; package-sync follow-through after PR #125.
+- Plan: `.osc/plans/active/106-dispatch-adapter-glue-package-sync.md`.
+- Run ID / run packet: N/A for release-sync.
+- Source Pull Request: https://github.com/graphanov/open-scaffold/pull/125.
+- Release-sync Pull Request: pending.
+- Trusted publishing run: pending.
+- GitHub Release: pending.
+
+## Verification
+
+- `npm view open-scaffold version dist-tags --json` — PRECHECK: npm/latest remains `1.0.2` before this release-sync candidate.
+- Fresh `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc dispatch` command before this release-sync candidate is published.
+- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
+- `npm test` — PASS, 42 files / 372 tests.
+- `npm run build` — PASS.
+- `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.3` (151 files, unpacked 1023178 bytes).
+- `npm run osc -- --help | grep -F 'osc dispatch <run-json> --adapter <adapter-id>'` — PASS.
+- `git diff --check` — PASS.
+- PR CI / latest-head Codex review — pending.
+- Trusted publishing workflow — pending.
+- Post-publish `npm view open-scaffold version dist-tags --json` — pending.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` dispatch command smoke — pending.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — pending.
+
+## Outcome
+
+Pending. This candidate should close only after npm `latest`, fresh `npx`, and GitHub Latest Release match the `main` dispatch adapter glue surface.
+
+## Follow-up
+
+- After this package surface is aligned, continue with `104-osc-work-dry-run-target` as the next Codex-first runtime adoption slice.

--- a/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
+++ b/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
@@ -10,7 +10,7 @@ Prepared `open-scaffold@1.0.3` as the package/public-surface sync candidate for 
 - Plan: `.osc/plans/active/106-dispatch-adapter-glue-package-sync.md`.
 - Run ID / run packet: N/A for release-sync.
 - Source Pull Request: https://github.com/graphanov/open-scaffold/pull/125.
-- Release-sync Pull Request: pending.
+- Release-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/126.
 - Trusted publishing run: pending.
 - GitHub Release: pending.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,24 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v1.0.3 — Dispatch adapter glue package sync
+
+Status: release-sync candidate; package version prepared locally, npm/GitHub Release publication pending trusted-publishing follow-through.
+
+Highlights:
+
+- Publishes the PR #125 package-visible runtime surface: `osc dispatch <run-json> --adapter <adapter-id>` for explicit local adapter invocation from existing run packets.
+- Keeps dispatch constrained to reviewed project-local adapter configs; core refuses unsafe adapters, auto-install/network/shell/platform-shim executables, symlinked outputs, stale inferred outputs, and out-of-run-directory receipt/evidence paths.
+- Keeps Open Scaffold core non-spawning: dispatch invokes a selected adapter command, captures reported outputs, and does not grant commit/push/PR/merge/publish/credential/provider-runtime authority.
+- Hardens PR validation workflows to checkout public merge refs without repository-token Git credentials when required checks need to run before repo code executes.
+
+Evidence:
+
+- Plan: `.osc/plans/active/106-dispatch-adapter-glue-package-sync.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/125
+- Evidence note: `.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md`
+- npm/GitHub Release: pending trusted-publishing follow-through
+
 ## v1.0.2 — Codex runtime preset package sync
 
 Status: published to npm as `open-scaffold@1.0.2`; GitHub Release `v1.0.2` is Latest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Prepare `open-scaffold@1.0.3` as the package/public-surface sync for PR #125's `osc dispatch` adapter glue.
- Add plan/evidence note 106 for the release-sync follow-through.
- Update changelog with v1.0.3 candidate status and dispatch/CI-checkout highlights.

## Verification

- `npm view open-scaffold version dist-tags --json` confirmed npm/latest still `1.0.2` before this sync.
- fresh `npx --yes open-scaffold@latest --help` confirmed npm/latest does not yet show `osc dispatch`.
- `./verify.sh --strict`
- `npm test`
- `npm run build`
- `npm pack --dry-run --json`
- `npm run osc -- --help | grep -F 'osc dispatch <run-json> --adapter <adapter-id>'`
- `git diff --check`

## Risk / Gates

- This PR only prepares the release candidate. Trusted publishing, fresh `npx` proof, GitHub Release `v1.0.3`, and plan closeout remain the post-merge public-surface follow-through.
