### PR TITLE
ci: avoid token checkout in remaining workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,36 @@ jobs:
     name: ci
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository without workflow token
+      - name: Check out repository with public fallback
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+          fetch_refs() {
+            local mode="$1"
+            shift
+            if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
+              local auth_header
+              auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+            else
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
+            fi
+          }
+          fetch_with_fallback() {
+            local description="$1"
+            shift
+            if ! fetch_refs auth "$@"; then
+              echo "Authenticated ${description} fetch failed; falling back to public unauthenticated fetch."
+              fetch_refs public "$@"
+            fi
+          }
+          fetch_with_fallback repository --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            fetch_with_fallback pull-request-merge --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
           else
             git checkout --force "$GITHUB_SHA"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,16 @@ jobs:
         run: |
           set -euo pipefail
           git init .
-          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          server_url="${GITHUB_SERVER_URL:-https://github.com}"
+          server_url="${server_url%/}"
+          git remote add origin "${server_url}/${GITHUB_REPOSITORY}.git"
           fetch_refs() {
             local mode="$1"
             shift
             if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
               local auth_header
               auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
-              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
             else
               GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"

--- a/.github/workflows/evidence-validate.yml
+++ b/.github/workflows/evidence-validate.yml
@@ -23,14 +23,16 @@ jobs:
         run: |
           set -euo pipefail
           git init .
-          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          server_url="${GITHUB_SERVER_URL:-https://github.com}"
+          server_url="${server_url%/}"
+          git remote add origin "${server_url}/${GITHUB_REPOSITORY}.git"
           fetch_refs() {
             local mode="$1"
             shift
             if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
               local auth_header
               auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
-              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
             else
               GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
             fi

--- a/.github/workflows/evidence-validate.yml
+++ b/.github/workflows/evidence-validate.yml
@@ -22,7 +22,7 @@ jobs:
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"

--- a/.github/workflows/evidence-validate.yml
+++ b/.github/workflows/evidence-validate.yml
@@ -16,15 +16,36 @@ jobs:
     name: Validate evidence notes
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository without workflow token
+      - name: Check out repository with public fallback
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+          fetch_refs() {
+            local mode="$1"
+            shift
+            if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
+              local auth_header
+              auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+            else
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
+            fi
+          }
+          fetch_with_fallback() {
+            local description="$1"
+            shift
+            if ! fetch_refs auth "$@"; then
+              echo "Authenticated ${description} fetch failed; falling back to public unauthenticated fetch."
+              fetch_refs public "$@"
+            fi
+          }
+          fetch_with_fallback repository --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            fetch_with_fallback pull-request-merge --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
           else
             git checkout --force "$GITHUB_SHA"

--- a/.github/workflows/plan-validate.yml
+++ b/.github/workflows/plan-validate.yml
@@ -22,15 +22,36 @@ jobs:
     name: Validate changed plans
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository without workflow token
+      - name: Check out repository with public fallback
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+          fetch_refs() {
+            local mode="$1"
+            shift
+            if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
+              local auth_header
+              auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+            else
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
+            fi
+          }
+          fetch_with_fallback() {
+            local description="$1"
+            shift
+            if ! fetch_refs auth "$@"; then
+              echo "Authenticated ${description} fetch failed; falling back to public unauthenticated fetch."
+              fetch_refs public "$@"
+            fi
+          }
+          fetch_with_fallback repository --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            fetch_with_fallback pull-request-merge --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
           else
             git checkout --force "$GITHUB_SHA"

--- a/.github/workflows/plan-validate.yml
+++ b/.github/workflows/plan-validate.yml
@@ -28,7 +28,7 @@ jobs:
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"

--- a/.github/workflows/plan-validate.yml
+++ b/.github/workflows/plan-validate.yml
@@ -29,14 +29,16 @@ jobs:
         run: |
           set -euo pipefail
           git init .
-          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          server_url="${GITHUB_SERVER_URL:-https://github.com}"
+          server_url="${server_url%/}"
+          git remote add origin "${server_url}/${GITHUB_REPOSITORY}.git"
           fetch_refs() {
             local mode="$1"
             shift
             if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
               local auth_header
               auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
-              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
             else
               GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
             fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,10 +22,20 @@ jobs:
     name: Publish package
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Check out repository without workflow token
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+          else
+            git checkout --force "$GITHUB_SHA"
+          fi
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,7 +28,7 @@ jobs:
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,14 +29,16 @@ jobs:
         run: |
           set -euo pipefail
           git init .
-          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          server_url="${GITHUB_SERVER_URL:-https://github.com}"
+          server_url="${server_url%/}"
+          git remote add origin "${server_url}/${GITHUB_REPOSITORY}.git"
           fetch_refs() {
             local mode="$1"
             shift
             if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
               local auth_header
               auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
-              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
             else
               GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
             fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,15 +22,36 @@ jobs:
     name: Publish package
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository without workflow token
+      - name: Check out repository with public fallback
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+          fetch_refs() {
+            local mode="$1"
+            shift
+            if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
+              local auth_header
+              auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+            else
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
+            fi
+          }
+          fetch_with_fallback() {
+            local description="$1"
+            shift
+            if ! fetch_refs auth "$@"; then
+              echo "Authenticated ${description} fetch failed; falling back to public unauthenticated fetch."
+              fetch_refs public "$@"
+            fi
+          }
+          fetch_with_fallback repository --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            fetch_with_fallback pull-request-merge --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
           else
             git checkout --force "$GITHUB_SHA"

--- a/.github/workflows/stale-plans.yml
+++ b/.github/workflows/stale-plans.yml
@@ -26,7 +26,7 @@ jobs:
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"

--- a/.github/workflows/stale-plans.yml
+++ b/.github/workflows/stale-plans.yml
@@ -20,10 +20,20 @@ jobs:
     name: Open issue for stale active plans
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Check out repository without workflow token
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+          else
+            git checkout --force "$GITHUB_SHA"
+          fi
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/stale-plans.yml
+++ b/.github/workflows/stale-plans.yml
@@ -27,14 +27,16 @@ jobs:
         run: |
           set -euo pipefail
           git init .
-          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          server_url="${GITHUB_SERVER_URL:-https://github.com}"
+          server_url="${server_url%/}"
+          git remote add origin "${server_url}/${GITHUB_REPOSITORY}.git"
           fetch_refs() {
             local mode="$1"
             shift
             if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
               local auth_header
               auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
-              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
             else
               GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
             fi

--- a/.github/workflows/stale-plans.yml
+++ b/.github/workflows/stale-plans.yml
@@ -20,15 +20,36 @@ jobs:
     name: Open issue for stale active plans
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository without workflow token
+      - name: Check out repository with public fallback
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+          fetch_refs() {
+            local mode="$1"
+            shift
+            if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
+              local auth_header
+              auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+            else
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
+            fi
+          }
+          fetch_with_fallback() {
+            local description="$1"
+            shift
+            if ! fetch_refs auth "$@"; then
+              echo "Authenticated ${description} fetch failed; falling back to public unauthenticated fetch."
+              fetch_refs public "$@"
+            fi
+          }
+          fetch_with_fallback repository --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            fetch_with_fallback pull-request-merge --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
             git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
           else
             git checkout --force "$GITHUB_SHA"

--- a/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
+++ b/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Prepared `open-scaffold@1.0.3` as the package/public-surface sync candidate for PR #125's `osc dispatch` adapter glue and GitHub Actions checkout resilience. npm/latest and GitHub Latest Release publication are pending trusted-publishing follow-through after this candidate is integrated.
+Prepared `open-scaffold@1.0.3` as the package/public-surface sync candidate for PR #125's `osc dispatch` adapter glue and GitHub Actions checkout resilience. The Actions checkout pattern now keeps private-repo compatibility through authenticated fetches while falling back to public unauthenticated refs when repository-token Git fetches are unavailable. npm/latest and GitHub Latest Release publication are pending trusted-publishing follow-through after this candidate is integrated.
 
 ## Traceability
 

--- a/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
+++ b/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Prepared `open-scaffold@1.0.3` as the package/public-surface sync candidate for PR #125's `osc dispatch` adapter glue and PR validation checkout resilience. npm/latest and GitHub Latest Release publication are pending trusted-publishing follow-through after this candidate is integrated.
+Prepared `open-scaffold@1.0.3` as the package/public-surface sync candidate for PR #125's `osc dispatch` adapter glue and GitHub Actions checkout resilience. npm/latest and GitHub Latest Release publication are pending trusted-publishing follow-through after this candidate is integrated.
 
 ## Traceability
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ Highlights:
 - Publishes the PR #125 package-visible runtime surface: `osc dispatch <run-json> --adapter <adapter-id>` for explicit local adapter invocation from existing run packets.
 - Keeps dispatch constrained to reviewed project-local adapter configs; core refuses unsafe adapters, auto-install/network/shell/platform-shim executables, symlinked outputs, stale inferred outputs, and out-of-run-directory receipt/evidence paths.
 - Keeps Open Scaffold core non-spawning: dispatch invokes a selected adapter command, captures reported outputs, and does not grant commit/push/PR/merge/publish/credential/provider-runtime authority.
-- Hardens GitHub Actions workflows to checkout public refs without repository-token Git credentials when checks or trusted publishing need to run before repository code executes.
+- Hardens GitHub Actions workflows to try authenticated fetches for private-repo compatibility while falling back to public unauthenticated refs when repository-token Git fetches are unavailable.
 
 Evidence:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ Highlights:
 - Publishes the PR #125 package-visible runtime surface: `osc dispatch <run-json> --adapter <adapter-id>` for explicit local adapter invocation from existing run packets.
 - Keeps dispatch constrained to reviewed project-local adapter configs; core refuses unsafe adapters, auto-install/network/shell/platform-shim executables, symlinked outputs, stale inferred outputs, and out-of-run-directory receipt/evidence paths.
 - Keeps Open Scaffold core non-spawning: dispatch invokes a selected adapter command, captures reported outputs, and does not grant commit/push/PR/merge/publish/credential/provider-runtime authority.
-- Hardens PR validation workflows to checkout public merge refs without repository-token Git credentials when required checks need to run before repo code executes.
+- Hardens GitHub Actions workflows to checkout public refs without repository-token Git credentials when checks or trusted publishing need to run before repository code executes.
 
 Evidence:
 

--- a/tests/github-actions-workflows.test.ts
+++ b/tests/github-actions-workflows.test.ts
@@ -14,8 +14,14 @@ describe('GitHub Actions workflow templates', () => {
     expect(workflow).toContain('node dist/cli.js plan validate "$plan"');
   });
 
-  it('checks out pull request validation workflows without repository token credentials', () => {
-    for (const workflowPath of ['.github/workflows/ci.yml', '.github/workflows/plan-validate.yml', '.github/workflows/evidence-validate.yml']) {
+  it('checks out workflows without repository token credentials', () => {
+    for (const workflowPath of [
+      '.github/workflows/ci.yml',
+      '.github/workflows/plan-validate.yml',
+      '.github/workflows/evidence-validate.yml',
+      '.github/workflows/publish-npm.yml',
+      '.github/workflows/stale-plans.yml',
+    ]) {
       const workflow = read(workflowPath);
 
       expect(workflow).not.toContain('actions/checkout');

--- a/tests/github-actions-workflows.test.ts
+++ b/tests/github-actions-workflows.test.ts
@@ -14,7 +14,7 @@ describe('GitHub Actions workflow templates', () => {
     expect(workflow).toContain('node dist/cli.js plan validate "$plan"');
   });
 
-  it('checks out workflows without repository token credentials', () => {
+  it('checks out workflows with authenticated fetch and public fallback', () => {
     for (const workflowPath of [
       '.github/workflows/ci.yml',
       '.github/workflows/plan-validate.yml',
@@ -25,7 +25,10 @@ describe('GitHub Actions workflow templates', () => {
       const workflow = read(workflowPath);
 
       expect(workflow).not.toContain('actions/checkout');
-      expect(workflow).toContain("GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'");
+      expect(workflow).toContain('GITHUB_TOKEN: ${{ github.token }}');
+      expect(workflow).toContain('http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}');
+      expect(workflow).toContain('falling back to public unauthenticated fetch');
+      expect(workflow).toContain("fetch_with_fallback repository --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'");
       expect(workflow).toContain('refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge');
       expect(workflow).toContain('git checkout --force "$GITHUB_SHA"');
     }

--- a/tests/github-actions-workflows.test.ts
+++ b/tests/github-actions-workflows.test.ts
@@ -25,8 +25,10 @@ describe('GitHub Actions workflow templates', () => {
       const workflow = read(workflowPath);
 
       expect(workflow).not.toContain('actions/checkout');
+      expect(workflow).toContain('server_url="${GITHUB_SERVER_URL:-https://github.com}"');
+      expect(workflow).toContain('git remote add origin "${server_url}/${GITHUB_REPOSITORY}.git"');
       expect(workflow).toContain('GITHUB_TOKEN: ${{ github.token }}');
-      expect(workflow).toContain('http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}');
+      expect(workflow).toContain('http.${server_url}/.extraheader=AUTHORIZATION: basic ${auth_header}');
       expect(workflow).toContain('falling back to public unauthenticated fetch');
       expect(workflow).toContain("fetch_with_fallback repository --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'");
       expect(workflow).toContain('refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge');

--- a/tests/github-actions-workflows.test.ts
+++ b/tests/github-actions-workflows.test.ts
@@ -25,7 +25,7 @@ describe('GitHub Actions workflow templates', () => {
       const workflow = read(workflowPath);
 
       expect(workflow).not.toContain('actions/checkout');
-      expect(workflow).toContain('GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin');
+      expect(workflow).toContain("GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'");
       expect(workflow).toContain('refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge');
       expect(workflow).toContain('git checkout --force "$GITHUB_SHA"');
     }


### PR DESCRIPTION
## Summary

- Replace the remaining token-backed `actions/checkout` uses in `publish-npm.yml` and `stale-plans.yml` with the same public unauthenticated checkout pattern already proven on PR validation workflows.
- Extend workflow-template coverage so all GitHub Actions workflows avoid repository-token Git checkout credentials.
- Update v1.0.3 candidate evidence/changelog wording from PR-validation-only to all workflow checkout resilience.

## Verification

- YAML parse for all workflows
- `npm test -- tests/github-actions-workflows.test.ts`
- `./verify.sh --strict`
- `npm run build`
- `git diff --check`
- independent staged-diff review: pass, no blocking security/logic issues

## Risk / Gates

- `publish-npm.yml` still keeps `id-token: write` for npm provenance; this only removes token-backed Git checkout.
- `stale-plans.yml` still uses `GH_TOKEN` only for the later issue create/comment step.
