### PR TITLE
docs: close dispatch adapter release sync

### DIFF
--- a/.osc/plans/done/106-dispatch-adapter-glue-package-sync.md
+++ b/.osc/plans/done/106-dispatch-adapter-glue-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
@@ -29,14 +29,14 @@ Prepare and verify `open-scaffold@1.0.3` as the package/public-surface sync for 
 
 ## Acceptance criteria
 
-- [ ] Root package version is bumped to `1.0.3` and lockfile metadata matches.
-- [ ] Changelog documents v1.0.3 as the package-surface sync for `osc dispatch` adapter glue and PR validation checkout resilience.
-- [ ] Local gates pass before PR: `./verify.sh --strict`, `npm test`, `npm run build`, `npm pack --dry-run --json`, `git diff --check`.
-- [ ] PR CI and latest-head Codex review are clean before PR integration.
-- [ ] Trusted publishing succeeds for `open-scaffold@1.0.3` after PR integration.
-- [ ] `npm view open-scaffold version dist-tags --json` shows `1.0.3` / `latest: 1.0.3`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc dispatch <run-json> --adapter <adapter-id>`.
-- [ ] GitHub Release `v1.0.3` exists, targets the integrated main commit, and is marked Latest.
+- [x] Root package version is bumped to `1.0.3` and lockfile metadata matches.
+- [x] Changelog documents v1.0.3 as the package-surface sync for `osc dispatch` adapter glue and PR validation checkout resilience.
+- [x] Local gates pass before PR: `./verify.sh --strict`, `npm test`, `npm run build`, `npm pack --dry-run --json`, `git diff --check`.
+- [x] PR CI and latest-head Codex review are clean before PR integration.
+- [x] Trusted publishing succeeds for `open-scaffold@1.0.3` after PR integration.
+- [x] `npm view open-scaffold version dist-tags --json` shows `1.0.3` / `latest: 1.0.3`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc dispatch <run-json> --adapter <adapter-id>`.
+- [x] GitHub Release `v1.0.3` exists, targets the integrated main commit, and is marked Latest.
 
 ## Verification steps
 

--- a/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
+++ b/.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md
@@ -2,37 +2,41 @@
 
 ## Summary
 
-Prepared `open-scaffold@1.0.3` as the package/public-surface sync candidate for PR #125's `osc dispatch` adapter glue and GitHub Actions checkout resilience. The Actions checkout pattern now keeps private-repo compatibility through authenticated fetches while falling back to public unauthenticated refs when repository-token Git fetches are unavailable. npm/latest and GitHub Latest Release publication are pending trusted-publishing follow-through after this candidate is integrated.
+Prepared and published `open-scaffold@1.0.3` as the package/public-surface sync for PR #125's `osc dispatch` adapter glue and GitHub Actions checkout resilience. The Actions checkout pattern now keeps private-repo compatibility through authenticated fetches while falling back to public unauthenticated refs when repository-token Git fetches are unavailable. npm `latest`, fresh isolated-cache `npx`, and GitHub Latest Release now match the integrated `main` dispatch adapter glue surface.
 
 ## Traceability
 
 - Roadmap / issue / task: Milestone 19 — Post-v1 Codex-first runtime adoption chain; package-sync follow-through after PR #125.
-- Plan: `.osc/plans/active/106-dispatch-adapter-glue-package-sync.md`.
+- Plan: `.osc/plans/done/106-dispatch-adapter-glue-package-sync.md`.
 - Run ID / run packet: N/A for release-sync.
 - Source Pull Request: https://github.com/graphanov/open-scaffold/pull/125.
 - Release-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/126.
-- Trusted publishing run: pending.
-- GitHub Release: pending.
+- Workflow checkout hardening Pull Request: https://github.com/graphanov/open-scaffold/pull/127.
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/26452718895.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v1.0.3.
 
 ## Verification
 
-- `npm view open-scaffold version dist-tags --json` — PRECHECK: npm/latest remains `1.0.2` before this release-sync candidate.
-- Fresh `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc dispatch` command before this release-sync candidate is published.
+- `npm view open-scaffold version dist-tags --json` — PRECHECK: npm/latest remained `1.0.2` before this release-sync candidate.
+- Fresh `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc dispatch` command before this release-sync candidate was published.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - `npm test` — PASS, 42 files / 372 tests.
 - `npm run build` — PASS.
-- `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.3` (151 files, unpacked 1023178 bytes).
+- `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.3` (151 files, unpacked 1023178 bytes before PR #127; 151 files, unpacked 1023209 bytes after PR #127).
 - `npm run osc -- --help | grep -F 'osc dispatch <run-json> --adapter <adapter-id>'` — PASS.
 - `git diff --check` — PASS.
-- PR CI / latest-head Codex review — pending.
-- Trusted publishing workflow — pending.
-- Post-publish `npm view open-scaffold version dist-tags --json` — pending.
-- Fresh isolated-cache `npx --yes open-scaffold@latest --help` dispatch command smoke — pending.
-- `gh release list --repo graphanov/open-scaffold --limit 5` — pending.
+- PR #126 CI / latest-head Codex review — PASS.
+- PR #127 CI / latest-head Codex review — PASS; final clean Codex comment at 2026-05-26T13:54:22Z and unresolved review threads = 0 after fixed outdated threads were resolved.
+- Main push CI after PR #127 — PASS: https://github.com/graphanov/open-scaffold/actions/runs/26452601331.
+- Trusted publishing workflow — PASS: https://github.com/graphanov/open-scaffold/actions/runs/26452718895.
+- Post-publish `npm view open-scaffold version dist-tags --json` — PASS: `version` = `1.0.3`, `latest` = `1.0.3`.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` dispatch command smoke — PASS: help includes `osc dispatch <run-json> --adapter <adapter-id>`.
+- Fresh isolated-cache `npx --yes open-scaffold@1.0.3 --version` — PASS: `1.0.3`.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS: `v1.0.3 — Dispatch adapter glue` is Latest and targets `cc7ed253d2a6df0105730213993d1e6adce7932d`.
 
 ## Outcome
 
-Pending. This candidate should close only after npm `latest`, fresh `npx`, and GitHub Latest Release match the `main` dispatch adapter glue surface.
+Complete. `open-scaffold@1.0.3`, npm `latest`, fresh isolated-cache `npx`, and GitHub Latest Release now expose the dispatch adapter glue surface and the hardened workflow checkout posture. The release-sync plan can move to `done/`; the next Codex-first runtime adoption slice is `104-osc-work-dry-run-target`.
 
 ## Follow-up
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-26: closed 106-dispatch-adapter-glue-package-sync — Closed 106 dispatch adapter glue package sync after v1.0.3 npm and GitHub Release verification.
 - 2026-05-26: closed 103-osc-dispatch-adapter-glue — added explicit dispatch adapter glue
 - 2026-05-26: closed 105-codex-runtime-adapter-package-release-sync — published 1.0.2 Codex runtime preset package sync
 - 2026-05-26: closed 102-codex-runtime-adapter-package-hardening — hardened Codex runtime adapter path


### PR DESCRIPTION
## Summary

- Close plan `106-dispatch-adapter-glue-package-sync` now that `open-scaffold@1.0.3` is published.
- Record final evidence for trusted publishing, npm `latest`, fresh isolated-cache `npx`, and GitHub Latest Release.
- Stamp `MISSION.md` changelog with the closeout.

## Verification

- `./verify.sh --strict`
- `npm test -- tests/github-actions-workflows.test.ts`
- `npm run build`
- `git diff --check`

## Public surface proof

- npm `latest`: `open-scaffold@1.0.3`
- GitHub Latest Release: `v1.0.3 — Dispatch adapter glue`
- Fresh `npx open-scaffold@latest --help` includes `osc dispatch <run-json> --adapter <adapter-id>`

## Codex review

Skipped by design: tiny evidence/plan closeout only after already-reviewed PRs #126 and #127 plus trusted-publishing verification.
