### PR TITLE
feat: add work dry-run preview

### DIFF
--- a/.osc/plans/done/104-osc-work-dry-run-target.md
+++ b/.osc/plans/done/104-osc-work-dry-run-target.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 
@@ -37,12 +38,12 @@ Add the first `osc work` composition as a dry-run intake command that drafts the
 
 ## Acceptance criteria
 
-- [ ] `osc work "TASK DESCRIPTION" --runtime codex --dry-run` produces a readable plan/run/dispatch preview.
-- [ ] The command clearly asks for scope confirmation before any execution path.
-- [ ] The command does not spawn runtime processes, call provider APIs, mutate source files, commit, push, or create PRs.
-- [ ] Output points to the next staged command (`osc start`, `osc run`, or `osc dispatch`) rather than hiding execution.
-- [ ] Tests cover no-spawn/no-source-mutation behavior.
-- [ ] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
+- [x] `osc work "TASK DESCRIPTION" --runtime codex --dry-run` produces a readable plan/run/dispatch preview.
+- [x] The command clearly asks for scope confirmation before any execution path.
+- [x] The command does not spawn runtime processes, call provider APIs, mutate source files, commit, push, or create PRs.
+- [x] Output points to the next staged command (`osc start`, `osc run`, or `osc dispatch`) rather than hiding execution.
+- [x] Tests cover no-spawn/no-source-mutation behavior.
+- [x] `./verify.sh --strict`, `npm test`, `npm run build`, and `git diff --check` pass.
 
 ## Verification steps
 

--- a/.osc/releases/2026-05-26-104-osc-work-dry-run-target.md
+++ b/.osc/releases/2026-05-26-104-osc-work-dry-run-target.md
@@ -13,8 +13,8 @@ Added `osc work <task-description> --runtime <preset> --dry-run` as the first na
 
 ## Verification
 
-- `npm test -- tests/cli-work.test.ts tests/artifacts.test.ts` — PASS, 12 tests.
-- `npm test` — PASS, 43 files / 377 tests.
+- `npm test -- tests/cli-work.test.ts tests/artifacts.test.ts` — PASS, 13 tests.
+- `npm test` — PASS, 43 files / 378 tests.
 - `npm run build` — PASS.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - `git diff --check` — PASS.

--- a/.osc/releases/2026-05-26-104-osc-work-dry-run-target.md
+++ b/.osc/releases/2026-05-26-104-osc-work-dry-run-target.md
@@ -8,18 +8,19 @@ Added `osc work <task-description> --runtime <preset> --dry-run` as the first na
 
 - Roadmap / issue / task: Milestone 19 — Post-v1 adoption workflow target.
 - Plan: `.osc/plans/done/104-osc-work-dry-run-target.md`.
-- Pull Request: implementation PR assigned after branch push.
+- Pull Request: `graphanov/open-scaffold#129`.
 - Public package sync: pending follow-up because this adds package-visible CLI behavior.
 
 ## Verification
 
-- `npm test -- tests/cli-work.test.ts tests/artifacts.test.ts` — PASS, 13 tests.
-- `npm test` — PASS, 43 files / 378 tests.
+- `npm test -- tests/cli-work.test.ts tests/artifacts.test.ts` — PASS, 14 tests.
+- `npm test` — PASS, 43 files / 379 tests.
 - `npm run build` — PASS.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - `git diff --check` — PASS.
 - Scratch smoke `npm run osc -- work "Add a /health endpoint with tests" --runtime codex --dry-run` — PASS; output includes candidate plan preview, run packet preview, dispatch preview, scope confirmation, and no-spawn/no-write boundary text.
 - Scratch JSON smoke `node_modules/.bin/tsx src/cli.ts work "Add a /health endpoint with tests" --runtime codex --dry-run --json` — PASS; JSON has schema `open-scaffold.work-dry-run.v1`, no-write/no-spawn booleans, executor spawning = `false`, and dispatch preview command.
+- Subdirectory JSON smoke using direct `tsx src/cli.ts work ... --runtime codex --workflow execute --dry-run --json` from `docs/notes/` — PASS; candidate plan, run manifest, dispatch preview, and suggested `osc run` commands render paths relative to invocation cwd, while the staged dispatch command uses the manifest path printed by the real `osc run`.
 - Private-marker scan over smoke outputs — PASS.
 
 ## Outcome

--- a/.osc/releases/2026-05-26-104-osc-work-dry-run-target.md
+++ b/.osc/releases/2026-05-26-104-osc-work-dry-run-target.md
@@ -1,0 +1,32 @@
+# Release / Evidence Note: 104-osc-work-dry-run-target
+
+## Summary
+
+Added `osc work <task-description> --runtime <preset> --dry-run` as the first natural-language composition layer in the Codex-first runtime adoption chain. The command previews a candidate plan, run packet, and dispatch command while refusing non-dry-run execution.
+
+## Traceability
+
+- Roadmap / issue / task: Milestone 19 — Post-v1 adoption workflow target.
+- Plan: `.osc/plans/done/104-osc-work-dry-run-target.md`.
+- Pull Request: implementation PR assigned after branch push.
+- Public package sync: pending follow-up because this adds package-visible CLI behavior.
+
+## Verification
+
+- `npm test -- tests/cli-work.test.ts tests/artifacts.test.ts` — PASS, 12 tests.
+- `npm test` — PASS, 43 files / 377 tests.
+- `npm run build` — PASS.
+- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
+- `git diff --check` — PASS.
+- Scratch smoke `npm run osc -- work "Add a /health endpoint with tests" --runtime codex --dry-run` — PASS; output includes candidate plan preview, run packet preview, dispatch preview, scope confirmation, and no-spawn/no-write boundary text.
+- Scratch JSON smoke `node_modules/.bin/tsx src/cli.ts work "Add a /health endpoint with tests" --runtime codex --dry-run --json` — PASS; JSON has schema `open-scaffold.work-dry-run.v1`, no-write/no-spawn booleans, executor spawning = `false`, and dispatch preview command.
+- Private-marker scan over smoke outputs — PASS.
+
+## Outcome
+
+Repo implementation candidate is ready for PR review. `osc work --dry-run` is preview-only: it does not write `.osc/plans`, does not write `.osc/runs`, does not spawn runtimes, does not call provider APIs, and does not perform GitHub/npm/release side effects. Non-dry-run `osc work` exits with usage error until a separate safety design exists.
+
+## Follow-up
+
+- After PR integration, prepare a package/public-surface sync so npm `latest`, fresh `npx`, and GitHub Latest Release expose `osc work --dry-run`.
+- Optional gated execution remains future work and requires a separate architecture/security decision.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-26: closed 104-osc-work-dry-run-target — Closed 104 osc work dry-run target.
 - 2026-05-26: closed 106-dispatch-adapter-glue-package-sync — Closed 106 dispatch adapter glue package sync after v1.0.3 npm and GitHub Release verification.
 - 2026-05-26: closed 103-osc-dispatch-adapter-glue — added explicit dispatch adapter glue
 - 2026-05-26: closed 105-codex-runtime-adapter-package-release-sync — published 1.0.2 Codex runtime preset package sync

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Chat, Discord, terminals, GitHub comments, and agent transcripts can help operat
 
 ### Target workflow
 
-The post-v1 target is a smoother Codex-first path that starts from plain intent while preserving the same record:
+The post-v1 target is a smoother Codex-first path that starts from plain intent while preserving the same record. The first natural-language composition is dry-run only:
 
 ```bash
-osc work "Add a /health endpoint with tests" --runtime codex
+osc work "Add a /health endpoint with tests" --runtime codex --dry-run
 ```
 
-That command is future direction, not a current v1 promise. The first no-spawn step is `osc start`, which prints a paste-ready Codex/OMX handoff prompt from an existing plan without launching a runtime. The next explicit bridge is `osc dispatch .osc/runs/RUN_ID/run.json --adapter <id>`, which invokes a reviewed local adapter config and captures receipt/evidence/log paths without auto-installing providers or granting commit/push/PR/merge/publish authority. The remaining staged path is: `osc work --dry-run` → optional gated execution after a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
+`osc work --dry-run` previews a candidate plan, run packet, and dispatch command without writing files, launching a runtime, calling provider APIs, or granting commit/push/PR/merge/publish authority. The supporting no-spawn pieces remain explicit: `osc start` prints a paste-ready Codex/OMX handoff from an existing plan, and `osc dispatch .osc/runs/RUN_ID/run.json --adapter <id>` invokes a reviewed local adapter config and captures receipt/evidence/log paths. Full execution remains future work behind a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -413,7 +413,7 @@ Owner gates:
 
 ### Milestone 19 — Post-v1 adoption workflow target
 
-Status: staged implementation through `.osc/plans/done/099-runtime-adoption-ux-reset.md`, `docs/RUNTIME_ADOPTION_WORKFLOW.md`, and follow-up Codex-first adoption slices through `103-osc-dispatch-adapter-glue`. The next planned composition layer is `osc work --dry-run`.
+Status: staged implementation through `.osc/plans/done/099-runtime-adoption-ux-reset.md`, `docs/RUNTIME_ADOPTION_WORKFLOW.md`, and follow-up Codex-first adoption slices through `104-osc-work-dry-run-target`. `osc work --dry-run` is now the first natural-language composition layer; full execution remains future gated work.
 
 Goal: turn the credible v1 work-record protocol into a smoother adoption path without collapsing Open Scaffold core into a provider-specific runtime.
 
@@ -440,8 +440,8 @@ Implementation sequence:
 1. Done — verification trust issue: unsafe strict-mode filename quoting fixed.
 2. Done — `osc start` added as a no-spawn, paste-ready Codex/OMX agent-entry command.
 3. Done — Codex-first adapter package path hardened around `runtime-omx` and the broad `codex` preset.
-4. Done in repo — `osc dispatch <run.json> --adapter <id>` added as explicit local-adapter invocation glue.
-5. Next — add `osc work --dry-run` as the first natural-language composition layer.
+4. Done — `osc dispatch <run.json> --adapter <id>` added as explicit local-adapter invocation glue.
+5. Done in repo — `osc work --dry-run` previews a natural-language task as candidate plan/run/dispatch steps without writing artifacts or launching runtimes.
 6. Later — reconsider optional gated execution only after receipt/evidence, conformance, worktree isolation, authority budgets, approval queues, and user evidence exist.
 
 Acceptance direction:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,24 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## Unreleased — `osc work --dry-run`
+
+Status: repo candidate; npm/GitHub Release publication pending after PR integration and package-sync follow-through.
+
+Highlights:
+
+- Adds `osc work "TASK" --runtime codex --dry-run` as the first natural-language composition layer.
+- Previews a candidate plan, run packet, and dispatch command without writing `.osc/plans` or `.osc/runs` artifacts.
+- Keeps non-dry-run `osc work` refused until a separate safety design exists.
+
+Evidence:
+
+- Plan: `.osc/plans/done/104-osc-work-dry-run-target.md`
+- Evidence note: `.osc/releases/2026-05-26-104-osc-work-dry-run-target.md`
+
 ## v1.0.3 — Dispatch adapter glue package sync
 
-Status: release-sync candidate; package version prepared locally, npm/GitHub Release publication pending trusted-publishing follow-through.
+Status: published to npm as `open-scaffold@1.0.3`; GitHub Release `v1.0.3` is Latest.
 
 Highlights:
 
@@ -17,10 +32,13 @@ Highlights:
 
 Evidence:
 
-- Plan: `.osc/plans/active/106-dispatch-adapter-glue-package-sync.md`
+- Plan: `.osc/plans/done/106-dispatch-adapter-glue-package-sync.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/125
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/126
+- Workflow checkout hardening PR: https://github.com/graphanov/open-scaffold/pull/127
 - Evidence note: `.osc/releases/2026-05-26-106-dispatch-adapter-glue-package-sync.md`
-- npm/GitHub Release: pending trusted-publishing follow-through
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v1.0.3
+- npm: `open-scaffold@1.0.3` / `latest`
 
 ## v1.0.2 — Codex runtime preset package sync
 

--- a/docs/RUNTIME_ADOPTION_WORKFLOW.md
+++ b/docs/RUNTIME_ADOPTION_WORKFLOW.md
@@ -8,7 +8,13 @@ The north-star command is intentionally simple:
 osc work "Add a /health endpoint with tests" --runtime codex
 ```
 
-That command does **not** mean Open Scaffold core becomes Codex, Claude Code, OpenHands, a daemon, or a hosted agent. It means Open Scaffold should own the durable control loop around work: plan, package, dispatch, evidence, verification, and approval gates.
+The current implemented composition layer is explicitly dry-run only:
+
+```bash
+osc work "Add a /health endpoint with tests" --runtime codex --dry-run
+```
+
+The north-star command does **not** mean Open Scaffold core becomes Codex, Claude Code, OpenHands, a daemon, or a hosted agent. It means Open Scaffold should own the durable control loop around work: plan, package, dispatch, evidence, verification, and approval gates.
 
 ## Target flow
 
@@ -156,20 +162,20 @@ The command:
 
 ### Stage 4 — `osc work --dry-run`
 
-Add the first version of `osc work` as a no-spawn composition:
+Current repo support adds the first no-spawn composition:
 
 ```bash
 osc work "Add a /health endpoint with tests" --runtime codex --dry-run
 ```
 
-It should draft or scaffold:
+It previews:
 
-- a candidate plan;
-- acceptance criteria;
-- a run packet preview;
-- the `osc start` / `osc dispatch` command the operator can approve.
+- a candidate plan path and draft scope;
+- draft acceptance criteria and verification checks;
+- an `open-scaffold.run.v1` run packet preview;
+- the next `osc start`, `osc run`, and `osc dispatch` commands the operator can approve.
 
-It should stop before runtime execution.
+It stops before writing `.osc/plans` or `.osc/runs` artifacts, before runtime execution, before provider API calls, and before any commit/push/PR/merge/publish/deploy side effect. Non-dry-run `osc work` remains intentionally refused until a separate safety design exists.
 
 ### Stage 5 — Optional gated execution
 

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -62,6 +62,7 @@ These surfaces are usable but not promised as final API shape. They may change i
 - Runtime profiles and runtime selection beyond run-packet metadata.
 - `osc run`, `osc delegate`, `osc review`, and `osc ultrareview` beyond their current no-spawn artifact-generation role.
 - `osc dispatch` as explicit local-adapter invocation glue; adapter commands, receipts, and launch policy remain experimental and adapter-owned.
+- `osc work --dry-run` as a no-spawn natural-language composition preview; non-dry-run work execution remains future-gated.
 - Evaluation and audit envelope helpers.
 - Optional MCP server interface.
 - Glass cockpit webhook examples for Discord and Slack.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { validateScaffold } from './validation.js';
 import { formatPlanValidationIssues, hasBlockingIssues, resolvePlanValidationPath, validatePlanFile } from './plan-validate.js';
 import { buildPlanGraph, normalizePlanReference, renderPlanGraphAscii, renderPlanGraphMermaid, type PlanGraphDirection, type PlanGraphFormat, type PlanGraphStageFilter } from './plan-graph.js';
 import { askInteractiveAnswers, assertWizardReady, createWizardPlan, loadAnswersFile, type PlanWizardAnswers } from './wizard.js';
+import { buildWorkDryRunPreview, formatWorkDryRunPreview } from './work.js';
 
 function printHelp(): void {
   console.log(`osc — Open Scaffold CLI
@@ -54,6 +55,7 @@ Usage:
   osc delegate <plan-path> [run binding options]
   osc run <plan-path> [--dry-run] [--json] [run binding options]
   osc dispatch <run-json> --adapter <adapter-id>
+  osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]
   osc review <plan-path> [run binding options]
   osc ultrareview <plan-path> [run binding options]
   osc eval init <run-or-plan> [--out <path>]
@@ -1192,6 +1194,110 @@ function dispatchCommand(args: string[]): void {
     console.error(error instanceof Error ? error.message : String(error));
     if (error instanceof DispatchUsageError) process.exit(2);
     process.exit(1);
+  }
+}
+
+function printWorkUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]
+
+Options:
+  --runtime <preset>          Runtime preset to preview: codex | omx | omc | plain | human | custom | project profile
+  --workflow <workflow>       Optional workflow override: interview | plan | team | loop | execute | goal | custom
+  --adapter <adapter-id>      Optional dispatch adapter id for the preview command
+  --dry-run                   Required: print plan/run/dispatch preview without writing files or launching runtimes
+  --json                      Print machine-readable dry-run JSON`, stream);
+}
+
+function takeWorkValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    console.error(`Missing value for ${flag}`);
+    printWorkUsage();
+    process.exit(2);
+  }
+  return value;
+}
+
+function isSafeWorkAdapterId(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value) && !value.includes('..');
+}
+
+function formatUnsafeWorkValue(value: string): string {
+  return JSON.stringify(value.trim());
+}
+
+function workCommand(args: string[]): void {
+  if (isHelpArg(args[0])) {
+    printWorkUsage('stdout');
+    return;
+  }
+  const intentParts: string[] = [];
+  const options: RunArtifactOptions = { commitPolicy: 'no commit/push/PR/merge/publish/deploy unless explicitly approved by the operator' };
+  let adapterId: string | undefined;
+  let dryRun = false;
+  let json = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      switch (arg) {
+        case '--runtime':
+          options.runtime = takeWorkValue(args, i, arg) as RuntimePreset;
+          i += 1;
+          break;
+        case '--workflow':
+          options.workflow = parseChoice(takeWorkValue(args, i, arg), RUNTIME_WORKFLOWS, arg) as RuntimeWorkflow;
+          i += 1;
+          break;
+        case '--adapter': {
+          const value = takeWorkValue(args, i, arg);
+          if (!isSafeWorkAdapterId(value)) {
+            console.error(`Unsafe adapter id: ${formatUnsafeWorkValue(value)}`);
+            process.exit(2);
+          }
+          adapterId = value;
+          i += 1;
+          break;
+        }
+        case '--dry-run':
+          dryRun = true;
+          break;
+        case '--json':
+          json = true;
+          break;
+        default:
+          console.error(`Unknown option for work: ${arg}`);
+          printWorkUsage();
+          process.exit(2);
+      }
+    } else {
+      intentParts.push(arg);
+    }
+  }
+
+  const intent = intentParts.join(' ').trim();
+  if (!intent) {
+    console.error('Missing required argument: task-description');
+    printWorkUsage();
+    process.exit(2);
+  }
+  if (!options.runtime) {
+    console.error('Missing required option: --runtime <preset>');
+    printWorkUsage();
+    process.exit(2);
+  }
+  if (!dryRun) {
+    console.error('osc work is preview-only in this release; pass --dry-run to print the plan/run/dispatch preview.');
+    process.exit(2);
+  }
+
+  const root = findScaffoldRoot(process.cwd()) ?? process.cwd();
+  applyRuntimeSelection(options, root);
+  const preview = buildWorkDryRunPreview(root, intent, options, adapterId);
+  if (json) {
+    console.log(JSON.stringify(preview, null, 2));
+  } else {
+    process.stdout.write(formatWorkDryRunPreview(preview));
   }
 }
 
@@ -2371,6 +2477,9 @@ async function main(): Promise<void> {
       return;
     case 'dispatch':
       dispatchCommand(args);
+      return;
+    case 'work':
+      workCommand(args);
       return;
     case 'review':
     case 'ultrareview':

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1293,7 +1293,7 @@ function workCommand(args: string[]): void {
 
   const root = findScaffoldRoot(process.cwd()) ?? process.cwd();
   applyRuntimeSelection(options, root);
-  const preview = buildWorkDryRunPreview(root, intent, options, adapterId);
+  const preview = buildWorkDryRunPreview(root, intent, options, adapterId, process.cwd());
   if (json) {
     console.log(JSON.stringify(preview, null, 2));
   } else {

--- a/src/work.ts
+++ b/src/work.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import { isAbsolute, join, relative } from 'node:path';
 import { previewRunArtifacts, type RunArtifactOptions, type RunManifest } from './artifacts.js';
 import type { ParsedPlan } from './scaffold.js';
 
@@ -47,6 +47,12 @@ function cleanSentence(value: string): string {
   const trimmed = value.replace(/[\u0000-\u001F\u007F]/g, ' ').trim().replace(/\s+/g, ' ');
   if (!trimmed) return 'Complete the requested work.';
   return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+function toDisplayPath(root: string, cwd: string, path: string): string {
+  const absolute = isAbsolute(path) ? path : join(root, path);
+  const display = relative(cwd, absolute).split('\\').join('/');
+  return display || '.';
 }
 
 function defaultAdapterId(runtime: string): string | null {
@@ -151,16 +157,21 @@ function buildCandidatePlan(root: string, intent: string): ParsedPlan {
   };
 }
 
-export function buildWorkDryRunPreview(root: string, intent: string, options: RunArtifactOptions, adapterId?: string): WorkDryRunPreview {
+export function buildWorkDryRunPreview(root: string, intent: string, options: RunArtifactOptions, adapterId?: string, cwd = root): WorkDryRunPreview {
   const runtime = options.runtime ?? 'plain';
   const plan = buildCandidatePlan(root, intent);
-  const runPreview = previewRunArtifacts(root, plan, 'run', options);
+  const artifactRoot = cwd;
+  const runPreview = previewRunArtifacts(artifactRoot, plan, 'run', { ...options, scaffoldRoot: root });
   const selectedAdapter = adapterId ?? defaultAdapterId(runtime);
   const workflowFlag = options.workflow ? ` --workflow ${options.workflow}` : '';
+  const manifestPath = toDisplayPath(root, cwd, runPreview.manifestPath);
   const dispatchCommand = selectedAdapter
-    ? `osc dispatch ${runPreview.manifest.artifacts.manifest} --adapter ${selectedAdapter}`
-    : `osc dispatch ${runPreview.manifest.artifacts.manifest} --adapter <adapter-id>`;
-  const planPath = `.osc/plans/active/${plan.slug}.md`;
+    ? `osc dispatch ${manifestPath} --adapter ${selectedAdapter}`
+    : `osc dispatch ${manifestPath} --adapter <adapter-id>`;
+  const dispatchNextCommand = selectedAdapter
+    ? `osc dispatch <manifest-path-from-osc-run-output> --adapter ${selectedAdapter}`
+    : 'osc dispatch <manifest-path-from-osc-run-output> --adapter <adapter-id>';
+  const planPath = toDisplayPath(root, cwd, plan.path);
   return {
     schemaVersion: 'open-scaffold.work-dry-run.v1',
     intent: intent.trim(),
@@ -177,7 +188,7 @@ export function buildWorkDryRunPreview(root: string, intent: string, options: Ru
     },
     run: {
       runId: runPreview.runId,
-      manifestPath: runPreview.manifest.artifacts.manifest,
+      manifestPath,
       manifest: runPreview.manifest,
       packageMarkdown: runPreview.packageMarkdown,
     },
@@ -185,15 +196,15 @@ export function buildWorkDryRunPreview(root: string, intent: string, options: Ru
       adapterId: selectedAdapter,
       command: dispatchCommand,
       note: selectedAdapter
-        ? 'Dispatch is a preview only. It requires a reviewed project-local adapter config before execution.'
-        : 'Choose a reviewed project-local adapter config before dispatching this run packet.',
+        ? 'Dispatch is a preview only. Use the manifest path printed by a real osc run command and a reviewed project-local adapter config before execution.'
+        : 'Choose a reviewed project-local adapter config and the manifest path printed by a real osc run command before dispatching this run packet.',
     },
     scopeConfirmationRequired: true,
     nextCommands: [
       `Review and materialize the candidate plan at ${planPath} only after confirming scope.`,
       `osc run ${planPath} --runtime ${runtime}${workflowFlag} --dry-run`,
       `osc run ${planPath} --runtime ${runtime}${workflowFlag}`,
-      dispatchCommand,
+      dispatchNextCommand,
     ],
     noFilesWritten: true,
     noRuntimeSpawned: true,

--- a/src/work.ts
+++ b/src/work.ts
@@ -156,6 +156,7 @@ export function buildWorkDryRunPreview(root: string, intent: string, options: Ru
   const plan = buildCandidatePlan(root, intent);
   const runPreview = previewRunArtifacts(root, plan, 'run', options);
   const selectedAdapter = adapterId ?? defaultAdapterId(runtime);
+  const workflowFlag = options.workflow ? ` --workflow ${options.workflow}` : '';
   const dispatchCommand = selectedAdapter
     ? `osc dispatch ${runPreview.manifest.artifacts.manifest} --adapter ${selectedAdapter}`
     : `osc dispatch ${runPreview.manifest.artifacts.manifest} --adapter <adapter-id>`;
@@ -190,9 +191,8 @@ export function buildWorkDryRunPreview(root: string, intent: string, options: Ru
     scopeConfirmationRequired: true,
     nextCommands: [
       `Review and materialize the candidate plan at ${planPath} only after confirming scope.`,
-      `osc start ${planPath} --runtime ${runtime}`,
-      `osc run ${planPath} --runtime ${runtime} --dry-run`,
-      `osc run ${planPath} --runtime ${runtime}`,
+      `osc run ${planPath} --runtime ${runtime}${workflowFlag} --dry-run`,
+      `osc run ${planPath} --runtime ${runtime}${workflowFlag}`,
       dispatchCommand,
     ],
     noFilesWritten: true,

--- a/src/work.ts
+++ b/src/work.ts
@@ -1,0 +1,255 @@
+import { join } from 'node:path';
+import { previewRunArtifacts, type RunArtifactOptions, type RunManifest } from './artifacts.js';
+import type { ParsedPlan } from './scaffold.js';
+
+export interface WorkDryRunPreview {
+  schemaVersion: 'open-scaffold.work-dry-run.v1';
+  intent: string;
+  root: string;
+  runtime: string;
+  candidatePlan: {
+    slug: string;
+    path: string;
+    markdown: string;
+    goal: string;
+    filesToTouch: string[];
+    acceptanceCriteria: string[];
+    verificationSteps: string[];
+  };
+  run: {
+    runId: string;
+    manifestPath: string;
+    manifest: RunManifest;
+    packageMarkdown: string;
+  };
+  dispatch: {
+    adapterId: string | null;
+    command: string;
+    note: string;
+  };
+  scopeConfirmationRequired: true;
+  nextCommands: string[];
+  noFilesWritten: true;
+  noRuntimeSpawned: true;
+}
+
+function slugifyIntent(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[`'"“”‘’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+    .replace(/-+$/g, '') || 'task';
+}
+
+function cleanSentence(value: string): string {
+  const trimmed = value.replace(/[\u0000-\u001F\u007F]/g, ' ').trim().replace(/\s+/g, ' ');
+  if (!trimmed) return 'Complete the requested work.';
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+function defaultAdapterId(runtime: string): string | null {
+  if (runtime === 'codex' || runtime === 'omx') return 'runtime-omx';
+  return null;
+}
+
+function candidatePlanMarkdown(plan: ParsedPlan): string {
+  const files = plan.filesToTouch.map((item) => `- ${item}`).join('\n');
+  const criteria = plan.acceptanceCriteria.map((item) => `- [ ] ${item}`).join('\n');
+  const verification = plan.verificationSteps.map((item, index) => `${index + 1}. ${item}`).join('\n');
+  const openQuestions = plan.openQuestions.map((item) => `- ${item}`).join('\n');
+  return `# Plan: ${plan.slug}
+
+## Status
+
+active
+
+## Context
+
+Drafted from operator intent. This preview is not written to disk until the operator confirms scope.
+
+## Goal
+
+${plan.goal}
+
+## Constraints / Out of scope
+
+- Confirm scope, files, acceptance criteria, and verification before execution.
+- Do not spawn runtimes, call provider APIs, commit, push, open PRs, merge, publish, or deploy from the dry run.
+
+## Files to touch
+
+${files}
+
+## Acceptance criteria
+
+${criteria}
+
+## Verification steps
+
+${verification}
+
+## Open questions
+
+${openQuestions}
+`;
+}
+
+function buildCandidatePlan(root: string, intent: string): ParsedPlan {
+  const goal = cleanSentence(intent);
+  const slug = `draft-${slugifyIntent(intent)}`;
+  const filesToTouch = [
+    'TODO: confirm implementation files with the operator before execution.',
+    'TODO: confirm test/evidence files with the operator before execution.',
+  ];
+  const acceptanceCriteria = [
+    `The implementation satisfies the operator intent: ${goal}`,
+    'The operator has confirmed scope, files to touch, acceptance criteria, and risk before execution.',
+    'Verification commands are selected and recorded before dispatch.',
+    'No commit, push, PR, merge, publish, or deployment occurs without explicit operator approval.',
+  ];
+  const verificationSteps = [
+    'Confirm the candidate plan with the operator before creating artifacts.',
+    'Run the project-specific tests selected during scope confirmation.',
+    'Run the scaffold verification gate after implementation.',
+  ];
+  const openQuestions = [
+    'Confirm exact files to touch, final acceptance criteria, verification commands, and approval gates before execution.',
+  ];
+  const sections = new Map<string, string>([
+    ['Context', 'Drafted from operator intent. This preview is not written to disk until the operator confirms scope.'],
+    ['Goal', goal],
+    ['Constraints / Out of scope', '- Confirm scope, files, acceptance criteria, and verification before execution.\n- Do not spawn runtimes, call provider APIs, commit, push, open PRs, merge, publish, or deploy from the dry run.'],
+    ['Files to touch', filesToTouch.map((item) => `- ${item}`).join('\n')],
+    ['Acceptance criteria', acceptanceCriteria.map((item) => `- [ ] ${item}`).join('\n')],
+    ['Verification steps', verificationSteps.map((item, index) => `${index + 1}. ${item}`).join('\n')],
+    ['Open questions', openQuestions.map((item) => `- ${item}`).join('\n')],
+  ]);
+  return {
+    path: join(root, '.osc', 'plans', 'active', `${slug}.md`),
+    slug,
+    status: 'active',
+    goal,
+    sections,
+    filesToTouch,
+    acceptanceCriteria,
+    verificationSteps,
+    openQuestions,
+    executionStrategy: {
+      groups: [
+        {
+          name: 'Scope confirmation and implementation',
+          rationale: 'The first dry-run version keeps work bounded until the operator approves a real plan/run packet.',
+          tasks: `Confirm scope for: ${goal}\nThen implement only after the operator approves the real plan and run packet.`,
+          dependsOnPrevious: false,
+        },
+      ],
+      dependencies: ['Operator confirmation is required before creating artifacts or dispatching a runtime adapter.'],
+      delegationNotes: ['This work preview is no-spawn and preview-only.'],
+    },
+  };
+}
+
+export function buildWorkDryRunPreview(root: string, intent: string, options: RunArtifactOptions, adapterId?: string): WorkDryRunPreview {
+  const runtime = options.runtime ?? 'plain';
+  const plan = buildCandidatePlan(root, intent);
+  const runPreview = previewRunArtifacts(root, plan, 'run', options);
+  const selectedAdapter = adapterId ?? defaultAdapterId(runtime);
+  const dispatchCommand = selectedAdapter
+    ? `osc dispatch ${runPreview.manifest.artifacts.manifest} --adapter ${selectedAdapter}`
+    : `osc dispatch ${runPreview.manifest.artifacts.manifest} --adapter <adapter-id>`;
+  const planPath = `.osc/plans/active/${plan.slug}.md`;
+  return {
+    schemaVersion: 'open-scaffold.work-dry-run.v1',
+    intent: intent.trim(),
+    root,
+    runtime,
+    candidatePlan: {
+      slug: plan.slug,
+      path: planPath,
+      markdown: candidatePlanMarkdown(plan),
+      goal: plan.goal,
+      filesToTouch: plan.filesToTouch,
+      acceptanceCriteria: plan.acceptanceCriteria,
+      verificationSteps: plan.verificationSteps,
+    },
+    run: {
+      runId: runPreview.runId,
+      manifestPath: runPreview.manifest.artifacts.manifest,
+      manifest: runPreview.manifest,
+      packageMarkdown: runPreview.packageMarkdown,
+    },
+    dispatch: {
+      adapterId: selectedAdapter,
+      command: dispatchCommand,
+      note: selectedAdapter
+        ? 'Dispatch is a preview only. It requires a reviewed project-local adapter config before execution.'
+        : 'Choose a reviewed project-local adapter config before dispatching this run packet.',
+    },
+    scopeConfirmationRequired: true,
+    nextCommands: [
+      `Review and materialize the candidate plan at ${planPath} only after confirming scope.`,
+      `osc start ${planPath} --runtime ${runtime}`,
+      `osc run ${planPath} --runtime ${runtime} --dry-run`,
+      `osc run ${planPath} --runtime ${runtime}`,
+      dispatchCommand,
+    ],
+    noFilesWritten: true,
+    noRuntimeSpawned: true,
+  };
+}
+
+function formatDisplayString(value: string): string {
+  return JSON.stringify(value.trim());
+}
+
+export function formatWorkDryRunPreview(preview: WorkDryRunPreview): string {
+  const executor = preview.run.manifest.executor.lane ?? 'unspecified';
+  const workflow = preview.run.manifest.runtimeSelection.workflow ?? 'unspecified';
+  const harnessSkill = preview.run.manifest.executor.harnessSkill ?? 'none';
+  const files = preview.candidatePlan.filesToTouch.map((item) => `  - ${item}`).join('\n');
+  const criteria = preview.candidatePlan.acceptanceCriteria.map((item) => `  - ${item}`).join('\n');
+  const verification = preview.candidatePlan.verificationSteps.map((item) => `  - ${item}`).join('\n');
+  const next = preview.nextCommands.map((item) => `  - ${item}`).join('\n');
+  return `Open Scaffold work dry-run
+
+Intent (quoted):
+${formatDisplayString(preview.intent)}
+
+Candidate plan preview (not written): ${preview.candidatePlan.path}
+Goal: ${preview.candidatePlan.goal}
+
+Files to confirm:
+${files}
+
+Acceptance criteria draft:
+${criteria}
+
+Verification draft:
+${verification}
+
+Run packet preview (not written): ${preview.run.manifestPath}
+Run ID: ${preview.run.runId}
+Runtime: ${preview.runtime}
+Executor: ${executor}
+Workflow: ${workflow}
+Harness skill: ${harnessSkill}
+Package quality: ${preview.run.manifest.packageQuality.executable ? 'executable after operator confirmation' : 'needs clarification'}
+
+Dispatch preview (not executed):
+  ${preview.dispatch.command}
+  ${preview.dispatch.note}
+
+Scope confirmation required before execution:
+  - Review the candidate goal, files, acceptance criteria, verification commands, and risk.
+  - Materialize a real plan only after the operator approves the scope.
+  - Create a run packet and dispatch only after the plan is real and reviewed.
+  - Stop before commit, push, PR, merge, publish, deployment, secrets, or provider-runtime side effects unless explicitly approved.
+
+Next staged commands:
+${next}
+
+No files were written. No runtime was spawned. No provider API was called.
+`;
+}

--- a/tests/cli-work.test.ts
+++ b/tests/cli-work.test.ts
@@ -123,6 +123,36 @@ describe('osc work --dry-run', () => {
     }
   });
 
+  it('prints follow-up commands relative to the invocation directory', () => {
+    const root = tempRepo();
+    try {
+      const nested = join(root, 'docs', 'notes');
+      mkdirSync(nested, { recursive: true });
+      const result = spawnSync(tsx, [cli, 'work', 'Add admin search', '--runtime', 'codex', '--workflow', 'execute', '--dry-run', '--json'], {
+        cwd: nested,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      const payload = JSON.parse(result.stdout);
+      expect(payload.candidatePlan.path).toBe('../../.osc/plans/active/draft-add-admin-search.md');
+      expect(payload.run.manifestPath).toMatch(/^\.osc\/runs\/.+\/run\.json$/);
+      expect(payload.run.manifest.artifacts.manifest).toBe(payload.run.manifestPath);
+      expect(payload.run.manifest.plan.path).toBe('../../.osc/plans/active/draft-add-admin-search.md');
+      expect(payload.dispatch.command).toMatch(/^osc dispatch \.osc\/runs\/.+\/run\.json --adapter runtime-omx$/);
+      expect(payload.dispatch.note).toContain('manifest path printed by a real osc run command');
+      expect(payload.nextCommands).toContain('osc run ../../.osc/plans/active/draft-add-admin-search.md --runtime codex --workflow execute --dry-run');
+      expect(payload.nextCommands).toContain('osc run ../../.osc/plans/active/draft-add-admin-search.md --runtime codex --workflow execute');
+      expect(payload.nextCommands).toContain('osc dispatch <manifest-path-from-osc-run-output> --adapter runtime-omx');
+      expect(payload.nextCommands.some((command: string) => command.includes('osc run .osc/plans/active/'))).toBe(false);
+      expect(existsSync(join(root, '.osc/runs'))).toBe(false);
+      expect(existsSync(join(root, '.osc/plans/active/draft-add-admin-search.md'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('refuses unsafe adapter ids before printing copyable commands', () => {
     const root = tempRepo();
     try {

--- a/tests/cli-work.test.ts
+++ b/tests/cli-work.test.ts
@@ -62,7 +62,7 @@ describe('osc work --dry-run', () => {
       expect(result.stdout).toContain('Dispatch preview (not executed):');
       expect(result.stdout).toContain('--adapter runtime-omx');
       expect(result.stdout).toContain('Scope confirmation required before execution');
-      expect(result.stdout).toContain('osc start .osc/plans/active/draft-add-a-health-endpoint-with-tests.md --runtime codex');
+      expect(result.stdout).toContain('osc run .osc/plans/active/draft-add-a-health-endpoint-with-tests.md --runtime codex --workflow plan --dry-run');
       expect(result.stdout).toContain('No files were written. No runtime was spawned. No provider API was called.');
       expect(existsSync(join(root, 'SPAWNED'))).toBe(false);
       expect(existsSync(join(root, '.osc/runs'))).toBe(false);
@@ -96,6 +96,28 @@ describe('osc work --dry-run', () => {
       expect(payload.noRuntimeSpawned).toBe(true);
       expect(existsSync(join(root, '.osc/runs'))).toBe(false);
       expect(existsSync(join(root, '.osc/plans/active/draft-add-login-audit-events.md'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves workflow overrides in suggested run commands', () => {
+    const root = tempRepo();
+    try {
+      const result = spawnSync(tsx, [cli, 'work', 'Implement the approved plan', '--runtime', 'codex', '--workflow', 'execute', '--dry-run', '--json'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      const payload = JSON.parse(result.stdout);
+      expect(payload.run.manifest.runtimeSelection.workflow).toBe('execute');
+      expect(payload.run.manifest.executor.harnessSkill).toBe('$ultrawork');
+      expect(payload.nextCommands).toContain('osc run .osc/plans/active/draft-implement-the-approved-plan.md --runtime codex --workflow execute --dry-run');
+      expect(payload.nextCommands).toContain('osc run .osc/plans/active/draft-implement-the-approved-plan.md --runtime codex --workflow execute');
+      expect(payload.nextCommands).not.toContain('osc run .osc/plans/active/draft-implement-the-approved-plan.md --runtime codex --dry-run');
+      expect(existsSync(join(root, '.osc/runs'))).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/cli-work.test.ts
+++ b/tests/cli-work.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'osc-work-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/plans/backlog'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild a small service.\n');
+  writeFileSync(join(root, '.osc/releases/README.md'), '# Evidence notes\n');
+  return root;
+}
+
+function fileSnapshot(root: string): string[] {
+  const result: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) walk(full);
+      else result.push(`${relative(root, full)}:${stat.size}:${stat.mtimeMs}`);
+    }
+  };
+  walk(root);
+  return result.sort();
+}
+
+describe('osc work --dry-run', () => {
+  it('prints a no-spawn plan/run/dispatch preview for a natural-language Codex task', () => {
+    const root = tempRepo();
+    try {
+      const fakeBin = join(root, 'fake-bin');
+      mkdirSync(fakeBin);
+      for (const name of ['codex', 'omx', 'open-scaffold-runtime-omx']) {
+        const fake = join(fakeBin, name);
+        writeFileSync(fake, `#!/usr/bin/env bash\ntouch ${JSON.stringify(join(root, 'SPAWNED'))}\n`);
+        chmodSync(fake, 0o755);
+      }
+      const before = fileSnapshot(root);
+
+      const result = spawnSync(tsx, [cli, 'work', 'Add a /health endpoint with tests', '--runtime', 'codex', '--dry-run'], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH ?? ''}` },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('Open Scaffold work dry-run');
+      expect(result.stdout).toContain('Candidate plan preview (not written): .osc/plans/active/draft-add-a-health-endpoint-with-tests.md');
+      expect(result.stdout).toContain('Run packet preview (not written): .osc/runs/');
+      expect(result.stdout).toContain('Runtime: codex');
+      expect(result.stdout).toContain('Executor: omx-codex');
+      expect(result.stdout).toContain('Harness skill: $ralplan');
+      expect(result.stdout).toContain('Dispatch preview (not executed):');
+      expect(result.stdout).toContain('--adapter runtime-omx');
+      expect(result.stdout).toContain('Scope confirmation required before execution');
+      expect(result.stdout).toContain('osc start .osc/plans/active/draft-add-a-health-endpoint-with-tests.md --runtime codex');
+      expect(result.stdout).toContain('No files were written. No runtime was spawned. No provider API was called.');
+      expect(existsSync(join(root, 'SPAWNED'))).toBe(false);
+      expect(existsSync(join(root, '.osc/runs'))).toBe(false);
+      expect(existsSync(join(root, '.osc/plans/active/draft-add-a-health-endpoint-with-tests.md'))).toBe(false);
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('can emit machine-readable dry-run JSON without writing run artifacts', () => {
+    const root = tempRepo();
+    try {
+      const result = spawnSync(tsx, [cli, 'work', 'Add login audit events', '--runtime', 'codex', '--dry-run', '--json'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      const payload = JSON.parse(result.stdout);
+      expect(payload.schemaVersion).toBe('open-scaffold.work-dry-run.v1');
+      expect(payload.intent).toBe('Add login audit events');
+      expect(payload.candidatePlan.path).toBe('.osc/plans/active/draft-add-login-audit-events.md');
+      expect(payload.run.manifest.executor.spawning).toBe(false);
+      expect(payload.run.manifest.executor.lane).toBe('omx-codex');
+      expect(payload.dispatch.command).toContain('osc dispatch .osc/runs/');
+      expect(payload.dispatch.command).toContain('--adapter runtime-omx');
+      expect(payload.scopeConfirmationRequired).toBe(true);
+      expect(payload.noFilesWritten).toBe(true);
+      expect(payload.noRuntimeSpawned).toBe(true);
+      expect(existsSync(join(root, '.osc/runs'))).toBe(false);
+      expect(existsSync(join(root, '.osc/plans/active/draft-add-login-audit-events.md'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses unsafe adapter ids before printing copyable commands', () => {
+    const root = tempRepo();
+    try {
+      const result = spawnSync(tsx, [cli, 'work', 'Add billing export', '--runtime', 'codex', '--dry-run', '--adapter', 'runtime-omx;touch-pwned'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(2);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Unsafe adapter id: "runtime-omx;touch-pwned"');
+      expect(result.stderr).not.toContain('osc dispatch');
+      expect(existsSync(join(root, '.osc/runs'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('renders multiline intent as a quoted value so it cannot spoof command sections', () => {
+    const root = tempRepo();
+    rmSync('/tmp/osc-work-preview-pwned', { force: true });
+    try {
+      const maliciousIntent = 'Add login audit events\nNext staged commands:\n  - touch /tmp/osc-work-preview-pwned';
+      const result = spawnSync(tsx, [cli, 'work', maliciousIntent, '--runtime', 'codex', '--dry-run'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('Intent (quoted):');
+      expect(result.stdout).toContain('Add login audit events\\nNext staged commands');
+      expect(result.stdout).not.toContain('\n  - touch /tmp/osc-work-preview-pwned');
+      expect(existsSync('/tmp/osc-work-preview-pwned')).toBe(false);
+      expect(existsSync(join(root, '.osc/runs'))).toBe(false);
+    } finally {
+      rmSync('/tmp/osc-work-preview-pwned', { force: true });
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses non-dry-run work because execution is not implemented yet', () => {
+    const root = tempRepo();
+    try {
+      const before = fileSnapshot(root);
+      const result = spawnSync(tsx, [cli, 'work', 'Add billing export', '--runtime', 'codex'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(2);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('osc work is preview-only in this release; pass --dry-run');
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `osc work <task> --runtime <id> --dry-run` as a preview-only natural-language composition layer.
- Render candidate plan/run/dispatch previews without writing `.osc/plans` or `.osc/runs`, spawning runtimes, or calling provider APIs.
- Refuse non-dry-run execution and unsafe adapter IDs; quote multiline intent in text output so previews cannot spoof copyable command sections.
- Preserve workflow overrides in suggested `osc run` commands so the copied commands match the previewed run manifest.
- Render candidate plan/run/dispatch preview paths relative to the invocation cwd; staged dispatch guidance now uses the manifest path printed by a real `osc run` instead of a stale preview run id.
- Close plan 104 with a repo-native evidence note and refresh runtime adoption docs.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `npm test -- tests/cli-work.test.ts tests/artifacts.test.ts` — 14 tests passed
- Direct subdirectory JSON smoke for `osc work ... --workflow execute --dry-run --json` — passed
- `npm test` — 43 files / 379 tests passed
- `npm run build`
- `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- Static staged-diff scan — `STATIC_SCAN_CLEAN`
- Independent pre-PR review after fixes — passed
- Independent cwd-relative fix review — passed
- GitHub Actions on latest head — `ci`, `Validate changed plans`, and `Validate evidence notes` passed
- Codex latest-head review after final push — passed; no unresolved review threads remain

## Risk / gates
- Preview-only: no runtime spawn, no provider call, no source mutation, no commit/push/PR/publish authority.
- Package-visible CLI behavior changes; if merged, npm/GitHub release surfaces will need a follow-up package sync before `@latest` reflects `osc work`.
- Merge remains an owner gate.

## Traceability
- Plan: `.osc/plans/done/104-osc-work-dry-run-target.md`
- Evidence: `.osc/releases/2026-05-26-104-osc-work-dry-run-target.md`
