### PR TITLE
chore: prepare work dry-run package sync

### DIFF
--- a/.osc/plans/active/107-work-dry-run-package-sync.md
+++ b/.osc/plans/active/107-work-dry-run-package-sync.md
@@ -1,0 +1,58 @@
+# Plan: 107-work-dry-run-package-sync
+
+## Status
+
+active
+
+## Context
+
+PR #129 is now present on `main` and adds `osc work <task-description> --runtime <preset> --dry-run` as a package-visible CLI/help surface. Local `main` exposes the command, but npm `latest` remains `open-scaffold@1.0.3` and fresh isolated-cache `npx open-scaffold@latest --help` does not show `osc work`.
+
+## Goal
+
+Prepare and verify `open-scaffold@1.0.4` as the package/public-surface sync for the work dry-run preview so npm `latest`, fresh `npx`, and the GitHub Latest Release can match `main` after the publish/release gate.
+
+## Constraints / Out of scope
+
+- Do not add new `osc work` behavior beyond PR #129.
+- Do not enable non-dry-run `osc work` execution in this slice.
+- Do not implement native runtime spawning, provider SDK imports, credential management, auto-install behavior, or adapter package publication.
+- Keep npm publishing and GitHub Release creation as explicit public-surface follow-through after PR integration.
+- Keep this release-sync plan active until npm/latest, fresh isolated-cache `npx`, and any approved GitHub Latest Release are verified.
+
+## Files to touch
+
+- `package.json` — bump root package version to `1.0.4`.
+- `package-lock.json` — keep root lockfile version metadata in sync.
+- `docs/CHANGELOG.md` — record the v1.0.4 package surface.
+- `.osc/releases/2026-05-27-107-work-dry-run-package-sync.md` — durable release-sync evidence.
+- `.osc/releases/2026-05-26-104-osc-work-dry-run-target.md` — reconcile source-slice evidence after PR #129 reached `main`.
+- This plan file and `MISSION.md` — closeout only after package/release proof exists.
+
+## Acceptance criteria
+
+- [x] Root package version is bumped to `1.0.4` and lockfile metadata matches.
+- [x] Changelog documents v1.0.4 as the package-surface sync for `osc work --dry-run`.
+- [x] Local gates pass before PR: `./verify.sh --strict`, focused package/CLI tests, `npm test`, `npm run build`, `npm pack --dry-run --json`, `npm publish --dry-run`, `git diff --check`.
+- [ ] PR CI and latest-head Codex review are clean before PR integration.
+- [ ] Trusted publishing succeeds for `open-scaffold@1.0.4` after PR integration and owner publish approval.
+- [ ] `npm view open-scaffold version dist-tags --json` shows `1.0.4` / `latest: 1.0.4`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]`.
+- [ ] GitHub Release `v1.0.4` exists, targets the integrated main commit, and is marked Latest if release publication is approved.
+
+## Verification steps
+
+1. Run `git diff --check`.
+2. Run `./verify.sh --strict`.
+3. Run focused package/CLI smokes for `osc work --dry-run`.
+4. Run `npm test`.
+5. Run `npm run build`.
+6. Run `npm pack --dry-run --json` and confirm the package includes `dist/work.js` / `dist/work.d.ts` and excludes product dogfood plans/releases.
+7. Run `npm publish --dry-run`.
+8. After PR integration/publication, run `npm view open-scaffold version dist-tags --json`.
+9. After publish, run fresh isolated-cache `npx --yes open-scaffold@latest --help` and verify `osc work` appears.
+10. Check `gh release list --repo graphanov/open-scaffold --limit 5` for `v1.0.4` as Latest if the GitHub Release gate is approved.
+
+## Open questions
+
+- None for the package-sync candidate. Actual npm publishing and GitHub Release creation remain owner gates.

--- a/.osc/releases/2026-05-26-104-osc-work-dry-run-target.md
+++ b/.osc/releases/2026-05-26-104-osc-work-dry-run-target.md
@@ -25,9 +25,9 @@ Added `osc work <task-description> --runtime <preset> --dry-run` as the first na
 
 ## Outcome
 
-Repo implementation candidate is ready for PR review. `osc work --dry-run` is preview-only: it does not write `.osc/plans`, does not write `.osc/runs`, does not spawn runtimes, does not call provider APIs, and does not perform GitHub/npm/release side effects. Non-dry-run `osc work` exits with usage error until a separate safety design exists.
+Integrated on `main` via PR #129. `osc work --dry-run` is preview-only: it does not write `.osc/plans`, does not write `.osc/runs`, does not spawn runtimes, does not call provider APIs, and does not perform GitHub/npm/release side effects. Non-dry-run `osc work` exits with usage error until a separate safety design exists.
 
 ## Follow-up
 
-- After PR integration, prepare a package/public-surface sync so npm `latest`, fresh `npx`, and GitHub Latest Release expose `osc work --dry-run`.
+- Package/public-surface sync is tracked by `.osc/plans/active/107-work-dry-run-package-sync.md` so npm `latest`, fresh `npx`, and GitHub Latest Release can expose `osc work --dry-run` after owner-approved release follow-through.
 - Optional gated execution remains future work and requires a separate architecture/security decision.

--- a/.osc/releases/2026-05-27-107-work-dry-run-package-sync.md
+++ b/.osc/releases/2026-05-27-107-work-dry-run-package-sync.md
@@ -1,0 +1,50 @@
+# Release / Evidence Note: 107-work-dry-run-package-sync
+
+## Summary
+
+Prepare `open-scaffold@1.0.4` as the package/public-surface sync for PR #129's `osc work <task-description> --runtime <preset> --dry-run` preview. The source feature reached `main`, but npm `latest` remains `open-scaffold@1.0.3` and fresh isolated-cache `npx open-scaffold@latest --help` does not expose the new `osc work` command.
+
+## Traceability
+
+- Roadmap / issue / task: Milestone 19 — Post-v1 Codex-first runtime adoption chain; package-sync follow-through after PR #129.
+- Source plan: `.osc/plans/done/104-osc-work-dry-run-target.md`.
+- Release-sync plan: `.osc/plans/active/107-work-dry-run-package-sync.md`.
+- Run ID / run packet: N/A for release-sync.
+- Source Pull Request: https://github.com/graphanov/open-scaffold/pull/129.
+- Release-sync Pull Request: pending.
+- Trusted publishing run: pending owner-approved publish follow-through.
+- GitHub Release: pending owner-approved release follow-through.
+
+## Verification
+
+- `gh pr view 129 --repo graphanov/open-scaffold --json state,mergedAt,mergeCommit,url` — PASS: PR #129 is merged; merge commit `ee4d5507036f4237cc2ca8562f79518b8a6e8660`.
+- Main push CI after PR #129 — PASS: https://github.com/graphanov/open-scaffold/actions/runs/26504074783.
+- `git diff --check` after syncing `main` — PASS.
+- `./verify.sh --strict` after syncing `main` — PASS, 10 pass / 0 fail / 0 warn.
+- `npm test` after syncing `main` — PASS, 43 files / 379 tests.
+- `npm run build` after syncing `main` — PASS.
+- `node dist/cli.js --help | grep -F 'osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]'` — PASS locally after PR #129.
+- `npm view open-scaffold version dist-tags versions --json` — PRECHECK: npm/latest remains `1.0.3` before this release-sync candidate.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc work` command before this release-sync candidate is published.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PRECHECK: GitHub Latest Release remains `v1.0.3 — Dispatch adapter glue`.
+- `node -p "require('./package.json').version"` — PASS on release-sync branch: `1.0.4`.
+- `node -p "require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `1.0.4 / 1.0.4`.
+- `git diff --check` on release-sync branch — PASS.
+- `./verify.sh --strict` on release-sync branch — PASS, 10 pass / 0 fail / 0 warn.
+- `npm test -- tests/cli-work.test.ts tests/package-payload.test.ts` — PASS, 2 files / 9 tests.
+- `npm test` — PASS, 43 files / 379 tests.
+- `npm run build` — PASS.
+- `node dist/cli.js --help | grep -F 'osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]'` — PASS.
+- `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.4` (153 files, unpacked 1,039,498 bytes); package includes `dist/work.js` and `dist/work.d.ts` and excludes product dogfood done/backlog plans and `.osc/runs`.
+- `npm publish --dry-run` — PASS for `open-scaffold@1.0.4`.
+
+## Outcome
+
+Candidate in progress. This release-sync branch bumps the package candidate to `1.0.4` and records the public-surface drift for `osc work --dry-run`. npm publishing, fresh post-publish `npx`, GitHub Latest Release alignment, and final plan closeout remain follow-through gates after PR integration and owner approval.
+
+## Follow-up
+
+- Open a release-sync PR for `open-scaffold@1.0.4`.
+- Trigger CI and latest-head Codex review for the release-sync PR.
+- After owner approval, merge the release-sync PR and run trusted publishing for `1.0.4`.
+- Verify npm/latest, fresh isolated-cache `npx`, GitHub Latest Release, then close this release-sync plan with final evidence.

--- a/.osc/releases/2026-05-27-107-work-dry-run-package-sync.md
+++ b/.osc/releases/2026-05-27-107-work-dry-run-package-sync.md
@@ -11,7 +11,7 @@ Prepare `open-scaffold@1.0.4` as the package/public-surface sync for PR #129's `
 - Release-sync plan: `.osc/plans/active/107-work-dry-run-package-sync.md`.
 - Run ID / run packet: N/A for release-sync.
 - Source Pull Request: https://github.com/graphanov/open-scaffold/pull/129.
-- Release-sync Pull Request: pending.
+- Release-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/130.
 - Trusted publishing run: pending owner-approved publish follow-through.
 - GitHub Release: pending owner-approved release follow-through.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,20 +4,24 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
-## Unreleased — `osc work --dry-run`
+## v1.0.4 — Work dry-run preview package sync
 
-Status: repo candidate; npm/GitHub Release publication pending after PR integration and package-sync follow-through.
+Status: release-sync candidate; npm/GitHub Release publication pending after PR integration and owner-approved package follow-through.
 
 Highlights:
 
-- Adds `osc work "TASK" --runtime codex --dry-run` as the first natural-language composition layer.
-- Previews a candidate plan, run packet, and dispatch command without writing `.osc/plans` or `.osc/runs` artifacts.
+- Prepares the PR #129 package-visible runtime surface: `osc work "TASK" --runtime codex --dry-run` as the first natural-language composition layer.
+- Previews a candidate plan, run packet, and dispatch command without writing `.osc/plans` or `.osc/runs` artifacts, spawning runtimes, or calling provider APIs.
 - Keeps non-dry-run `osc work` refused until a separate safety design exists.
+- Preserves workflow overrides in suggested `osc run` commands and renders subdirectory-invocation paths relative to the caller cwd.
 
 Evidence:
 
-- Plan: `.osc/plans/done/104-osc-work-dry-run-target.md`
-- Evidence note: `.osc/releases/2026-05-26-104-osc-work-dry-run-target.md`
+- Source plan: `.osc/plans/done/104-osc-work-dry-run-target.md`
+- Release-sync plan: `.osc/plans/active/107-work-dry-run-package-sync.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/129
+- Source evidence note: `.osc/releases/2026-05-26-104-osc-work-dry-run-target.md`
+- Release-sync evidence note: `.osc/releases/2026-05-27-107-work-dry-run-package-sync.md`
 
 ## v1.0.3 — Dispatch adapter glue package sync
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Prepare `open-scaffold@1.0.4` as the package/public-surface sync for PR #129's `osc work --dry-run` command.
- Bump `package.json` and `package-lock.json` to `1.0.4` because npm `latest` is already `1.0.3` and does not expose `osc work`.
- Add active release-sync plan 107 and evidence note for the public-surface drift/follow-through gates.
- Update changelog and reconcile the source 104 evidence note now that PR #129 is on `main`.
- Link this release-sync PR from the evidence note on the final head.

## Verification
- `git diff --check`
- `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- `npm test -- tests/cli-work.test.ts tests/package-payload.test.ts` — 2 files / 9 tests passed
- `npm test` — 43 files / 379 tests passed
- `npm run build`
- local help smoke for `osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]`
- `npm pack --dry-run --json` — `open-scaffold@1.0.4`, 153 files, includes `dist/work.js` / `dist/work.d.ts`, excludes dogfood done/backlog plans and `.osc/runs`
- `npm publish --dry-run`
- post-PR-link traceability recheck: `git diff --check`; `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- static staged-diff scan — `STATIC_SCAN_CLEAN`
- independent pre-commit review — passed

## Risk / gates
- Release-sync only: no new `osc work` behavior beyond PR #129.
- Non-dry-run `osc work` remains refused.
- npm trusted publishing, fresh post-publish `npx`, GitHub Latest Release alignment, and final plan closeout remain owner-gated follow-through after PR integration.

## Traceability
- Source PR: https://github.com/graphanov/open-scaffold/pull/129
- Source plan: `.osc/plans/done/104-osc-work-dry-run-target.md`
- Release-sync plan: `.osc/plans/active/107-work-dry-run-package-sync.md`
- Release-sync evidence: `.osc/releases/2026-05-27-107-work-dry-run-package-sync.md`
