### PR TITLE
chore: close work dry-run package sync

### DIFF
--- a/.osc/plans/done/107-work-dry-run-package-sync.md
+++ b/.osc/plans/done/107-work-dry-run-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
@@ -34,11 +34,11 @@ Prepare and verify `open-scaffold@1.0.4` as the package/public-surface sync for 
 - [x] Root package version is bumped to `1.0.4` and lockfile metadata matches.
 - [x] Changelog documents v1.0.4 as the package-surface sync for `osc work --dry-run`.
 - [x] Local gates pass before PR: `./verify.sh --strict`, focused package/CLI tests, `npm test`, `npm run build`, `npm pack --dry-run --json`, `npm publish --dry-run`, `git diff --check`.
-- [ ] PR CI and latest-head Codex review are clean before PR integration.
-- [ ] Trusted publishing succeeds for `open-scaffold@1.0.4` after PR integration and owner publish approval.
-- [ ] `npm view open-scaffold version dist-tags --json` shows `1.0.4` / `latest: 1.0.4`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]`.
-- [ ] GitHub Release `v1.0.4` exists, targets the integrated main commit, and is marked Latest if release publication is approved.
+- [x] PR CI and latest-head Codex review are clean before PR integration.
+- [x] Trusted publishing succeeds for `open-scaffold@1.0.4` after PR integration and owner publish approval.
+- [x] `npm view open-scaffold version dist-tags --json` shows `1.0.4` / `latest: 1.0.4`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]`.
+- [x] GitHub Release `v1.0.4` exists, targets the integrated main commit, and is marked Latest if release publication is approved.
 
 ## Verification steps
 

--- a/.osc/releases/2026-05-27-107-work-dry-run-package-sync.md
+++ b/.osc/releases/2026-05-27-107-work-dry-run-package-sync.md
@@ -2,18 +2,20 @@
 
 ## Summary
 
-Prepare `open-scaffold@1.0.4` as the package/public-surface sync for PR #129's `osc work <task-description> --runtime <preset> --dry-run` preview. The source feature reached `main`, but npm `latest` remains `open-scaffold@1.0.3` and fresh isolated-cache `npx open-scaffold@latest --help` does not expose the new `osc work` command.
+Published `open-scaffold@1.0.4` as the package/public-surface sync for PR #129's `osc work <task-description> --runtime <preset> --dry-run` preview. The source feature reached `main` in PR #129, the release-sync PR #130 bumped the package to `1.0.4`, trusted publishing updated npm `latest`, and GitHub Release `v1.0.4` is now the Latest release.
 
 ## Traceability
 
 - Roadmap / issue / task: Milestone 19 — Post-v1 Codex-first runtime adoption chain; package-sync follow-through after PR #129.
 - Source plan: `.osc/plans/done/104-osc-work-dry-run-target.md`.
-- Release-sync plan: `.osc/plans/active/107-work-dry-run-package-sync.md`.
+- Release-sync plan: `.osc/plans/done/107-work-dry-run-package-sync.md`.
 - Run ID / run packet: N/A for release-sync.
 - Source Pull Request: https://github.com/graphanov/open-scaffold/pull/129.
 - Release-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/130.
-- Trusted publishing run: pending owner-approved publish follow-through.
-- GitHub Release: pending owner-approved release follow-through.
+- Release-sync merge commit: `094688afa9f5f28950665683763a9b00e024d357`.
+- Main CI after PR #130: https://github.com/graphanov/open-scaffold/actions/runs/26505195587.
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/26505406882.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v1.0.4.
 
 ## Verification
 
@@ -24,9 +26,9 @@ Prepare `open-scaffold@1.0.4` as the package/public-surface sync for PR #129's `
 - `npm test` after syncing `main` — PASS, 43 files / 379 tests.
 - `npm run build` after syncing `main` — PASS.
 - `node dist/cli.js --help | grep -F 'osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]'` — PASS locally after PR #129.
-- `npm view open-scaffold version dist-tags versions --json` — PRECHECK: npm/latest remains `1.0.3` before this release-sync candidate.
-- Fresh isolated-cache `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc work` command before this release-sync candidate is published.
-- `gh release list --repo graphanov/open-scaffold --limit 5` — PRECHECK: GitHub Latest Release remains `v1.0.3 — Dispatch adapter glue`.
+- `npm view open-scaffold version dist-tags versions --json` — PRECHECK: npm/latest was `1.0.3` before this release-sync candidate.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc work` command before this release-sync candidate was published.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PRECHECK: GitHub Latest Release was `v1.0.3 — Dispatch adapter glue`.
 - `node -p "require('./package.json').version"` — PASS on release-sync branch: `1.0.4`.
 - `node -p "require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `1.0.4 / 1.0.4`.
 - `git diff --check` on release-sync branch — PASS.
@@ -35,16 +37,32 @@ Prepare `open-scaffold@1.0.4` as the package/public-surface sync for PR #129's `
 - `npm test` — PASS, 43 files / 379 tests.
 - `npm run build` — PASS.
 - `node dist/cli.js --help | grep -F 'osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]'` — PASS.
-- `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.4` (153 files, unpacked 1,039,498 bytes); package includes `dist/work.js` and `dist/work.d.ts` and excludes product dogfood done/backlog plans and `.osc/runs`.
+- `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.4` (153 files); package includes `dist/work.js` and `dist/work.d.ts` and excludes product dogfood done/backlog plans and `.osc/runs`.
 - `npm publish --dry-run` — PASS for `open-scaffold@1.0.4`.
+- PR #130 CI — PASS: `ci`, `Validate changed plans`, and `Validate evidence notes` were successful.
+- PR #130 latest-head Codex review — PASS: Codex reported no major issues and review threads were zero before merge.
+- Post-merge `git diff --check` on `main` — PASS.
+- Post-merge `./verify.sh --strict` on `main` — PASS, 10 pass / 0 fail / 0 warn.
+- Post-merge `npm test` on `main` — PASS, 43 files / 379 tests.
+- Post-merge `npm run build` on `main` — PASS.
+- Post-merge `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.4` (153 files); package includes `dist/work.js` and `dist/work.d.ts` and excludes product dogfood done/backlog plans and `.osc/runs`.
+- Post-merge `npm publish --dry-run` — PASS.
+- `gh workflow run publish-npm.yml --ref main -f expected-version=1.0.4 -f npm-tag=latest` — PASS via trusted publishing run `26505406882`.
+- `gh run view 26505406882 --repo graphanov/open-scaffold --json status,conclusion,headSha,url,jobs` — PASS: completed successfully on head `094688afa9f5f28950665683763a9b00e024d357`.
+- `npm view open-scaffold version dist-tags repository homepage bugs keywords --json --prefer-online` — PASS: `version` is `1.0.4`; `dist-tags.latest` is `1.0.4`; repository/homepage/bugs/keywords metadata is present.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` from a temporary directory — PASS: help includes `osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]`.
+- Fresh isolated-cache `npx --yes open-scaffold@latest init --tier min --target <tmp>` — PASS: generated expected min-tier scaffold files including `MISSION.md`, `.osc/RULES.md`, `.osc/plans/WORKFLOW.md`, and `verify.sh`.
+- `gh release create v1.0.4 --target 094688afa9f5f28950665683763a9b00e024d357 --latest` — PASS.
+- `gh release view v1.0.4 --repo graphanov/open-scaffold --json tagName,name,publishedAt,targetCommitish,url,isDraft,isPrerelease` — PASS: release targets `094688afa9f5f28950665683763a9b00e024d357`, is not draft, and is not prerelease.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS: `v1.0.4 — Work dry-run preview package sync` is marked Latest.
+- `gh api repos/graphanov/open-scaffold/git/ref/tags/v1.0.4` — PASS: tag points to commit `094688afa9f5f28950665683763a9b00e024d357`.
+- Remote branch cleanup — PASS: stale merged branch `release/work-dry-run-package-sync` was deleted and no longer appears in `git ls-remote --heads origin release/work-dry-run-package-sync`.
 
 ## Outcome
 
-Candidate in progress. This release-sync branch bumps the package candidate to `1.0.4` and records the public-surface drift for `osc work --dry-run`. npm publishing, fresh post-publish `npx`, GitHub Latest Release alignment, and final plan closeout remain follow-through gates after PR integration and owner approval.
+Complete. `main`, npm `latest`, fresh isolated-cache `npx`, and GitHub Latest Release now expose `open-scaffold@1.0.4` with the `osc work --dry-run` preview surface. The release-sync plan is closed after public-surface proof.
 
 ## Follow-up
 
-- Open a release-sync PR for `open-scaffold@1.0.4`.
-- Trigger CI and latest-head Codex review for the release-sync PR.
-- After owner approval, merge the release-sync PR and run trusted publishing for `1.0.4`.
-- Verify npm/latest, fresh isolated-cache `npx`, GitHub Latest Release, then close this release-sync plan with final evidence.
+- Stop at the continuation gate before starting another runtime-adoption slice.
+- Recommended next decision: choose whether to continue the Codex-first adoption chain with a docs/example proof for `osc work --dry-run`, start a gated execution design, or pause mutating automation and keep only read-only/status lanes active.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-27: closed 107-work-dry-run-package-sync — published 1.0.4 and aligned work dry-run public surfaces
 - 2026-05-26: closed 104-osc-work-dry-run-target — Closed 104 osc work dry-run target.
 - 2026-05-26: closed 106-dispatch-adapter-glue-package-sync — Closed 106 dispatch adapter glue package sync after v1.0.3 npm and GitHub Release verification.
 - 2026-05-26: closed 103-osc-dispatch-adapter-glue — added explicit dispatch adapter glue


### PR DESCRIPTION
## Summary
- Close release-sync plan 107 after `open-scaffold@1.0.4` was published and public surfaces aligned.
- Update the release/evidence note with final npm, fresh isolated-cache `npx`, trusted-publishing, GitHub Release, and branch-cleanup proof.
- Stamp `MISSION.md` through `osc close`.
- Align the moved plan's `## Status` with `done/` and check off the completed closeout acceptance criteria after Codex caught both closure hygiene issues.
- Squash the closeout branch back to one commit so plan immutability verification remains clean.

## Verification
- `npm view open-scaffold version dist-tags repository homepage bugs keywords --json --prefer-online` — `1.0.4` / `latest: 1.0.4`
- fresh isolated-cache `npx --yes open-scaffold@latest --help` — includes `osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]`
- fresh isolated-cache `npx --yes open-scaffold@latest init --tier min --target <tmp>` — generated expected min-tier scaffold files
- `gh release list --repo graphanov/open-scaffold --limit 5` — `v1.0.4` marked Latest
- `node dist/cli.js plan validate .osc/plans/done/107-work-dry-run-package-sync.md` — 0 issues
- `git diff --check`
- `./verify.sh --strict` — 10 pass / 0 fail / 0 warn after branch squash
- static added-line scan — clean

## Risk / gates
- Evidence/closeout only. No product code, package version, workflow, or public CLI behavior changes.
- No npm publish or GitHub Release side effects in this PR; those are already completed and verified in the evidence note.
