### PR TITLE
docs: record adoption strategy backlog

### DIFF
--- a/.osc/plans/backlog/070-runtime-adapter-registry-amendment-1.md
+++ b/.osc/plans/backlog/070-runtime-adapter-registry-amendment-1.md
@@ -1,0 +1,24 @@
+# Amendment 1: 070-runtime-adapter-registry
+
+## Parent
+
+070-runtime-adapter-registry
+
+## Date
+
+2026-05-27
+
+## Learning
+
+The post-v1 adoption strategy review found that an adapter registry shipped while Open Scaffold has only one serious adapter path would weaken the runtime-neutral claim. A registry with only the OMX/Codex lane reads as a directory of absence, not an ecosystem. The safer sequence is: first prove a second adapter, then publish a registry, then add installer behavior only after separate safety review.
+
+## New direction
+
+Keep the registry plan, but gate it behind a second reference adapter and a public conformance story. The first registry should be a curated, read-only directory with explicit self-declared status and conformance evidence. It may show installation commands, but it must not execute arbitrary registry-provided commands or imply adapter certification.
+
+## Impact on acceptance criteria
+
+- AC #37 changes from "includes at minimum the built-in OMX adapter" to "includes at least two reference adapters with linked conformance evidence."
+- AC #42 and AC #43 are deferred or rewritten: `osc runtimes install ADAPTER_ID` may print/manual-confirm a known safe command, but automatic `--yes` execution is out of scope until a separate installer-safety plan exists.
+- Add an acceptance criterion that registry docs state: listed adapters are curated records, not security certification, compliance certification, or runtime endorsement.
+- This plan should be sequenced after a second-reference-adapter proof and preferably after the public conformance pack exists.

--- a/.osc/plans/backlog/071-evidence-chain-verifier-amendment-1.md
+++ b/.osc/plans/backlog/071-evidence-chain-verifier-amendment-1.md
@@ -1,0 +1,24 @@
+# Amendment 1: 071-evidence-chain-verifier
+
+## Parent
+
+071-evidence-chain-verifier
+
+## Date
+
+2026-05-27
+
+## Learning
+
+The post-v1 adoption strategy review identified traceability as one of Open Scaffold's strongest existing stories and evidence-chain verification as the highest-leverage trust slice. The current plan is still directionally right, but the product reason is sharper: this command should turn a folder of plans, runs, evidence, releases, and PR references into a one-command answer to "does the work record check out?" without claiming evidence quality or legal compliance.
+
+## New direction
+
+Prioritize `osc verify --evidence-chain` as the structural trust command for the repo-native work record. It should produce both a concise human-readable chain summary and JSON findings, stay local-only by default, and preserve the boundary between structural linkage verification and correctness/compliance judgment.
+
+## Impact on acceptance criteria
+
+- Add an acceptance criterion for a concise summary line such as: `plans checked`, `links intact`, `broken`, `missing`, `unverifiable`, and `strict result`.
+- Add an acceptance criterion for a documented `--since GIT_REF_OR_DATE` or explicitly deferred incremental mode, so larger repos can adopt the verifier without reading the whole history every time.
+- Add docs wording that frames the command as "the story checks out structurally," not "the work is correct" or "the project is compliance-grade."
+- Keep the local-only constraint: GitHub, npm, CI, and external URLs may be recognized syntactically, but network verification remains out of scope for this plan.

--- a/.osc/plans/backlog/108-public-work-record-positioning.md
+++ b/.osc/plans/backlog/108-public-work-record-positioning.md
@@ -1,0 +1,57 @@
+# Plan: 108-public-work-record-positioning
+
+## Status
+
+backlog
+
+## Context
+
+A post-v1 adoption strategy review found that the strongest public line is simple: AI work should not disappear into chat logs. Current public wording still leans on abstract or over-large phrases such as "operating system," "control plane," and "evolution ledger" before a new reader understands the concrete payoff.
+
+## Goal
+
+Reframe the first public surfaces around Open Scaffold as the repo-native work record for AI-assisted software, with explicit auditability boundaries and no compliance-grade overclaim.
+
+## Constraints / Out of scope
+
+- Documentation and positioning only; no CLI behavior, runtime spawning, registry, or schema changes.
+- Do not remove the underlying product ambition; translate it into plain public language.
+- Do not claim legal compliance, tamper-proof storage, automatic correctness, or runtime certification.
+- Keep owner-neutral public wording; do not name private workflows or internal research paths.
+
+## Files to touch
+
+- `README.md` — replace the hero and first-scroll explanation with the work-record promise.
+- `MISSION.md` — align public mission language away from "operating system" overclaim if the slice elects to touch mission wording.
+- `docs/FAQ.md` — clarify substrate-versus-program boundaries and non-compliance claims.
+- `docs/COMPARISON.md` — position Open Scaffold as the record layer alongside Spec Kit, BMAD, Agent OS, and LangSmith.
+- `docs/AUDITABILITY.md` — new plain-language page separating evidence substrate, verification, approval, and compliance programs.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adoption trust, audit trails, authority boundaries, and public comprehension.
+- Audit envelope: before/after phrase audit for prohibited overclaims and final touched-file list.
+- Evaluation envelope: grep-based vocabulary check plus manual first-scroll review.
+- Feedback routing: unclear public claims become follow-up backlog, not hidden edits.
+- Boundary: no runtime execution, no dashboard, no compliance certification.
+
+## Acceptance criteria
+
+- [ ] README first screen uses a plain headline equivalent to: "Your AI agent's work belongs in your repo, not its chat history."
+- [ ] README explains the concrete record chain in one paragraph: goal, plan, handoff, evidence, approval, and lessons.
+- [ ] Public docs avoid leading with "agent OS," "control plane," "compliance-grade," and "operating system" as the category claim.
+- [ ] `docs/AUDITABILITY.md` explains what Open Scaffold can prove structurally and what remains a human/process/compliance responsibility.
+- [ ] `docs/COMPARISON.md` frames Spec Kit/BMAD/Agent OS/LangSmith as adjacent layers, not enemies Open Scaffold must beat head-on.
+- [ ] A grep audit records remaining occurrences of high-risk terms with either removal or explicit rationale.
+
+## Verification steps
+
+1. Run a grep audit for `operating system|control plane|compliance-grade|agentic OS|tamper-proof` across changed public docs.
+2. Manually read the README first 80 lines and verify a cold reader can answer: what it is, who it is for, and what artifact it creates.
+3. Run `npm test -- --run` if docs tests exist for links or generated content.
+4. Run `./verify.sh --strict` and confirm no plan/evidence drift is introduced.
+
+## Open questions
+
+- Should mission wording change in the same PR, or should the mission keep internal ambition while README/docs carry the external category line?
+- Which exact public category phrase should become canonical for six months: "repo-native work record," "AI work ledger," or "flight recorder for AI-coded work"?

--- a/.osc/plans/backlog/109-bare-attempt-compare.md
+++ b/.osc/plans/backlog/109-bare-attempt-compare.md
@@ -1,0 +1,59 @@
+# Plan: 109-bare-attempt-compare
+
+## Status
+
+backlog
+
+## Context
+
+`osc evolve compare` already produces the most differentiated artifact in the product: a side-by-side record of attempts, evidence, and acceptance-criteria movement. The problem is reachability. A cold user must learn plans, runs, evaluation envelopes, and evolution loops before seeing the payoff.
+
+## Goal
+
+Ship a prerequisite-free `osc compare ATTEMPT_A ATTEMPT_B` command that turns simple agent-attempt folders into a PR-pasteable attempt-diff table.
+
+## Constraints / Out of scope
+
+- Reuse existing evolution comparison rendering where practical; do not create a second visual language.
+- No automatic scoring, model judging, frontier promotion, or claims that a score is objective.
+- No runtime spawning. The command reads local files only.
+- No dependency on `.osc/runs/`, a plan file, or an evaluation envelope for the bare path.
+- Full `osc evolve` stays intact for structured loops.
+
+## Files to touch
+
+- `src/evolution.ts` or a new `src/compare.ts` — shared attempt-diff parsing and rendering.
+- `src/cli.ts` — add `osc compare ATTEMPT_A ATTEMPT_B [--json] [--output OUTPUT_PATH]`.
+- `tests/evolution.test.ts` or `tests/compare.test.ts` — fixture coverage for bare attempt folders.
+- `docs/EVOLUTION_LOOP.md` — document when to use bare compare versus full evolution loop.
+- `examples/attempt-compare/` — small fixture with two attempts and expected output.
+
+## Implementation Architecture Coverage
+
+- Strengthens: evaluation, recovery, adoption magic moment, and evidence portability.
+- Audit envelope: input folders, rendered comparison output, and fixture expected-output snapshots.
+- Evaluation envelope: deterministic tests for parsing, missing optional files, JSON output, and markdown table output.
+- Feedback routing: malformed input should return actionable local errors, not partial output.
+- Boundary: no automatic quality judgment, no model benchmark, no hidden runtime launch.
+
+## Acceptance criteria
+
+- [ ] `osc compare attempt-a attempt-b` reads local attempt folders containing `diff.patch`, `transcript.md`, `rationale.txt`, and optional `ac-status.json`.
+- [ ] The markdown output includes a concise summary, input paths, rationale comparison, changed-file or diff summary, and acceptance-criteria deltas when `ac-status.json` is present.
+- [ ] `--json` emits machine-readable comparison data with stable keys and without embedding full transcripts by default.
+- [ ] Missing optional files produce warnings; missing both meaningful diff and rationale fails with a clear error.
+- [ ] Scores, if present, are labeled as user-provided judgment rather than automatic benchmark results.
+- [ ] Existing `osc evolve compare` tests still pass and use the shared renderer where practical.
+
+## Verification steps
+
+1. Run `npm test -- --run tests/compare.test.ts tests/evolution.test.ts`.
+2. Run `npm run build`.
+3. Run `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` and inspect the markdown table.
+4. Run the same command with `--json` and parse the output with `node -e 'JSON.parse(require("fs").readFileSync(0,"utf8"))'`.
+5. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Should the command accept more than two attempts in v1, or should multi-attempt comparison stay in `osc evolve compare` until the two-folder path is proven?
+- Should the optional AC file be named `ac-status.json`, `acceptance.json`, or reuse the existing evaluation-envelope schema when present?

--- a/.osc/plans/backlog/110-attempt-diff-demo-readme.md
+++ b/.osc/plans/backlog/110-attempt-diff-demo-readme.md
@@ -1,0 +1,58 @@
+# Plan: 110-attempt-diff-demo-readme
+
+## Status
+
+backlog
+
+## Context
+
+Open Scaffold needs a visible magic moment before serious promotion. The strategy review converged on a short demo showing multiple AI attempts becoming a durable comparison artifact in the repo. The demo should make the product useful before the viewer learns the full methodology vocabulary.
+
+## Goal
+
+Publish a short README-linked demo asset that shows the attempt-diff workflow from local attempt folders to a PR-ready work-record table.
+
+## Constraints / Out of scope
+
+- Depends on a usable attempt-diff path, either `osc compare` from plan 109 or a documented equivalent from `osc evolve compare`.
+- Do not launch HN, Reddit, or broad promotion in this slice.
+- Do not create a hosted dashboard or live demo service.
+- Keep the asset public-safe, low-copy, and focused on the artifact rather than the maintainer.
+- Avoid private chat, orchestration, or workspace references.
+
+## Files to touch
+
+- `README.md` — embed or link the demo asset above the fold.
+- `docs/assets/` or `docs/media/` — committed GIF/MP4/cast asset and source notes if small enough.
+- `docs/DEMO.md` — reproducible script for regenerating the demo.
+- `examples/attempt-compare/` — demo fixture if not already added by plan 109.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adoption, public comprehension, and credibility transfer.
+- Audit envelope: committed demo script, media source path, generated asset checksum or size, and README link.
+- Evaluation envelope: cold-reader checklist plus local link/media existence checks.
+- Feedback routing: taste or visual-quality disagreement becomes an owner gate before final README placement.
+- Boundary: no product behavior beyond the demo fixture unless plan 109 is in scope.
+
+## Acceptance criteria
+
+- [ ] README first screen contains a visible demo link or embedded asset showing the work-record payoff.
+- [ ] The demo is 30-90 seconds and has a five-beat structure: problem, two or three attempts, compare command, rendered table, PR/evidence use.
+- [ ] The demo does not imply automatic model scoring, hidden spawning, or compliance certification.
+- [ ] `docs/DEMO.md` documents the exact commands and fixture files needed to regenerate the asset.
+- [ ] All README media links resolve locally in the repository.
+- [ ] The demo uses current CLI commands and package naming.
+
+## Verification steps
+
+1. Run the documented demo commands from `docs/DEMO.md` in a clean temp directory.
+2. Verify the README media paths exist and are tracked.
+3. Run a link/path check for changed docs if available, otherwise inspect all changed markdown links manually.
+4. Run `npm test -- --run` if the demo fixture touches test-covered examples.
+5. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Should the demo be a terminal-only asciinema/GIF, an HTML-rendered clip, or a short narrated video?
+- Should the first public demo compare Claude Code/Codex outputs, or use generic attempt folders to avoid runtime endorsement before the second-adapter proof?

--- a/.osc/plans/backlog/111-anatomy-of-a-slice-public-proof.md
+++ b/.osc/plans/backlog/111-anatomy-of-a-slice-public-proof.md
@@ -1,0 +1,56 @@
+# Plan: 111-anatomy-of-a-slice-public-proof
+
+## Status
+
+backlog
+
+## Context
+
+The project has strong dogfood evidence, but a first-time visitor cannot easily reconstruct one real slice from roadmap to release. A public anatomy page would turn the existing chain into credibility without relying on broad claims about auditability or methodology.
+
+## Goal
+
+Publish one public-safe walkthrough of a real Open Scaffold slice that links the plan, amendment or run packet, evidence note, PR, release note, and package/release outcome.
+
+## Constraints / Out of scope
+
+- Documentation only unless missing links require tiny evidence corrections.
+- Use owner-neutral wording and public repository facts only.
+- Do not expose private research, private chat surfaces, raw agent logs, or unpublished credentials.
+- Do not claim the example proves all future work is correct; it demonstrates reconstructability.
+- Prefer one excellent slice over a catalog of many examples.
+
+## Files to touch
+
+- `docs/anatomy-of-a-slice.md` — new walkthrough page.
+- `README.md` or `docs/index.html` — one link to the walkthrough.
+- Existing `.osc/releases/*.md` — only if a public path reference is stale and must be corrected.
+
+## Implementation Architecture Coverage
+
+- Strengthens: audit trails, recovery, adoption trust, and human review.
+- Audit envelope: chosen slice ID, PR URL, plan path, evidence path, release note, package/release facts.
+- Evaluation envelope: every link in the walkthrough must resolve and map to the same slice.
+- Feedback routing: if the chosen slice has gaps, record those as follow-up backlog rather than silently editing history.
+- Boundary: no raw transcripts, no private evidence, no compliance certification.
+
+## Acceptance criteria
+
+- [ ] The page walks one slice end-to-end: why it existed, where the plan lived, what was executed, what evidence was captured, what PR changed, and what release/public surface changed.
+- [ ] All internal links resolve to tracked repository files or public GitHub URLs.
+- [ ] The page includes a small diagram or ordered chain showing `roadmap -> plan -> run/evidence -> PR -> release`.
+- [ ] The page explicitly says the chain demonstrates reconstructability, not automatic correctness.
+- [ ] README or docs index links the page from a credibility/proof section.
+- [ ] The chosen example is current enough that CLI/package names match npm latest at the time of the PR.
+
+## Verification steps
+
+1. Manually click or grep-check every local link in `docs/anatomy-of-a-slice.md`.
+2. Verify the public PR URL and release/tag URL exist with `gh pr view` and `gh release view` where applicable.
+3. Run a forbidden-content scan for private workspace markers, private chat-surface names, and raw agent-log paths in the new page.
+4. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Which shipped slice should be the canonical example: work dry-run preview, evolution compare visibility, or v1.0.0 launch?
+- Should this page be purely docs, or should the README include a small static screenshot from the walkthrough?

--- a/.osc/plans/backlog/112-second-reference-adapter-proof.md
+++ b/.osc/plans/backlog/112-second-reference-adapter-proof.md
@@ -1,0 +1,59 @@
+# Plan: 112-second-reference-adapter-proof
+
+## Status
+
+backlog
+
+## Context
+
+Runtime-neutrality is credible in architecture but still thin in public proof because the serious adapter path is effectively the OMX/Codex lane. The strategy review found that a registry or broad runtime claim should wait until a second reference adapter proves the handoff contract is not single-runtime theater.
+
+## Goal
+
+Ship a second no-spawn reference adapter proof that can consume an Open Scaffold run packet and produce a valid dispatch receipt and evidence note without core owning runtime execution.
+
+## Constraints / Out of scope
+
+- No hidden spawning in Open Scaffold core.
+- No claim of full production support for the selected runtime.
+- No registry or marketplace behavior in this slice.
+- No secrets, hosted service, or remote execution requirement.
+- Adapter choice must be justified before implementation; likely candidates are Claude Code, Aider, or a plain local-agent adapter.
+
+## Files to touch
+
+- `packages/runtime-ADAPTER/` — new package or fixture for the selected second adapter.
+- `src/runtimes.ts` — add a profile only if the adapter has real handoff evidence.
+- `docs/RUNTIME_BINDING_CONTRACT.md` — document second-adapter conformance expectations.
+- `docs/RUNTIME_PROFILES.md` — explain the new reference adapter boundary.
+- `tests/` or `packages/runtime-ADAPTER/tests/` — conformance and no-spawn receipt tests.
+
+## Implementation Architecture Coverage
+
+- Strengthens: runtime boundaries, adapter conformance, evidence, and ecosystem credibility.
+- Audit envelope: run-packet fixture, adapter invocation transcript or dry-run, dispatch receipt, evidence note, and conformance test output.
+- Evaluation envelope: schema validation, no-spawn assertions, private-path guards, and receipt identity checks.
+- Feedback routing: adapter gaps become registry blockers or conformance follow-ups.
+- Boundary: no marketplace, no automatic install, no certification, no core runtime launch.
+
+## Acceptance criteria
+
+- [ ] The PR selects exactly one second adapter candidate and documents why it is the right proof target.
+- [ ] The adapter consumes a local `run.json` fixture and writes `dispatch-receipt.json` with the existing dispatch receipt schema.
+- [ ] The adapter writes or documents a corresponding evidence note path without storing raw private transcripts by default.
+- [ ] Tests prove the adapter does not spawn from Open Scaffold core and does not write outside the intended run directory.
+- [ ] Runtime docs explicitly state support level, setup requirements, and non-certification boundary.
+- [ ] Plan 070's registry dependency is satisfied or clearly moved closer by the shipped proof.
+
+## Verification steps
+
+1. Run the adapter package tests and schema validation tests for dispatch receipts.
+2. Run a local fixture invocation against a temp `.osc/runs/RUN_ID/run.json`.
+3. Inspect generated receipt/evidence for correct run ID, plan slug, adapter ID, and paths.
+4. Run `npm run build` and `npm test -- --run`.
+5. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Which adapter is the best second proof after the Codex/OMX lane: Claude Code, Aider, Cursor/manual export, or a plain local-agent adapter?
+- Should the second adapter be a package, a documented fixture, or a conformance harness first?

--- a/.osc/plans/backlog/113-public-spec-conformance-pack.md
+++ b/.osc/plans/backlog/113-public-spec-conformance-pack.md
@@ -1,0 +1,58 @@
+# Plan: 113-public-spec-conformance-pack
+
+## Status
+
+backlog
+
+## Context
+
+The strategy review found that Open Scaffold's strongest long-term defensibility is becoming a citable protocol for AI-coded work records. That requires stable public schemas and conformance checks, not just prose conventions and an implementation CLI.
+
+## Goal
+
+Publish versioned public schemas and a conformance test pack that lets other tools validate whether their work-record artifacts are Open Scaffold-compatible.
+
+## Constraints / Out of scope
+
+- No hosted registry, telemetry service, or certification authority.
+- No new schema family unless it reflects already-shipped artifacts.
+- Conformance means structural compatibility, not security approval, legal compliance, or quality judgment.
+- Do not break existing v1 artifacts without a documented migration path.
+
+## Files to touch
+
+- `spec/` — versioned JSON Schemas for plan metadata, run packet, dispatch receipt, evidence note metadata, amendment metadata, audit envelope, and usage if available.
+- `packages/conformance/` or `@open-scaffold/conformance` package path — validation harness and fixtures.
+- `docs/STANDARD.md` — plain-language protocol overview and compatibility levels.
+- `docs/RUNTIME_BINDING_CONTRACT.md` — link adapter-facing conformance requirements.
+- `tests/` — schema fixture tests for valid and invalid artifacts.
+
+## Implementation Architecture Coverage
+
+- Strengthens: interoperability, audit trails, runtime boundaries, and external adoption.
+- Audit envelope: schema list, fixture corpus, conformance command output, and compatibility notes.
+- Evaluation envelope: tests must cover valid fixtures, invalid fixtures, missing required keys, and version mismatch handling.
+- Feedback routing: non-conforming existing artifacts become migration follow-ups, not silent schema weakening.
+- Boundary: no certification badge beyond local structural pass/fail.
+
+## Acceptance criteria
+
+- [ ] `spec/` contains versioned schemas for the currently stable public artifact types selected by the slice.
+- [ ] A conformance command or package validates a fixture directory and reports pass/fail per artifact type.
+- [ ] Valid fixtures are drawn from current repository artifacts where possible and sanitized if needed.
+- [ ] Invalid fixtures cover missing required fields, bad schema version, path traversal, and mismatched run/plan identity.
+- [ ] `docs/STANDARD.md` explains compatibility levels and explicitly says conformance is not compliance certification.
+- [ ] Existing build/test/strict verification passes without weakening current artifact validation.
+
+## Verification steps
+
+1. Run the conformance harness against valid fixtures and verify all pass.
+2. Run the conformance harness against invalid fixtures and verify expected failures.
+3. Run `npm run build`.
+4. Run `npm test -- --run`.
+5. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Should the conformance package be published to npm immediately or remain in-repo until at least one external adapter attempts to use it?
+- Which artifact types are stable enough for `spec/v1` versus still internal implementation detail?

--- a/.osc/plans/backlog/114-work-usage-ledger-v1.md
+++ b/.osc/plans/backlog/114-work-usage-ledger-v1.md
@@ -1,0 +1,59 @@
+# Plan: 114-work-usage-ledger-v1
+
+## Status
+
+backlog
+
+## Context
+
+Open Scaffold records plans, runs, evidence, releases, and attempt comparisons, but it does not record what a work unit cost to produce. The strategy review found that Open Scaffold should not compete with LangSmith-style span tracing; its distinct lane is cost and usage joined to plan/run/PR/frontier artifacts.
+
+## Goal
+
+Add an optional `open-scaffold.usage.v1` per-run usage record and `osc ledger` roll-up that reports usage by work unit without storing prompts or tool-call traces.
+
+## Constraints / Out of scope
+
+- No hosted dashboard, live monitoring, per-token trace viewer, or per-tool-call span capture.
+- Usage fields are nullable and source-labeled; do not fake exact costs when the adapter cannot provide them.
+- Do not store prompt bodies, secrets, environment variables, or raw transcripts in `usage.json`.
+- No automatic pricing tables in core unless explicitly versioned and optional.
+- Ledger is per repository, like `git log`, not global analytics.
+
+## Files to touch
+
+- `docs/USAGE_LEDGER.md` — schema, source enum, nullability, privacy, and examples.
+- `src/usage.ts` — usage schema validation and read helpers.
+- `src/cli.ts` — add `osc ledger [--json] [--plan PLAN_SLUG] [--since DATE]`.
+- `packages/runtime-omx/` — write a reference `usage.json` with nulls where exact numbers are unknown.
+- `tests/usage.test.ts` — schema and ledger aggregation tests.
+
+## Implementation Architecture Coverage
+
+- Strengthens: token/cost accountability, audit trails, and work-unit reporting.
+- Audit envelope: run IDs, plan slugs, usage source, ledger output, and adapter write evidence.
+- Evaluation envelope: schema validation, aggregation tests, privacy scan for forbidden prompt/body fields.
+- Feedback routing: unknown provider usage becomes `source: "unknown"`, not a blocker.
+- Boundary: no observability SaaS, no pricing authority, no productivity benchmark claims.
+
+## Acceptance criteria
+
+- [ ] `docs/USAGE_LEDGER.md` defines `open-scaffold.usage.v1` with required `schemaVersion`, `runId`, `adapter`, and `source` fields plus nullable token, wall-clock, and estimated-cost fields.
+- [ ] `osc ledger` joins `.osc/runs/*/usage.json` to `run.json` plan slugs and plan folder status.
+- [ ] Markdown output includes plan slug, run ID, adapter, source, token fields, estimated USD, and status.
+- [ ] `--json` outputs stable machine-readable ledger rows.
+- [ ] Runtime OMX writes a minimal valid `usage.json` or explicitly documents why a source is `unknown`.
+- [ ] Tests prove prompt bodies and raw transcripts are not required or duplicated in usage records.
+
+## Verification steps
+
+1. Run `npm test -- --run tests/usage.test.ts`.
+2. Run a fixture `osc ledger --json` and parse the output as JSON.
+3. Inspect generated `usage.json` fixtures for absence of prompt/transcript/secret fields.
+4. Run `npm run build`.
+5. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Should `usage.json` be tracked by default, ignored by default, or left to project policy?
+- Which adapters can provide real token/cost data without brittle log scraping?

--- a/.osc/plans/backlog/115-downstream-example-proof.md
+++ b/.osc/plans/backlog/115-downstream-example-proof.md
@@ -1,0 +1,57 @@
+# Plan: 115-downstream-example-proof
+
+## Status
+
+backlog
+
+## Context
+
+The project is heavily dogfooded, but a skeptical adopter may dismiss the proof as self-referential. The strategy review found that one external or downstream example with a real merged change would reduce the "only the maintainer uses it" objection more than more internal documentation.
+
+## Goal
+
+Create and document a small downstream example that uses Open Scaffold to plan, execute, verify, and close one real code change outside the Open Scaffold repository itself.
+
+## Constraints / Out of scope
+
+- Do not use private work, client code, or internal operating-workshop material.
+- Keep the example small enough that a reader can inspect it in minutes.
+- Do not fake adoption; label owner-created examples honestly.
+- Do not require external credentials or paid services.
+- Do not expand Open Scaffold product code unless the example reveals a blocker that must be fixed first.
+
+## Files to touch
+
+- `docs/examples/downstream-proof.md` — walkthrough and link to the example repository or fixture.
+- `examples/downstream-proof/` — optional in-repo minimal fixture if a separate public repo is not used.
+- `README.md` — one link from proof/adoption section.
+- `.osc/plans/backlog/` — follow-up plan only if the example exposes product gaps.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adoption trust, recovery, and user-facing examples.
+- Audit envelope: example repo URL or fixture path, plan slug, evidence path, PR/commit link, verification output.
+- Evaluation envelope: reader can clone/run/inspect the example without private context.
+- Feedback routing: example friction becomes concrete backlog, not hidden maintainer knowledge.
+- Boundary: no fake third-party endorsement, no private data, no broad marketing launch.
+
+## Acceptance criteria
+
+- [ ] A downstream example exists either as a small public repository or a tracked fixture with a clear provenance note.
+- [ ] The example includes a mission, one plan, one evidence note, and a clear before/after code change.
+- [ ] The walkthrough shows the exact commands used and the resulting Open Scaffold artifacts.
+- [ ] README links the example as proof of use outside the core repository.
+- [ ] The example states whether it is owner-created, collaborator-created, or third-party.
+- [ ] Any friction found during the example is either fixed in-scope or recorded as follow-up backlog.
+
+## Verification steps
+
+1. Clone or copy the example into a temp directory and run its documented verification command.
+2. Verify all walkthrough links resolve.
+3. Run a private-marker scan on the example docs and files.
+4. Run `./verify.sh --strict` in the Open Scaffold repo.
+
+## Open questions
+
+- Should the canonical example be a tiny TypeScript API, Python CLI, or documentation-only repo?
+- Should the example live inside `graphanov/open-scaffold` as a fixture or as a separate public demo repository?

--- a/.osc/plans/backlog/116-launch-readiness-distribution-pack.md
+++ b/.osc/plans/backlog/116-launch-readiness-distribution-pack.md
@@ -1,0 +1,56 @@
+# Plan: 116-launch-readiness-distribution-pack
+
+## Status
+
+backlog
+
+## Context
+
+The strategy review warned that broad promotion before the magic moment exists would waste the project's first public launch opportunity. After positioning, attempt-diff demo, evidence-chain verification, and downstream proof are ready, the project needs a launch checklist that binds star tactics to real adoption surfaces.
+
+## Goal
+
+Prepare a public launch-readiness pack with the checklist, post templates, awesome-list targets, and proof links required before any broad HN/Reddit/social launch.
+
+## Constraints / Out of scope
+
+- Planning and documentation only; do not post to HN, Reddit, X, LinkedIn, or awesome lists in this slice.
+- Do not include private outreach lists or private conversations in the repo.
+- Do not inflate traction numbers or promise adoption targets as facts.
+- Do not launch before README demo, npm/latest, downstream proof, and public docs are aligned.
+
+## Files to touch
+
+- `docs/LAUNCH_CHECKLIST.md` — launch prerequisites, timing, proof links, and rollback criteria.
+- `docs/LAUNCH_POSTS.md` — public-safe draft copy for Show HN, Reddit, and short social posts.
+- `docs/ADOPTION.md` — optional install/use path tying launch attention to a first successful command.
+- `README.md` — one restrained link to adoption/launch proof if appropriate.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adoption readiness, public accuracy, and release discipline.
+- Audit envelope: launch gates, required proof links, package version checks, and no-go criteria.
+- Evaluation envelope: checklist must be verifiable from public repo/npm/GitHub surfaces.
+- Feedback routing: missing prerequisites block launch rather than being hand-waved in posts.
+- Boundary: no live posting, no marketing automation, no fake testimonials.
+
+## Acceptance criteria
+
+- [ ] Launch checklist has explicit gates for README hero/demo, fresh `npx open-scaffold@latest`, GitHub Latest Release, downstream proof, and at least one sharp comparison paragraph.
+- [ ] Draft posts use the work-record/attempt-diff framing and avoid "agent OS" or compliance-grade claims.
+- [ ] Awesome-list target section names relevant lists and the concrete artifact each submission will point to.
+- [ ] Checklist includes no-go conditions such as stale npm, broken demo, unresolved PR, or missing downstream proof.
+- [ ] All public copy is owner-neutral and does not mention private internal tooling.
+- [ ] The docs make clear that actual posting/submission is a separate owner gate.
+
+## Verification steps
+
+1. Run `npx --yes open-scaffold@latest --help` and record whether public package truth is launch-ready.
+2. Verify every proof link named in the checklist resolves.
+3. Grep changed launch docs for prohibited overclaim terms.
+4. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Which launch venue should be first after prerequisites pass: Show HN, GitHub/awesome-list submissions, Reddit, or a founder-authored essay?
+- Should launch drafts live in the repo or in a separate public website/content repository?

--- a/.osc/plans/backlog/117-osc-trace-work-record-replay.md
+++ b/.osc/plans/backlog/117-osc-trace-work-record-replay.md
@@ -1,0 +1,59 @@
+# Plan: 117-osc-trace-work-record-replay
+
+## Status
+
+backlog
+
+## Context
+
+Traceability is one of Open Scaffold's strongest stories, but today a reader must manually jump through plans, runs, dispatch receipts, evidence notes, releases, and PR links. The strategy review identified the missing product surface as one read-only command that reconstructs the chain for a plan.
+
+## Goal
+
+Ship `osc trace PLAN_SLUG` as a read-only chain replay command that prints the work record for one plan from plan file through runs, evidence, release notes, and public references.
+
+## Constraints / Out of scope
+
+- Read-only local filesystem command by default.
+- Does not judge correctness or evidence quality; it reconstructs and labels known links.
+- Does not require GitHub API or network access, though it may print recognized external references.
+- Does not replace `osc verify --evidence-chain`; trace explains the chain, verify checks structural integrity.
+- No dashboard or hosted trace viewer.
+
+## Files to touch
+
+- `src/trace.ts` — chain discovery and rendering.
+- `src/cli.ts` — add `osc trace PLAN_SLUG [--json] [--include-unverified]`.
+- `tests/trace.test.ts` — fixtures for full chain, partial chain, missing evidence, and external refs.
+- `docs/TRACE.md` — user guide and relationship to evidence-chain verification.
+- `docs/SLICE_CLOSE_PROTOCOL.md` — link trace command as the reconstruction path.
+
+## Implementation Architecture Coverage
+
+- Strengthens: recovery, audit trails, onboarding, and reviewability.
+- Audit envelope: plan slug, found file paths, run IDs, evidence paths, release notes, PR refs, and warnings.
+- Evaluation envelope: deterministic fixtures for complete and incomplete chains.
+- Feedback routing: missing links become warnings and can feed evidence-chain verifier follow-ups.
+- Boundary: no correctness judgment, no network verification, no compliance certification.
+
+## Acceptance criteria
+
+- [ ] `osc trace PLAN_SLUG` finds a plan in active/backlog/blocked/done and prints its status, goal, acceptance criteria summary, and file path.
+- [ ] The command lists local run packets that reference the plan slug and local evidence notes that cite the plan.
+- [ ] The command lists release notes and PR/issue references when they can be found in local files.
+- [ ] Output clearly labels each link as local, external, missing, or unverified.
+- [ ] `--json` emits stable machine-readable chain data.
+- [ ] Docs explain how `osc trace` differs from `osc verify --evidence-chain`.
+
+## Verification steps
+
+1. Run `npm test -- --run tests/trace.test.ts`.
+2. Run `npm run build`.
+3. Run `node dist/cli.js trace 107-work-dry-run-package-sync` or another done plan with known evidence.
+4. Run the same command with `--json` and parse it as JSON.
+5. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Should `osc trace` be included inside `osc verify --evidence-chain` output as a detail mode, or remain a separate read-only discovery command?
+- Should external references be optionally verified via GitHub API in a later network-enabled mode?

--- a/.osc/plans/backlog/118-audit-signing-external-anchoring.md
+++ b/.osc/plans/backlog/118-audit-signing-external-anchoring.md
@@ -1,0 +1,59 @@
+# Plan: 118-audit-signing-external-anchoring
+
+## Status
+
+backlog
+
+## Context
+
+Open Scaffold's records are git-native and reviewable, but git history alone is not the same as external anchoring or cryptographic attestation. The strategy review warned against tamper-proof or compliance-grade claims until a signing story exists.
+
+## Goal
+
+Investigate and, if still justified, ship a minimal `osc audit sign` path that signs selected work-record artifacts or digests without turning Open Scaffold into a compliance platform.
+
+## Constraints / Out of scope
+
+- Start with an explicit design decision before implementation.
+- Do not claim legal-grade evidence, SOC 2, ISO, GDPR, HIPAA, or regulator-ready status.
+- Do not require a hosted Open Scaffold service.
+- Do not sign raw private transcripts, secrets, or uncurated logs.
+- Prefer existing signing mechanisms such as git signing or sigstore before inventing new cryptography.
+
+## Files to touch
+
+- `docs/decisions/` — ADR for signing mechanism and threat model.
+- `docs/AUDITABILITY.md` — update boundaries once signing exists or is rejected.
+- `src/audit-sign.ts` — implementation only if the ADR selects an implementation path.
+- `src/cli.ts` — add `osc audit sign` only after the design decision is approved.
+- `tests/audit-sign.test.ts` — digest/signature fixture tests if implemented.
+
+## Implementation Architecture Coverage
+
+- Strengthens: audit trails and tamper-evidence boundary clarity.
+- Audit envelope: selected artifacts, digest manifest, signing identity metadata, verification command output.
+- Evaluation envelope: tests for deterministic digests, path containment, missing files, and invalid signatures.
+- Feedback routing: if signing proves too heavy or misleading, close with an ADR that defers implementation and updates wording.
+- Boundary: no compliance certification, no hosted notarization, no private-log signing by default.
+
+## Acceptance criteria
+
+- [ ] An ADR compares at least git commit signing, sigstore, and local digest-only manifests for Open Scaffold's artifact model.
+- [ ] The ADR defines what threat is addressed and what remains unaddressed.
+- [ ] If implemented, `osc audit sign` signs or records digests for selected plan/run/evidence/release artifacts with deterministic output.
+- [ ] If implemented, `osc audit verify-signature` or equivalent verifies the signature/digest locally.
+- [ ] Docs state the signing boundary in plain language and remove or avoid stronger claims than the mechanism supports.
+- [ ] Tests cover path traversal, missing artifacts, changed artifact digest mismatch, and unsupported signing configuration.
+
+## Verification steps
+
+1. Review the ADR and confirm it names the selected mechanism and rejected alternatives.
+2. If code is implemented, run `npm test -- --run tests/audit-sign.test.ts`.
+3. Run `npm run build`.
+4. Run a local sign/verify fixture in a temp scaffold.
+5. Run `./verify.sh --strict`.
+
+## Open questions
+
+- Is external signing necessary before Open Scaffold has broader adoption, or is clear wording plus git history enough for the next launch window?
+- Should signing be core CLI behavior, an optional adapter package, or documentation around existing git/sigstore workflows?

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,8 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-27: prioritize evidence-chain verifier as the trust-story command from adoption strategy audit — see .osc/plans/backlog/071-evidence-chain-verifier-amendment-1.md
+- 2026-05-27: defer runtime adapter registry until second adapter and conformance proof exist — see .osc/plans/backlog/070-runtime-adapter-registry-amendment-1.md
 - 2026-05-27: closed 107-work-dry-run-package-sync — published 1.0.4 and aligned work dry-run public surfaces
 - 2026-05-26: closed 104-osc-work-dry-run-target — Closed 104 osc work dry-run target.
 - 2026-05-26: closed 106-dispatch-adapter-glue-package-sync — Closed 106 dispatch adapter glue package sync after v1.0.3 npm and GitHub Release verification.


### PR DESCRIPTION
## Summary
- Records the post-v1 adoption strategy investigation as public backlog plans.
- Adds 11 new backlog items for positioning, bare attempt-diff, demo proof, slice anatomy, second adapter proof, spec/conformance, usage ledger, downstream proof, launch readiness, trace replay, and audit signing.
- Adds amendments to the existing runtime registry and evidence-chain verifier plans so sequencing matches the strategy findings.

## Backlog captured
- 108 public work-record positioning
- 109 bare `osc compare` attempt diff
- 110 attempt-diff README/demo asset
- 111 anatomy-of-a-slice public proof
- 112 second reference adapter proof
- 113 public spec/conformance pack
- 114 work usage ledger v1
- 115 downstream example proof
- 116 launch-readiness distribution pack
- 117 `osc trace` work-record replay
- 118 audit signing / external anchoring
- amendment to 070: registry waits for second adapter + conformance proof
- amendment to 071: evidence-chain verifier becomes the trust-story command

## Verification
- Structural heading validation for 108-118: PASS
- Placeholder/private-marker scan on new files: PASS
- `git diff --check`: PASS
- `./verify.sh --strict`: 10 pass, 0 fail, 0 warn
- `npm test -- --run`: 43 files passed, 379 tests passed
- `npm run build`: PASS

## Risk / gates
- Planning-only PR: no runtime behavior, package version, npm publish, release creation, or production automation change.
- Merge remains owner-gated.
- This prepares the backlog for a later autonomous PR release train; it does not start that train.