### PR TITLE
Add bare attempt compare command

### DIFF
--- a/.osc/plans/done/109-bare-attempt-compare.md
+++ b/.osc/plans/done/109-bare-attempt-compare.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 
@@ -38,12 +39,12 @@ Ship a prerequisite-free `osc compare ATTEMPT_A ATTEMPT_B` command that turns si
 
 ## Acceptance criteria
 
-- [ ] `osc compare attempt-a attempt-b` reads local attempt folders containing `diff.patch`, `transcript.md`, `rationale.txt`, and optional `ac-status.json`.
-- [ ] The markdown output includes a concise summary, input paths, rationale comparison, changed-file or diff summary, and acceptance-criteria deltas when `ac-status.json` is present.
-- [ ] `--json` emits machine-readable comparison data with stable keys and without embedding full transcripts by default.
-- [ ] Missing optional files produce warnings; missing both meaningful diff and rationale fails with a clear error.
-- [ ] Scores, if present, are labeled as user-provided judgment rather than automatic benchmark results.
-- [ ] Existing `osc evolve compare` tests still pass and use the shared renderer where practical.
+- [x] `osc compare attempt-a attempt-b` reads local attempt folders containing `diff.patch`, `transcript.md`, `rationale.txt`, and optional `ac-status.json`.
+- [x] The markdown output includes a concise summary, input paths, rationale comparison, changed-file or diff summary, and acceptance-criteria deltas when `ac-status.json` is present.
+- [x] `--json` emits machine-readable comparison data with stable keys and without embedding full transcripts by default.
+- [x] Missing optional files produce warnings; missing both meaningful diff and rationale fails with a clear error.
+- [x] Scores, if present, are labeled as user-provided judgment rather than automatic benchmark results.
+- [x] Existing `osc evolve compare` tests still pass and use the shared renderer where practical.
 
 ## Verification steps
 

--- a/.osc/releases/2026-05-27-109-bare-attempt-compare.md
+++ b/.osc/releases/2026-05-27-109-bare-attempt-compare.md
@@ -1,0 +1,36 @@
+# Release / Evidence Note: 109-bare-attempt-compare
+
+## Summary
+
+Added a prerequisite-free `osc compare <attempt-a-dir> <attempt-b-dir>` command that turns two simple local attempt folders into a PR-pasteable work-record comparison. The command is intentionally local-file-only: it does not spawn runtimes, score models, promote a frontier, or approve work.
+
+## Traceability
+
+- Roadmap / issue / task: next release-train slice after plan 108, focused on the adoption "magic moment" for comparing repeated agent attempts.
+- Plan: .osc/plans/done/109-bare-attempt-compare.md
+- Run ID / run packet: N/A — direct CLI implementation and local fixture; no runtime execution.
+- Branch / PR: `cli/bare-attempt-compare`; https://github.com/graphanov/open-scaffold/pull/134
+
+## Verification
+
+- RED check: `npm test -- tests/compare.test.ts --run` — failed before implementation with `Unknown command: compare`.
+- Focused GREEN check: `npm test -- tests/compare.test.ts --run` — 1 file passed, 5 tests passed.
+- Related evolution regression: `npm test -- tests/compare.test.ts tests/evolution.test.ts --run` — 2 files passed, 27 tests passed.
+- Full suite: `npm test -- --run` — 45 files passed, 393 tests passed.
+- Build: `npm run build` — PASS.
+- Markdown fixture smoke: `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` — output matches `examples/attempt-compare/expected.md`.
+- JSON smoke: `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b --json` — parses as `open-scaffold.attempt-comparison.v1`, reports `docs/onboarding.md`, and keeps transcript bodies out of JSON.
+- Plan validation: `node dist/cli.js plan validate .osc/plans/done/109-bare-attempt-compare.md` — 0 issues found.
+- Scaffold verifier: `./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
+- Whitespace: `git diff --check` — PASS.
+- Static scan: added-line scan found 0 hardcoded secrets, 0 shell injection, 0 dangerous eval/exec, and 0 private key/token markers.
+- Independent review: pre-commit reviewer passed the diff with no security concerns and no logic errors; one markdown-escaping suggestion was applied before final verification.
+
+## Outcome
+
+Open Scaffold now exposes the attempt-comparison payoff without requiring a user to first create a plan, run packet, evaluation envelope, or full evolution loop. The full `osc evolve compare` path remains the durable structured loop for append-only state, frontier rationale, adapter receipts, and evaluation binding.
+
+## Follow-up
+
+- Owner gate remains: merge PR #134 after CI and latest-head Codex review are clean.
+- No package publish or GitHub Release is included in this PR.

--- a/.osc/releases/2026-05-27-109-bare-attempt-compare.md
+++ b/.osc/releases/2026-05-27-109-bare-attempt-compare.md
@@ -28,6 +28,7 @@ Added a prerequisite-free `osc compare <attempt-a-dir> <attempt-b-dir>` command 
 - Codex latest-head review: first pass flagged transcript-body loading for metadata-only output; fixed by stat-only handling for `transcript.md`.
 - Codex latest-head review: second pass flagged timestamped plain `diff -u` headers leaking timestamps into changed-file names; fixed by stripping tab-delimited header metadata and adding a regression test.
 - Codex latest-head review: third pass flagged plain unified deletion diffs losing the deleted path when `+++ /dev/null`; fixed by retaining the previous `---` path and adding a deletion regression test.
+- Codex latest-head review: fourth pass flagged body lines beginning with `++` or `--` being mistaken for file headers; fixed by only skipping real header lines with whitespace after `+++`/`---` and adding a regression test.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-27-109-bare-attempt-compare.md
+++ b/.osc/releases/2026-05-27-109-bare-attempt-compare.md
@@ -25,7 +25,8 @@ Added a prerequisite-free `osc compare <attempt-a-dir> <attempt-b-dir>` command 
 - Whitespace: `git diff --check` — PASS.
 - Static scan: added-line scan found 0 hardcoded secrets, 0 shell injection, 0 dangerous eval/exec, and 0 private key/token markers.
 - Independent review: pre-commit reviewer passed the diff with no security concerns and no logic errors; one markdown-escaping suggestion was applied before final verification.
-- Codex latest-head review: initial PR review flagged transcript-body loading for metadata-only output; fixed by stat-only handling for `transcript.md` before re-triggering review.
+- Codex latest-head review: first pass flagged transcript-body loading for metadata-only output; fixed by stat-only handling for `transcript.md`.
+- Codex latest-head review: second pass flagged timestamped plain `diff -u` headers leaking timestamps into changed-file names; fixed by stripping tab-delimited header metadata and adding a regression test.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-27-109-bare-attempt-compare.md
+++ b/.osc/releases/2026-05-27-109-bare-attempt-compare.md
@@ -25,6 +25,7 @@ Added a prerequisite-free `osc compare <attempt-a-dir> <attempt-b-dir>` command 
 - Whitespace: `git diff --check` — PASS.
 - Static scan: added-line scan found 0 hardcoded secrets, 0 shell injection, 0 dangerous eval/exec, and 0 private key/token markers.
 - Independent review: pre-commit reviewer passed the diff with no security concerns and no logic errors; one markdown-escaping suggestion was applied before final verification.
+- Codex latest-head review: initial PR review flagged transcript-body loading for metadata-only output; fixed by stat-only handling for `transcript.md` before re-triggering review.
 
 ## Outcome
 

--- a/.osc/releases/2026-05-27-109-bare-attempt-compare.md
+++ b/.osc/releases/2026-05-27-109-bare-attempt-compare.md
@@ -27,6 +27,7 @@ Added a prerequisite-free `osc compare <attempt-a-dir> <attempt-b-dir>` command 
 - Independent review: pre-commit reviewer passed the diff with no security concerns and no logic errors; one markdown-escaping suggestion was applied before final verification.
 - Codex latest-head review: first pass flagged transcript-body loading for metadata-only output; fixed by stat-only handling for `transcript.md`.
 - Codex latest-head review: second pass flagged timestamped plain `diff -u` headers leaking timestamps into changed-file names; fixed by stripping tab-delimited header metadata and adding a regression test.
+- Codex latest-head review: third pass flagged plain unified deletion diffs losing the deleted path when `+++ /dev/null`; fixed by retaining the previous `---` path and adding a deletion regression test.
 
 ## Outcome
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-27: closed 109-bare-attempt-compare — added prerequisite-free bare attempt comparison
 - 2026-05-27: broaden positioning beyond software-only work — see .osc/plans/done/108-public-work-record-positioning-amendment-1.md
 - 2026-05-27: closed 108-public-work-record-positioning — aligned public work-record positioning
 - 2026-05-27: align public category language around repo-native work records — see .osc/plans/done/108-public-work-record-positioning.md

--- a/docs/EVOLUTION_LOOP.md
+++ b/docs/EVOLUTION_LOOP.md
@@ -74,7 +74,27 @@ osc evolve check .osc/evolution/demo-loop
 
 ## See it in one screen
 
-The quickest way to understand the value is the compare walkthrough:
+The quickest low-friction payoff is the bare attempt comparison command. Use it when you have two local attempt folders and want a PR-pasteable work-record artifact without first creating a full evolution loop:
+
+```bash
+osc compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b
+osc compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b --json
+osc compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b --output comparison.md
+```
+
+A bare attempt folder may contain:
+
+```text
+attempt-a/
+  diff.patch       # optional, but at least diff.patch or rationale.txt must be meaningful
+  rationale.txt    # optional, but at least diff.patch or rationale.txt must be meaningful
+  transcript.md    # optional; JSON output records metadata only, not full transcript content
+  ac-status.json   # optional criteria/score metadata supplied by the user/reviewer
+```
+
+`osc compare` reads local files only. It does not spawn a runtime, score attempts automatically, promote a frontier, or approve work. Scores in `ac-status.json` are displayed as user-provided judgment metadata, not benchmark results.
+
+Use the full evolution loop when the project needs durable loop state, append-only attempt history, frontier rationale, run/evaluation binding, or adapter receipts:
 
 ```text
 one task -> attempt A -> attempt B -> osc evolve compare -> frontier rationale
@@ -82,7 +102,9 @@ one task -> attempt A -> attempt B -> osc evolve compare -> frontier rationale
 
 Read [`docs/examples/evolution-loop-compare.md`](examples/evolution-loop-compare.md) for a small public-safe example that shows two attempts, linked evaluation envelopes, a PR-ready markdown comparison, and an acceptance-criteria delta table.
 
-To run the same shape against checked-in files, see [`examples/evolution-ledger-demo/`](../examples/evolution-ledger-demo/). It ships recorded attempts, evaluation envelopes, a promoted frontier, and committed expected `osc evolve compare` output so the proof can be checked mechanically.
+To run the same full-loop shape against checked-in files, see [`examples/evolution-ledger-demo/`](../examples/evolution-ledger-demo/). It ships recorded attempts, evaluation envelopes, a promoted frontier, and committed expected `osc evolve compare` output so the proof can be checked mechanically.
+
+For the prerequisite-free comparison fixture, see [`examples/attempt-compare/`](../examples/attempt-compare/).
 
 ## Concepts
 

--- a/examples/attempt-compare/attempt-a/ac-status.json
+++ b/examples/attempt-compare/attempt-a/ac-status.json
@@ -1,0 +1,16 @@
+{
+  "score": 0.62,
+  "score_label": "human reviewer score",
+  "criteria": [
+    {
+      "id": "AC1",
+      "text": "Names the first file a cold agent should inspect.",
+      "status": "pass"
+    },
+    {
+      "id": "AC2",
+      "text": "Explains which evidence a reviewer should inspect.",
+      "status": "fail"
+    }
+  ]
+}

--- a/examples/attempt-compare/attempt-a/diff.patch
+++ b/examples/attempt-compare/attempt-a/diff.patch
@@ -1,0 +1,9 @@
+diff --git a/docs/onboarding.md b/docs/onboarding.md
+--- a/docs/onboarding.md
++++ b/docs/onboarding.md
+@@ -1,3 +1,4 @@
+ # Onboarding
+-Read the README first.
++Read the README first, then inspect the active plan.
++If no active plan exists, check the backlog.
+ Run the tests before opening a PR.

--- a/examples/attempt-compare/attempt-a/rationale.txt
+++ b/examples/attempt-compare/attempt-a/rationale.txt
@@ -1,0 +1,1 @@
+Attempt A improved the onboarding note, but it still reads like a checklist and does not explain what evidence a reviewer should inspect.

--- a/examples/attempt-compare/attempt-a/transcript.md
+++ b/examples/attempt-compare/attempt-a/transcript.md
@@ -1,0 +1,3 @@
+# Attempt A transcript excerpt
+
+The agent focused on making the onboarding page slightly more concrete. This fixture is intentionally short and public-safe.

--- a/examples/attempt-compare/attempt-b/ac-status.json
+++ b/examples/attempt-compare/attempt-b/ac-status.json
@@ -1,0 +1,16 @@
+{
+  "score": 0.91,
+  "score_label": "human reviewer score",
+  "criteria": [
+    {
+      "id": "AC1",
+      "text": "Names the first file a cold agent should inspect.",
+      "status": "pass"
+    },
+    {
+      "id": "AC2",
+      "text": "Explains which evidence a reviewer should inspect.",
+      "status": "pass"
+    }
+  ]
+}

--- a/examples/attempt-compare/attempt-b/diff.patch
+++ b/examples/attempt-compare/attempt-b/diff.patch
@@ -1,0 +1,10 @@
+diff --git a/docs/onboarding.md b/docs/onboarding.md
+--- a/docs/onboarding.md
++++ b/docs/onboarding.md
+@@ -1,3 +1,5 @@
+ # Onboarding
+-Read the README first.
++Read the README first, then inspect the active plan.
++If no active plan exists, check the backlog.
++Before reviewing the PR, open the evidence note and match it to the plan acceptance criteria.
+ Run the tests before opening a PR.

--- a/examples/attempt-compare/attempt-b/rationale.txt
+++ b/examples/attempt-compare/attempt-b/rationale.txt
@@ -1,0 +1,1 @@
+Attempt B keeps the concrete onboarding path and adds the missing evidence-review step, so the reviewer can connect the PR to plan acceptance criteria.

--- a/examples/attempt-compare/attempt-b/transcript.md
+++ b/examples/attempt-compare/attempt-b/transcript.md
@@ -1,0 +1,3 @@
+# Attempt B transcript excerpt
+
+The agent preserved the useful checklist but added the evidence-review link that makes the work record inspectable.

--- a/examples/attempt-compare/expected.md
+++ b/examples/attempt-compare/expected.md
@@ -1,0 +1,34 @@
+# Attempt comparison: attempt-a → attempt-b
+
+| Field | Attempt A | Attempt B | Δ |
+|---|---|---|---|
+| Path | `examples/attempt-compare/attempt-a` | `examples/attempt-compare/attempt-b` | — |
+| Rationale present | yes | yes | — |
+| Diff summary | docs/onboarding.md (2+/1-) | docs/onboarding.md (3+/1-) | additions +1, deletions 0 |
+| User-provided score (human reviewer score; not automatic benchmark) | 0.62 | 0.91 | +0.29 ▲ |
+| Transcript captured | 156 bytes | 147 bytes | metadata only |
+
+## Summary
+
+- Changed files: `docs/onboarding.md`
+- Scores are user-provided judgment metadata when present; Open Scaffold does not auto-rank or benchmark attempts.
+- This command reads local files only. It does not spawn runtimes, promote a frontier, or approve work.
+
+## Rationale
+
+**A:** Attempt A improved the onboarding note, but it still reads like a checklist and does not explain what evidence a reviewer should inspect.
+
+**B:** Attempt B keeps the concrete onboarding path and adds the missing evidence-review step, so the reviewer can connect the PR to plan acceptance criteria.
+
+## Acceptance criteria delta
+
+| Criterion | A | B |
+|---|---|---|
+| AC1 — Names the first file a cold agent should inspect. | ✓ pass | ✓ pass |
+| AC2 — Explains which evidence a reviewer should inspect. | ✗ fail | ✓ pass ▲ |
+
+## Diff files
+
+- Only in A: —
+- Only in B: —
+- In both: `docs/onboarding.md`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { renderStartPrompt, parseStartRuntime, START_RUNTIMES } from './start.js
 import { renderAuditManifest, validateAuditManifestFile, writeAuditManifest, type AuditArtifactInput } from './audit.js';
 import { createRunArtifacts, previewRunArtifacts, type ArtifactMode, type ExecutorLane, type OperatorSurface, type RunArtifactOptions, type RuntimePreset, type RuntimeWorkflow } from './artifacts.js';
 import { COCKPIT_EVENT_TYPES, CockpitConfigError, CockpitUsageError, formatCockpitConfig, formatCockpitDispatchSummary, hasCockpitDispatchFailures, loadCockpitConfig, postCockpitEvent, type CockpitEventType, type CockpitPostOptions } from './cockpit.js';
+import { compareBareAttempts, renderAttemptComparisonJson, renderAttemptComparisonMarkdown } from './compare.js';
 import { runDashboard, type DashboardRunOptions } from './dashboard.js';
 import { DispatchUsageError, formatDispatchSummary, runDispatch } from './dispatch.js';
 import { doctorExitCode, formatDoctorReport, parseDoctorCheckName, runDoctor, type DoctorOptions, type DoctorSeverity } from './doctor.js';
@@ -56,6 +57,7 @@ Usage:
   osc run <plan-path> [--dry-run] [--json] [run binding options]
   osc dispatch <run-json> --adapter <adapter-id>
   osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]
+  osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]
   osc review <plan-path> [run binding options]
   osc ultrareview <plan-path> [run binding options]
   osc eval init <run-or-plan> [--out <path>]
@@ -869,6 +871,65 @@ function isHelpArg(arg: string | undefined): boolean {
 function printUsage(message: string, stream: 'stdout' | 'stderr' = 'stderr'): void {
   if (stream === 'stdout') console.log(message);
   else console.error(message);
+}
+
+function printCompareUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]', stream);
+}
+
+function compareCommand(args: string[]): void {
+  if (isHelpArg(args[0])) {
+    printCompareUsage('stdout');
+    return;
+  }
+  const attemptA = args[0];
+  const attemptB = args[1];
+  if (!attemptA || !attemptB) {
+    printCompareUsage();
+    process.exit(2);
+  }
+  let json = false;
+  let outPath: string | undefined;
+  const rest = args.slice(2);
+  for (let i = 0; i < rest.length; i += 1) {
+    const flag = rest[i];
+    switch (flag) {
+      case '--json':
+        json = true;
+        break;
+      case '--output':
+      case '--out': {
+        const value = rest[i + 1];
+        if (!value || value.startsWith('--')) {
+          console.error(`Missing value for ${flag}`);
+          printCompareUsage();
+          process.exit(2);
+        }
+        outPath = value;
+        i += 1;
+        break;
+      }
+      default:
+        console.error(`Unknown option for compare: ${flag}`);
+        printCompareUsage();
+        process.exit(2);
+    }
+  }
+
+  try {
+    const comparison = compareBareAttempts(attemptA, attemptB);
+    const rendered = json ? renderAttemptComparisonJson(comparison) : renderAttemptComparisonMarkdown(comparison);
+    if (outPath) {
+      const resolvedOut = resolve(outPath);
+      writeFileSync(resolvedOut, rendered, 'utf8');
+      console.log(`Wrote attempt comparison: ${resolvedOut}`);
+    } else {
+      process.stdout.write(rendered.endsWith('\n') ? rendered : `${rendered}\n`);
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 }
 
 function printEvidenceUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
@@ -2480,6 +2541,9 @@ async function main(): Promise<void> {
       return;
     case 'work':
       workCommand(args);
+      return;
+    case 'compare':
+      compareCommand(args);
       return;
     case 'review':
     case 'ultrareview':

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -113,17 +113,26 @@ function diffSummary(diffText: string): { changedFiles: string[]; additions: num
   const files = new Set<string>();
   let additions = 0;
   let deletions = 0;
+  let pendingMinusFile: string | null = null;
   for (const line of diffText.split('\n')) {
     const gitMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
     if (gitMatch) {
       const normalized = normalizeChangedFile(gitMatch[2]);
       if (normalized) files.add(normalized);
+      pendingMinusFile = null;
+      continue;
+    }
+    const minusMatch = line.match(/^---\s+(.+)$/);
+    if (minusMatch) {
+      pendingMinusFile = normalizeChangedFile(minusMatch[1]);
       continue;
     }
     const plusMatch = line.match(/^\+\+\+\s+(.+)$/);
     if (plusMatch) {
       const normalized = normalizeChangedFile(plusMatch[1]);
       if (normalized) files.add(normalized);
+      else if (pendingMinusFile) files.add(pendingMinusFile);
+      pendingMinusFile = null;
       continue;
     }
     if (line.startsWith('+') && !line.startsWith('+++')) additions += 1;

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -135,8 +135,8 @@ function diffSummary(diffText: string): { changedFiles: string[]; additions: num
       pendingMinusFile = null;
       continue;
     }
-    if (line.startsWith('+') && !line.startsWith('+++')) additions += 1;
-    if (line.startsWith('-') && !line.startsWith('---')) deletions += 1;
+    if (line.startsWith('+') && !/^\+\+\+\s+/.test(line)) additions += 1;
+    if (line.startsWith('-') && !/^---\s+/.test(line)) deletions += 1;
   }
   return { changedFiles: [...files].sort(), additions, deletions };
 }

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -93,13 +93,13 @@ function meaningfulString(value: string): boolean {
   return value.trim().length > 0 && !/^(todo|tbd|n\/a|none)$/i.test(value.trim());
 }
 
-function readOptionalFile(dir: string, name: AttemptFileName): { present: boolean; bytes: number; content: string } {
+function readOptionalFile(dir: string, name: AttemptFileName, readContent = true): { present: boolean; bytes: number; content: string } {
   const path = resolve(dir, name);
   if (!existsSync(path)) return { present: false, bytes: 0, content: '' };
   const stat = statSync(path);
   if (!stat.isFile()) return { present: false, bytes: 0, content: '' };
-  const content = readFileSync(path, 'utf8');
-  return { present: true, bytes: Buffer.byteLength(content, 'utf8'), content };
+  const content = readContent ? readFileSync(path, 'utf8') : '';
+  return { present: true, bytes: stat.size, content };
 }
 
 function normalizeChangedFile(value: string): string | null {
@@ -163,7 +163,7 @@ function loadBareAttempt(pathArg: string, label: 'attempt-a' | 'attempt-b'): Bar
 
   const diffFile = readOptionalFile(absolute, 'diff.patch');
   const rationaleFile = readOptionalFile(absolute, 'rationale.txt');
-  const transcriptFile = readOptionalFile(absolute, 'transcript.md');
+  const transcriptFile = readOptionalFile(absolute, 'transcript.md', false);
   const acStatusFile = readOptionalFile(absolute, 'ac-status.json');
   const warnings: string[] = [];
 

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,0 +1,394 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+
+export const ATTEMPT_COMPARISON_SCHEMA = 'open-scaffold.attempt-comparison.v1';
+
+type AttemptFileName = 'diff.patch' | 'rationale.txt' | 'transcript.md' | 'ac-status.json';
+
+export interface AttemptCriterionStatus {
+  id: string;
+  text: string;
+  status: string | null;
+}
+
+export interface BareAttemptSummary {
+  name: string;
+  path: string;
+  files: Record<AttemptFileName, { present: boolean; bytes: number }>;
+  diff: {
+    present: boolean;
+    changedFiles: string[];
+    additions: number;
+    deletions: number;
+  };
+  rationale: {
+    present: boolean;
+    text: string;
+  };
+  transcript: {
+    present: boolean;
+    bytes: number;
+  };
+  acStatus: {
+    present: boolean;
+    score: number | null;
+    scoreLabel: string | null;
+    criteria: AttemptCriterionStatus[];
+  };
+  warnings: string[];
+}
+
+export interface AttemptCriterionDelta {
+  id: string;
+  text: string;
+  aStatus: string | null;
+  bStatus: string | null;
+}
+
+export interface BareAttemptComparison {
+  schema: typeof ATTEMPT_COMPARISON_SCHEMA;
+  attempts: {
+    a: BareAttemptSummary;
+    b: BareAttemptSummary;
+  };
+  summary: {
+    changedFiles: string[];
+    additionsDelta: number;
+    deletionsDelta: number;
+    scoreDelta: number | null;
+  };
+  diff: {
+    changedFiles: string[];
+    onlyInA: string[];
+    onlyInB: string[];
+    inBoth: string[];
+  };
+  acceptanceCriteria: {
+    rows: AttemptCriterionDelta[];
+    aPresent: boolean;
+    bPresent: boolean;
+  };
+  warnings: string[];
+  boundary: {
+    runtimeSpawning: false;
+    automaticScoring: false;
+    modelBenchmarking: false;
+    frontierPromotion: false;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function meaningfulString(value: string): boolean {
+  return value.trim().length > 0 && !/^(todo|tbd|n\/a|none)$/i.test(value.trim());
+}
+
+function readOptionalFile(dir: string, name: AttemptFileName): { present: boolean; bytes: number; content: string } {
+  const path = resolve(dir, name);
+  if (!existsSync(path)) return { present: false, bytes: 0, content: '' };
+  const stat = statSync(path);
+  if (!stat.isFile()) return { present: false, bytes: 0, content: '' };
+  const content = readFileSync(path, 'utf8');
+  return { present: true, bytes: Buffer.byteLength(content, 'utf8'), content };
+}
+
+function normalizeChangedFile(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '/dev/null') return null;
+  return trimmed.replace(/^[ab]\//, '');
+}
+
+function diffSummary(diffText: string): { changedFiles: string[]; additions: number; deletions: number } {
+  const files = new Set<string>();
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diffText.split('\n')) {
+    const gitMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (gitMatch) {
+      const normalized = normalizeChangedFile(gitMatch[2]);
+      if (normalized) files.add(normalized);
+      continue;
+    }
+    const plusMatch = line.match(/^\+\+\+\s+(.+)$/);
+    if (plusMatch) {
+      const normalized = normalizeChangedFile(plusMatch[1]);
+      if (normalized) files.add(normalized);
+      continue;
+    }
+    if (line.startsWith('+') && !line.startsWith('+++')) additions += 1;
+    if (line.startsWith('-') && !line.startsWith('---')) deletions += 1;
+  }
+  return { changedFiles: [...files].sort(), additions, deletions };
+}
+
+function normalizeCriteria(raw: unknown): AttemptCriterionStatus[] {
+  const container = Array.isArray(raw)
+    ? raw
+    : isRecord(raw) && Array.isArray(raw.criteria)
+      ? raw.criteria
+      : isRecord(raw) && Array.isArray(raw.acceptance_criteria)
+        ? raw.acceptance_criteria
+        : [];
+  return container.filter(isRecord).map((criterion, index) => ({
+    id: asString(criterion.id) ?? `AC${index + 1}`,
+    text: asString(criterion.text) ?? asString(criterion.title) ?? asString(criterion.id) ?? `AC${index + 1}`,
+    status: asString(criterion.status),
+  }));
+}
+
+function parseAcStatus(content: string): { score: number | null; scoreLabel: string | null; criteria: AttemptCriterionStatus[] } {
+  if (!meaningfulString(content)) return { score: null, scoreLabel: null, criteria: [] };
+  const parsed = JSON.parse(content) as unknown;
+  return {
+    score: isRecord(parsed) ? asNumber(parsed.score) : null,
+    scoreLabel: isRecord(parsed) ? asString(parsed.score_label) ?? asString(parsed.scoreLabel) : null,
+    criteria: normalizeCriteria(parsed),
+  };
+}
+
+function loadBareAttempt(pathArg: string, label: 'attempt-a' | 'attempt-b'): BareAttemptSummary {
+  const absolute = resolve(pathArg);
+  if (!existsSync(absolute)) throw new Error(`${label}: attempt folder does not exist: ${pathArg}`);
+  if (!statSync(absolute).isDirectory()) throw new Error(`${label}: attempt path must be a directory: ${pathArg}`);
+
+  const diffFile = readOptionalFile(absolute, 'diff.patch');
+  const rationaleFile = readOptionalFile(absolute, 'rationale.txt');
+  const transcriptFile = readOptionalFile(absolute, 'transcript.md');
+  const acStatusFile = readOptionalFile(absolute, 'ac-status.json');
+  const warnings: string[] = [];
+
+  for (const file of [diffFile.present ? null : 'diff.patch', rationaleFile.present ? null : 'rationale.txt', transcriptFile.present ? null : 'transcript.md', acStatusFile.present ? null : 'ac-status.json'].filter(Boolean) as AttemptFileName[]) {
+    warnings.push(`${label}: missing optional \`${file}\``);
+  }
+
+  const meaningfulDiff = diffFile.present && meaningfulString(diffFile.content);
+  const rationaleText = rationaleFile.content.trim();
+  const meaningfulRationale = rationaleFile.present && meaningfulString(rationaleText);
+  if (!meaningfulDiff && !meaningfulRationale) {
+    throw new Error(`Each attempt must include meaningful \`diff.patch\` or \`rationale.txt\` (${label} did not).`);
+  }
+
+  const diff = diffSummary(diffFile.content);
+  let acStatus = { score: null as number | null, scoreLabel: null as string | null, criteria: [] as AttemptCriterionStatus[] };
+  if (acStatusFile.present && meaningfulString(acStatusFile.content)) {
+    try {
+      acStatus = parseAcStatus(acStatusFile.content);
+    } catch (error) {
+      throw new Error(`${label}: invalid ac-status.json: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  return {
+    name: basename(absolute),
+    path: pathArg,
+    files: {
+      'diff.patch': { present: diffFile.present, bytes: diffFile.bytes },
+      'rationale.txt': { present: rationaleFile.present, bytes: rationaleFile.bytes },
+      'transcript.md': { present: transcriptFile.present, bytes: transcriptFile.bytes },
+      'ac-status.json': { present: acStatusFile.present, bytes: acStatusFile.bytes },
+    },
+    diff: {
+      present: meaningfulDiff,
+      changedFiles: diff.changedFiles,
+      additions: diff.additions,
+      deletions: diff.deletions,
+    },
+    rationale: {
+      present: meaningfulRationale,
+      text: meaningfulRationale ? rationaleText : '',
+    },
+    transcript: {
+      present: transcriptFile.present,
+      bytes: transcriptFile.bytes,
+    },
+    acStatus: {
+      present: acStatusFile.present,
+      score: acStatus.score,
+      scoreLabel: acStatus.scoreLabel,
+      criteria: acStatus.criteria,
+    },
+    warnings,
+  };
+}
+
+function setDelta(a: string[], b: string[]) {
+  const aSet = new Set(a);
+  const bSet = new Set(b);
+  return {
+    onlyInA: a.filter((item) => !bSet.has(item)),
+    onlyInB: b.filter((item) => !aSet.has(item)),
+    inBoth: a.filter((item) => bSet.has(item)),
+  };
+}
+
+function acceptanceCriteriaDelta(a: AttemptCriterionStatus[], b: AttemptCriterionStatus[]) {
+  const rows = new Map<string, AttemptCriterionDelta>();
+  for (const criterion of a) {
+    rows.set(criterion.id, { id: criterion.id, text: criterion.text, aStatus: criterion.status, bStatus: null });
+  }
+  for (const criterion of b) {
+    const existing = rows.get(criterion.id);
+    if (existing) {
+      existing.text = existing.text || criterion.text;
+      existing.bStatus = criterion.status;
+    } else {
+      rows.set(criterion.id, { id: criterion.id, text: criterion.text, aStatus: null, bStatus: criterion.status });
+    }
+  }
+  return [...rows.values()];
+}
+
+export function compareBareAttempts(attemptAPath: string, attemptBPath: string): BareAttemptComparison {
+  const a = loadBareAttempt(attemptAPath, 'attempt-a');
+  const b = loadBareAttempt(attemptBPath, 'attempt-b');
+  const diff = setDelta(a.diff.changedFiles, b.diff.changedFiles);
+  const scoreDelta = a.acStatus.score !== null && b.acStatus.score !== null
+    ? Number((b.acStatus.score - a.acStatus.score).toFixed(6))
+    : null;
+  const rows = acceptanceCriteriaDelta(a.acStatus.criteria, b.acStatus.criteria);
+  return {
+    schema: ATTEMPT_COMPARISON_SCHEMA,
+    attempts: { a, b },
+    summary: {
+      changedFiles: [...new Set([...a.diff.changedFiles, ...b.diff.changedFiles])].sort(),
+      additionsDelta: b.diff.additions - a.diff.additions,
+      deletionsDelta: b.diff.deletions - a.diff.deletions,
+      scoreDelta,
+    },
+    diff: {
+      changedFiles: [...new Set([...a.diff.changedFiles, ...b.diff.changedFiles])].sort(),
+      ...diff,
+    },
+    acceptanceCriteria: {
+      rows,
+      aPresent: a.acStatus.present,
+      bPresent: b.acStatus.present,
+    },
+    warnings: [...a.warnings, ...b.warnings],
+    boundary: {
+      runtimeSpawning: false,
+      automaticScoring: false,
+      modelBenchmarking: false,
+      frontierPromotion: false,
+    },
+  };
+}
+
+function formatScore(score: number | null): string {
+  return score === null ? '—' : Number(score.toFixed(6)).toString();
+}
+
+function formatDelta(delta: number | null): string {
+  if (delta === null) return '—';
+  const rounded = Number(delta.toFixed(6));
+  if (rounded === 0) return '0';
+  return `${rounded > 0 ? '+' : ''}${rounded} ${rounded > 0 ? '▲' : '▼'}`;
+}
+
+function formatCountDelta(delta: number): string {
+  if (delta === 0) return '0';
+  return `${delta > 0 ? '+' : ''}${delta}`;
+}
+
+function formatStatus(status: string | null): string {
+  switch (status) {
+    case 'pass':
+      return '✓ pass';
+    case 'fail':
+      return '✗ fail';
+    case 'partial':
+      return '◐ partial';
+    case 'blocked':
+      return 'blocked';
+    case 'not_evaluated':
+      return 'not evaluated';
+    case null:
+      return '—';
+    default:
+      return status;
+  }
+}
+
+function statusMarker(aStatus: string | null, bStatus: string | null): string {
+  if (aStatus === bStatus || bStatus === null) return '';
+  if (bStatus === 'pass' && aStatus !== 'pass') return ' ▲';
+  if (aStatus === 'pass' && bStatus !== 'pass') return ' ▼';
+  return ' changed';
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, '<br>');
+}
+
+function diffText(attempt: BareAttemptSummary): string {
+  const files = attempt.diff.changedFiles.length > 0 ? attempt.diff.changedFiles.join(', ') : '—';
+  return `${files} (${attempt.diff.additions}+/${attempt.diff.deletions}-)`;
+}
+
+function scoreLabel(comparison: BareAttemptComparison): string {
+  const labels = [comparison.attempts.a.acStatus.scoreLabel, comparison.attempts.b.acStatus.scoreLabel].filter(Boolean);
+  return labels.length > 0 ? `User-provided score (${[...new Set(labels)].join(', ')}; not automatic benchmark)` : 'User-provided score (not automatic benchmark)';
+}
+
+export function renderAttemptComparisonMarkdown(comparison: BareAttemptComparison): string {
+  const { a, b } = comparison.attempts;
+  const lines = [
+    `# Attempt comparison: ${a.name} → ${b.name}`,
+    '',
+    '| Field | Attempt A | Attempt B | Δ |',
+    '|---|---|---|---|',
+    `| Path | \`${escapeCell(a.path)}\` | \`${escapeCell(b.path)}\` | — |`,
+    `| Rationale present | ${a.rationale.present ? 'yes' : 'no'} | ${b.rationale.present ? 'yes' : 'no'} | ${a.rationale.present === b.rationale.present ? '—' : 'changed'} |`,
+    `| Diff summary | ${escapeCell(diffText(a))} | ${escapeCell(diffText(b))} | additions ${formatCountDelta(comparison.summary.additionsDelta)}, deletions ${formatCountDelta(comparison.summary.deletionsDelta)} |`,
+    `| ${escapeCell(scoreLabel(comparison))} | ${formatScore(a.acStatus.score)} | ${formatScore(b.acStatus.score)} | ${formatDelta(comparison.summary.scoreDelta)} |`,
+    `| Transcript captured | ${a.transcript.present ? `${a.transcript.bytes} bytes` : '—'} | ${b.transcript.present ? `${b.transcript.bytes} bytes` : '—'} | metadata only |`,
+    '',
+    '## Summary',
+    '',
+    `- Changed files: ${comparison.summary.changedFiles.length > 0 ? comparison.summary.changedFiles.map((file) => `\`${file}\``).join(', ') : '—'}`,
+    '- Scores are user-provided judgment metadata when present; Open Scaffold does not auto-rank or benchmark attempts.',
+    '- This command reads local files only. It does not spawn runtimes, promote a frontier, or approve work.',
+    '',
+    '## Rationale',
+    '',
+    `**A:** ${a.rationale.text || '—'}`,
+    '',
+    `**B:** ${b.rationale.text || '—'}`,
+    '',
+    ...(comparison.acceptanceCriteria.rows.length > 0 ? [
+      '## Acceptance criteria delta',
+      '',
+      '| Criterion | A | B |',
+      '|---|---|---|',
+      ...comparison.acceptanceCriteria.rows.map((row) => `| ${escapeCell(`${row.id} — ${row.text}`)} | ${escapeCell(formatStatus(row.aStatus))} | ${escapeCell(formatStatus(row.bStatus))}${statusMarker(row.aStatus, row.bStatus)} |`),
+      '',
+    ] : []),
+    '## Diff files',
+    '',
+    `- Only in A: ${comparison.diff.onlyInA.length > 0 ? comparison.diff.onlyInA.map((file) => `\`${file}\``).join(', ') : '—'}`,
+    `- Only in B: ${comparison.diff.onlyInB.length > 0 ? comparison.diff.onlyInB.map((file) => `\`${file}\``).join(', ') : '—'}`,
+    `- In both: ${comparison.diff.inBoth.length > 0 ? comparison.diff.inBoth.map((file) => `\`${file}\``).join(', ') : '—'}`,
+    '',
+    ...(comparison.warnings.length > 0 ? [
+      '## Warnings',
+      '',
+      ...comparison.warnings.map((warning) => `- ${warning}`),
+      '',
+    ] : []),
+  ];
+  return `${lines.join('\n').replace(/\n+$/, '')}\n`;
+}
+
+export function renderAttemptComparisonJson(comparison: BareAttemptComparison): string {
+  return `${JSON.stringify(comparison, null, 2)}\n`;
+}

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -103,7 +103,8 @@ function readOptionalFile(dir: string, name: AttemptFileName, readContent = true
 }
 
 function normalizeChangedFile(value: string): string | null {
-  const trimmed = value.trim();
+  const withoutTimestamp = value.split('\t', 1)[0];
+  const trimmed = withoutTimestamp.trim();
   if (!trimmed || trimmed === '/dev/null') return null;
   return trimmed.replace(/^[ab]\//, '');
 }

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -57,6 +57,13 @@ const timestampedPlainDiff = `--- src/widget.ts	2026-05-27 14:30:00
  }
 `;
 
+const plainDeletionDiff = `--- src/old-widget.ts	2026-05-27 14:30:00
++++ /dev/null	2026-05-27 14:31:00
+@@ -1,2 +0,0 @@
+-export function oldWidget() {
+-}
+`;
+
 describe('osc compare', () => {
   it('keeps the checked-in attempt-compare fixture reproducible', () => {
     const output = execFileSync(tsx, [cli, 'compare', 'examples/attempt-compare/attempt-a', 'examples/attempt-compare/attempt-b'], { cwd: repoRoot, encoding: 'utf8' });
@@ -152,6 +159,25 @@ describe('osc compare', () => {
     expect(parsed.diff.changedFiles).toEqual(['src/widget.ts']);
     expect(parsed.diff.onlyInA).toEqual([]);
     expect(parsed.diff.onlyInB).toEqual([]);
+  });
+
+  it('keeps deleted paths from plain unified diffs that use /dev/null as the new file', () => {
+    const root = tempDir();
+    const attemptA = writeAttempt(root, 'attempt-a', {
+      diff: plainDeletionDiff,
+      rationale: 'Plain deletion diff generated outside git.',
+    });
+    const attemptB = writeAttempt(root, 'attempt-b', {
+      diff: plainDeletionDiff.replace('14:31:00', '14:50:00'),
+      rationale: 'Same deleted path with a later timestamp.',
+    });
+
+    const output = execFileSync(tsx, [cli, 'compare', attemptA, attemptB, '--json'], { cwd: repoRoot, encoding: 'utf8' });
+    const parsed = JSON.parse(output) as Record<string, any>;
+
+    expect(parsed.diff.changedFiles).toEqual(['src/old-widget.ts']);
+    expect(parsed.attempts.a.diff.deletions).toBe(2);
+    expect(parsed.attempts.a.diff.additions).toBe(0);
   });
 
   it('writes markdown to --output and reports missing optional files as warnings', () => {

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -64,6 +64,15 @@ const plainDeletionDiff = `--- src/old-widget.ts	2026-05-27 14:30:00
 -}
 `;
 
+const operatorPrefixDiff = `--- src/counter.ts	2026-05-27 14:30:00
++++ src/counter.ts	2026-05-27 14:31:00
+@@ -1,4 +1,4 @@
+ export function bump(i: number) {
+---i;
++++i;
+ }
+`;
+
 describe('osc compare', () => {
   it('keeps the checked-in attempt-compare fixture reproducible', () => {
     const output = execFileSync(tsx, [cli, 'compare', 'examples/attempt-compare/attempt-a', 'examples/attempt-compare/attempt-b'], { cwd: repoRoot, encoding: 'utf8' });
@@ -178,6 +187,25 @@ describe('osc compare', () => {
     expect(parsed.diff.changedFiles).toEqual(['src/old-widget.ts']);
     expect(parsed.attempts.a.diff.deletions).toBe(2);
     expect(parsed.attempts.a.diff.additions).toBe(0);
+  });
+
+  it('counts changed body lines whose content starts with plus or minus operators', () => {
+    const root = tempDir();
+    const attemptA = writeAttempt(root, 'attempt-a', {
+      diff: operatorPrefixDiff,
+      rationale: 'Diff body contains increment/decrement-style prefixes.',
+    });
+    const attemptB = writeAttempt(root, 'attempt-b', {
+      diff: operatorPrefixDiff,
+      rationale: 'Same operator-prefixed body lines.',
+    });
+
+    const output = execFileSync(tsx, [cli, 'compare', attemptA, attemptB, '--json'], { cwd: repoRoot, encoding: 'utf8' });
+    const parsed = JSON.parse(output) as Record<string, any>;
+
+    expect(parsed.diff.changedFiles).toEqual(['src/counter.ts']);
+    expect(parsed.attempts.a.diff.additions).toBe(1);
+    expect(parsed.attempts.a.diff.deletions).toBe(1);
   });
 
   it('writes markdown to --output and reports missing optional files as warnings', () => {

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), 'osc-compare-'));
+}
+
+function writeAttempt(root: string, name: string, options: {
+  diff?: string;
+  rationale?: string;
+  transcript?: string;
+  acStatus?: unknown;
+}) {
+  const dir = join(root, name);
+  mkdirSync(dir, { recursive: true });
+  if (options.diff !== undefined) writeFileSync(join(dir, 'diff.patch'), options.diff);
+  if (options.rationale !== undefined) writeFileSync(join(dir, 'rationale.txt'), options.rationale);
+  if (options.transcript !== undefined) writeFileSync(join(dir, 'transcript.md'), options.transcript);
+  if (options.acStatus !== undefined) writeFileSync(join(dir, 'ac-status.json'), JSON.stringify(options.acStatus, null, 2));
+  return dir;
+}
+
+const diffA = `diff --git a/src/widget.ts b/src/widget.ts
+--- a/src/widget.ts
++++ b/src/widget.ts
+@@ -1,3 +1,4 @@
+ export function widget(input: string) {
++  if (!input) return 'empty';
+   return input.trim();
+ }
+`;
+
+const diffB = `diff --git a/src/widget.ts b/src/widget.ts
+--- a/src/widget.ts
++++ b/src/widget.ts
+@@ -1,3 +1,6 @@
+ export function widget(input: string) {
++  if (!input) {
++    throw new Error('input required');
++  }
+   return input.trim();
+ }
+`;
+
+describe('osc compare', () => {
+  it('keeps the checked-in attempt-compare fixture reproducible', () => {
+    const output = execFileSync(tsx, [cli, 'compare', 'examples/attempt-compare/attempt-a', 'examples/attempt-compare/attempt-b'], { cwd: repoRoot, encoding: 'utf8' });
+    const expected = readFileSync(join(repoRoot, 'examples/attempt-compare/expected.md'), 'utf8');
+
+    expect(output).toBe(expected);
+  });
+
+  it('renders a PR-pasteable markdown attempt comparison from two bare folders', () => {
+    const root = tempDir();
+    const attemptA = writeAttempt(root, 'attempt-a', {
+      diff: diffA,
+      rationale: 'Fast patch, but it silently accepts empty input.',
+      transcript: 'PRIVATE FULL TRANSCRIPT A SHOULD NOT MATTER.',
+      acStatus: {
+        score: 0.62,
+        score_label: 'human reviewer score',
+        criteria: [
+          { id: 'AC1', text: 'Trims valid input.', status: 'pass' },
+          { id: 'AC2', text: 'Rejects empty input.', status: 'fail|needs review' },
+        ],
+      },
+    });
+    const attemptB = writeAttempt(root, 'attempt-b', {
+      diff: diffB,
+      rationale: 'Stronger behavior because empty input is explicit.',
+      transcript: 'PRIVATE FULL TRANSCRIPT B SHOULD NOT MATTER.',
+      acStatus: {
+        score: 0.91,
+        score_label: 'human reviewer | score\nline',
+        criteria: [
+          { id: 'AC1', text: 'Trims valid input.', status: 'pass' },
+          { id: 'AC2', text: 'Rejects empty input.', status: 'pass' },
+        ],
+      },
+    });
+
+    const output = execFileSync(tsx, [cli, 'compare', attemptA, attemptB], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(output).toContain('# Attempt comparison: attempt-a → attempt-b');
+    expect(output).toContain('| Field | Attempt A | Attempt B | Δ |');
+    expect(output).toContain('User-provided score');
+    expect(output).toContain('src/widget.ts');
+    expect(output).toContain('Fast patch, but it silently accepts empty input.');
+    expect(output).toContain('User-provided score (human reviewer score, human reviewer \\| score<br>line; not automatic benchmark)');
+    expect(output).toContain('AC2 — Rejects empty input.');
+    expect(output).toContain('fail\\|needs review');
+    expect(output).toContain('✓ pass ▲');
+  });
+
+  it('emits stable JSON without embedding full transcripts by default', () => {
+    const root = tempDir();
+    const attemptA = writeAttempt(root, 'attempt-a', {
+      diff: diffA,
+      rationale: 'A rationale.',
+      transcript: 'PRIVATE FULL TRANSCRIPT A SHOULD NOT APPEAR IN JSON.',
+      acStatus: { criteria: [{ id: 'AC1', text: 'Works', status: 'partial' }] },
+    });
+    const attemptB = writeAttempt(root, 'attempt-b', {
+      diff: diffB,
+      rationale: 'B rationale.',
+      transcript: 'PRIVATE FULL TRANSCRIPT B SHOULD NOT APPEAR IN JSON.',
+      acStatus: { criteria: [{ id: 'AC1', text: 'Works', status: 'pass' }] },
+    });
+
+    const output = execFileSync(tsx, [cli, 'compare', attemptA, attemptB, '--json'], { cwd: repoRoot, encoding: 'utf8' });
+    const parsed = JSON.parse(output) as Record<string, any>;
+
+    expect(parsed.schema).toBe('open-scaffold.attempt-comparison.v1');
+    expect(parsed.attempts.a.name).toBe('attempt-a');
+    expect(parsed.attempts.a.transcript.present).toBe(true);
+    expect(parsed.attempts.a.transcript.bytes).toBeGreaterThan(0);
+    expect(parsed.attempts.a.transcript.content).toBeUndefined();
+    expect(parsed.diff.changedFiles).toContain('src/widget.ts');
+    expect(parsed.acceptanceCriteria.rows[0]).toMatchObject({ id: 'AC1', aStatus: 'partial', bStatus: 'pass' });
+    expect(JSON.stringify(parsed)).not.toContain('PRIVATE FULL TRANSCRIPT');
+  });
+
+  it('writes markdown to --output and reports missing optional files as warnings', () => {
+    const root = tempDir();
+    const attemptA = writeAttempt(root, 'attempt-a', {
+      diff: diffA,
+      rationale: 'A rationale.',
+      transcript: 'Transcript A.',
+      acStatus: { criteria: [{ id: 'AC1', text: 'Works', status: 'pass' }] },
+    });
+    const attemptB = writeAttempt(root, 'attempt-b', {
+      rationale: 'B rationale without optional files.',
+    });
+    const outPath = join(root, 'comparison.md');
+
+    const stdout = execFileSync(tsx, [cli, 'compare', attemptA, attemptB, '--output', outPath], { cwd: repoRoot, encoding: 'utf8' });
+    const written = readFileSync(outPath, 'utf8');
+
+    expect(stdout).toContain('Wrote attempt comparison:');
+    expect(existsSync(outPath)).toBe(true);
+    expect(written).toContain('## Warnings');
+    expect(written).toContain('attempt-b: missing optional `diff.patch`');
+    expect(written).toContain('attempt-b: missing optional `transcript.md`');
+    expect(written).toContain('attempt-b: missing optional `ac-status.json`');
+  });
+
+  it('fails clearly when neither attempt has meaningful diff nor rationale', () => {
+    const root = tempDir();
+    const attemptA = writeAttempt(root, 'attempt-a', { transcript: 'Only transcript A.' });
+    const attemptB = writeAttempt(root, 'attempt-b', { transcript: 'Only transcript B.' });
+
+    const result = spawnSync(tsx, [cli, 'compare', attemptA, attemptB], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Each attempt must include meaningful `diff.patch` or `rationale.txt`');
+  });
+});

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -49,6 +49,14 @@ const diffB = `diff --git a/src/widget.ts b/src/widget.ts
  }
 `;
 
+const timestampedPlainDiff = `--- src/widget.ts	2026-05-27 14:30:00
++++ src/widget.ts	2026-05-27 14:31:00
+@@ -1,2 +1,3 @@
+ export function widget(input: string) {
++  if (!input) return 'empty';
+ }
+`;
+
 describe('osc compare', () => {
   it('keeps the checked-in attempt-compare fixture reproducible', () => {
     const output = execFileSync(tsx, [cli, 'compare', 'examples/attempt-compare/attempt-a', 'examples/attempt-compare/attempt-b'], { cwd: repoRoot, encoding: 'utf8' });
@@ -125,6 +133,25 @@ describe('osc compare', () => {
     expect(parsed.diff.changedFiles).toContain('src/widget.ts');
     expect(parsed.acceptanceCriteria.rows[0]).toMatchObject({ id: 'AC1', aStatus: 'partial', bStatus: 'pass' });
     expect(JSON.stringify(parsed)).not.toContain('PRIVATE FULL TRANSCRIPT');
+  });
+
+  it('strips timestamps from plain unified diff headers before comparing file names', () => {
+    const root = tempDir();
+    const attemptA = writeAttempt(root, 'attempt-a', {
+      diff: timestampedPlainDiff,
+      rationale: 'Plain diff generated with timestamped headers.',
+    });
+    const attemptB = writeAttempt(root, 'attempt-b', {
+      diff: timestampedPlainDiff.replace('14:31:00', '14:45:00'),
+      rationale: 'Same file changed later should not look like a different path.',
+    });
+
+    const output = execFileSync(tsx, [cli, 'compare', attemptA, attemptB, '--json'], { cwd: repoRoot, encoding: 'utf8' });
+    const parsed = JSON.parse(output) as Record<string, any>;
+
+    expect(parsed.diff.changedFiles).toEqual(['src/widget.ts']);
+    expect(parsed.diff.onlyInA).toEqual([]);
+    expect(parsed.diff.onlyInB).toEqual([]);
   });
 
   it('writes markdown to --output and reports missing optional files as warnings', () => {


### PR DESCRIPTION
## Summary
- Adds `osc compare <attempt-a-dir> <attempt-b-dir>` for prerequisite-free local attempt comparison.
- Renders PR-pasteable markdown and stable JSON without embedding transcript bodies.
- Adds a checked-in `examples/attempt-compare/` fixture and documents when bare compare is enough versus full `osc evolve compare`.
- Records slice evidence in `.osc/releases/2026-05-27-109-bare-attempt-compare.md`.

## Verification
- `npm test -- --run` — 45 files passed, 393 tests passed.
- `npm run build` — pass.
- `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` — matches checked-in expected markdown.
- `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b --json` — parses as `open-scaffold.attempt-comparison.v1`; transcripts remain metadata only.
- `node dist/cli.js plan validate .osc/plans/done/109-bare-attempt-compare.md` — 0 issues found.
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn.
- `git diff --check` — pass.

## Risk / gates
- Local-file-only command; no runtime spawning, automatic scoring, benchmark claim, frontier promotion, npm publish, or GitHub Release in this PR.
- Scores from `ac-status.json` are labeled as user-provided reviewer metadata.
- Merge remains owner-gated.

## Traceability
- Plan: `.osc/plans/done/109-bare-attempt-compare.md`.
- Evidence: `.osc/releases/2026-05-27-109-bare-attempt-compare.md`.
- Branch: `cli/bare-attempt-compare`.
