### PR TITLE
Prepare compare command package sync

### DIFF
--- a/.osc/plans/active/122-compare-package-release-sync.md
+++ b/.osc/plans/active/122-compare-package-release-sync.md
@@ -1,0 +1,64 @@
+# Plan: 122-compare-package-release-sync
+
+## Status
+
+active
+
+## Context
+
+The compare source feature from #134 is now present on `main` as a package-visible CLI surface: `osc compare <attempt-a-dir> <attempt-b-dir>`. Local `main` exposes the command, but npm `latest` remains `open-scaffold@1.0.4` and a fresh isolated-cache `npx open-scaffold@latest --help` does not show `osc compare`. GitHub Latest Release is also still `v1.0.4`, cut before the compare source feature.
+
+Context Authority work is designed and ready, but package/public-surface truth must be reconciled first so new users can install the command that just landed.
+
+## Goal
+
+Prepare and verify `open-scaffold@1.0.5` as the package/public-surface sync for the bare attempt compare command so npm `latest`, fresh `npx`, and GitHub Latest Release can match `main` after the owner-approved publish/release gate.
+
+## Constraints / Out of scope
+
+- Do not add new `osc compare` behavior beyond PR #134.
+- Do not change attempt comparison scoring, model judgment, frontier promotion, runtime spawning, or evolution-loop semantics.
+- Do not start Context Authority 071/117/119/120/121 in this slice.
+- Keep npm publishing and GitHub Release creation as explicit owner-gated follow-through after PR integration.
+- Keep this release-sync plan active until npm/latest, fresh isolated-cache `npx`, and any approved GitHub Latest Release are verified.
+
+## Files to touch
+
+- `package.json` — bump root package version to `1.0.5`.
+- `package-lock.json` — keep root lockfile version metadata in sync.
+- `docs/CHANGELOG.md` — record the v1.0.5 package surface and keep previous release status truthful.
+- `.osc/plans/active/122-compare-package-release-sync.md` — this plan.
+- `.osc/releases/2026-05-27-122-compare-package-release-sync.md` — durable release-sync candidate evidence.
+- This plan file and `MISSION.md` — closeout only after package/release proof exists.
+
+## Acceptance criteria
+
+- [x] Root package version is bumped to `1.0.5` and lockfile metadata matches.
+- [x] Changelog documents v1.0.5 as the package-surface sync for `osc compare`.
+- [x] Local gates pass before PR: `./verify.sh --strict`, focused compare tests, `npm test`, `npm run build`, `npm pack --dry-run --json`, `npm publish --dry-run`, `git diff --check`.
+- [ ] PR CI and latest-head Codex review are clean before PR integration.
+- [ ] Trusted publishing succeeds for `open-scaffold@1.0.5` after PR integration and owner publish approval.
+- [ ] `npm view open-scaffold version dist-tags --json` shows `1.0.5` / `latest: 1.0.5`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest compare <attempt-a-dir> <attempt-b-dir>` runs against a temporary copy of the example fixture.
+- [ ] GitHub Release `v1.0.5` exists, targets the integrated main commit, and is marked Latest if release publication is approved.
+
+## Verification steps
+
+1. Run `git diff --check`.
+2. Run `./verify.sh --strict`.
+3. Run `npm test -- tests/compare.test.ts --run`.
+4. Run `npm test`.
+5. Run `npm run build`.
+6. Run `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` and compare output to `examples/attempt-compare/expected.md`.
+7. Run `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b --json` and parse it as JSON.
+8. Run `npm pack --dry-run --json` and confirm the package includes `dist/compare.js` / `dist/compare.d.ts`.
+9. Run `npm publish --dry-run`.
+10. After PR integration/publication, run `npm view open-scaffold version dist-tags --json`.
+11. After publish, run fresh isolated-cache `npx --yes open-scaffold@latest --help` and verify `osc compare` appears.
+12. After publish, run fresh isolated-cache `npx --yes open-scaffold@latest compare` against a temporary copy of the attempt-compare fixture.
+13. Check `gh release list --repo graphanov/open-scaffold --limit 5` for `v1.0.5` as Latest if the GitHub Release gate is approved.
+
+## Open questions
+
+- None for the package-sync candidate. Actual npm publishing, GitHub Release creation, plan closeout, and Kanban completion remain owner-gated follow-through after this PR.

--- a/.osc/releases/2026-05-27-122-compare-package-release-sync.md
+++ b/.osc/releases/2026-05-27-122-compare-package-release-sync.md
@@ -1,0 +1,54 @@
+# Release / Evidence Note: 122-compare-package-release-sync
+
+## Summary
+
+Prepared `open-scaffold@1.0.5` as the package/public-surface sync for PR #134's `osc compare <attempt-a-dir> <attempt-b-dir>` command. The source feature reached `main` in PR #134, but npm `latest` and GitHub Latest Release still point to `1.0.4`, so this release-sync candidate bumps the package metadata and records the gates needed before publication.
+
+This is candidate evidence only. The release-sync plan remains active until owner-approved merge, trusted publishing, fresh `npx` verification, GitHub Latest Release publication, and closeout proof are complete.
+
+## Traceability
+
+- Roadmap / issue / task: adoption wedge / attempt-diff magic moment; package-sync follow-through after PR #134.
+- Source plan: `.osc/plans/done/109-bare-attempt-compare.md`.
+- Release-sync plan: `.osc/plans/active/122-compare-package-release-sync.md`.
+- Run ID / run packet: N/A for release-sync.
+- Source Pull Request: https://github.com/graphanov/open-scaffold/pull/134.
+- Release-sync Pull Request: pending.
+- Trusted publishing run: pending owner-approved merge/publication.
+- GitHub Release: pending owner-approved release publication.
+
+## Verification
+
+- `gh pr view 134 --repo graphanov/open-scaffold --json state,mergedAt,mergeCommit,url` — PASS: PR #134 is merged; merge commit `fc55df6` on local `main`.
+- PR #134 checks — PASS: `Validate changed plans`, `Validate evidence notes`, and `ci` passed before merge.
+- `git diff --check` after syncing `main` — PASS.
+- `node dist/cli.js --help | grep -F 'osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]'` — PASS locally after PR #134.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc compare` command before this release-sync candidate is published.
+- `npm view open-scaffold version dist-tags --json` — PRECHECK: npm/latest is `1.0.4` before this release-sync candidate.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PRECHECK: GitHub Latest Release is `v1.0.4 — Work dry-run preview package sync` before this release-sync candidate.
+- `node -p "require('./package.json').version"` — PASS on release-sync branch: `1.0.5`.
+- `node -p "require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `1.0.5 / 1.0.5`.
+- `node dist/cli.js plan validate .osc/plans/active/122-compare-package-release-sync.md` — PASS: 0 issues found.
+- `git diff --check` on release-sync branch — PASS.
+- `./verify.sh --strict` on release-sync branch — PASS: 10 pass / 0 fail / 0 warn.
+- `npm test -- tests/compare.test.ts --run` — PASS: 1 file / 8 tests.
+- `npm test` — PASS: 45 files / 396 tests.
+- `npm run build` — PASS.
+- `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` compared to `examples/attempt-compare/expected.md` — PASS.
+- `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b --json` parsed as JSON — PASS: schema `open-scaffold.attempt-comparison.v1`.
+- `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.5` (156 files); package includes `dist/compare.js` and `dist/compare.d.ts`.
+- `npm publish --dry-run` — PASS for `open-scaffold@1.0.5`.
+- PR CI and latest-head Codex review — pending after PR creation.
+- Trusted publishing for `open-scaffold@1.0.5` — pending owner-approved merge/publication.
+- Fresh isolated-cache `npx` verification for `osc compare` — pending after publication.
+- GitHub Release `v1.0.5` marked Latest — pending owner-approved release publication.
+
+## Outcome
+
+Candidate prepared; owner-gated public-surface follow-through pending.
+
+## Follow-up
+
+- Open a focused release-sync PR and keep it latest-head clean.
+- After owner approval, merge the release-sync PR, run trusted publishing for `open-scaffold@1.0.5`, verify fresh isolated-cache `npx` exposes and runs `osc compare`, create GitHub Release `v1.0.5` as Latest, then close this plan.
+- After this public-surface sync is complete, resume Context Authority in the order `071-evidence-chain-verifier` → `117-osc-trace-work-record-replay` → reserved Context Authority slices.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,27 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
-## v1.0.4 — Work dry-run preview package sync
+## v1.0.5 — Compare command package sync
 
 Status: release-sync candidate; npm/GitHub Release publication pending after PR integration and owner-approved package follow-through.
+
+Highlights:
+
+- Prepares the PR #134 package-visible attempt-diff surface: `osc compare <attempt-a-dir> <attempt-b-dir>` for comparing two local attempt folders without a full evolution-loop ledger.
+- Keeps comparison local and deterministic: no model scoring, no frontier promotion, no runtime spawning, no network requirement, and no provider calls.
+- Supports both human-readable Markdown output and JSON output for downstream automation.
+
+Evidence:
+
+- Source plan: `.osc/plans/done/109-bare-attempt-compare.md`
+- Release-sync plan: `.osc/plans/active/122-compare-package-release-sync.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/134
+- Source evidence note: `.osc/releases/2026-05-27-109-bare-attempt-compare.md`
+- Release-sync evidence note: `.osc/releases/2026-05-27-122-compare-package-release-sync.md`
+
+## v1.0.4 — Work dry-run preview package sync
+
+Status: published to npm as `open-scaffold@1.0.4`; GitHub Release `v1.0.4` is Latest until the compare command package sync is published.
 
 Highlights:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump root package metadata to `open-scaffold@1.0.5` for the merged `osc compare` command from PR #134.
- Add the active release-sync plan and candidate evidence note for the compare package/public-surface follow-through.
- Update the changelog with v1.0.5 candidate notes and correct the v1.0.4 status.

## Verification
- [x] `git diff --check`
- [x] `node dist/cli.js plan validate .osc/plans/active/122-compare-package-release-sync.md`
- [x] `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- [x] `npm test -- tests/compare.test.ts --run` — 1 file / 8 tests
- [x] `npm test` — 45 files / 396 tests
- [x] `npm run build`
- [x] `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` compared to `examples/attempt-compare/expected.md`
- [x] `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b --json` parsed as `open-scaffold.attempt-comparison.v1`
- [x] `npm pack --dry-run --json` — includes `dist/compare.js` and `dist/compare.d.ts`
- [x] `npm publish --dry-run`

## Owner gates
- Do not merge without owner approval.
- Do not run trusted npm publishing without owner approval.
- Do not create/update GitHub Release `v1.0.5` without owner approval.
- Keep `.osc/plans/active/122-compare-package-release-sync.md` active until registry + fresh `npx` + GitHub Latest proof exists.

## Scope boundaries
- No new `osc compare` behavior beyond PR #134.
- No Context Authority 071/117/119/120/121 work in this PR.
- No schemas, RAG, MCP, `.osc/context/*`, runtime spawning, model scoring, or frontier promotion.
