### PR TITLE
Close compare package sync

### DIFF
--- a/.osc/plans/done/122-compare-package-release-sync.md
+++ b/.osc/plans/done/122-compare-package-release-sync.md
@@ -2,11 +2,13 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
-The compare source feature from #134 is now present on `main` as a package-visible CLI surface: `osc compare <attempt-a-dir> <attempt-b-dir>`. Local `main` exposes the command, but npm `latest` remains `open-scaffold@1.0.4` and a fresh isolated-cache `npx open-scaffold@latest --help` does not show `osc compare`. GitHub Latest Release is also still `v1.0.4`, cut before the compare source feature.
+At plan start, the compare source feature from #134 was present on `main` as a package-visible CLI surface: `osc compare <attempt-a-dir> <attempt-b-dir>`, while npm `latest` and GitHub Latest Release still pointed to `open-scaffold@1.0.4`.
+
+After execution, `open-scaffold@1.0.5` is published as npm `latest`, fresh isolated-cache `npx open-scaffold@latest --help` shows `osc compare`, fresh `npx` compare/init smokes pass, and GitHub Release `v1.0.5` is marked Latest.
 
 Context Authority work is designed and ready, but package/public-surface truth must be reconciled first so new users can install the command that just landed.
 
@@ -27,7 +29,7 @@ Prepare and verify `open-scaffold@1.0.5` as the package/public-surface sync for 
 - `package.json` — bump root package version to `1.0.5`.
 - `package-lock.json` — keep root lockfile version metadata in sync.
 - `docs/CHANGELOG.md` — record the v1.0.5 package surface and keep previous release status truthful.
-- `.osc/plans/active/122-compare-package-release-sync.md` — this plan.
+- `.osc/plans/done/122-compare-package-release-sync.md` — this plan after closeout.
 - `.osc/releases/2026-05-27-122-compare-package-release-sync.md` — durable release-sync candidate evidence.
 - This plan file and `MISSION.md` — closeout only after package/release proof exists.
 
@@ -36,12 +38,12 @@ Prepare and verify `open-scaffold@1.0.5` as the package/public-surface sync for 
 - [x] Root package version is bumped to `1.0.5` and lockfile metadata matches.
 - [x] Changelog documents v1.0.5 as the package-surface sync for `osc compare`.
 - [x] Local gates pass before PR: `./verify.sh --strict`, focused compare tests, `npm test`, `npm run build`, `npm pack --dry-run --json`, `npm publish --dry-run`, `git diff --check`.
-- [ ] PR CI and latest-head Codex review are clean before PR integration.
-- [ ] Trusted publishing succeeds for `open-scaffold@1.0.5` after PR integration and owner publish approval.
-- [ ] `npm view open-scaffold version dist-tags --json` shows `1.0.5` / `latest: 1.0.5`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest compare <attempt-a-dir> <attempt-b-dir>` runs against a temporary copy of the example fixture.
-- [ ] GitHub Release `v1.0.5` exists, targets the integrated main commit, and is marked Latest if release publication is approved.
+- [x] PR CI and latest-head Codex review are clean before PR integration.
+- [x] Trusted publishing succeeds for `open-scaffold@1.0.5` after PR integration and owner publish approval.
+- [x] `npm view open-scaffold version dist-tags --json` shows `1.0.5` / `latest: 1.0.5`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` includes `osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest compare <attempt-a-dir> <attempt-b-dir>` runs against the example fixture.
+- [x] GitHub Release `v1.0.5` exists, targets the integrated main commit, and is marked Latest.
 
 ## Verification steps
 
@@ -61,4 +63,4 @@ Prepare and verify `open-scaffold@1.0.5` as the package/public-surface sync for 
 
 ## Open questions
 
-- None for the package-sync candidate. Actual npm publishing, GitHub Release creation, plan closeout, and Kanban completion remain owner-gated follow-through after this PR.
+- None. Package publication, GitHub Release, public-surface verification, and closeout are complete.

--- a/.osc/releases/2026-05-27-122-compare-package-release-sync.md
+++ b/.osc/releases/2026-05-27-122-compare-package-release-sync.md
@@ -2,30 +2,35 @@
 
 ## Summary
 
-Prepared `open-scaffold@1.0.5` as the package/public-surface sync for PR #134's `osc compare <attempt-a-dir> <attempt-b-dir>` command. The source feature reached `main` in PR #134, but npm `latest` and GitHub Latest Release still point to `1.0.4`, so this release-sync candidate bumps the package metadata and records the gates needed before publication.
+Completed the `open-scaffold@1.0.5` package/public-surface sync for PR #134's `osc compare <attempt-a-dir> <attempt-b-dir>` command.
 
-This is candidate evidence only. The release-sync plan remains active until owner-approved merge, trusted publishing, fresh `npx` verification, GitHub Latest Release publication, and closeout proof are complete.
+The source feature reached `main` in PR #134. PR #135 prepared and merged the version/changelog/release-sync candidate. Owner-approved follow-through then published `open-scaffold@1.0.5` via trusted publishing, verified npm/latest and fresh isolated-cache `npx` behavior, created GitHub Release `v1.0.5`, and moved the release-sync plan to `done/`.
 
 ## Traceability
 
 - Roadmap / issue / task: adoption wedge / attempt-diff magic moment; package-sync follow-through after PR #134.
 - Source plan: `.osc/plans/done/109-bare-attempt-compare.md`.
-- Release-sync plan: `.osc/plans/active/122-compare-package-release-sync.md`.
+- Release-sync plan: `.osc/plans/done/122-compare-package-release-sync.md`.
 - Run ID / run packet: N/A for release-sync.
 - Source Pull Request: https://github.com/graphanov/open-scaffold/pull/134.
-- Release-sync Pull Request: pending.
-- Trusted publishing run: pending owner-approved merge/publication.
-- GitHub Release: pending owner-approved release publication.
+- Release-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/135.
+- PR #135 merge commit: `3d5e6e22a6d0003eef3cae7b7fadbcb1a0a5eb35`.
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/26523258650.
+- npm package: `open-scaffold@1.0.5` with `latest: 1.0.5`.
+- npm tarball: https://registry.npmjs.org/open-scaffold/-/open-scaffold-1.0.5.tgz.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v1.0.5.
 
 ## Verification
+
+Pre-publication candidate gates:
 
 - `gh pr view 134 --repo graphanov/open-scaffold --json state,mergedAt,mergeCommit,url` — PASS: PR #134 is merged; merge commit `fc55df6` on local `main`.
 - PR #134 checks — PASS: `Validate changed plans`, `Validate evidence notes`, and `ci` passed before merge.
 - `git diff --check` after syncing `main` — PASS.
 - `node dist/cli.js --help | grep -F 'osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]'` — PASS locally after PR #134.
-- Fresh isolated-cache `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc compare` command before this release-sync candidate is published.
-- `npm view open-scaffold version dist-tags --json` — PRECHECK: npm/latest is `1.0.4` before this release-sync candidate.
-- `gh release list --repo graphanov/open-scaffold --limit 5` — PRECHECK: GitHub Latest Release is `v1.0.4 — Work dry-run preview package sync` before this release-sync candidate.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` — PRECHECK: no `osc compare` command before this release-sync candidate was published.
+- `npm view open-scaffold version dist-tags --json` — PRECHECK: npm/latest was `1.0.4` before this release-sync candidate.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PRECHECK: GitHub Latest Release was `v1.0.4 — Work dry-run preview package sync` before this release-sync candidate.
 - `node -p "require('./package.json').version"` — PASS on release-sync branch: `1.0.5`.
 - `node -p "require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `1.0.5 / 1.0.5`.
 - `node dist/cli.js plan validate .osc/plans/active/122-compare-package-release-sync.md` — PASS: 0 issues found.
@@ -38,17 +43,34 @@ This is candidate evidence only. The release-sync plan remains active until owne
 - `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b --json` parsed as JSON — PASS: schema `open-scaffold.attempt-comparison.v1`.
 - `npm pack --dry-run --json` — PASS for `open-scaffold@1.0.5` (156 files); package includes `dist/compare.js` and `dist/compare.d.ts`.
 - `npm publish --dry-run` — PASS for `open-scaffold@1.0.5`.
-- PR CI and latest-head Codex review — pending after PR creation.
-- Trusted publishing for `open-scaffold@1.0.5` — pending owner-approved merge/publication.
-- Fresh isolated-cache `npx` verification for `osc compare` — pending after publication.
-- GitHub Release `v1.0.5` marked Latest — pending owner-approved release publication.
+- PR #135 CI and Codex latest-head review — PASS before merge: Validate evidence notes, Validate changed plans, and CI passed; Codex reported no major issues; unresolved review threads were 0.
+
+Post-merge/publication gates:
+
+- `git checkout main && git pull --ff-only origin main` — PASS: local `main` synced to `3d5e6e22a6d0003eef3cae7b7fadbcb1a0a5eb35`.
+- `git diff --check` — PASS on synced `main` before publish.
+- `./verify.sh --strict` — PASS on synced `main`: 10 pass / 0 fail / 0 warn.
+- `npm test -- --run` — PASS on synced `main`: 45 files / 396 tests.
+- `npm run build` — PASS on synced `main`.
+- `npm pack --dry-run --json` — PASS on synced `main`; package includes `dist/compare.js` and `dist/compare.d.ts`.
+- `npm publish --dry-run` — PASS on synced `main`.
+- Trusted publishing workflow `publish-npm.yml` — PASS: run `26523258650`, conclusion `success`, head SHA `3d5e6e22a6d0003eef3cae7b7fadbcb1a0a5eb35`.
+- `npm view open-scaffold version dist-tags repository homepage bugs keywords --json --prefer-online` — PASS: `version: 1.0.5`, `dist-tags.latest: 1.0.5`.
+- `npm view open-scaffold@1.0.5 version dist.integrity dist.tarball --json --prefer-online` — PASS: tarball `https://registry.npmjs.org/open-scaffold/-/open-scaffold-1.0.5.tgz`.
+- Fresh isolated-cache `npx --yes open-scaffold@latest --help` from a temp directory — PASS: help includes `osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]`.
+- Fresh isolated-cache `npx --yes open-scaffold@1.0.5 --help` from a temp directory — PASS: help includes `osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]`.
+- Fresh isolated-cache `npx --yes open-scaffold@latest compare /Users/danimal/Projects/open-scaffold/examples/attempt-compare/attempt-a /Users/danimal/Projects/open-scaffold/examples/attempt-compare/attempt-b` — PASS: Markdown compare output produced expected diff sections.
+- Fresh isolated-cache `npx --yes open-scaffold@latest compare ... --json` — PASS: parsed JSON schema `open-scaffold.attempt-comparison.v1`.
+- Fresh isolated-cache `npx --yes open-scaffold@latest init --tier min --target <tmp>` — PASS: created `MISSION.md`, `.osc/RULES.md`, `.osc/plans/WORKFLOW.md`, and `verify.sh` in the target.
+- `gh release create v1.0.5 --target 3d5e6e22a6d0003eef3cae7b7fadbcb1a0a5eb35 --latest` — PASS.
+- `gh release view v1.0.5 --repo graphanov/open-scaffold --json tagName,name,publishedAt,targetCommitish,url,isDraft,isPrerelease` — PASS: tag `v1.0.5`, target `3d5e6e22a6d0003eef3cae7b7fadbcb1a0a5eb35`, not draft, not prerelease.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS: `v1.0.5 — Compare command package sync` is marked Latest.
+- `gh workflow list --repo graphanov/open-scaffold --json id,name,path,state --jq '.[] | select(.path|contains("publish"))'` — PASS: only `.github/workflows/publish-npm.yml` is active for publish.
 
 ## Outcome
 
-Candidate prepared; owner-gated public-surface follow-through pending.
+Published and verified. `open-scaffold@latest` is now `1.0.5`; fresh `npx` exposes and runs `osc compare`; GitHub Release `v1.0.5` is Latest; release-sync plan `122-compare-package-release-sync` is closed to `done/`.
 
 ## Follow-up
 
-- Open a focused release-sync PR and keep it latest-head clean.
-- After owner approval, merge the release-sync PR, run trusted publishing for `open-scaffold@1.0.5`, verify fresh isolated-cache `npx` exposes and runs `osc compare`, create GitHub Release `v1.0.5` as Latest, then close this plan.
-- After this public-surface sync is complete, resume Context Authority in the order `071-evidence-chain-verifier` → `117-osc-trace-work-record-replay` → reserved Context Authority slices.
+Resume Context Authority in the order `071-evidence-chain-verifier` → `117-osc-trace-work-record-replay` → reserved Context Authority slices.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-27: closed 122-compare-package-release-sync — published 1.0.5 and aligned compare package public surfaces
 - 2026-05-27: closed 109-bare-attempt-compare — added prerequisite-free bare attempt comparison
 - 2026-05-27: broaden positioning beyond software-only work — see .osc/plans/done/108-public-work-record-positioning-amendment-1.md
 - 2026-05-27: closed 108-public-work-record-positioning — aligned public work-record positioning


### PR DESCRIPTION
## Summary
- Close plan `122-compare-package-release-sync` after npm/latest, fresh `npx`, and GitHub Latest Release proof completed.
- Update the release/evidence note with final trusted-publishing, registry, fresh npx, and GitHub Release evidence.
- Stamp `MISSION.md` via the close command.

## Verification
- [x] `node dist/cli.js plan validate .osc/plans/done/122-compare-package-release-sync.md` — 0 issues
- [x] `git diff --check`
- [x] `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- [x] `npm view open-scaffold version dist-tags --json` — `1.0.5` / `latest: 1.0.5`
- [x] fresh isolated-cache `npx open-scaffold@latest --help` includes `osc compare`
- [x] fresh isolated-cache `npx open-scaffold@latest compare ...` works in Markdown and JSON modes
- [x] fresh isolated-cache `npx open-scaffold@latest init --tier min` creates expected min-tier files
- [x] GitHub Release `v1.0.5` exists and is marked Latest

## Scope
- Evidence/plan closeout only.
- No package/code/CLI behavior changes.
