### PR TITLE
docs(cli): make compare the first-read demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It does not replace your agent, IDE, task tracker, CI, or compliance process. Th
 - **Clarity** — the mission, plan, and next action live in the repo.
 - **Reviewability** — evidence, checks, and decisions stay attached to the work.
 - **Handoff** — `run.json` packages work for an agent, runtime, teammate, or future session.
-- **Improvement loops** — `osc evolve` records repeated attempts, compares them, and explains which one became the frontier.
+- **Improvement loops** — repeated attempts can be recorded after the core work record is in place.
 
 Under the hood, this is just files:
 
@@ -38,101 +38,63 @@ MISSION.md                         why this repo exists
 .osc/plans/                        scoped work with acceptance criteria
 .osc/runs/<run_id>/run.json         handoff package for a worker or reviewer
 .osc/releases/                     evidence notes and release records
-.osc/evolution/<loop_id>/           attempts, comparison, and frontier history
 ```
+
+---
+
+## Try the core idea in 30 seconds
+
+From this repository checkout, you do not need a runtime, provider account, or full scaffold to see the point. Compare two included attempts and get a reviewable work-record artifact:
+
+```bash
+npx open-scaffold@latest compare \
+  examples/attempt-compare/attempt-a \
+  examples/attempt-compare/attempt-b
+```
+
+In a source checkout, after `npm install`:
+
+```bash
+npm run osc -- compare \
+  examples/attempt-compare/attempt-a \
+  examples/attempt-compare/attempt-b
+```
+
+This does not run an agent and does not choose an objective winner. It shows the core pattern: attempts become inspectable files, the differences become reviewable, and the decision can be recorded instead of disappearing into chat.
 
 ---
 
 ## The basic loop
 
 ```text
-        goal
-         │
-         ▼
-      plan.md
-         │
-         ▼
-  handoff package
-      run.json
-         │
-         ▼
- agent / runtime / human
-         │
-         ▼
-      output
-         │
-         ▼
- evidence + verification
-         │
-         ▼
- review / approve / amend
-         │
-         ▼
- durable repo record
+MISSION.md
+    │
+    ▼
+plan.md
+    │
+    ├─ optional amendment when scope changes
+    │
+    ▼
+run.json handoff package
+    │
+    ▼
+agent / runtime / human output
+    │
+    ▼
+evidence
+    │
+    ▼
+verification
+    │
+    ▼
+close the slice
 ```
 
 Chat, Discord, terminals, GitHub comments, and agent transcripts can help operate the work. They are not the source of truth. The repo record is.
 
-### Target workflow
-
-The post-v1 target is a smoother Codex-first path that starts from plain intent while preserving the same record. The first natural-language composition is dry-run only:
-
-```bash
-osc work "Add a /health endpoint with tests" --runtime codex --dry-run
-```
-
-`osc work --dry-run` previews a candidate plan, run packet, and dispatch command without writing files, launching a runtime, calling provider APIs, or granting commit/push/PR/merge/publish authority. The supporting no-spawn pieces remain explicit: `osc start` prints a paste-ready Codex/OMX handoff from an existing plan, and `osc dispatch .osc/runs/RUN_ID/run.json --adapter <id>` invokes a reviewed local adapter config and captures receipt/evidence/log paths. Full execution remains future work behind a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
-
----
-
-## When one attempt is not enough
-
-Modern AI work often means trying the same task more than once: a better prompt, a different runtime, a stronger review pass, or a repaired implementation.
-
-Open Scaffold records that loop instead of burying the decision in chat.
-
-```text
-One task, several attempts
-
-                ┌─ attempt A ─ evidence ─ result
-                │
-goal + plan ────┼─ attempt B ─ evidence ─ result
-                │
-                └─ attempt C ─ evidence ─ result
-                                      │
-                                      ▼
-                                evolve compare
-                                      │
-                                      ▼
-                           frontier: "C won because..."
-```
-
-Example:
-
-```bash
-npx open-scaffold evolve init .osc/plans/active/my-task.md \
-  --out .osc/evolution/my-task \
-  --strategy manual
-
-npx open-scaffold evolve record .osc/evolution/my-task \
-  --run .osc/runs/<run_id>/run.json \
-  --decision promote \
-  --rationale "Best evidence so far."
-
-npx open-scaffold evolve compare .osc/evolution/my-task \
-  --format markdown \
-  --out .osc/releases/evolution-compare.md
-```
-
-`osc evolve` records attempt/frontier state only. It does not launch agents, rank models, certify compliance, or approve releases.
-
-For the one-screen version, see [`docs/examples/evolution-loop-compare.md`](docs/examples/evolution-loop-compare.md). For a small fixture you can run locally, see [`examples/evolution-ledger-demo/`](examples/evolution-ledger-demo/).
-
----
-
 ## Quickstart
 
-This is the smallest useful path: add the scaffold, define the mission, create one active plan, verify, record evidence, and close the slice.
+This is the smallest stable path: add the scaffold, define `MISSION.md`, create one active plan, optionally hand it off with a run packet or amendment, capture evidence, verify, and close the slice.
 
 ### 1. Add Open Scaffold to a repo
 
@@ -195,33 +157,7 @@ Shell fallback:
 cp .osc/plans/handoff-template.md .osc/plans/active/my-first-task.md
 ```
 
-### 4. Verify, record evidence, and close
-
-```bash
-./verify.sh --standard
-osc evidence new my-first-task
-osc close my-first-task --message "verified first task"
-# or without local install:
-npx open-scaffold evidence new my-first-task
-npx open-scaffold close my-first-task --message "verified first task"
-```
-
-If the scope changes, amend instead of rewriting history:
-
-```bash
-osc amend my-first-task --message "scope changed after review"
-# or without local install:
-npx open-scaffold amend my-first-task --message "scope changed after review"
-```
-
-Shell fallbacks remain available:
-
-```bash
-./amend.sh my-first-task --message "scope changed after review"
-./close.sh my-first-task --message "verified first task"
-```
-
-### 5. Optional: hand off to another tool
+### 4. Optional: create a run packet or amendment
 
 To print a paste-ready prompt for a Codex/OMX worker without writing run artifacts or launching anything:
 
@@ -244,6 +180,94 @@ npx open-scaffold run .osc/plans/active/my-first-task.md \
 
 That creates a `run.json` work package. The outside tool executes. Evidence comes back into the repo.
 
+If the scope changes, amend instead of rewriting history:
+
+```bash
+osc amend my-first-task --message "scope changed after review"
+# or without local install:
+npx open-scaffold amend my-first-task --message "scope changed after review"
+```
+
+Shell fallbacks remain available:
+
+```bash
+./amend.sh my-first-task --message "scope changed after review"
+```
+
+### 5. Verify, record evidence, and close
+
+```bash
+./verify.sh --standard
+osc evidence new my-first-task
+osc close my-first-task --message "verified first task"
+# or without local install:
+npx open-scaffold evidence new my-first-task
+npx open-scaffold close my-first-task --message "verified first task"
+```
+
+Shell fallback:
+
+```bash
+./close.sh my-first-task --message "verified first task"
+```
+
+---
+
+## Lab preview: plain-intent work
+
+The post-v1 target is a smoother Codex-first path that starts from plain intent while preserving the same record. The first natural-language composition is dry-run only:
+
+```bash
+osc work "Add a /health endpoint with tests" --runtime codex --dry-run
+```
+
+`osc work --dry-run` previews a candidate plan, run packet, and dispatch command without writing files, launching a runtime, calling provider APIs, or granting commit/push/PR/merge/publish authority. The supporting no-spawn pieces remain explicit: `osc start` prints a paste-ready Codex/OMX handoff from an existing plan, and `osc dispatch .osc/runs/RUN_ID/run.json --adapter <id>` invokes a reviewed local adapter config and captures receipt/evidence/log paths. Full execution remains future work behind a separate safety decision. See [`docs/RUNTIME_ADOPTION_WORKFLOW.md`](docs/RUNTIME_ADOPTION_WORKFLOW.md).
+
+---
+
+## When one compare is not enough
+
+The 30-second `osc compare` demo is the simplest version: two attempts, one reviewable comparison. Real AI work often means trying the same task more than once: a better prompt, a different runtime, a stronger review pass, or a repaired implementation.
+
+Open Scaffold can record that larger loop too, without burying the decision in chat.
+
+```text
+One task, several attempts
+
+                ┌─ attempt A ─ evidence ─ result
+                │
+goal + plan ────┼─ attempt B ─ evidence ─ result
+                │
+                └─ attempt C ─ evidence ─ result
+                                      │
+                                      ▼
+                                evolve compare
+                                      │
+                                      ▼
+                           frontier: "C won because..."
+```
+
+Example:
+
+```bash
+npx open-scaffold evolve init .osc/plans/active/my-task.md \
+  --out .osc/evolution/my-task \
+  --strategy manual
+
+npx open-scaffold evolve record .osc/evolution/my-task \
+  --run .osc/runs/<run_id>/run.json \
+  --decision promote \
+  --rationale "Best evidence so far."
+
+npx open-scaffold evolve compare .osc/evolution/my-task \
+  --format markdown \
+  --out .osc/releases/evolution-compare.md
+```
+
+`osc evolve` records attempt/frontier state only. It is a record, not an execution, compliance, model-evaluation, or approval system.
+
+For the one-screen version, see [`docs/examples/evolution-loop-compare.md`](docs/examples/evolution-loop-compare.md). For a small fixture you can run locally, see [`examples/evolution-ledger-demo/`](examples/evolution-ledger-demo/).
+
 ---
 
 ## v1.0.x stable release line
@@ -263,9 +287,9 @@ Experimental:
 
 Future / not included:
 
-- Native autonomous spawning in core.
+- Native agent spawning in core.
 - Compliance certification.
-- Provider/model benchmarking or ranking.
+- Provider/model benchmarking.
 
 Use cases the stable contract supports today:
 
@@ -336,7 +360,7 @@ Skip it for:
 - [`docs/STABILITY.md`](docs/STABILITY.md) — v1.0.0 stable, experimental, and future surfaces.
 - [`docs/CHANGELOG.md`](docs/CHANGELOG.md) — curated release history.
 - [`docs/DEV_CONTAINER.md`](docs/DEV_CONTAINER.md) — optional container setup for consistent team onboarding.
-- [`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md) — attempts, frontier promotion, and `osc evolve`.
+- [`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md) — attempts, frontier records, and `osc evolve`.
 - [`docs/EXAMPLES.md`](docs/EXAMPLES.md) — examples and viewer demos.
 - [`docs/OPEN_SCAFFOLD_SYSTEM.md`](docs/OPEN_SCAFFOLD_SYSTEM.md) — full system map and boundaries.
 - [`docs/RUNTIME_SELECTION.md`](docs/RUNTIME_SELECTION.md) — choosing runtime lanes and profiles.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -2,7 +2,7 @@
 
 This page defines what Open Scaffold v1.0.0 means for adopters.
 
-The short version: the repo protocol, folder state machine, core plan schema, evidence notes, and day-two CLI helpers are the stable contract. Runtime launch, provider-specific automation, and external cockpit transports remain opt-in or experimental unless a later release explicitly promotes them.
+The short version: the stable contract is the repo-native work-record loop — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus the read-only `osc compare` demo that shows why work records matter. Runtime launch, provider-specific automation, evaluation helpers, dashboards, and external cockpit transports remain opt-in lab/experimental surfaces unless a later release explicitly promotes them.
 
 ## Release status
 
@@ -12,7 +12,7 @@ The short version: the repo protocol, folder state machine, core plan schema, ev
 
 The repository may carry `package.json` version `1.0.0` before the owner completes the external publication gates. Do not treat repo version alone as proof that npm publication or GitHub Release latest movement has happened.
 
-## Stable in v1.0.0
+## Stable core in v1.0.0
 
 These surfaces are covered by semantic-versioning expectations.
 
@@ -24,7 +24,7 @@ These surfaces are covered by semantic-versioning expectations.
 - The 7-section plan schema in `.osc/plans/handoff-template.md`.
 - Mechanical amendments and closures through `osc amend`, `osc close`, `./amend.sh`, and `./close.sh`.
 - `.osc/releases/` as curated release/evidence notes.
-- `.osc/runs/<run_id>/run.json` as a handoff package format produced by core commands.
+- `.osc/runs/<run_id>/run.json` as a repo-native handoff package record. Core commands can create the package; external agents or adapters do the work and return receipts/evidence.
 
 ### CLI and shell floor
 
@@ -40,6 +40,7 @@ The stable day-two CLI surface is:
 - `osc evidence new`
 - `osc evidence collect`
 - `osc verify`
+- `osc compare` as a read-only first-read demo for comparing two recorded attempts
 
 The zero-dependency shell helpers remain a stable fallback floor:
 
@@ -55,7 +56,7 @@ The zero-dependency shell helpers remain a stable fallback floor:
 - `npm test` and `npm run build` remain the package-level local gates for this repository.
 - Public PRs should cite the plan, evidence note, verification commands, review state, and owner gates.
 
-## Experimental in v1.0.0
+## Lab / experimental in v1.0.0
 
 These surfaces are usable but not promised as final API shape. They may change in minor versions when the change is additive or in a future major version if the contract changes.
 
@@ -63,6 +64,7 @@ These surfaces are usable but not promised as final API shape. They may change i
 - `osc run`, `osc delegate`, `osc review`, and `osc ultrareview` beyond their current no-spawn artifact-generation role.
 - `osc dispatch` as explicit local-adapter invocation glue; adapter commands, receipts, and launch policy remain experimental and adapter-owned.
 - `osc work --dry-run` as a no-spawn natural-language composition preview; non-dry-run work execution remains future-gated.
+- `osc evolve` ledger helpers for repeated attempts; they record attempt/frontier decisions but do not execute or approve work.
 - Evaluation and audit envelope helpers.
 - Optional MCP server interface.
 - Glass cockpit webhook examples for Discord and Slack.
@@ -77,10 +79,10 @@ Experimental does not mean unsupported; it means users should avoid building irr
 
 These are explicitly not v1.0.0 guarantees:
 
-- Native autonomous agent spawning in Open Scaffold core.
+- Native agent spawning in Open Scaffold core.
 - Hosted orchestration services.
 - Compliance certification or legal audit certification.
-- Provider-specific model benchmarking or model-ranking claims.
+- Provider-specific model benchmarking claims.
 - Tamper-evident external ledger anchoring.
 - Marketplace, network registry, or installer behavior for runtimes.
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,6 +1,8 @@
 # Workflow
 
-A phase-to-tool reference for agent-orchestrated development. This file is the operational reference; `README.md` is the landing page. When in doubt about which tool to reach for, start here.
+A phase-to-tool reference for agent-orchestrated development. This file is the operational reference; `README.md` is the landing page. When in doubt about which tool to reach for, start with the stable repo record: `MISSION.md` → plan → run packet or amendment → evidence → verification → close.
+
+The stable core is the file protocol and lifecycle helpers. Lab surfaces such as natural-language work previews, evolution ledgers, dashboards, cockpit webhooks, and adapter dispatch glue are optional layers around that record; they do not replace the plan/evidence/verification/close chain.
 
 Named coordinators, harnesses, and status/approval channels (operator surfaces) in this guide are examples. Use [`docs/REFERENCE_TRUTH.md`](REFERENCE_TRUTH.md) to distinguish public examples, private deployment examples, runtime lanes, adapter candidates, and operator surfaces.
 
@@ -8,7 +10,7 @@ Named coordinators, harnesses, and status/approval channels (operator surfaces) 
 
 Every task moves through a natural progression. You do not need to use every phase — small fixes skip straight to Execute. The phases exist so you know where you are and what to reach for.
 
-For first-use setup, start with the [Minimum Viable Scaffold](MINIMUM_VIABLE_SCAFFOLD.md): choose a scaffold tier with `osc init --tier min|standard|max --target <repo>` for greenfield setup or `osc init --from-existing --tier min --target .` for an existing repo, define the mission, add one active plan, verify, record evidence, and close.
+For a no-setup first read, run `osc compare` against two recorded attempts to see the work-record idea before adopting the whole scaffold. For first-use setup, start with the [Minimum Viable Scaffold](MINIMUM_VIABLE_SCAFFOLD.md): choose a scaffold tier with `osc init --tier min|standard|max --target <repo>` for greenfield setup or `osc init --from-existing --tier min --target .` for an existing repo, define the mission, add one active plan, optionally create a run packet or amendment, verify, record evidence, and close.
 
 ### 1. Clarify (when the goal is fuzzy)
 
@@ -81,7 +83,7 @@ Then fill every TODO before implementation. The helpers create and move structur
 
 Implement what the plan says. Independent tasks can run in parallel. Every change must trace back to a plan file or amendment.
 
-For day-one local task tracking without an external board, use `osc task` as a repo-local task bridge:
+For day-one local task tracking without an external board, `osc task` is a lab repo-local task bridge:
 
 ```bash
 osc task new "Fix login redirect bug" --priority high --plan <plan-slug>
@@ -101,7 +103,7 @@ osc run .osc/plans/active/<plan>.md --dry-run --json
 
 `--dry-run` validates the plan, renders the `run.json` and package markdown in memory, lists files from the plan, and exits without creating `.osc/runs/` artifacts. Re-run without `--dry-run` only when the preview is acceptable.
 
-For multi-attempt improvement loops, create a curated evolution ledger after the first plan/run exists:
+For multi-attempt improvement loops, create a lab evolution ledger after the first plan/run exists:
 
 ```bash
 osc evolve init .osc/plans/active/<plan>.md --out .osc/evolution/<loop-id> --strategy manual
@@ -109,9 +111,9 @@ osc evolve record .osc/evolution/<loop-id> --run .osc/runs/<run-id>/run.json --e
 osc evolve check .osc/evolution/<loop-id>
 ```
 
-The evolution ledger records attempts and frontier promotion only. External coordinators or OMX-based runtime packages execute attempts; Open Scaffold core does not spawn runtimes or rank models.
+The evolution ledger records attempts and frontier state only. External coordinators or OMX-based runtime packages execute attempts; Open Scaffold core does not spawn runtimes or choose a winner.
 
-> **With OMC harness:** `/ralph` for Claude Code autonomous completion loops; `/team` or `/ultrawork` for parallel fan-out across multiple Claude Code-oriented agents.
+> **With OMC harness:** `/ralph` for Claude Code completion loops; `/team` or `/ultrawork` for parallel fan-out across multiple Claude Code-oriented agents.
 >
 > **With OMX harness:** `$ralph` for Codex persistent completion loops; `$team` for tmux-backed Codex worker teams; `$ultrawork` for parallel execution; promote runtime evidence back into Open Scaffold.
 >

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,19 +29,17 @@ import { buildWorkDryRunPreview, formatWorkDryRunPreview } from './work.js';
 function printHelp(): void {
   console.log(`osc — Open Scaffold CLI
 
+Repo-native work record: MISSION.md → plan → run packet/amendment → evidence → verification → close.
+
 Usage:
+First-read demo:
+  osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]
+
+Stable core protocol:
   osc init --tier <min|standard|max> --target <dir> [--force]
   osc init --from-existing --tier min --target <dir> [--force]
   osc init --min|--standard|--max --target <dir> [--force]
   osc status [--json|--dashboard]
-  osc dashboard [--watch] [--interval <seconds>]
-  osc task new <title> [--priority <high|medium|low>] [--plan <slug>]
-  osc task list [--status <status>] [--priority <priority>] [--plan <slug>] [--json]
-  osc task show <task-id>
-  osc task claim|start|complete|cancel <task-id>
-  osc task block <task-id> --reason <text>
-  osc task comment <task-id> <comment>
-  osc task link <task-id> --plan <slug>
   osc plan <plan-path>
   osc plan new <slug> --stage <active|backlog|blocked> [--from-template <name>]
   osc plan new --from-template list
@@ -53,14 +51,25 @@ Usage:
   osc evidence new <slug>
   osc evidence collect <slug> [--ci] [--dry-run] [--verbose]
   osc close <plan-slug> [--message <text>]
+  osc verify [--evidence-chain [--plan <slug>] [--json] [--strict]]
+
+Handoff and run packages:
   osc start <plan-slug-or-path> --runtime <codex|omx|plain|human|custom>
   osc delegate <plan-path> [run binding options]
   osc run <plan-path> [--dry-run] [--json] [run binding options]
   osc dispatch <run-json> --adapter <adapter-id>
-  osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]
-  osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]
   osc review <plan-path> [run binding options]
   osc ultrareview <plan-path> [run binding options]
+
+Lab and experimental:
+  osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]
+  osc task new <title> [--priority <high|medium|low>] [--plan <slug>]
+  osc task list [--status <status>] [--priority <priority>] [--plan <slug>] [--json]
+  osc task show <task-id>
+  osc task claim|start|complete|cancel <task-id>
+  osc task block <task-id> --reason <text>
+  osc task comment <task-id> <comment>
+  osc task link <task-id> --plan <slug>
   osc eval init <run-or-plan> [--out <path>]
   osc eval check <evaluation-path>
   osc audit init <run-or-plan> [--artifact <role> <path>]... [--out <path>]
@@ -72,11 +81,13 @@ Usage:
   osc cockpit config
   osc cockpit test [--dry-run]
   osc cockpit post --event <event> [--message <text>] [--run-id <id>] [--plan <slug>] [--task-id <id>] [--pr <url>] [--evidence-path <path>] [--dry-run]
+  osc dashboard [--watch] [--interval <seconds>]
   osc dashboard --web [--out <path>]
   osc dashboard --serve [--port <port>] [--open]
+
+Diagnostics and advanced:
   osc mcp serve [--repo <path>] [--allow-write] [--validate]
   osc metrics [--json] [--since <date>] [--lookback <weeks>] [--table] [--verbose]
-  osc verify [--evidence-chain [--plan <slug>] [--json] [--strict]]
   osc doctor [--fix] [--dry-run] [--severity <info|warn|error>] [--check <name>]
   osc runtimes list [--json]
   osc runtimes show <id>
@@ -97,7 +108,7 @@ Run binding options:
   --pr <id-or-url>            Optional PR binding
   --commit-policy <text>      Commit/push approval rule
 
-Generic open-scaffold generates prompts/artifacts only. External coordinators/agents and runtime harnesses perform autonomous spawning.`);
+Generic open-scaffold generates prompts/artifacts only. External coordinators, agents, and runtime harnesses perform any execution outside core.`);
 }
 
 function packageVersion(): string {

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..');
-const tsx = join(repoRoot, 'node_modules/.bin/tsx');
-const cli = join(repoRoot, 'src/cli.ts');
+const node = process.execPath;
+const cli = resolve(repoRoot, 'src/cli.ts');
+const cliArgs = ['--import', 'tsx', cli];
 
 type HelpCase = {
   name: string;
@@ -12,6 +13,67 @@ type HelpCase = {
   expected: string;
   forbidden?: string;
 };
+
+const topLevelHelpSections = [
+  'First-read demo:',
+  'Stable core protocol:',
+  'Handoff and run packages:',
+  'Lab and experimental:',
+  'Diagnostics and advanced:',
+];
+
+const topLevelHelpCommands = [
+  'osc init --tier <min|standard|max> --target <dir> [--force]',
+  'osc init --from-existing --tier min --target <dir> [--force]',
+  'osc init --min|--standard|--max --target <dir> [--force]',
+  'osc status [--json|--dashboard]',
+  'osc plan <plan-path>',
+  'osc plan new <slug> --stage <active|backlog|blocked> [--from-template <name>]',
+  'osc plan new --from-template list',
+  'osc plan validate <slug-or-path> [--json] [--strict]',
+  'osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]',
+  'osc plan move <slug> --to <active|backlog|blocked>',
+  'osc plan graph [--format <ascii|mermaid|json>] [--stage <active|backlog|all>] [--direction <downstream|upstream|both>] [--plan <slug>]',
+  'osc amend <plan-slug> [--message <text>]',
+  'osc evidence new <slug>',
+  'osc evidence collect <slug> [--ci] [--dry-run] [--verbose]',
+  'osc close <plan-slug> [--message <text>]',
+  'osc verify [--evidence-chain [--plan <slug>] [--json] [--strict]]',
+  'osc start <plan-slug-or-path> --runtime <codex|omx|plain|human|custom>',
+  'osc delegate <plan-path> [run binding options]',
+  'osc run <plan-path> [--dry-run] [--json] [run binding options]',
+  'osc dispatch <run-json> --adapter <adapter-id>',
+  'osc work <task-description> --runtime <preset> --dry-run [--json] [--adapter <adapter-id>]',
+  'osc review <plan-path> [run binding options]',
+  'osc ultrareview <plan-path> [run binding options]',
+  'osc task new <title> [--priority <high|medium|low>] [--plan <slug>]',
+  'osc task list [--status <status>] [--priority <priority>] [--plan <slug>] [--json]',
+  'osc task show <task-id>',
+  'osc task claim|start|complete|cancel <task-id>',
+  'osc task block <task-id> --reason <text>',
+  'osc task comment <task-id> <comment>',
+  'osc task link <task-id> --plan <slug>',
+  'osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]',
+  'osc eval init <run-or-plan> [--out <path>]',
+  'osc eval check <evaluation-path>',
+  'osc audit init <run-or-plan> [--artifact <role> <path>]... [--out <path>]',
+  'osc audit check <audit-manifest-path>',
+  'osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>]',
+  'osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text>',
+  'osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>]',
+  'osc evolve check <loop-dir>',
+  'osc cockpit config',
+  'osc cockpit test [--dry-run]',
+  'osc cockpit post --event <event> [--message <text>] [--run-id <id>] [--plan <slug>] [--task-id <id>] [--pr <url>] [--evidence-path <path>] [--dry-run]',
+  'osc dashboard [--watch] [--interval <seconds>]',
+  'osc dashboard --web [--out <path>]',
+  'osc dashboard --serve [--port <port>] [--open]',
+  'osc mcp serve [--repo <path>] [--allow-write] [--validate]',
+  'osc metrics [--json] [--since <date>] [--lookback <weeks>] [--table] [--verbose]',
+  'osc doctor [--fix] [--dry-run] [--severity <info|warn|error>] [--check <name>]',
+  'osc runtimes list [--json]',
+  'osc runtimes show <id>',
+];
 
 const cases: HelpCase[] = [
   {
@@ -58,10 +120,35 @@ const cases: HelpCase[] = [
   },
 ];
 
+describe('top-level help', () => {
+  it('groups commands without hiding representative coverage', () => {
+    const result = spawnSync(node, [...cliArgs, '--help'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('MISSION.md → plan → run packet/amendment → evidence → verification → close');
+
+    for (const section of topLevelHelpSections) {
+      expect(result.stdout).toContain(section);
+    }
+
+    const sectionPositions = topLevelHelpSections.map((section) => result.stdout.indexOf(section));
+    expect(sectionPositions.every((position) => position >= 0)).toBe(true);
+    expect(sectionPositions).toEqual([...sectionPositions].sort((a, b) => a - b));
+    expect(result.stdout.indexOf('osc compare <attempt-a-dir>')).toBeLessThan(
+      result.stdout.indexOf('Stable core protocol:'),
+    );
+
+    for (const command of topLevelHelpCommands) {
+      expect(result.stdout).toContain(command);
+    }
+  });
+});
+
 describe('plan lifecycle help flags', () => {
   for (const item of cases) {
     it(`prints help for ${item.name}`, () => {
-      const result = spawnSync(tsx, [cli, ...item.args], { cwd: repoRoot, encoding: 'utf8' });
+      const result = spawnSync(node, [...cliArgs, ...item.args], { cwd: repoRoot, encoding: 'utf8' });
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe('');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [
+      ...configDefaults.exclude,
+      '**/.claude/**',
+      '**/.omc/**',
+      '**/.omx/**',
+      '**/.osc/research/**',
+      '**/.osc/runs/**',
+      '**/.osc/state/**',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- Makes `osc compare` the first-read demo surface in the README and top-level CLI help.
- Reframes the stable path around the repo-native work-record loop while keeping `osc work --dry-run` and broader evolution surfaces in lab/experimental framing.
- Adds Vitest config exclusions so ignored Open Scaffold research/runtime folders do not pollute local test discovery.

## Verification
- `npm test`
- `npm run build`
- `./verify.sh --strict`
- `git diff --check`
- `npm run osc -- compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b`

## Risk / gates
- Docs/help/test-discovery slice only.
- Does not add runtime spawning, provider dependencies, npm publication, or release changes.
