### PR TITLE
chore: close evidence-chain package sync

### DIFF
--- a/.osc/plans/done/123-evidence-chain-package-release-sync.md
+++ b/.osc/plans/done/123-evidence-chain-package-release-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
@@ -29,7 +29,7 @@ Prepare a package/public-surface release candidate that publishes the evidence-c
 - `docs/CHANGELOG.md` — add the `v0.20.0` package-sync candidate entry and preserve `1.0.x` as historical.
 - `AGENTS.md` and `CLAUDE.md` — keep paired agent-entry descriptions aligned with the corrected stability/current-cadence wording.
 - `.osc/releases/2026-05-28-123-evidence-chain-package-release-sync.md` — record candidate evidence and post-merge/publication gates.
-- `.osc/plans/active/123-evidence-chain-package-release-sync.md` — this plan.
+- `.osc/plans/done/123-evidence-chain-package-release-sync.md` — this plan after closeout.
 
 ## Implementation Architecture Coverage
 
@@ -41,13 +41,13 @@ Prepare a package/public-surface release candidate that publishes the evidence-c
 
 ## Acceptance criteria
 
-- [ ] `package.json` and `package-lock.json` both declare `0.20.0`.
-- [ ] The candidate documents that `0.20.0` is an intentional pre-1.0 cadence correction, while historical `1.0.x` versions remain published history.
-- [ ] `docs/CHANGELOG.md` includes a `v0.20.0` candidate entry for `osc verify --evidence-chain`, first-read `osc compare` help grouping, and version-cadence correction.
-- [ ] `README.md`, `docs/STABILITY.md`, `AGENTS.md`, and `CLAUDE.md` no longer frame the current line as a pressure-heavy `v1.0.x` stable line.
-- [ ] Candidate package gates pass: `./verify.sh --strict`, `npm test`, `npm run build`, `npm pack --dry-run --json`, `npm publish --dry-run --tag latest`, and `git diff --check`.
-- [ ] Local built CLI help exposes `osc verify --evidence-chain` and the first-read `osc compare` help grouping before PR publication.
-- [ ] The PR stops before merge, npm publish, GitHub Release creation/update, and optional npm deprecation of historical `1.0.x` versions.
+- [x] `package.json` and `package-lock.json` both declare `0.20.0`.
+- [x] The candidate documents that `0.20.0` is an intentional pre-1.0 cadence correction, while historical `1.0.x` versions remain published history.
+- [x] `docs/CHANGELOG.md` includes a `v0.20.0` candidate entry for `osc verify --evidence-chain`, first-read `osc compare` help grouping, and version-cadence correction.
+- [x] `README.md`, `docs/STABILITY.md`, `AGENTS.md`, and `CLAUDE.md` no longer frame the current line as a pressure-heavy `v1.0.x` stable line.
+- [x] Candidate package gates pass: `./verify.sh --strict`, `npm test`, `npm run build`, `npm pack --dry-run --json`, `npm publish --dry-run --tag latest`, and `git diff --check`.
+- [x] Local built CLI help exposes `osc verify --evidence-chain` and the first-read `osc compare` help grouping before PR publication.
+- [x] The PR stops before merge, npm publish, GitHub Release creation/update, and optional npm deprecation of historical `1.0.x` versions.
 
 ## Verification steps
 
@@ -64,5 +64,5 @@ Prepare a package/public-surface release candidate that publishes the evidence-c
 
 ## Open questions
 
-- Owner gate after PR merge: publish `open-scaffold@0.20.0` via trusted publishing and mark GitHub Release `v0.20.0` as Latest?
-- Owner gate after public sync: optionally deprecate the historical `1.0.x` npm versions with a gentle cadence-correction message, or leave them alone as normal history?
+- Owner gate after PR merge: resolved — `open-scaffold@0.20.0` was published via trusted publishing and GitHub Release `v0.20.0` was marked Latest.
+- Owner gate after public sync: still deferred — optionally deprecate the historical `1.0.x` npm versions with a gentle cadence-correction message, or leave them alone as normal history.

--- a/.osc/releases/2026-05-27-122-compare-package-release-sync.md
+++ b/.osc/releases/2026-05-27-122-compare-package-release-sync.md
@@ -64,12 +64,12 @@ Post-merge/publication gates:
 - Fresh isolated-cache `npx --yes open-scaffold@latest init --tier min --target <tmp>` — PASS: created `MISSION.md`, `.osc/RULES.md`, `.osc/plans/WORKFLOW.md`, and `verify.sh` in the target.
 - `gh release create v1.0.5 --target 3d5e6e22a6d0003eef3cae7b7fadbcb1a0a5eb35 --latest` — PASS.
 - `gh release view v1.0.5 --repo graphanov/open-scaffold --json tagName,name,publishedAt,targetCommitish,url,isDraft,isPrerelease` — PASS: tag `v1.0.5`, target `3d5e6e22a6d0003eef3cae7b7fadbcb1a0a5eb35`, not draft, not prerelease.
-- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS: `v1.0.5 — Compare command package sync` is marked Latest.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS at publication time: `v1.0.5 — Compare command package sync` was marked Latest.
 - `gh workflow list --repo graphanov/open-scaffold --json id,name,path,state --jq '.[] | select(.path|contains("publish"))'` — PASS: only `.github/workflows/publish-npm.yml` is active for publish.
 
 ## Outcome
 
-Published and verified. `open-scaffold@latest` is now `1.0.5`; fresh `npx` exposes and runs `osc compare`; GitHub Release `v1.0.5` is Latest; release-sync plan `122-compare-package-release-sync` is closed to `done/`.
+Published and verified at the time of this release. `open-scaffold@latest` became `1.0.5`; fresh `npx` exposed and ran `osc compare`; GitHub Release `v1.0.5` was marked Latest until superseded by a later release; release-sync plan `122-compare-package-release-sync` is closed to `done/`.
 
 ## Follow-up
 

--- a/.osc/releases/2026-05-28-123-evidence-chain-package-release-sync.md
+++ b/.osc/releases/2026-05-28-123-evidence-chain-package-release-sync.md
@@ -2,9 +2,9 @@
 
 ## Summary
 
-Prepares `open-scaffold@0.20.0` as the package/public-surface sync for `osc verify --evidence-chain` and the latest first-read `osc compare` help grouping.
+Publishes `open-scaffold@0.20.0` as the package/public-surface sync for `osc verify --evidence-chain` and the latest first-read `osc compare` help grouping.
 
-This release candidate intentionally corrects the public version cadence back to pre-1.0 hardening. Historical `1.0.x` packages and GitHub Releases remain published history, but the intended forward-moving `latest` channel should be `0.20.0` after owner-approved publish and GitHub Release follow-through.
+This release intentionally corrects the public version cadence back to pre-1.0 hardening. Historical `1.0.x` packages and GitHub Releases remain published history, while the forward-moving `latest` channel is now `0.20.0`.
 
 ## Traceability
 
@@ -14,11 +14,15 @@ This release candidate intentionally corrects the public version cadence back to
 - Source Pull Request: https://github.com/graphanov/open-scaffold/pull/137.
 - First-read compare docs/help source Pull Request: https://github.com/graphanov/open-scaffold/pull/138.
 - Runtime-control-loop decision source Pull Request: https://github.com/graphanov/open-scaffold/pull/139.
-- Release-sync plan: `.osc/plans/active/123-evidence-chain-package-release-sync.md`.
+- Release-sync plan: `.osc/plans/done/123-evidence-chain-package-release-sync.md`.
 - Release-sync branch: `release/evidence-chain-package-sync-020`.
 - Release-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/140.
 - Run ID / run packet: N/A for release-sync.
-- npm precheck: current live `latest` is `open-scaffold@1.0.5`; `0.20.0` is not yet published.
+- npm precheck: before publish, live `latest` was `open-scaffold@1.0.5`; `0.20.0` was not yet published.
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/26570236888.
+- npm final state: `open-scaffold@latest` is `0.20.0`.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.20.0.
+- Closeout Pull Request: https://github.com/graphanov/open-scaffold/pull/141.
 
 ## Verification
 
@@ -35,21 +39,22 @@ Candidate gates completed before PR-ready:
 - [x] `npm publish --dry-run` — EXPECTED FAIL for cadence correction: npm refuses to implicitly apply `latest` to lower semver `0.20.0` while `1.0.5` is published.
 - [x] `npm publish --dry-run --tag latest` — PASS; real trusted publishing must pass `npm-tag=latest` explicitly.
 - [x] `git diff --check` — PASS.
-- [ ] PR CI and latest-head Codex review — evaluated in the PR conversation after the final push, so this evidence note does not freeze a stale head SHA.
+- [x] PR CI and latest-head Codex review — PASS on PR #140 after the final push; no unresolved current review threads.
 
 Post-merge/publication gates, if the owner approves follow-through:
 
-- [ ] Sync clean `main` after merge.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.20.0` with workflow input `npm-tag=latest`.
-- [ ] `npm view open-scaffold version dist-tags --json` reports `latest: 0.20.0`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest verify --help` exposes `--evidence-chain`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` exposes the first-read `osc compare` grouping.
-- [ ] GitHub Release `v0.20.0` is created/marked Latest.
-- [ ] Release-sync plan can be closed to `done/` with final public proof.
+- [x] Sync clean `main` after merge — PASS at `ebf69e24a22a7980e4d23fa289aa7dacae4637c0`.
+- [x] Trusted publishing workflow publishes `open-scaffold@0.20.0` with workflow input `npm-tag=latest` — PASS, run https://github.com/graphanov/open-scaffold/actions/runs/26570236888.
+- [x] `npm view open-scaffold version dist-tags --json` reports `latest: 0.20.0` — PASS.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest verify --help` exposes `--evidence-chain` — PASS.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` exposes the first-read `osc compare` grouping — PASS.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest init --tier min --target <tmp>` creates the expected min-tier scaffold files — PASS.
+- [x] GitHub Release `v0.20.0` is created/marked Latest — PASS.
+- [x] Release-sync plan can be closed to `done/` with final public proof — completed in closeout PR.
 
 ## Outcome
 
-Candidate preparation in progress. Publication is not complete until the owner approves merge, trusted npm publishing, fresh `npx` verification, GitHub Release Latest movement, and closeout.
+Complete. PR #140 merged, trusted publishing moved npm `latest` to `0.20.0`, fresh isolated-cache `npx` verified the public command surface, and GitHub Release `v0.20.0` is marked Latest. Historical `1.0.x` releases remain published history; optional npm deprecation of those versions is deferred.
 
 ## Follow-up
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-28: closed 123-evidence-chain-package-release-sync — Close evidence-chain package release sync after 0.20.0 npm publish and GitHub Release
 - 2026-05-27: closed 071-evidence-chain-verifier — evidence-chain verifier implemented and verified
 - 2026-05-27: closed 122-compare-package-release-sync — published 1.0.5 and aligned compare package public surfaces
 - 2026-05-27: closed 109-bare-attempt-compare — added prerequisite-free bare attempt comparison

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -393,7 +393,7 @@ Acceptance criteria:
 
 ### Milestone 18 — historical v1.0.0 stability launch
 
-Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` candidate, the forward-moving channel is intentionally corrected back to pre-1.0 hardening (`v0.20.x`) until the public product surface earns a mature 1.0 contract.
+Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel is intentionally corrected back to pre-1.0 hardening (`v0.20.x`) until the public product surface earns a mature 1.0 contract.
 
 Goal: make the adoption contract explicit before the first major-release experiment.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,11 +6,11 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.20.0 — Evidence-chain package sync and cadence correction
 
-Status: release-sync candidate; npm/GitHub Release publication pending after PR integration and owner-approved package follow-through.
+Status: published to npm as `open-scaffold@0.20.0`; GitHub Release `v0.20.0` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
-- Prepares the PR #137 package-visible evidence-chain verifier: `osc verify --evidence-chain` and scoped checks such as `osc verify --evidence-chain --plan <slug> --strict`.
+- Publishes the PR #137 package-visible evidence-chain verifier: `osc verify --evidence-chain` and scoped checks such as `osc verify --evidence-chain --plan <slug> --strict`.
 - Publishes the latest first-read help grouping so fresh installs see `osc compare` as the prerequisite-free work-record demo.
 - Corrects the forward-moving release cadence from the historical `v1.0.x` line back to pre-1.0 hardening as `v0.20.x`. The `1.0.x` packages remain published history; `0.20.x` is the honest current maturity signal.
 - Keeps the verifier structural only: it checks links among plans, evidence notes, run packets, PR references, and close-decision fields without judging evidence quality or calling external services.
@@ -18,7 +18,7 @@ Highlights:
 Evidence:
 
 - Source plan: `.osc/plans/done/071-evidence-chain-verifier.md`
-- Release-sync plan: `.osc/plans/active/123-evidence-chain-package-release-sync.md`
+- Release-sync plan: `.osc/plans/done/123-evidence-chain-package-release-sync.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/137
 - Related first-read help PR: https://github.com/graphanov/open-scaffold/pull/138
 - Runtime-control-loop ADR PR: https://github.com/graphanov/open-scaffold/pull/139
@@ -27,7 +27,7 @@ Evidence:
 
 ## v1.0.5 — Compare command package sync
 
-Status: published to npm as `open-scaffold@1.0.5`; GitHub Release `v1.0.5` is Latest until the next owner-approved package/release follow-through.
+Status: published to npm as `open-scaffold@1.0.5`; historical release line after `v0.20.0` became the GitHub Latest release.
 
 Highlights:
 


### PR DESCRIPTION
## Summary
- Close plan 123 after the approved `0.20.0` publish/release follow-through completed.
- Move the release-sync plan from `active` to `done` and stamp `MISSION.md` via `close.sh`.
- Update the release/evidence note with final trusted publishing, npm/latest, fresh `npx`, and GitHub Release proof.

## Verification
- `npm view open-scaffold version dist-tags --json --prefer-online` → `0.20.0` / `latest: 0.20.0`
- Fresh external-cache `npx --yes open-scaffold@latest --help` → shows first-read `osc compare`
- Fresh external-cache `npx --yes open-scaffold@latest verify --help` → shows `--evidence-chain`
- Fresh external-cache `npx --yes open-scaffold@latest init --tier min --target <tmp>` → expected min-tier files created
- `npm run osc -- plan validate .osc/plans/done/123-evidence-chain-package-release-sync.md` → `0 issues found`
- `git diff --check`
- `./verify.sh --strict` → `10 pass / 0 fail / 0 warn`

## Risk / gates
- No product code, package version, workflow, npm publish, or GitHub Release mutation in this PR.
- Codex review intentionally skipped for this evidence-only closeout unless requested.
- Optional future decision remains separate: whether to deprecate historical `1.0.x` npm versions with a cadence-correction message.
