### PR TITLE
feat: add work-record trace command

### DIFF
--- a/.osc/plans/done/117-osc-trace-work-record-replay.md
+++ b/.osc/plans/done/117-osc-trace-work-record-replay.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+done
 
 ## Context
 
@@ -38,12 +38,12 @@ Ship `osc trace PLAN_SLUG` as a read-only chain replay command that prints the w
 
 ## Acceptance criteria
 
-- [ ] `osc trace PLAN_SLUG` finds a plan in active/backlog/blocked/done and prints its status, goal, acceptance criteria summary, and file path.
-- [ ] The command lists local run packets that reference the plan slug and local evidence notes that cite the plan.
-- [ ] The command lists release notes and PR/issue references when they can be found in local files.
-- [ ] Output clearly labels each link as local, external, missing, or unverified.
-- [ ] `--json` emits stable machine-readable chain data.
-- [ ] Docs explain how `osc trace` differs from `osc verify --evidence-chain`.
+- [x] `osc trace PLAN_SLUG` finds a plan in active/backlog/blocked/done and prints its status, goal, acceptance criteria summary, and file path.
+- [x] The command lists local run packets that reference the plan slug and local evidence notes that cite the plan.
+- [x] The command lists release notes and PR/issue references when they can be found in local files.
+- [x] Output clearly labels each link as local, external, missing, or unverified.
+- [x] `--json` emits stable machine-readable chain data.
+- [x] Docs explain how `osc trace` differs from `osc verify --evidence-chain`.
 
 ## Verification steps
 
@@ -55,5 +55,5 @@ Ship `osc trace PLAN_SLUG` as a read-only chain replay command that prints the w
 
 ## Open questions
 
-- Should `osc trace` be included inside `osc verify --evidence-chain` output as a detail mode, or remain a separate read-only discovery command?
-- Should external references be optionally verified via GitHub API in a later network-enabled mode?
+- Trace remains a separate read-only discovery command for this slice; an evidence-chain detail mode is deferred unless a future plan proves it useful.
+- Network-backed external reference verification is deferred to a future plan because this slice is local/read-only only.

--- a/.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md
+++ b/.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md
@@ -13,14 +13,14 @@ Adds `osc trace <plan-slug>` as a read-only work-record replay command. The comm
 
 ## Verification
 
-- `npm test -- --run tests/trace.test.ts` — PASS during RED/GREEN loop after implementation, and PASS after security regressions plus Codex regressions for run-packet external references and shorthand PR/issue references (`11 passed`).
-- `npm test -- --run tests/trace.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts` — PASS after docs/boundary/security/Codex updates (`31 passed`).
+- `npm test -- --run tests/trace.test.ts` — PASS during RED/GREEN loop after implementation, and PASS after security regressions plus Codex regressions for run-packet external references, shorthand PR/issue references, and stage-authoritative trace status (`12 passed`).
+- `npm test -- --run tests/trace.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts` — PASS after docs/boundary/security/Codex updates (`32 passed`).
 - `npm run build` — PASS for core and runtime-omx TypeScript builds.
 - `node dist/cli.js trace 107-work-dry-run-package-sync` — PASS; produced human trace output with plan, acceptance criteria, release notes, external PR refs, and missing run packet label.
 - `node dist/cli.js trace 107-work-dry-run-package-sync --json` plus Python `json.loads` schema/slug assertions — PASS.
-- `npm test -- --run` — PASS (`47` test files, `425` tests).
+- `npm test -- --run` — PASS (`47` test files, `426` tests).
 - `node dist/cli.js plan validate .osc/plans/done/117-osc-trace-work-record-replay.md` — PASS (`0 issues found`).
-- `node dist/cli.js trace 117-osc-trace-work-record-replay --json` plus Python `json.loads` schema/stage/release-note assertions — PASS.
+- `node dist/cli.js trace 117-osc-trace-work-record-replay --json` plus Python `json.loads` schema/stage/status/release-note assertions — PASS.
 - `git diff --check` — PASS.
 - `./verify.sh --strict` — PASS (`10 pass, 0 fail, 0 warn`).
 

--- a/.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md
+++ b/.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md
@@ -1,0 +1,34 @@
+# Release / Evidence Note: 117-osc-trace-work-record-replay
+
+## Summary
+
+Adds `osc trace <plan-slug>` as a read-only work-record replay command. The command reconstructs one plan's local chain across stage folders, acceptance criteria, run packets, evidence/release notes, and recognized PR/issue references while keeping verification, external API checks, runtime spawning, publishing, and approval out of scope.
+
+## Traceability
+
+- Roadmap / issue / task: Kanban task `t_df8003f0` / plan 117.
+- Plan: `.osc/plans/done/117-osc-trace-work-record-replay.md` after closeout; `.osc/plans/active/117-osc-trace-work-record-replay.md` during implementation.
+- Run ID / run packet: `N/A` — this slice was implemented directly under the active plan with read-only scout subagents; no durable `.osc/runs/` packet was created.
+- Branch / PR: branch `cli/work-record-trace`; PR pending owner review.
+
+## Verification
+
+- `npm test -- --run tests/trace.test.ts` — PASS during RED/GREEN loop after implementation, and PASS after security regressions for terminal-control sanitization plus symlinked trace directories (`9 passed`).
+- `npm test -- --run tests/trace.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts` — PASS after docs/boundary/security updates (`29 passed`).
+- `npm run build` — PASS for core and runtime-omx TypeScript builds.
+- `node dist/cli.js trace 107-work-dry-run-package-sync` — PASS; produced human trace output with plan, acceptance criteria, release notes, external PR refs, and missing run packet label.
+- `node dist/cli.js trace 107-work-dry-run-package-sync --json` plus Python `json.loads` schema/slug assertions — PASS.
+- `npm test -- --run` — PASS (`47` test files, `423` tests).
+- `node dist/cli.js plan validate .osc/plans/done/117-osc-trace-work-record-replay.md` — PASS (`0 issues found`).
+- `node dist/cli.js trace 117-osc-trace-work-record-replay --json` plus Python `json.loads` schema/stage/release-note assertions — PASS.
+- `git diff --check` — PASS.
+- `./verify.sh --strict` — PASS (`10 pass, 0 fail, 0 warn`).
+
+## Outcome
+
+Repository feature implementation is ready for PR review, CI, and Codex latest-head review. The shipped behavior is local/read-only reconstruction only: no GitHub API calls, no network verification, no evidence-quality judgment, no runtime spawning, no hosted trace viewer, no approval, and no publication/release side effects.
+
+## Follow-up
+
+- If this package-visible command merges, run the normal post-merge public-surface check to decide whether a narrow npm/GitHub Release sync is needed.
+- Future network-backed PR/issue/CI verification for trace output remains out of scope and would require a separate plan.

--- a/.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md
+++ b/.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md
@@ -13,12 +13,12 @@ Adds `osc trace <plan-slug>` as a read-only work-record replay command. The comm
 
 ## Verification
 
-- `npm test -- --run tests/trace.test.ts` — PASS during RED/GREEN loop after implementation, and PASS after security regressions for terminal-control sanitization plus symlinked trace directories (`9 passed`).
-- `npm test -- --run tests/trace.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts` — PASS after docs/boundary/security updates (`29 passed`).
+- `npm test -- --run tests/trace.test.ts` — PASS during RED/GREEN loop after implementation, and PASS after security regressions plus the Codex run-packet external-reference regression (`10 passed`).
+- `npm test -- --run tests/trace.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts` — PASS after docs/boundary/security/Codex updates (`30 passed`).
 - `npm run build` — PASS for core and runtime-omx TypeScript builds.
 - `node dist/cli.js trace 107-work-dry-run-package-sync` — PASS; produced human trace output with plan, acceptance criteria, release notes, external PR refs, and missing run packet label.
 - `node dist/cli.js trace 107-work-dry-run-package-sync --json` plus Python `json.loads` schema/slug assertions — PASS.
-- `npm test -- --run` — PASS (`47` test files, `423` tests).
+- `npm test -- --run` — PASS (`47` test files, `424` tests).
 - `node dist/cli.js plan validate .osc/plans/done/117-osc-trace-work-record-replay.md` — PASS (`0 issues found`).
 - `node dist/cli.js trace 117-osc-trace-work-record-replay --json` plus Python `json.loads` schema/stage/release-note assertions — PASS.
 - `git diff --check` — PASS.

--- a/.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md
+++ b/.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md
@@ -9,16 +9,16 @@ Adds `osc trace <plan-slug>` as a read-only work-record replay command. The comm
 - Roadmap / issue / task: Kanban task `t_df8003f0` / plan 117.
 - Plan: `.osc/plans/done/117-osc-trace-work-record-replay.md` after closeout; `.osc/plans/active/117-osc-trace-work-record-replay.md` during implementation.
 - Run ID / run packet: `N/A` — this slice was implemented directly under the active plan with read-only scout subagents; no durable `.osc/runs/` packet was created.
-- Branch / PR: branch `cli/work-record-trace`; PR pending owner review.
+- Branch / PR: branch `cli/work-record-trace`; PR #142 — https://github.com/graphanov/open-scaffold/pull/142.
 
 ## Verification
 
-- `npm test -- --run tests/trace.test.ts` — PASS during RED/GREEN loop after implementation, and PASS after security regressions plus the Codex run-packet external-reference regression (`10 passed`).
-- `npm test -- --run tests/trace.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts` — PASS after docs/boundary/security/Codex updates (`30 passed`).
+- `npm test -- --run tests/trace.test.ts` — PASS during RED/GREEN loop after implementation, and PASS after security regressions plus Codex regressions for run-packet external references and shorthand PR/issue references (`11 passed`).
+- `npm test -- --run tests/trace.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts` — PASS after docs/boundary/security/Codex updates (`31 passed`).
 - `npm run build` — PASS for core and runtime-omx TypeScript builds.
 - `node dist/cli.js trace 107-work-dry-run-package-sync` — PASS; produced human trace output with plan, acceptance criteria, release notes, external PR refs, and missing run packet label.
 - `node dist/cli.js trace 107-work-dry-run-package-sync --json` plus Python `json.loads` schema/slug assertions — PASS.
-- `npm test -- --run` — PASS (`47` test files, `424` tests).
+- `npm test -- --run` — PASS (`47` test files, `425` tests).
 - `node dist/cli.js plan validate .osc/plans/done/117-osc-trace-work-record-replay.md` — PASS (`0 issues found`).
 - `node dist/cli.js trace 117-osc-trace-work-record-replay --json` plus Python `json.loads` schema/stage/release-note assertions — PASS.
 - `git diff --check` — PASS.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-28: closed 117-osc-trace-work-record-replay — added read-only work-record trace command
 - 2026-05-28: closed 123-evidence-chain-package-release-sync — Close evidence-chain package release sync after 0.20.0 npm publish and GitHub Release
 - 2026-05-27: closed 071-evidence-chain-verifier — evidence-chain verifier implemented and verified
 - 2026-05-27: closed 122-compare-package-release-sync — published 1.0.5 and aligned compare package public surfaces

--- a/README.md
+++ b/README.md
@@ -198,12 +198,15 @@ Shell fallbacks remain available:
 
 ```bash
 ./verify.sh --standard
+osc trace my-first-task
 osc evidence new my-first-task
 osc close my-first-task --message "verified first task"
-# or without local install:
+# or without local install for the evidence/close helpers:
 npx open-scaffold evidence new my-first-task
 npx open-scaffold close my-first-task --message "verified first task"
 ```
+
+`osc trace` replays the local work record for review; evidence-chain verification checks whether structural links are intact.
 
 Shell fallback:
 
@@ -276,7 +279,7 @@ Open Scaffold is usable, but it is still in active credibility and adoption hard
 
 Stable enough to rely on today:
 
-- CLI: `osc init`, `osc status`, `osc plan new`, `osc plan validate`, `osc plan move`, `osc amend`, `osc close`, `osc evidence new`, `osc evidence collect`, `osc verify`, and read-only `osc compare`.
+- CLI: `osc init`, `osc status`, `osc plan new`, `osc plan validate`, `osc plan move`, `osc amend`, `osc close`, `osc evidence new`, `osc evidence collect`, `osc verify`, `osc trace`, and read-only `osc compare`.
 - Protocol: `MISSION.md`, `ROADMAP.md`, `.osc/plans/`, the 7-section plan schema, folder-as-status workflow, amendments, evidence notes, and run-packet records.
 - Verification floor: `verify.sh` plus package tests/builds for this repository.
 
@@ -359,6 +362,7 @@ Skip it for:
 - [`docs/MINIMUM_VIABLE_SCAFFOLD.md`](docs/MINIMUM_VIABLE_SCAFFOLD.md) — smallest practical day-one adoption path.
 - [`docs/STABILITY.md`](docs/STABILITY.md) — current package-contract, experimental, and future surfaces.
 - [`docs/CHANGELOG.md`](docs/CHANGELOG.md) — curated release history.
+- [`docs/TRACE.md`](docs/TRACE.md) — replaying a plan's local work record with `osc trace`.
 - [`docs/DEV_CONTAINER.md`](docs/DEV_CONTAINER.md) — optional container setup for consistent team onboarding.
 - [`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md) — attempts, frontier records, and `osc evolve`.
 - [`docs/EXAMPLES.md`](docs/EXAMPLES.md) — examples and viewer demos.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.20.x — Trace work-record replay
+
+Status: prepared in repo; npm publication and GitHub Release follow-through remain separate owner-approved public-surface gates.
+
+Highlights:
+
+- Adds `osc trace <plan-slug>`, a read-only command for replaying one plan's local work-record chain.
+- Complements `osc verify --evidence-chain`: trace explains the known chain, verify checks structural integrity.
+- Labels links as `local`, `external`, `missing`, or `unverified` without judging correctness, evidence quality, PR state, or compliance.
+- Requires no GitHub API, network access, runtime launch, hosted dashboard, or provider credentials.
+
+Evidence:
+
+- Source plan: `.osc/plans/done/117-osc-trace-work-record-replay.md`
+- Source evidence note: `.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md`
+- Source PR: this feature PR
+
 ## v0.20.0 — Evidence-chain package sync and cadence correction
 
 Status: published to npm as `open-scaffold@0.20.0`; GitHub Release `v0.20.0` is Latest after owner-approved trusted publishing and release follow-through.

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -37,7 +37,8 @@ Open Scaffold core owns the portable project substrate:
 - `docs/EVOLUTION_LOOP.md` — multi-attempt loop state, attempt journals, frontier promotion, and improvement routing.
 - `osc mcp serve` / `osc-mcp` — optional stdio MCP server that exposes local mission, plan, evidence, status, rules, and roadmap state to MCP-capable tools without requiring each agent to parse markdown directly.
 - `osc task` — optional local SQLite task bridge for day-one repo-local task tracking in `.osc/tasks.db`; see [`docs/TASKS.md`](TASKS.md).
-- `verify.sh` / `osc verify` — methodology compliance checks.
+- `verify.sh` / `osc verify` — methodology compliance and evidence-chain structural checks.
+- `osc trace` — read-only local work-record replay for one plan.
 - `.github/` templates — issue and PR traceability for GitHub-centered workflows.
 
 Core does **not** spawn agents. It defines the contract that agents and tools can use. The MCP server is an interface over local repo truth, not a planner, task database, or runtime launcher.

--- a/docs/SLICE_CLOSE_PROTOCOL.md
+++ b/docs/SLICE_CLOSE_PROTOCOL.md
@@ -44,7 +44,22 @@ roadmap_item
 
 Not every tiny task needs every link. But if a slice changes product direction, public docs, code, release notes, or a multi-agent workflow, it should have enough of this chain for the next human or agent to resume without chat memory.
 
+## Work-record replay
+
+`osc trace <plan-slug>` is the reconstruction path for one slice. It searches the plan stage folders, local run packets, evidence/release notes, and recognized references in local files, then prints a human-readable chain with each link labeled as `local`, `external`, `missing`, or `unverified`.
+
+Use trace when a reviewer, operator, or future agent needs to understand what is known before deciding what to check next:
+
+```bash
+osc trace <plan-slug>
+osc trace <plan-slug> --json
+```
+
+Trace is explanatory. It does not make a close decision, judge evidence quality, verify GitHub state, call external services, run tests, spawn runtimes, provide compliance guarantees, or approve the slice.
+
 ## Evidence chain verification
+
+Use `osc trace <plan-slug>` to replay the known local chain for a human. Use `osc verify --evidence-chain --plan <plan-slug>` to check whether the structural evidence links are intact.
 
 `osc verify --evidence-chain` checks whether the repo work record links together structurally: done plan, acceptance criteria, run packet, evidence note, close decision, and release or PR references.
 

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -2,7 +2,7 @@
 
 This page defines Open Scaffold's current package contract and maturity boundary.
 
-The short version: Open Scaffold is back on a pre-1.0 hardening line (`v0.20.x`) because the protocol is useful but the public product surface, runtime boundary, and adoption story are still moving quickly. The stable-enough core is the repo-native work-record loop — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus the read-only `osc compare` demo that shows why work records matter. Runtime launch, provider-specific automation, evaluation helpers, dashboards, and external cockpit transports remain opt-in lab/experimental surfaces unless a later release explicitly promotes them.
+The short version: Open Scaffold is back on a pre-1.0 hardening line (`v0.20.x`) because the protocol is useful but the public product surface, runtime boundary, and adoption story are still moving quickly. The stable-enough core is the repo-native work-record loop — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus read-only work-record commands such as `osc compare` and `osc trace` that help humans inspect recorded work without launching runtimes. Runtime launch, provider-specific automation, evaluation helpers, dashboards, and external cockpit transports remain opt-in lab/experimental surfaces unless a later release explicitly promotes them.
 
 The historical `v1.0.x` packages and GitHub Releases remain available for provenance. They are not erased, but they should not set the current expectation that Open Scaffold has fully earned a mature 1.0 contract.
 
@@ -45,6 +45,7 @@ The stable day-two CLI surface is:
 - `osc evidence collect`
 - `osc verify`
 - `osc compare` as a read-only first-read demo for comparing two recorded attempts
+- `osc trace` as a read-only replay of one plan's local work-record chain
 
 The zero-dependency shell helpers remain a stable fallback floor:
 
@@ -59,6 +60,7 @@ The zero-dependency shell helpers remain a stable fallback floor:
 - `./verify.sh --quick`, `--standard`, and `--strict` remain the canonical repository compliance tiers.
 - `npm test` and `npm run build` remain the package-level local gates for this repository.
 - Public PRs should cite the plan, evidence note, verification commands, review state, and owner gates.
+- `osc trace <plan-slug>` is a reconstruction aid; `osc verify --evidence-chain` remains the structural integrity check.
 
 ## Lab / experimental in the current line
 
@@ -89,6 +91,7 @@ These are explicitly not current-package guarantees:
 - Compliance certification or legal audit certification.
 - Provider-specific model benchmarking or model-ranking claims.
 - Tamper-evident external ledger anchoring.
+- Network-backed GitHub/API verification for trace output.
 - Marketplace, network registry, or installer behavior for runtimes.
 
 Future work can explore those areas only through explicit plans, evidence, safety analysis, and owner approval.

--- a/docs/TRACE.md
+++ b/docs/TRACE.md
@@ -28,7 +28,7 @@ Trace explains the known chain. Evidence-chain verification checks the chain str
 - `.osc/plans/{active,backlog,blocked,done}/<plan-slug>.md`
 - `.osc/runs/*/run.json`
 - `.osc/releases/*.md`
-- recognized GitHub PR and issue references already written in those local notes
+- recognized GitHub PR and issue references already written in those local notes, including full GitHub URLs and common local shorthand such as `PR #123`, `Pull Request: owner/repo#123`, and `Issue: #456`
 
 The command resolves the scaffold root from the current working directory, so it can be run from a subdirectory inside the repo.
 

--- a/docs/TRACE.md
+++ b/docs/TRACE.md
@@ -1,0 +1,116 @@
+# Trace work records
+
+`osc trace <plan-slug>` is a read-only work-record replay command. It reconstructs the known local chain for one plan: plan file, status, acceptance criteria summary, run packets, evidence/release notes, and recognized PR/issue references found in local files.
+
+Use it to understand, review, or resume a slice before deciding what to verify or close.
+
+## Quick start
+
+```bash
+osc trace <plan-slug>
+osc trace <plan-slug> --json
+osc trace <plan-slug> --include-unverified
+```
+
+Example:
+
+```bash
+osc trace 117-osc-trace-work-record-replay
+osc verify --evidence-chain --plan 117-osc-trace-work-record-replay
+```
+
+Trace explains the known chain. Evidence-chain verification checks the chain structurally.
+
+## What `osc trace` reads
+
+`osc trace` reads only local files under the current Open Scaffold root:
+
+- `.osc/plans/{active,backlog,blocked,done}/<plan-slug>.md`
+- `.osc/runs/*/run.json`
+- `.osc/releases/*.md`
+- recognized GitHub PR and issue references already written in those local notes
+
+The command resolves the scaffold root from the current working directory, so it can be run from a subdirectory inside the repo.
+
+## Output labels
+
+Trace links are labeled with four statuses:
+
+- `local` — a local file or local plan/run/release link was found.
+- `external` — a PR or issue reference was recognized in a local file, but not checked over the network.
+- `missing` — an expected local work-record link was not found.
+- `unverified` — an optional weak local mention was included with `--include-unverified`.
+
+Missing links do not make trace fail. They tell the reviewer what part of the work record has not been written yet.
+
+## Trace vs verify
+
+Use the commands together, but do not treat them as interchangeable:
+
+- `osc trace <plan-slug>` is the human-readable replay view for a plan's local work record.
+- `osc verify --evidence-chain --plan <plan-slug>` is the structural integrity checker for evidence-chain links.
+
+Neither command judges whether the implementation is correct, whether the evidence is strong, whether CI passed, or whether a PR should merge.
+
+## JSON output
+
+`--json` emits a stable machine-readable object with schema `open-scaffold.trace.v1`. This abridged placeholder example shows the shape; real output includes the plan's actual criteria and discovered links.
+
+```json
+{
+  "schema": "open-scaffold.trace.v1",
+  "query": {
+    "plan_slug": "example-plan",
+    "include_unverified": false
+  },
+  "plan": {
+    "slug": "example-plan",
+    "stage": "done",
+    "status": "done",
+    "path": ".osc/plans/done/example-plan.md",
+    "goal": "Replay the local work record.",
+    "acceptance_criteria": [
+      { "id": "AC1", "text": "Document the trace output.", "checked": true }
+    ]
+  },
+  "links": [
+    { "type": "plan_file", "status": "local", "reference": ".osc/plans/done/example-plan.md", "detail": "Plan file found in local scaffold stage." },
+    { "type": "run_packet", "status": "missing", "reference": ".osc/runs/*/run.json", "detail": "No local run packet found for example-plan." }
+  ],
+  "warnings": [],
+  "summary": {
+    "local": 1,
+    "external": 0,
+    "missing": 1,
+    "unverified": 0,
+    "runs": 0,
+    "release_notes": 0,
+    "external_refs": 0
+  }
+}
+```
+
+Use JSON mode for dashboards, scripts, or reviews that need deterministic link data without parsing terminal text.
+
+## Boundaries
+
+`osc trace` is local and read-only by default. It does not:
+
+- call GitHub or require network access;
+- verify PR, issue, CI, npm, or release state;
+- run tests or CI;
+- spawn runtimes, agents, or adapters;
+- approve work, close a plan, merge a PR, publish npm, or create a release;
+- judge correctness, evidence quality, or readiness;
+- provide compliance, trust, or external provenance guarantees.
+
+External references are listed as recognized references, not verified facts. It does not call GitHub, does not spawn runtimes, and does not judge correctness, evidence quality, or readiness.
+
+## Troubleshooting incomplete chains
+
+If trace prints `missing` links, decide what the slice actually needs:
+
+- No run packet may be fine for docs-only or planning-only work.
+- No release/evidence note usually means the slice is not ready for closeout.
+- External references should be checked through the normal PR/CI/release workflow when they matter.
+- If the chain should be structurally complete, run `osc verify --evidence-chain --plan <plan-slug>` and fix the reported links.

--- a/docs/TRACE.md
+++ b/docs/TRACE.md
@@ -30,7 +30,7 @@ Trace explains the known chain. Evidence-chain verification checks the chain str
 - `.osc/releases/*.md`
 - recognized GitHub PR and issue references already written in those local notes, including full GitHub URLs and common local shorthand such as `PR #123`, `Pull Request: owner/repo#123`, and `Issue: #456`
 
-The command resolves the scaffold root from the current working directory, so it can be run from a subdirectory inside the repo.
+The command resolves the scaffold root from the current working directory, so it can be run from a subdirectory inside the repo. The public `plan.status` value follows the authoritative plan stage folder (`active`, `backlog`, `blocked`, `done`) because older lifecycle moves may leave the markdown `## Status` section stale.
 
 ## Output labels
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -123,13 +123,22 @@ The evolution ledger records attempts and frontier state only. External coordina
 
 Check the plan's acceptance criteria one by one. Run tests. Read the diff. Verification traces to criteria, not vibes.
 
+When you need to reconstruct the work record before or after verification, run:
+
+```bash
+osc trace <plan-slug>
+osc verify --evidence-chain --plan <plan-slug>
+```
+
+Trace shows the known local chain; evidence-chain verification checks that chain structurally.
+
 Run `./verify.sh` for a zero-dependency methodology compliance report (mission defined, plans exist, amendments sequential, changelog coverage). Use `./verify.sh --strict` for full checks including plan schema validation and paired-view drift detection. `osc verify` performs the generic CLI check; adapter repos keep their own namespace-specific verify behavior. Use `osc metrics` when you need numeric scaffold health: plan distribution, cycle time, stale active plans, close velocity, evidence completeness, and approval distribution. Use `osc metrics --json` for CI dashboards or status views that consume machine-readable output. When verification or manual review points at mechanical scaffold hygiene, run `osc doctor --fix --dry-run` first to preview safe repairs, then `osc doctor --fix` to apply fixable status alignment, amendment changelog backfills, narrow paired-view section drops, stale active-plan blocking, or missing release README repair. Use `osc evidence new <slug>` to scaffold a `.osc/releases/<date>-<slug>.md` evidence note after verification, then run `osc evidence collect <slug>` to append local verification output, git context, changed files, and explicit skipped-collector notes without overwriting your narrative. Add `--ci` only when you want `gh`-based PR/check collection. Replace any remaining TODOs with human-reviewed outcome text, then use `osc close <slug> --message "<what shipped>"` (or `npx open-scaffold close <slug> --message "<what shipped>"`) to move a verified plan to `done/`. Shell scripts remain the day-zero floor; `osc` is the canonical tested path for richer run/package behavior.
 
 > **With adapters:** OMC/OMX handoffs should still end by running the repo-local `./verify.sh` plus acceptance-criteria checks. Runtime-native verify commands are wrappers around this evidence, not replacements for it.
 
 ### 5. Publish/review (when code or public docs change)
 
-Open a traceable GitHub PR for meaningful changes. The PR should link issue/task, plan/spec, `run.json` work package when delegated, verification, evidence, and review gates. If the Codex connector is enabled, trigger review by opening the PR for review, marking a draft ready, or commenting `@codex review`. When a configured Discord or Slack cockpit should see the update, use `osc cockpit post --event pr_link --pr <url>` or `osc cockpit post --event completion_report --run-id <id> --plan <slug> --pr <url>` after redaction review. See `docs/GITHUB_WORKFLOW.md`.
+Open a traceable GitHub PR for meaningful changes. The PR should link issue/task, plan/spec, `run.json` work package when delegated, verification, evidence, and review gates. Before writing the PR body, `osc trace <plan-slug>` can help gather the plan, run, evidence, release-note, and recognized PR/issue references already present in local files; it does not query GitHub or prove PR/CI state. If the Codex connector is enabled, trigger review by opening the PR for review, marking a draft ready, or commenting `@codex review`. When a configured Discord or Slack cockpit should see the update, use `osc cockpit post --event pr_link --pr <url>` or `osc cockpit post --event completion_report --run-id <id> --plan <slug> --pr <url>` after redaction review. See `docs/GITHUB_WORKFLOW.md`.
 
 ### 6. Capture amendments (when you "get smarter")
 
@@ -205,7 +214,7 @@ Multi-agent development spans sessions. Without discipline, context is lost betw
 
 1. Before ending: review the latest plan + amendments. Is everything captured, or are decisions only in the conversation?
 2. Write down unfinished work as open questions in the plan file (Section 7).
-3. The next session starts by reading MISSION.md → latest plan → amendments in order. This is the full context handoff — no re-explanation needed.
+3. The next session starts by reading MISSION.md → latest plan → amendments in order. If the slice already has a plan slug, it can also start with `osc trace <plan-slug>` to see the durable local work record without relying on chat memory.
 
 For stage-folder movement rules and lifecycle conventions, see `.osc/plans/WORKFLOW.md`. For non-negotiable principles, see `.osc/RULES.md`.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import { formatPlanValidationIssues, hasBlockingIssues, resolvePlanValidationPat
 import { buildPlanGraph, normalizePlanReference, renderPlanGraphAscii, renderPlanGraphMermaid, type PlanGraphDirection, type PlanGraphFormat, type PlanGraphStageFilter } from './plan-graph.js';
 import { askInteractiveAnswers, assertWizardReady, createWizardPlan, loadAnswersFile, type PlanWizardAnswers } from './wizard.js';
 import { buildWorkDryRunPreview, formatWorkDryRunPreview } from './work.js';
+import { buildTrace, formatTraceReport, TraceUsageError } from './trace.js';
 
 function printHelp(): void {
   console.log(`osc — Open Scaffold CLI
@@ -51,6 +52,7 @@ Stable core protocol:
   osc evidence new <slug>
   osc evidence collect <slug> [--ci] [--dry-run] [--verbose]
   osc close <plan-slug> [--message <text>]
+  osc trace <plan-slug> [--json] [--include-unverified]
   osc verify [--evidence-chain [--plan <slug>] [--json] [--strict]]
 
 Handoff and run packages:
@@ -954,6 +956,61 @@ function printEvidenceNewUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
 
 function printEvidenceCollectUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
   printUsage('Usage: osc evidence collect <slug> [--ci] [--dry-run] [--verbose]', stream);
+}
+
+function printTraceUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc trace <plan-slug> [--json] [--include-unverified]', stream);
+}
+
+interface TraceCommandOptions {
+  slug: string;
+  json: boolean;
+  includeUnverified: boolean;
+}
+
+function parseTraceOptions(args: string[]): TraceCommandOptions {
+  const slug = args[0];
+  if (!slug || slug.startsWith('--')) {
+    console.error('Missing required argument: plan-slug');
+    printTraceUsage();
+    process.exit(2);
+  }
+  const options: TraceCommandOptions = { slug, json: false, includeUnverified: false };
+  for (let i = 1; i < args.length; i += 1) {
+    const flag = args[i];
+    switch (flag) {
+      case '--json':
+        options.json = true;
+        break;
+      case '--include-unverified':
+        options.includeUnverified = true;
+        break;
+      default:
+        console.error(`Unknown option for trace: ${flag}`);
+        printTraceUsage();
+        process.exit(2);
+    }
+  }
+  return options;
+}
+
+function traceCommand(args: string[]): void {
+  if (isHelpArg(args[0])) {
+    printTraceUsage('stdout');
+    return;
+  }
+  const options = parseTraceOptions(args);
+  try {
+    const report = buildTrace(process.cwd(), options.slug, { includeUnverified: options.includeUnverified });
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      process.stdout.write(formatTraceReport(report));
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(error instanceof TraceUsageError ? 2 : 1);
+  }
 }
 
 function printVerifyUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
@@ -2643,6 +2700,9 @@ async function main(): Promise<void> {
       return;
     case 'compare':
       compareCommand(args);
+      return;
+    case 'trace':
+      traceCommand(args);
       return;
     case 'review':
     case 'ultrareview':

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -246,15 +246,43 @@ function collectRunLinks(root: string, planSlug: string, options: Required<Trace
   return links;
 }
 
+function addExternalRef(links: TraceLink[], type: 'pr_reference' | 'issue_reference', reference: string, sourcePath: string, shorthand = false): void {
+  const label = type === 'pr_reference' ? 'PR' : 'issue';
+  links.push({
+    type,
+    status: 'external',
+    reference,
+    source_path: sourcePath,
+    detail: `Recognized ${shorthand ? 'shorthand ' : ''}${label} reference in local note; not verified over the network.`,
+  });
+}
+
+function shorthandTypeForLine(line: string): 'pr_reference' | 'issue_reference' {
+  const lower = line.toLowerCase();
+  const issueContext = /\bissues?\b/.test(lower);
+  const prContext = /\bpr\b|\bpull request\b/.test(lower);
+  if (issueContext && !prContext) return 'issue_reference';
+  return 'pr_reference';
+}
+
 function extractExternalRefs(text: string, sourcePath: string): TraceLink[] {
   const links: TraceLink[] = [];
   const prUrls = text.match(/https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+/g) ?? [];
   const issueUrls = text.match(/https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/issues\/\d+/g) ?? [];
-  for (const reference of prUrls) {
-    links.push({ type: 'pr_reference', status: 'external', reference, source_path: sourcePath, detail: 'Recognized PR reference in local note; not verified over the network.' });
-  }
-  for (const reference of issueUrls) {
-    links.push({ type: 'issue_reference', status: 'external', reference, source_path: sourcePath, detail: 'Recognized issue reference in local note; not verified over the network.' });
+  for (const reference of prUrls) addExternalRef(links, 'pr_reference', reference, sourcePath);
+  for (const reference of issueUrls) addExternalRef(links, 'issue_reference', reference, sourcePath);
+
+  for (const line of text.split(/\r?\n/)) {
+    const lineType = shorthandTypeForLine(line);
+    for (const match of line.matchAll(/(^|[^A-Za-z0-9_.-])([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#\d+)\b/g)) {
+      addExternalRef(links, lineType, match[2], sourcePath, true);
+    }
+    for (const match of line.matchAll(/\b(?:PR|Pull Request)\s*:?\s*#(\d+)\b/gi)) {
+      addExternalRef(links, 'pr_reference', `PR #${match[1]}`, sourcePath, true);
+    }
+    for (const match of line.matchAll(/\b(?:GitHub Issue|Follow-up Issue|Issue)\s*:?\s*#(\d+)\b/gi)) {
+      addExternalRef(links, 'issue_reference', `#${match[1]}`, sourcePath, true);
+    }
   }
   return links;
 }

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,0 +1,384 @@
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, type Dirent } from 'node:fs';
+import { basename, extname, isAbsolute, join, relative, resolve } from 'node:path';
+import { findScaffoldRoot, parsePlanFile, PLAN_STAGES, splitSections, type PlanStage } from './scaffold.js';
+
+export type TraceLinkStatus = 'local' | 'external' | 'missing' | 'unverified';
+export type TraceLinkType =
+  | 'plan_file'
+  | 'acceptance_criterion'
+  | 'run_packet'
+  | 'release_note'
+  | 'evidence_reference'
+  | 'pr_reference'
+  | 'issue_reference'
+  | 'generic_reference';
+
+export interface TraceAcceptanceCriterion {
+  id: `AC${number}`;
+  text: string;
+  checked: boolean;
+}
+
+export interface TraceLink {
+  type: TraceLinkType;
+  status: TraceLinkStatus;
+  reference: string;
+  detail: string;
+  source_path?: string;
+  target_path?: string;
+  run_id?: string;
+  title?: string;
+}
+
+export interface TraceWarning {
+  code: string;
+  message: string;
+  path?: string;
+}
+
+export interface TraceReport {
+  schema: 'open-scaffold.trace.v1';
+  root: string;
+  query: {
+    plan_slug: string;
+    include_unverified: boolean;
+  };
+  plan: {
+    slug: string;
+    stage: PlanStage;
+    status: string;
+    path: string;
+    goal: string;
+    acceptance_criteria: TraceAcceptanceCriterion[];
+  };
+  links: TraceLink[];
+  warnings: TraceWarning[];
+  summary: {
+    local: number;
+    external: number;
+    missing: number;
+    unverified: number;
+    runs: number;
+    release_notes: number;
+    external_refs: number;
+  };
+}
+
+export interface TraceOptions {
+  includeUnverified?: boolean;
+}
+
+export class TraceUsageError extends Error {}
+
+const LINK_ORDER: TraceLinkType[] = [
+  'plan_file',
+  'acceptance_criterion',
+  'run_packet',
+  'release_note',
+  'evidence_reference',
+  'pr_reference',
+  'issue_reference',
+  'generic_reference',
+];
+
+function normalizePlanSlug(slug: string): string {
+  const trimmed = slug.trim();
+  if (!trimmed || trimmed.endsWith('.md') || trimmed.includes('/') || trimmed.includes('\\') || trimmed.includes('..') || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed)) {
+    throw new TraceUsageError(`Unsafe plan slug: ${slug}`);
+  }
+  return trimmed;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function containsExactToken(text: string, token: string): boolean {
+  const escaped = escapeRegex(token);
+  return new RegExp(`(^|[^A-Za-z0-9._-])${escaped}(?=$|[^A-Za-z0-9._-])`).test(text);
+}
+
+function safeText(value: string): string {
+  return value
+    .replace(/[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g, '')
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+    .trim();
+}
+
+function repoRelative(root: string, path: string): string {
+  return relative(root, path).split('\\').join('/');
+}
+
+function isContained(root: string, path: string): boolean {
+  const rootReal = realpathSync(root);
+  const pathReal = realpathSync(path);
+  const rel = relative(rootReal, pathReal);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function readContainedText(root: string, path: string): string | null {
+  try {
+    if (!existsSync(path)) return null;
+    const stat = lstatSync(path);
+    if (!stat.isFile()) return null;
+    if (!isContained(root, path)) return null;
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function readContainedDirectory(root: string, dir: string, warningCode: string, warnings: TraceWarning[]): Dirent[] {
+  const rel = repoRelative(root, dir);
+  try {
+    if (!existsSync(dir)) return [];
+    const stat = lstatSync(dir);
+    if (!stat.isDirectory() || stat.isSymbolicLink() || !isContained(root, dir)) {
+      warnings.push({ code: warningCode, message: 'Trace directory is not a contained local directory; skipping.', path: rel });
+      return [];
+    }
+    return readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  } catch {
+    warnings.push({ code: warningCode, message: 'Trace directory could not be safely read; skipping.', path: rel });
+    return [];
+  }
+}
+
+function findPlan(root: string, slug: string): { stage: PlanStage; path: string } {
+  const matches: Array<{ stage: PlanStage; path: string }> = [];
+  for (const stage of PLAN_STAGES) {
+    const path = join(root, '.osc', 'plans', stage, `${slug}.md`);
+    try {
+      if (existsSync(path) && lstatSync(path).isFile() && isContained(root, path)) {
+        matches.push({ stage, path });
+      }
+    } catch {
+      // Ignore unreadable candidates and continue deterministic search.
+    }
+  }
+  if (matches.length === 0) {
+    throw new Error(`Plan not found in .osc/plans/{active,backlog,blocked,done}: ${slug}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`Plan slug appears in multiple stages: ${matches.map((match) => repoRelative(root, match.path)).join(', ')}`);
+  }
+  return matches[0];
+}
+
+function parseAcceptanceCriteria(section: string): TraceAcceptanceCriterion[] {
+  const criteria: TraceAcceptanceCriterion[] = [];
+  for (const line of section.split(/\r?\n/)) {
+    const match = line.trim().match(/^[-*]\s+(?:\[([ xX])\]\s*)?(.+)$/);
+    if (!match) continue;
+    const text = safeText(match[2]);
+    if (!text) continue;
+    criteria.push({ id: `AC${criteria.length + 1}` as `AC${number}`, text, checked: /^x$/i.test(match[1] ?? '') });
+  }
+  return criteria;
+}
+
+function releaseSlug(file: string): string | null {
+  const match = file.match(/^\d{4}-\d{2}-\d{2}-(.+)\.md$/);
+  return match ? match[1] : null;
+}
+
+function planPathsForSlug(slug: string): string[] {
+  return PLAN_STAGES.map((stage) => `.osc/plans/${stage}/${slug}.md`);
+}
+
+function dedupeLinks(links: TraceLink[]): TraceLink[] {
+  const seen = new Set<string>();
+  const unique: TraceLink[] = [];
+  for (const link of links) {
+    const key = `${link.type}\0${link.status}\0${link.reference}\0${link.source_path ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(link);
+  }
+  return unique.sort((a, b) => {
+    const typeDelta = LINK_ORDER.indexOf(a.type) - LINK_ORDER.indexOf(b.type);
+    if (typeDelta !== 0) return typeDelta;
+    const statusDelta = a.status.localeCompare(b.status);
+    if (statusDelta !== 0) return statusDelta;
+    return a.reference.localeCompare(b.reference);
+  });
+}
+
+function planMatchesRun(planSlug: string, run: unknown): { matches: boolean; runId?: string } {
+  if (!run || typeof run !== 'object') return { matches: false };
+  const record = run as Record<string, unknown>;
+  const rawPlan = record.plan;
+  const runId = typeof record.runId === 'string' ? record.runId : undefined;
+  if (typeof rawPlan === 'string') return { matches: rawPlan === planSlug, runId };
+  if (rawPlan && typeof rawPlan === 'object') {
+    const plan = rawPlan as Record<string, unknown>;
+    if (plan.slug === planSlug) return { matches: true, runId };
+    if (typeof plan.path === 'string' && basename(plan.path, extname(plan.path)) === planSlug) return { matches: true, runId };
+  }
+  return { matches: false, runId };
+}
+
+function collectRunLinks(root: string, planSlug: string, options: Required<TraceOptions>, warnings: TraceWarning[]): TraceLink[] {
+  const links: TraceLink[] = [];
+  const runsDir = join(root, '.osc', 'runs');
+  for (const entry of readContainedDirectory(root, runsDir, 'unsafe_runs_dir', warnings)) {
+    if (!entry.isDirectory()) continue;
+    const runJson = join(runsDir, entry.name, 'run.json');
+    const rel = repoRelative(root, runJson);
+    const text = readContainedText(root, runJson);
+    if (text === null) continue;
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      const match = planMatchesRun(planSlug, parsed);
+      if (match.matches) {
+        links.push({ type: 'run_packet', status: 'local', reference: rel, detail: 'Run packet references this plan.', run_id: match.runId ?? entry.name });
+      } else if (options.includeUnverified && containsExactToken(text, planSlug)) {
+        links.push({ type: 'run_packet', status: 'unverified', reference: rel, detail: 'Run packet mentions the plan slug but does not expose a canonical plan slug/path.', run_id: match.runId ?? entry.name });
+      }
+    } catch {
+      warnings.push({ code: 'unreadable_run_packet', message: 'Run packet is not valid JSON.', path: rel });
+      if (options.includeUnverified && containsExactToken(text, planSlug)) {
+        links.push({ type: 'run_packet', status: 'unverified', reference: rel, detail: 'Malformed run packet mentions the plan slug.' });
+      }
+    }
+  }
+  return links;
+}
+
+function extractExternalRefs(text: string, sourcePath: string): TraceLink[] {
+  const links: TraceLink[] = [];
+  const prUrls = text.match(/https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+/g) ?? [];
+  const issueUrls = text.match(/https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/issues\/\d+/g) ?? [];
+  for (const reference of prUrls) {
+    links.push({ type: 'pr_reference', status: 'external', reference, source_path: sourcePath, detail: 'Recognized PR reference in local note; not verified over the network.' });
+  }
+  for (const reference of issueUrls) {
+    links.push({ type: 'issue_reference', status: 'external', reference, source_path: sourcePath, detail: 'Recognized issue reference in local note; not verified over the network.' });
+  }
+  return links;
+}
+
+function releaseReferencesPlan(text: string, file: string, planSlug: string): boolean {
+  if (releaseSlug(file) === planSlug) return true;
+  return planPathsForSlug(planSlug).some((path) => text.includes(path));
+}
+
+function collectReleaseLinks(root: string, planSlug: string, options: Required<TraceOptions>, warnings: TraceWarning[]): TraceLink[] {
+  const links: TraceLink[] = [];
+  const releasesDir = join(root, '.osc', 'releases');
+  for (const entry of readContainedDirectory(root, releasesDir, 'unsafe_releases_dir', warnings)) {
+    if (!entry.isFile() || !entry.name.endsWith('.md') || entry.name === 'README.md') continue;
+    const path = join(releasesDir, entry.name);
+    const rel = repoRelative(root, path);
+    const text = readContainedText(root, path);
+    if (text === null) continue;
+    if (releaseReferencesPlan(text, entry.name, planSlug)) {
+      links.push({ type: 'release_note', status: 'local', reference: rel, source_path: rel, detail: 'Release/evidence note cites this plan.' });
+      links.push(...extractExternalRefs(text, rel));
+    } else if (options.includeUnverified && containsExactToken(text, planSlug)) {
+      links.push({ type: 'generic_reference', status: 'unverified', reference: rel, source_path: rel, detail: 'Local note mentions the plan slug but does not cite a canonical plan path.' });
+    }
+  }
+  return links;
+}
+
+function addMissingLinks(links: TraceLink[], planSlug: string): TraceLink[] {
+  const next = [...links];
+  if (!next.some((link) => link.type === 'run_packet' && link.status === 'local')) {
+    next.push({ type: 'run_packet', status: 'missing', reference: '.osc/runs/*/run.json', detail: `No local run packet found for ${planSlug}.` });
+  }
+  if (!next.some((link) => link.type === 'release_note' && link.status === 'local')) {
+    next.push({ type: 'release_note', status: 'missing', reference: `.osc/releases/*-${planSlug}.md`, detail: `No local release/evidence note found for ${planSlug}.` });
+  }
+  return next;
+}
+
+function summarizeLinks(links: TraceLink[]): TraceReport['summary'] {
+  return {
+    local: links.filter((link) => link.status === 'local').length,
+    external: links.filter((link) => link.status === 'external').length,
+    missing: links.filter((link) => link.status === 'missing').length,
+    unverified: links.filter((link) => link.status === 'unverified').length,
+    runs: links.filter((link) => link.type === 'run_packet' && link.status === 'local').length,
+    release_notes: links.filter((link) => link.type === 'release_note' && link.status === 'local').length,
+    external_refs: links.filter((link) => (link.type === 'pr_reference' || link.type === 'issue_reference') && link.status === 'external').length,
+  };
+}
+
+export function buildTrace(start: string, slug: string, options: TraceOptions = {}): TraceReport {
+  const planSlug = normalizePlanSlug(slug);
+  const includeUnverified = options.includeUnverified ?? false;
+  const root = findScaffoldRoot(resolve(start)) ?? null;
+  if (!root) throw new Error(`No Open Scaffold root found from ${resolve(start)}. Run this inside a repo with .osc/plans and .osc/releases.`);
+
+  const foundPlan = findPlan(root, planSlug);
+  const plan = parsePlanFile(foundPlan.path);
+  const planText = readFileSync(foundPlan.path, 'utf8');
+  const sections = splitSections(planText);
+  const acceptanceCriteria = parseAcceptanceCriteria(sections.get('Acceptance criteria') ?? '');
+  const warnings: TraceWarning[] = [];
+
+  const links: TraceLink[] = [
+    { type: 'plan_file', status: 'local', reference: repoRelative(root, foundPlan.path), target_path: repoRelative(root, foundPlan.path), detail: 'Plan file found in local scaffold stage.' },
+    ...acceptanceCriteria.map((criterion): TraceLink => ({
+      type: 'acceptance_criterion',
+      status: 'local',
+      reference: criterion.id,
+      detail: criterion.checked ? criterion.text : `${criterion.text} (unchecked)`,
+      source_path: repoRelative(root, foundPlan.path),
+    })),
+    ...collectRunLinks(root, planSlug, { includeUnverified }, warnings),
+    ...collectReleaseLinks(root, planSlug, { includeUnverified }, warnings),
+  ];
+
+  const finalLinks = dedupeLinks(addMissingLinks(links, planSlug));
+  return {
+    schema: 'open-scaffold.trace.v1',
+    root,
+    query: { plan_slug: planSlug, include_unverified: includeUnverified },
+    plan: {
+      slug: planSlug,
+      stage: foundPlan.stage,
+      status: plan.status,
+      path: repoRelative(root, foundPlan.path),
+      goal: plan.goal,
+      acceptance_criteria: acceptanceCriteria,
+    },
+    links: finalLinks,
+    warnings,
+    summary: summarizeLinks(finalLinks),
+  };
+}
+
+export function formatTraceReport(report: TraceReport): string {
+  const lines = [
+    `Open Scaffold trace: ${safeText(report.plan.slug)}`,
+    `Status: ${safeText(report.plan.status)}`,
+    `Stage: ${safeText(report.plan.stage)}`,
+    `Path: ${safeText(report.plan.path)}`,
+    `Goal: ${safeText(report.plan.goal) || '(none)'}`,
+    '',
+    'Acceptance criteria:',
+  ];
+  if (report.plan.acceptance_criteria.length === 0) {
+    lines.push('  (none listed)');
+  } else {
+    for (const criterion of report.plan.acceptance_criteria) {
+      lines.push(`  - ${criterion.id} ${criterion.checked ? '[x]' : '[ ]'} ${safeText(criterion.text)}`);
+    }
+  }
+  lines.push('', 'Links:');
+  for (const link of report.links) {
+    const detail = link.detail ? ` — ${safeText(link.detail)}` : '';
+    lines.push(`  [${safeText(link.status)}] ${safeText(link.type)}: ${safeText(link.reference)}${detail}`);
+  }
+  if (report.warnings.length > 0) {
+    lines.push('', 'Warnings:');
+    for (const warning of report.warnings) {
+      const path = warning.path ? ` (${safeText(warning.path)})` : '';
+      lines.push(`  - ${safeText(warning.code)}: ${safeText(warning.message)}${path}`);
+    }
+  }
+  lines.push('', `Summary: local=${report.summary.local}, external=${report.summary.external}, missing=${report.summary.missing}, unverified=${report.summary.unverified}`);
+  return `${lines.join('\n')}\n`;
+}

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -232,6 +232,7 @@ function collectRunLinks(root: string, planSlug: string, options: Required<Trace
       const match = planMatchesRun(planSlug, parsed);
       if (match.matches) {
         links.push({ type: 'run_packet', status: 'local', reference: rel, detail: 'Run packet references this plan.', run_id: match.runId ?? entry.name });
+        links.push(...extractExternalRefs(text, rel));
       } else if (options.includeUnverified && containsExactToken(text, planSlug)) {
         links.push({ type: 'run_packet', status: 'unverified', reference: rel, detail: 'Run packet mentions the plan slug but does not expose a canonical plan slug/path.', run_id: match.runId ?? entry.name });
       }

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -368,7 +368,7 @@ export function buildTrace(start: string, slug: string, options: TraceOptions = 
     plan: {
       slug: planSlug,
       stage: foundPlan.stage,
-      status: plan.status,
+      status: foundPlan.stage,
       path: repoRelative(root, foundPlan.path),
       goal: plan.goal,
       acceptance_criteria: acceptanceCriteria,

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -38,6 +38,7 @@ const topLevelHelpCommands = [
   'osc evidence new <slug>',
   'osc evidence collect <slug> [--ci] [--dry-run] [--verbose]',
   'osc close <plan-slug> [--message <text>]',
+  'osc trace <plan-slug> [--json] [--include-unverified]',
   'osc verify [--evidence-chain [--plan <slug>] [--json] [--strict]]',
   'osc start <plan-slug-or-path> --runtime <codex|omx|plain|human|custom>',
   'osc delegate <plan-path> [run binding options]',
@@ -117,6 +118,12 @@ const cases: HelpCase[] = [
     args: ['close', '--help'],
     expected: 'Usage: osc close <plan-slug> [--message <text>]',
     forbidden: 'Unsafe slug',
+  },
+  {
+    name: 'trace',
+    args: ['trace', '--help'],
+    expected: 'Usage: osc trace <plan-slug> [--json] [--include-unverified]',
+    forbidden: 'Missing required argument',
   },
 ];
 

--- a/tests/public-positioning.test.ts
+++ b/tests/public-positioning.test.ts
@@ -121,6 +121,18 @@ describe('public work-record positioning', () => {
     expect(section).not.toMatch(/trusted|compliance-grade|tamper-proof|trust score/i);
   });
 
+  it('documents trace as read-only replay, not verification or certification', () => {
+    const trace = read('docs/TRACE.md');
+
+    expect(trace).toContain('osc trace <plan-slug>');
+    expect(trace).toContain('read-only work-record replay');
+    expect(trace).toContain('osc verify --evidence-chain');
+    expect(trace).toContain('does not call GitHub');
+    expect(trace).toContain('does not spawn runtimes');
+    expect(trace).toContain('does not judge correctness, evidence quality, or readiness');
+    expect(trace).not.toMatch(/trust score|compliance-grade|tamper-proof|certif(y|ies|ied)/i);
+  });
+
   it('positions comparison tools as adjacent layers rather than enemies', () => {
     const comparison = read('docs/COMPARISON.md');
 

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -247,6 +247,30 @@ describe('trace work-record replay', () => {
     expect(report.links).toContainEqual(expect.objectContaining({ type: 'release_note', status: 'missing' }));
   });
 
+  it('recognizes local shorthand PR and issue references in release notes', () => {
+    const root = tempRepo();
+    writePlan(root, 'done', '008-shorthand');
+    writeFileSync(join(root, '.osc/releases/2026-05-27-008-shorthand.md'), `# Release / Evidence Note: 008-shorthand
+
+## Traceability
+
+- Plan: .osc/plans/done/008-shorthand.md
+- Pull Request: \`graphanov/open-scaffold#129\`
+- Follow-up Issue: #130
+
+## Outcome
+
+Integrated via PR #129 with follow-up issue #130.
+`);
+
+    const report = buildTrace(root, '008-shorthand');
+
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'pr_reference', status: 'external', reference: 'graphanov/open-scaffold#129' }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'pr_reference', status: 'external', reference: 'PR #129' }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'issue_reference', status: 'external', reference: '#130' }));
+    expect(report.summary.external_refs).toBeGreaterThanOrEqual(3);
+  });
+
   it('sanitizes control characters in human-readable output', () => {
     const root = tempRepo();
     const esc = '\u001b';

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -271,6 +271,50 @@ Integrated via PR #129 with follow-up issue #130.
     expect(report.summary.external_refs).toBeGreaterThanOrEqual(3);
   });
 
+  it('uses the authoritative folder stage as the public status when plan text is stale', () => {
+    const root = tempRepo();
+    writeFileSync(join(root, '.osc/plans/done/009-stale-status.md'), `# Plan: 009-stale-status
+
+## Status
+
+active
+
+## Context
+
+Fixture context.
+
+## Goal
+
+Replay stale lifecycle status.
+
+## Constraints / Out of scope
+
+- Local-only fixture.
+
+## Files to touch
+
+- Fixture files.
+
+## Acceptance criteria
+
+- [x] AC1 is backed.
+
+## Verification steps
+
+1. Run trace.
+
+## Open questions
+
+- None.
+`);
+
+    const report = buildTrace(root, '009-stale-status');
+
+    expect(report.plan.stage).toBe('done');
+    expect(report.plan.status).toBe('done');
+    expect(formatTraceReport(report)).toContain('Status: done');
+  });
+
   it('sanitizes control characters in human-readable output', () => {
     const root = tempRepo();
     const esc = '\u001b';

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -224,6 +224,29 @@ describe('trace work-record replay', () => {
     expect(readdirSync(join(root, '.osc/releases')).join('\n')).toBe(before);
   });
 
+  it('extracts PR and issue references from matching run packets even without release notes', () => {
+    const root = tempRepo();
+    writePlan(root, 'done', '007-run-refs');
+    const runId = '20260527T120000Z-007-run-refs-run';
+    const runDir = join(root, '.osc/runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, 'run.json'), JSON.stringify({
+      schemaVersion: 'open-scaffold.run.v1',
+      runId,
+      plan: { slug: '007-run-refs', path: '.osc/plans/done/007-run-refs.md' },
+      bindings: {
+        githubPr: 'https://github.com/example/repo/pull/77',
+        githubIssue: 'https://github.com/example/repo/issues/88',
+      },
+    }, null, 2));
+
+    const report = buildTrace(root, '007-run-refs');
+
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'pr_reference', status: 'external', reference: 'https://github.com/example/repo/pull/77', source_path: `.osc/runs/${runId}/run.json` }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'issue_reference', status: 'external', reference: 'https://github.com/example/repo/issues/88', source_path: `.osc/runs/${runId}/run.json` }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'release_note', status: 'missing' }));
+  });
+
   it('sanitizes control characters in human-readable output', () => {
     const root = tempRepo();
     const esc = '\u001b';

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { buildTrace, formatTraceReport } from '../src/trace.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempRepo(prefix = 'osc-trace-') {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  for (const stage of ['active', 'backlog', 'blocked', 'done']) mkdirSync(join(root, `.osc/plans/${stage}`), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  mkdirSync(join(root, '.osc/runs'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nDefined.\n\n## Changelog\n\n<!-- append YYYY-MM-DD entries below this line -->\n');
+  writeFileSync(join(root, '.osc/releases/README.md'), '# Release / evidence notes\n');
+  return root;
+}
+
+function writePlan(root: string, stage: 'active' | 'backlog' | 'blocked' | 'done', slug: string, options: { goal?: string; ac?: string; extra?: string } = {}) {
+  writeFileSync(join(root, `.osc/plans/${stage}`, `${slug}.md`), `# Plan: ${slug}
+
+## Status
+
+${stage}
+
+## Context
+
+Fixture context.
+
+## Goal
+
+${options.goal ?? 'Replay the local work record.'}
+
+## Constraints / Out of scope
+
+- Local-only fixture.
+
+## Files to touch
+
+- Fixture files.
+
+## Acceptance criteria
+
+${options.ac ?? '- [x] AC1 is backed.\n- [ ] AC2 still needs evidence.'}
+
+## Verification steps
+
+1. Run trace.
+
+## Open questions
+
+- None.
+${options.extra ?? ''}`);
+}
+
+function writeRun(root: string, slug: string, runId = `20260527T120000Z-${slug}-run`) {
+  const runDir = join(root, '.osc/runs', runId);
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(join(runDir, 'run.json'), JSON.stringify({
+    schemaVersion: 'open-scaffold.run.v1',
+    runId,
+    plan: {
+      slug,
+      path: `.osc/plans/done/${slug}.md`,
+      goal: 'Replay the local work record.',
+      acceptanceCriteria: ['AC1 is backed.'],
+    },
+  }, null, 2));
+  return runId;
+}
+
+function writeRelease(root: string, slug: string, body = '') {
+  writeFileSync(join(root, '.osc/releases', `2026-05-27-${slug}.md`), `# Release / Evidence Note: ${slug}
+
+## Summary
+
+Fixture evidence note.
+
+## Traceability
+
+- Source plan: .osc/plans/done/${slug}.md
+- Run ID: 20260527T120000Z-${slug}-run
+- Source Pull Request: https://github.com/example/repo/pull/42
+- Follow-up Issue: https://github.com/example/repo/issues/24
+${body}
+
+## Verification
+
+- PASS.
+
+## Outcome
+
+Approved fixture.
+`);
+}
+
+function runCli(root: string, args: string[]) {
+  return spawnSync(tsx, [cli, ...args], { cwd: root, encoding: 'utf8' });
+}
+
+describe('trace work-record replay', () => {
+  it('finds a plan in any stage and summarizes status, goal, path, and acceptance criteria', () => {
+    const root = tempRepo();
+    writePlan(root, 'backlog', '117-fixture', {
+      goal: 'Replay a fixture chain.',
+      ac: '- [x] AC1 has local evidence.\n- [ ] AC2 is missing follow-up evidence.',
+    });
+
+    const report = buildTrace(root, '117-fixture');
+
+    expect(report.schema).toBe('open-scaffold.trace.v1');
+    expect(report.plan).toMatchObject({
+      slug: '117-fixture',
+      stage: 'backlog',
+      status: 'backlog',
+      path: '.osc/plans/backlog/117-fixture.md',
+      goal: 'Replay a fixture chain.',
+    });
+    expect(report.plan.acceptance_criteria).toEqual([
+      { id: 'AC1', text: 'AC1 has local evidence.', checked: true },
+      { id: 'AC2', text: 'AC2 is missing follow-up evidence.', checked: false },
+    ]);
+    expect(formatTraceReport(report)).toContain('Open Scaffold trace: 117-fixture');
+    expect(formatTraceReport(report)).toContain('Status: backlog');
+    expect(formatTraceReport(report)).toContain('AC2 [ ] AC2 is missing follow-up evidence.');
+  });
+
+  it('replays local run packets, release notes, and recognized external PR/issue references', () => {
+    const root = tempRepo();
+    writePlan(root, 'done', '001-full');
+    const runId = writeRun(root, '001-full');
+    writeRelease(root, '001-full');
+
+    const report = buildTrace(root, '001-full');
+
+    expect(report.summary).toMatchObject({ runs: 1, release_notes: 1, external_refs: 2 });
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'plan_file', status: 'local', reference: '.osc/plans/done/001-full.md' }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'run_packet', status: 'local', reference: `.osc/runs/${runId}/run.json`, run_id: runId }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'release_note', status: 'local', reference: '.osc/releases/2026-05-27-001-full.md' }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'pr_reference', status: 'external', reference: 'https://github.com/example/repo/pull/42' }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'issue_reference', status: 'external', reference: 'https://github.com/example/repo/issues/24' }));
+    expect(formatTraceReport(report)).toContain(`[local] run_packet: .osc/runs/${runId}/run.json`);
+    expect(formatTraceReport(report)).toContain('[external] pr_reference: https://github.com/example/repo/pull/42');
+  });
+
+  it('labels missing local chain links without failing trace construction', () => {
+    const root = tempRepo();
+    writePlan(root, 'active', '002-partial');
+
+    const report = buildTrace(root, '002-partial');
+
+    expect(report.plan.stage).toBe('active');
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'run_packet', status: 'missing' }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'release_note', status: 'missing' }));
+    expect(report.summary.missing).toBeGreaterThanOrEqual(2);
+  });
+
+  it('keeps slug matching exact and includes weak local mentions only when requested', () => {
+    const root = tempRepo();
+    writePlan(root, 'done', '001-foo');
+    writePlan(root, 'done', '001-foo-bar');
+    writeRun(root, '001-foo-bar');
+    writeRelease(root, '001-foo-bar');
+    writeFileSync(join(root, '.osc/releases/2026-05-27-related.md'), '# Related\n\nThis note mentions 001-foo in prose only.\n');
+
+    const defaultReport = buildTrace(root, '001-foo');
+    expect(defaultReport.links.some((link) => link.reference.includes('001-foo-bar'))).toBe(false);
+    expect(defaultReport.links.some((link) => link.status === 'unverified')).toBe(false);
+
+    const withUnverified = buildTrace(root, '001-foo', { includeUnverified: true });
+    expect(withUnverified.links).toContainEqual(expect.objectContaining({
+      type: 'generic_reference',
+      status: 'unverified',
+      reference: '.osc/releases/2026-05-27-related.md',
+    }));
+  });
+
+  it('emits parseable JSON from the CLI without human preamble', () => {
+    const root = tempRepo();
+    writePlan(root, 'done', '003-json');
+    writeRun(root, '003-json');
+    writeRelease(root, '003-json');
+
+    const result = runCli(root, ['trace', '003-json', '--json']);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.schema).toBe('open-scaffold.trace.v1');
+    expect(parsed.query).toEqual({ plan_slug: '003-json', include_unverified: false });
+    expect(parsed.plan.slug).toBe('003-json');
+    expect(parsed.links.map((link: { status: string }) => link.status)).toContain('local');
+    expect(parsed.links.map((link: { status: string }) => link.status)).toContain('external');
+  });
+
+  it('rejects unsafe slugs and unknown options with usage errors', () => {
+    const root = tempRepo();
+
+    const unsafe = runCli(root, ['trace', '../secret']);
+    expect(unsafe.status).toBe(2);
+    expect(unsafe.stderr).toContain('Unsafe plan slug: ../secret');
+
+    const unknown = runCli(root, ['trace', '001-demo', '--network']);
+    expect(unknown.status).toBe(2);
+    expect(unknown.stderr).toContain('Unknown option for trace: --network');
+  });
+
+  it('stays read-only while tracing from a subdirectory', () => {
+    const root = tempRepo();
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writePlan(root, 'done', '004-subdir');
+    writeRun(root, '004-subdir');
+    writeRelease(root, '004-subdir');
+    const before = readdirSync(join(root, '.osc/releases')).join('\n');
+
+    const result = spawnSync(tsx, [cli, 'trace', '004-subdir'], { cwd: join(root, 'src'), encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Path: .osc/plans/done/004-subdir.md');
+    expect(existsSync(join(root, 'src/.osc'))).toBe(false);
+    expect(readdirSync(join(root, '.osc/releases')).join('\n')).toBe(before);
+  });
+
+  it('sanitizes control characters in human-readable output', () => {
+    const root = tempRepo();
+    const esc = '\u001b';
+    const dcs = '\u0090';
+    const planPath = join(root, '.osc/plans/done/005-control.md');
+    writeFileSync(planPath, `# Plan: 005-control
+
+## Status
+
+done${esc}[31m${dcs}
+
+## Context
+
+Fixture context.
+
+## Goal
+
+Replay the local work record.
+
+## Constraints / Out of scope
+
+- Local-only fixture.
+
+## Files to touch
+
+- Fixture files.
+
+## Acceptance criteria
+
+- [x] AC1 is backed.
+
+## Verification steps
+
+1. Run trace.
+
+## Open questions
+
+- None.
+`);
+    writeRun(root, '005-control', `20260527T120000Z-005-control-${esc}[31m${dcs}run`);
+
+    const rendered = formatTraceReport(buildTrace(root, '005-control'));
+
+    expect(rendered).toContain('Status: done');
+    expect(rendered).not.toMatch(/[\u001B\u0090-\u009F]/);
+  });
+
+  it('skips symlinked or broken trace directories instead of traversing outside the scaffold root', () => {
+    const root = tempRepo();
+    writePlan(root, 'done', '006-symlinked');
+    const outside = mkdtempSync(join(tmpdir(), 'osc-trace-outside-'));
+    mkdirSync(join(outside, 'run-outside'), { recursive: true });
+    writeFileSync(join(outside, 'run-outside/run.json'), JSON.stringify({ schemaVersion: 'open-scaffold.run.v1', runId: 'outside', plan: { slug: '006-symlinked' } }, null, 2));
+    rmSync(join(root, '.osc/runs'), { recursive: true, force: true });
+    symlinkSync(outside, join(root, '.osc/runs'), 'dir');
+    mkdirSync(join(outside, 'releases-outside'), { recursive: true });
+    writeFileSync(join(outside, 'releases-outside/2026-05-27-006-symlinked.md'), '- Source plan: .osc/plans/done/006-symlinked.md\n');
+    rmSync(join(root, '.osc/releases'), { recursive: true, force: true });
+    symlinkSync(join(outside, 'releases-outside'), join(root, '.osc/releases'), 'dir');
+
+    const report = buildTrace(root, '006-symlinked');
+
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'run_packet', status: 'missing' }));
+    expect(report.links).toContainEqual(expect.objectContaining({ type: 'release_note', status: 'missing' }));
+    expect(report.links.some((link) => link.reference.includes('run-outside'))).toBe(false);
+    expect(report.warnings.map((warning) => warning.code)).toContain('unsafe_runs_dir');
+    expect(report.warnings.map((warning) => warning.code)).toContain('unsafe_releases_dir');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `osc trace <plan-slug>` as a local, read-only work-record replay command with human and JSON output.
- Reconstructs one plan's known local chain across plan metadata, acceptance criteria, run packets, release/evidence notes, and recognized PR/issue references.
- Reports the public plan status from the authoritative plan stage folder, so older markdown `## Status` drift does not mislead trace consumers.
- Recognizes full GitHub PR/issue URLs plus common local shorthand such as `PR #123`, `Pull Request: owner/repo#123`, and `Issue: #456`, without network verification.
- Documents the trace/verify split and keeps trace explicitly out of GitHub/API verification, runtime spawning, evidence-quality judgment, approval, and publication side effects.
- Closes plan 117 with a repo-native evidence note.

## Verification
- `npm test -- --run tests/trace.test.ts` — PASS, 12 tests
- `npm test -- --run tests/trace.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts` — PASS, 32 tests
- `npm test -- --run` — PASS, 47 files / 426 tests
- `npm run build` — PASS
- `node dist/cli.js trace 107-work-dry-run-package-sync` — PASS
- `node dist/cli.js trace 107-work-dry-run-package-sync --json` plus JSON parse/schema assertions — PASS
- `node dist/cli.js trace 117-osc-trace-work-record-replay --json` plus JSON parse/schema/stage/status/release-note assertions — PASS
- `node dist/cli.js plan validate .osc/plans/done/117-osc-trace-work-record-replay.md` — PASS, 0 issues found
- `git diff --check` — PASS
- `git diff --cached --check` — PASS before commits
- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn

## Risk / gates
- Package-visible CLI command: npm publication and GitHub Release follow-through are not included in this PR.
- External PR/issue references are recognized from local files only; trace does not call GitHub or verify network state.
- Codex latest-head loop is in progress and must be clean before merge consideration.
