### PR TITLE
chore: prepare trace package sync

### DIFF
--- a/.osc/plans/active/124-trace-package-release-sync.md
+++ b/.osc/plans/active/124-trace-package-release-sync.md
@@ -1,0 +1,63 @@
+# Plan: 124-trace-package-release-sync
+
+## Status
+
+active
+
+## Context
+
+PR #142 landed `osc trace <plan-slug>` on `main`, but the current public package `open-scaffold@latest` remains `0.20.0` and fresh `npx open-scaffold@latest --help` does not expose the new trace command. Local `main` is clean and green after that source slice, so the next narrow slice is a package/public-surface sync candidate.
+
+## Goal
+
+Prepare a package/public-surface release candidate that publishes the trace work-record replay command through the public install path as `open-scaffold@0.20.1`, while keeping npm publication and GitHub Release follow-through as separate owner-approved gates.
+
+## Constraints / Out of scope
+
+- Do not publish to npm in this PR.
+- Do not create or update a GitHub Release in this PR.
+- Do not change trace behavior beyond package/public-surface metadata unless verification exposes a candidate blocker.
+- Do not deprecate historical `1.0.x` npm versions in this PR.
+- Do not land this release-sync PR without owner approval.
+
+## Files to touch
+
+- `package.json` — set the next package candidate to `0.20.1`.
+- `package-lock.json` — keep the lockfile root version aligned with `package.json`.
+- `docs/CHANGELOG.md` — promote the trace package-sync candidate entry and link the source PR/evidence.
+- `.osc/releases/2026-05-28-124-trace-package-release-sync.md` — record candidate evidence and owner-gated publication proof slots.
+- `.osc/plans/active/124-trace-package-release-sync.md` — this active plan.
+
+## Implementation Architecture Coverage
+
+- Strengthens: adoption trust, package/public-surface truth, trace/work-record visibility.
+- Audit envelope: source plan `117`, source PR #142, release-sync plan `124`, npm registry checks, fresh `npx` smoke after owner-approved publish.
+- Evaluation envelope: local gates prove the candidate builds/tests/packs/publish-dry-runs; owner-gated public checks must prove npm/latest and GitHub Latest before final plan proof.
+- Feedback routing: any publish, dist-tag, GitHub Release, or old-version deprecation decision remains an owner gate and should be recorded in the release evidence note or a follow-up plan.
+- Boundary: no npm publish, GitHub Release, deprecated-package write, runtime execution, or feature implementation happens in this PR.
+
+## Acceptance criteria
+
+- [x] `package.json` and `package-lock.json` both declare `0.20.1`.
+- [x] The candidate documents that `0.20.1` publishes the PR #142 package-visible trace command.
+- [x] `docs/CHANGELOG.md` includes the `v0.20.1` package-sync candidate entry for `osc trace`.
+- [x] Candidate package gates pass: `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm pack --dry-run --json`, `npm publish --dry-run --tag latest`, and `git diff --check`.
+- [x] Local built CLI help exposes `osc trace <plan-slug> [--json] [--include-unverified]` before PR publication.
+- [x] The PR stops before landing, npm publish, GitHub Release creation/update, and optional npm deprecation of historical `1.0.x` versions.
+
+## Verification steps
+
+1. `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — expect `0.20.1 / 0.20.1 / 0.20.1`.
+2. `npm view open-scaffold version dist-tags versions --json` — confirm live npm before publish is still `0.20.0` and `0.20.1` is not already published.
+3. `npm run build` then `node dist/cli.js --help` — help includes `osc trace <plan-slug> [--json] [--include-unverified]`.
+4. `./verify.sh --strict` — all scaffold checks pass.
+5. `npm test -- --run` — full test suite passes.
+6. `npm pack --dry-run --json` — package candidate is packable as `open-scaffold@0.20.1` and includes trace docs/dist output.
+7. `npm publish --dry-run --tag latest` — candidate publish dry-run succeeds; real trusted publishing remains owner-gated.
+8. `git diff --check` — whitespace check passes.
+
+## Open questions
+
+- Owner gate after PR lands: publish `open-scaffold@0.20.1` via trusted publishing with npm dist-tag `latest`.
+- Owner gate after publish: create/mark GitHub Release `v0.20.1` as Latest after fresh isolated-cache `npx` proof.
+- Optional deferred decision: whether to deprecate historical `1.0.x` npm versions with a gentle cadence-correction message, or leave them as published history.

--- a/.osc/releases/2026-05-28-124-trace-package-release-sync.md
+++ b/.osc/releases/2026-05-28-124-trace-package-release-sync.md
@@ -14,7 +14,7 @@ The candidate keeps the forward-moving public package cadence in the `0.20.x` li
 - Source merge commit: `5bd33e96d7b34e24d74ecbb4a618060a9f009566`.
 - Release-sync plan: `.osc/plans/active/124-trace-package-release-sync.md`.
 - Release-sync branch: `release/trace-package-sync-0201`.
-- Release-sync Pull Request: pending.
+- Release-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/143.
 - Run ID / run packet: N/A for release-sync.
 - npm precheck: before candidate publish, live `latest` is `open-scaffold@0.20.0`; `0.20.1` is not yet published.
 

--- a/.osc/releases/2026-05-28-124-trace-package-release-sync.md
+++ b/.osc/releases/2026-05-28-124-trace-package-release-sync.md
@@ -1,0 +1,52 @@
+# Release / Evidence Note: 124-trace-package-release-sync
+
+## Summary
+
+Prepares `open-scaffold@0.20.1` as the package/public-surface sync for the newly merged `osc trace <plan-slug>` work-record replay command.
+
+The candidate keeps the forward-moving public package cadence in the `0.20.x` line. It does not publish to npm or create a GitHub Release; those remain owner-approved follow-through gates after merge.
+
+## Traceability
+
+- Source plan: `.osc/plans/done/117-osc-trace-work-record-replay.md`.
+- Source evidence note: `.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md`.
+- Source Pull Request: https://github.com/graphanov/open-scaffold/pull/142.
+- Source merge commit: `5bd33e96d7b34e24d74ecbb4a618060a9f009566`.
+- Release-sync plan: `.osc/plans/active/124-trace-package-release-sync.md`.
+- Release-sync branch: `release/trace-package-sync-0201`.
+- Release-sync Pull Request: pending.
+- Run ID / run packet: N/A for release-sync.
+- npm precheck: before candidate publish, live `latest` is `open-scaffold@0.20.0`; `0.20.1` is not yet published.
+
+## Verification
+
+Candidate gates completed before PR-ready:
+
+- [x] `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `0.20.1 / 0.20.1 / 0.20.1`.
+- [x] `npm view open-scaffold version dist-tags versions --json` — PASS: live npm remains `0.20.0`, `latest: 0.20.0`, and `0.20.1` is not in the published versions list.
+- [x] `npm run build` — PASS.
+- [x] `node dist/cli.js --help` — PASS: includes `osc trace <plan-slug> [--json] [--include-unverified]`.
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
+- [x] `npm test -- --run` — PASS: 47 files / 426 tests.
+- [x] `npm pack --dry-run --json` — PASS for `open-scaffold@0.20.1` (162 files); includes `dist/trace.js`, `dist/trace.d.ts`, and `docs/TRACE.md`.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.20.1` with `latest` tag in dry-run mode.
+- [x] `git diff --check` — PASS.
+- [ ] PR CI and latest-head Codex review — pending after PR creation.
+
+Post-merge/publication gates, if the owner approves follow-through:
+
+- [ ] Sync clean `main` after merge.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.20.1` with workflow input `npm-tag=latest` if required.
+- [ ] `npm view open-scaffold version dist-tags --json` reports `latest: 0.20.1`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` exposes `osc trace`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest trace 117-osc-trace-work-record-replay --json` works from a repo with the merged plan/evidence, or equivalent local package smoke confirms the command surface.
+- [ ] GitHub Release `v0.20.1` is created/marked Latest.
+- [ ] Release-sync plan can be closed to `done/` with final public proof.
+
+## Outcome
+
+Candidate in progress. This PR prepares package metadata and adoption-facing evidence only. npm publish, GitHub Latest Release, and final closeout remain separate owner-gated steps.
+
+## Follow-up
+
+After owner-approved merge and public package surfaces are aligned, close plan `124` with final npm/GitHub Release proof in a tiny closeout PR if needed.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,22 +4,25 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
-## v0.20.x — Trace work-record replay
+## v0.20.1 — Trace work-record replay package sync
 
-Status: prepared in repo; npm publication and GitHub Release follow-through remain separate owner-approved public-surface gates.
+Status: package/public-surface candidate prepared in repo; npm publication and GitHub Release follow-through remain separate owner-approved gates.
 
 Highlights:
 
-- Adds `osc trace <plan-slug>`, a read-only command for replaying one plan's local work-record chain.
+- Publishes the PR #142 package-visible trace command: `osc trace <plan-slug>`, a read-only command for replaying one plan's local work-record chain.
 - Complements `osc verify --evidence-chain`: trace explains the known chain, verify checks structural integrity.
 - Labels links as `local`, `external`, `missing`, or `unverified` without judging correctness, evidence quality, PR state, or compliance.
+- Recognizes full GitHub PR/issue URLs plus common local shorthand such as `PR #123`, `Pull Request: owner/repo#123`, and `Issue: #456` from local files only.
 - Requires no GitHub API, network access, runtime launch, hosted dashboard, or provider credentials.
 
 Evidence:
 
 - Source plan: `.osc/plans/done/117-osc-trace-work-record-replay.md`
 - Source evidence note: `.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md`
-- Source PR: this feature PR
+- Source PR: https://github.com/graphanov/open-scaffold/pull/142
+- Release-sync plan: `.osc/plans/active/124-trace-package-release-sync.md`
+- Release-sync evidence note: `.osc/releases/2026-05-28-124-trace-package-release-sync.md`
 
 ## v0.20.0 — Evidence-chain package sync and cadence correction
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Prepares `open-scaffold@0.20.1` as the package/public-surface sync for the merged `osc trace <plan-slug>` command from PR #142.
- Bumps `package.json` and `package-lock.json` to `0.20.1`.
- Adds active release-sync plan/evidence for the owner-gated publish/GitHub Release follow-through.
- Updates the changelog so the trace command has an adoption-facing `v0.20.1` candidate entry.

## Verification
- `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `0.20.1 / 0.20.1 / 0.20.1`
- `npm view open-scaffold version dist-tags versions --json` — PASS: live npm remains `0.20.0`, `latest: 0.20.0`, and `0.20.1` is unpublished
- `npm run build` — PASS
- `node dist/cli.js --help` — PASS: includes `osc trace <plan-slug> [--json] [--include-unverified]`
- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn
- `npm test -- --run` — PASS, 47 files / 426 tests
- `npm pack --dry-run --json` — PASS for `open-scaffold@0.20.1`; includes `dist/trace.js`, `dist/trace.d.ts`, and `docs/TRACE.md`
- `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.20.1` with `latest` tag in dry-run mode
- `git diff --check` — PASS
- `git diff --cached --check` — PASS before commit

## Risk / gates
- This PR does not publish to npm.
- This PR does not create or update a GitHub Release.
- After merge, owner approval is still required to run trusted publishing for `open-scaffold@0.20.1` and mark GitHub Release `v0.20.1` as Latest after fresh `npx` proof.
