### PR TITLE
chore: close trace package release sync

### DIFF
--- a/.osc/plans/done/124-trace-package-release-sync.md
+++ b/.osc/plans/done/124-trace-package-release-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
@@ -26,15 +26,15 @@ Prepare a package/public-surface release candidate that publishes the trace work
 - `package-lock.json` — keep the lockfile root version aligned with `package.json`.
 - `docs/CHANGELOG.md` — promote the trace package-sync candidate entry and link the source PR/evidence.
 - `.osc/releases/2026-05-28-124-trace-package-release-sync.md` — record candidate evidence and owner-gated publication proof slots.
-- `.osc/plans/active/124-trace-package-release-sync.md` — this active plan.
+- `.osc/plans/done/124-trace-package-release-sync.md` — this closed plan.
 
 ## Implementation Architecture Coverage
 
 - Strengthens: adoption trust, package/public-surface truth, trace/work-record visibility.
 - Audit envelope: source plan `117`, source PR #142, release-sync plan `124`, npm registry checks, fresh `npx` smoke after owner-approved publish.
-- Evaluation envelope: local gates prove the candidate builds/tests/packs/publish-dry-runs; owner-gated public checks must prove npm/latest and GitHub Latest before final plan proof.
-- Feedback routing: any publish, dist-tag, GitHub Release, or old-version deprecation decision remains an owner gate and should be recorded in the release evidence note or a follow-up plan.
-- Boundary: no npm publish, GitHub Release, deprecated-package write, runtime execution, or feature implementation happens in this PR.
+- Evaluation envelope: local gates proved the candidate builds/tests/packs/publish-dry-runs; owner-approved public checks proved npm/latest and GitHub Latest before final plan closeout.
+- Feedback routing: any future dist-tag correction, historical-version deprecation, or release-line decision remains an owner gate and should be recorded in a follow-up plan or evidence note.
+- Boundary: the release-sync PR did not change trace behavior or perform publish/release side effects; publish and GitHub Release follow-through were completed only after explicit owner approval.
 
 ## Acceptance criteria
 
@@ -43,7 +43,10 @@ Prepare a package/public-surface release candidate that publishes the trace work
 - [x] `docs/CHANGELOG.md` includes the `v0.20.1` package-sync candidate entry for `osc trace`.
 - [x] Candidate package gates pass: `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm pack --dry-run --json`, `npm publish --dry-run --tag latest`, and `git diff --check`.
 - [x] Local built CLI help exposes `osc trace <plan-slug> [--json] [--include-unverified]` before PR publication.
-- [x] The PR stops before landing, npm publish, GitHub Release creation/update, and optional npm deprecation of historical `1.0.x` versions.
+- [x] The release-sync PR stopped before landing, npm publish, GitHub Release creation/update, and optional npm deprecation of historical `1.0.x` versions.
+- [x] After owner-approved merge, trusted publishing published `open-scaffold@0.20.1` with npm dist-tag `latest`.
+- [x] Fresh isolated-cache `npx open-scaffold@latest --help` exposes `osc trace <plan-slug> [--json] [--include-unverified]`.
+- [x] GitHub Release `v0.20.1` exists and is marked Latest.
 
 ## Verification steps
 
@@ -58,6 +61,9 @@ Prepare a package/public-surface release candidate that publishes the trace work
 
 ## Open questions
 
-- Owner gate after PR lands: publish `open-scaffold@0.20.1` via trusted publishing with npm dist-tag `latest`.
-- Owner gate after publish: create/mark GitHub Release `v0.20.1` as Latest after fresh isolated-cache `npx` proof.
+- PR #143 merged to `main` at `161c968a1d342be6b89c05c6da4a31bde8e8c395`.
+- Trusted publishing workflow `26603167168` published `open-scaffold@0.20.1` with npm dist-tag `latest`.
+- Fresh isolated-cache `npx open-scaffold@latest --help` exposes `osc trace <plan-slug> [--json] [--include-unverified]`.
+- Fresh isolated-cache `npm exec --package open-scaffold@latest -- open-scaffold trace 117-osc-trace-work-record-replay --json` works from the repository and reports plan `117` as `done`.
+- GitHub Release `v0.20.1` is created and marked Latest.
 - Optional deferred decision: whether to deprecate historical `1.0.x` npm versions with a gentle cadence-correction message, or leave them as published history.

--- a/.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md
+++ b/.osc/releases/2026-05-26-105-codex-runtime-adapter-package-release-sync.md
@@ -30,7 +30,7 @@ Published `open-scaffold@1.0.2` so npm/latest, fresh `npx`, and GitHub Latest Re
 
 ## Outcome
 
-`open-scaffold@1.0.2` is published and GitHub Release `v1.0.2` is Latest. npm/latest now matches `main` for the Codex runtime preset surface. No runtime behavior beyond PR #121 was added; `@open-scaffold/runtime-omx` remains private/repo-source only.
+`open-scaffold@1.0.2` was published and GitHub Release `v1.0.2` was marked Latest at publication time. npm/latest matched `main` for the Codex runtime preset surface at that point, before later releases superseded it. No runtime behavior beyond PR #121 was added; `@open-scaffold/runtime-omx` remains private/repo-source only.
 
 ## Follow-up
 

--- a/.osc/releases/2026-05-28-123-evidence-chain-package-release-sync.md
+++ b/.osc/releases/2026-05-28-123-evidence-chain-package-release-sync.md
@@ -49,12 +49,12 @@ Post-merge/publication gates, if the owner approves follow-through:
 - [x] Fresh isolated-cache `npx --yes open-scaffold@latest verify --help` exposes `--evidence-chain` — PASS.
 - [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` exposes the first-read `osc compare` grouping — PASS.
 - [x] Fresh isolated-cache `npx --yes open-scaffold@latest init --tier min --target <tmp>` creates the expected min-tier scaffold files — PASS.
-- [x] GitHub Release `v0.20.0` is created/marked Latest — PASS.
+- [x] GitHub Release `v0.20.0` was created/marked Latest at publication time — PASS; it was later superseded by `v0.20.1`.
 - [x] Release-sync plan can be closed to `done/` with final public proof — completed in closeout PR.
 
 ## Outcome
 
-Complete. PR #140 merged, trusted publishing moved npm `latest` to `0.20.0`, fresh isolated-cache `npx` verified the public command surface, and GitHub Release `v0.20.0` is marked Latest. Historical `1.0.x` releases remain published history; optional npm deprecation of those versions is deferred.
+Complete. PR #140 merged, trusted publishing moved npm `latest` to `0.20.0`, fresh isolated-cache `npx` verified the public command surface, and GitHub Release `v0.20.0` was marked Latest at publication time. It was later superseded by `v0.20.1`. Historical `1.0.x` releases remain published history; optional npm deprecation of those versions is deferred.
 
 ## Follow-up
 

--- a/.osc/releases/2026-05-28-124-trace-package-release-sync.md
+++ b/.osc/releases/2026-05-28-124-trace-package-release-sync.md
@@ -2,9 +2,9 @@
 
 ## Summary
 
-Prepares `open-scaffold@0.20.1` as the package/public-surface sync for the newly merged `osc trace <plan-slug>` work-record replay command.
+Publishes `open-scaffold@0.20.1` as the package/public-surface sync for the `osc trace <plan-slug>` work-record replay command.
 
-The candidate keeps the forward-moving public package cadence in the `0.20.x` line. It does not publish to npm or create a GitHub Release; those remain owner-approved follow-through gates after merge.
+The release keeps the forward-moving public package cadence in the `0.20.x` line and makes the trace command available through fresh `npx open-scaffold@latest` installs. `osc trace` remains local, read-only, and non-authoritative: it reconstructs local work-record links and does not call GitHub, verify evidence quality, approve work, merge, publish, or claim trust/provenance.
 
 ## Traceability
 
@@ -12,18 +12,21 @@ The candidate keeps the forward-moving public package cadence in the `0.20.x` li
 - Source evidence note: `.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md`.
 - Source Pull Request: https://github.com/graphanov/open-scaffold/pull/142.
 - Source merge commit: `5bd33e96d7b34e24d74ecbb4a618060a9f009566`.
-- Release-sync plan: `.osc/plans/active/124-trace-package-release-sync.md`.
+- Release-sync plan: `.osc/plans/done/124-trace-package-release-sync.md`.
 - Release-sync branch: `release/trace-package-sync-0201`.
 - Release-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/143.
+- Release-sync merge commit: `161c968a1d342be6b89c05c6da4a31bde8e8c395`.
+- Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/26603167168.
+- npm package: `open-scaffold@0.20.1` with dist-tag `latest`.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.20.1.
 - Run ID / run packet: N/A for release-sync.
-- npm precheck: before candidate publish, live `latest` is `open-scaffold@0.20.0`; `0.20.1` is not yet published.
 
 ## Verification
 
 Candidate gates completed before PR-ready:
 
 - [x] `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `0.20.1 / 0.20.1 / 0.20.1`.
-- [x] `npm view open-scaffold version dist-tags versions --json` — PASS: live npm remains `0.20.0`, `latest: 0.20.0`, and `0.20.1` is not in the published versions list.
+- [x] `npm view open-scaffold version dist-tags versions --json` — PASS before publish: live npm was `0.20.0`, `latest: 0.20.0`, and `0.20.1` was not in the published versions list.
 - [x] `npm run build` — PASS.
 - [x] `node dist/cli.js --help` — PASS: includes `osc trace <plan-slug> [--json] [--include-unverified]`.
 - [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
@@ -31,22 +34,23 @@ Candidate gates completed before PR-ready:
 - [x] `npm pack --dry-run --json` — PASS for `open-scaffold@0.20.1` (162 files); includes `dist/trace.js`, `dist/trace.d.ts`, and `docs/TRACE.md`.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.20.1` with `latest` tag in dry-run mode.
 - [x] `git diff --check` — PASS.
-- [ ] PR CI and latest-head Codex review — pending after PR creation.
+- [x] PR CI and latest-head Codex review — PASS: PR #143 checks were green, Codex reported no major issues, and unresolved current Codex review threads were `0`.
 
-Post-merge/publication gates, if the owner approves follow-through:
+Post-merge/publication gates completed after owner approval:
 
-- [ ] Sync clean `main` after merge.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.20.1` with workflow input `npm-tag=latest` if required.
-- [ ] `npm view open-scaffold version dist-tags --json` reports `latest: 0.20.1`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` exposes `osc trace`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest trace 117-osc-trace-work-record-replay --json` works from a repo with the merged plan/evidence, or equivalent local package smoke confirms the command surface.
-- [ ] GitHub Release `v0.20.1` is created/marked Latest.
-- [ ] Release-sync plan can be closed to `done/` with final public proof.
+- [x] Sync clean `main` after merge — PASS: local `main` fast-forwarded to `161c968a1d342be6b89c05c6da4a31bde8e8c395`.
+- [x] Trusted publishing workflow publishes `open-scaffold@0.20.1` with workflow input `npm-tag=latest` — PASS: workflow run `26603167168` succeeded.
+- [x] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.20.1` and `latest: 0.20.1` — PASS.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` exposes `osc trace <plan-slug> [--json] [--include-unverified]` — PASS.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest trace` prints trace usage from the published package — PASS.
+- [x] Fresh isolated-cache `npm exec --yes --package open-scaffold@latest -- open-scaffold trace 117-osc-trace-work-record-replay --json` works from the repository and reports plan `117-osc-trace-work-record-replay` as `done` — PASS.
+- [x] GitHub Release `v0.20.1` is created/marked Latest — PASS.
+- [x] Release-sync plan can be closed to `done/` with final public proof — PASS in this closeout branch.
 
 ## Outcome
 
-Candidate in progress. This PR prepares package metadata and adoption-facing evidence only. npm publish, GitHub Latest Release, and final closeout remain separate owner-gated steps.
+Complete. PR #143 merged, trusted publishing moved npm `latest` to `0.20.1`, fresh isolated-cache `npx` verified the public trace command surface, GitHub Release `v0.20.1` is marked Latest, and plan `124` is closed with final evidence.
 
 ## Follow-up
 
-After owner-approved merge and public package surfaces are aligned, close plan `124` with final npm/GitHub Release proof in a tiny closeout PR if needed.
+Optional deferred decision: whether to deprecate historical `1.0.x` npm versions with a gentle cadence-correction message, or leave them as published history.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-28: closed 124-trace-package-release-sync — Close trace package release sync after npm and GitHub Release proof
 - 2026-05-28: closed 117-osc-trace-work-record-replay — added read-only work-record trace command
 - 2026-05-28: closed 123-evidence-chain-package-release-sync — Close evidence-chain package release sync after 0.20.0 npm publish and GitHub Release
 - 2026-05-27: closed 071-evidence-chain-verifier — evidence-chain verifier implemented and verified

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.20.1 — Trace work-record replay package sync
 
-Status: package/public-surface candidate prepared in repo; npm publication and GitHub Release follow-through remain separate owner-approved gates.
+Status: published to npm as `open-scaffold@0.20.1`; GitHub Release `v0.20.1` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
@@ -21,12 +21,12 @@ Evidence:
 - Source plan: `.osc/plans/done/117-osc-trace-work-record-replay.md`
 - Source evidence note: `.osc/releases/2026-05-28-117-osc-trace-work-record-replay.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/142
-- Release-sync plan: `.osc/plans/active/124-trace-package-release-sync.md`
+- Release-sync plan: `.osc/plans/done/124-trace-package-release-sync.md`
 - Release-sync evidence note: `.osc/releases/2026-05-28-124-trace-package-release-sync.md`
 
 ## v0.20.0 — Evidence-chain package sync and cadence correction
 
-Status: published to npm as `open-scaffold@0.20.0`; GitHub Release `v0.20.0` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.20.0`; GitHub Release `v0.20.0` was marked Latest after owner-approved trusted publishing and release follow-through, then superseded by `v0.20.1`.
 
 Highlights:
 
@@ -47,7 +47,7 @@ Evidence:
 
 ## v1.0.5 — Compare command package sync
 
-Status: published to npm as `open-scaffold@1.0.5`; historical release line after `v0.20.0` became the GitHub Latest release.
+Status: published to npm as `open-scaffold@1.0.5`; historical release line before the cadence reset to `v0.20.x`.
 
 Highlights:
 
@@ -65,7 +65,7 @@ Evidence:
 
 ## v1.0.4 — Work dry-run preview package sync
 
-Status: published to npm as `open-scaffold@1.0.4`; GitHub Release `v1.0.4` is Latest until the compare command package sync is published.
+Status: published to npm as `open-scaffold@1.0.4`; GitHub Release `v1.0.4` was marked Latest at publication time and later superseded.
 
 Highlights:
 
@@ -84,7 +84,7 @@ Evidence:
 
 ## v1.0.3 — Dispatch adapter glue package sync
 
-Status: published to npm as `open-scaffold@1.0.3`; GitHub Release `v1.0.3` is Latest.
+Status: published to npm as `open-scaffold@1.0.3`; GitHub Release `v1.0.3` was marked Latest at publication time and later superseded.
 
 Highlights:
 
@@ -105,7 +105,7 @@ Evidence:
 
 ## v1.0.2 — Codex runtime preset package sync
 
-Status: published to npm as `open-scaffold@1.0.2`; GitHub Release `v1.0.2` is Latest.
+Status: published to npm as `open-scaffold@1.0.2`; GitHub Release `v1.0.2` was marked Latest at publication time and later superseded.
 
 Highlights:
 
@@ -124,7 +124,7 @@ Evidence:
 
 ## v1.0.1 — No-spawn Codex handoff entry
 
-Status: published to npm as `open-scaffold@1.0.1`; GitHub Release `v1.0.1` is Latest.
+Status: published to npm as `open-scaffold@1.0.1`; GitHub Release `v1.0.1` was marked Latest at publication time and later superseded.
 
 Highlights:
 


### PR DESCRIPTION
## Summary
- Close plan 124 after owner-approved PR #143 merge, trusted npm publish, fresh npx proof, and GitHub Release v0.20.1 Latest follow-through.
- Update the trace package-sync evidence note with final npm, npx, workflow, release, and closeout proof.
- Update changelog/recent evidence wording so superseded releases are historical rather than current Latest claims.

## Verification
- [x] `node dist/cli.js plan validate .osc/plans/done/124-trace-package-release-sync.md` — 0 issues
- [x] `git diff --check`
- [x] `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- [x] focused stale-current scan for active 124 path / pending candidate wording / superseded Latest claims
- [x] `npm view open-scaffold version dist-tags --json --prefer-online` — 0.20.1 / latest 0.20.1
- [x] GitHub Release list shows v0.20.1 as Latest

No product/package behavior changes in this closeout PR.
