### PR TITLE
Add PR summary and A/B pilot harness

### DIFF
--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -97,7 +97,11 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Upsert single PR comment
-        if: github.event_name == 'pull_request' && steps.summary.outputs.skip == 'false'
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.summary.outputs.skip == 'false' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -1,0 +1,117 @@
+name: PR summary (opt-in mirror)
+
+# Optional, opt-in, read-only mirror of an Open Scaffold plan onto its pull
+# request. It renders `osc pr-summary <plan>` and upserts a single PR comment.
+# It is NOT canonical state: the `.osc/` plan and evidence files remain the
+# source of truth. Enable it by setting the repository variable
+# OSC_PR_SUMMARY=true and pointing OSC_PR_SUMMARY_PLAN at the plan slug (or pass
+# the plan input on a manual run). Left disabled, this workflow does nothing.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      plan:
+        description: "Plan slug to summarize (e.g. 126-pr-native-evidence-surface)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  pr-summary:
+    name: Mirror plan summary to PR
+    if: vars.OSC_PR_SUMMARY == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository with public fallback
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git init .
+          server_url="${GITHUB_SERVER_URL:-https://github.com}"
+          server_url="${server_url%/}"
+          git remote add origin "${server_url}/${GITHUB_REPOSITORY}.git"
+          fetch_refs() {
+            local mode="$1"
+            shift
+            if [[ "$mode" == "auth" && -n "${GITHUB_TOKEN:-}" ]]; then
+              local auth_header
+              auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= -c "http.${server_url}/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch "$@"
+            else
+              GIT_TERMINAL_PROMPT=0 git -c credential.helper= fetch "$@"
+            fi
+          }
+          fetch_with_fallback() {
+            local description="$1"
+            shift
+            if ! fetch_refs auth "$@"; then
+              echo "Authenticated ${description} fetch failed; falling back to public unauthenticated fetch."
+              fetch_refs public "$@"
+            fi
+          }
+          fetch_with_fallback repository --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            fetch_with_fallback pull-request-merge --no-tags origin "refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+            git checkout --force "refs/remotes/pull/${{ github.event.pull_request.number }}/merge"
+          else
+            git checkout --force "$GITHUB_SHA"
+          fi
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build
+
+      - name: Render plan summary
+        id: summary
+        shell: bash
+        env:
+          OSC_PR_SUMMARY_PLAN: ${{ inputs.plan || vars.OSC_PR_SUMMARY_PLAN }}
+        run: |
+          set -euo pipefail
+          plan="${OSC_PR_SUMMARY_PLAN:-}"
+          if [[ -z "$plan" ]]; then
+            echo "No plan slug configured. Set repository variable OSC_PR_SUMMARY_PLAN or pass the workflow_dispatch 'plan' input. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # pr-summary is read-only and always exits 0, rendering an explicit
+          # "no plan found" body rather than failing if the slug is missing.
+          node dist/cli.js pr-summary "$plan" --format markdown > pr-summary.md
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert single PR comment
+        if: github.event_name == 'pull_request' && steps.summary.outputs.skip == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            // Must match PR_SUMMARY_MARKER in src/pr-summary.ts; the find-and-update
+            // by this marker is what keeps the mirror to exactly one comment.
+            const marker = '<!-- osc-pr-summary -->';
+            const body = fs.readFileSync('pr-summary.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const existing = comments.find((comment) => typeof comment.body === 'string' && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.osc/plans/done/126-pr-native-evidence-surface.md
+++ b/.osc/plans/done/126-pr-native-evidence-surface.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-backlog
+done
+
 
 ## Context
 
@@ -36,11 +37,11 @@ Provide an `osc pr-summary <plan-slug> [--format markdown]` renderer that emits 
 
 ## Acceptance criteria
 
-- [ ] Pre-work check recorded: a one-line note in the PR/commit stating whether `docs/GITHUB_WORKFLOW.md` / `063` / webhooks already cover this, with the decision to proceed or downgrade.
-- [ ] `osc pr-summary <slug>` renders goal, AC checklist with checked/unchecked state, evidence-note presence, and open questions.
-- [ ] The renderer reuses existing plan/evidence readers and `plan-validate` rather than re-parsing plans independently.
-- [ ] The optional GitHub Action is opt-in, runs read-only, and upserts exactly one PR comment on re-run.
-- [ ] Tests prove idempotent comment content (no duplication) and a graceful "no/invalid plan" path.
+- [x] Pre-work check recorded: a one-line note in the PR/commit stating whether `docs/GITHUB_WORKFLOW.md` / `063` / webhooks already cover this, with the decision to proceed or downgrade.
+- [x] `osc pr-summary <slug>` renders goal, AC checklist with checked/unchecked state, evidence-note presence, and open questions.
+- [x] The renderer reuses existing plan/evidence readers and `plan-validate` rather than re-parsing plans independently.
+- [x] The optional GitHub Action is opt-in, runs read-only, and upserts exactly one PR comment on re-run.
+- [x] Tests prove idempotent comment content (no duplication) and a graceful "no/invalid plan" path.
 
 ## Verification steps
 

--- a/.osc/plans/done/127-ab-comparison-pilot-harness.md
+++ b/.osc/plans/done/127-ab-comparison-pilot-harness.md
@@ -1,0 +1,61 @@
+# Plan: 127-ab-comparison-pilot-harness
+
+## Status
+
+done
+
+## Context
+
+The controlled comparison (A/B) protocol at `docs/AB_COMPARISON_PROTOCOL.md` (written under plan `125`) is text-only — a recipe, not something an adopter can pick up and run. To move beyond the observational self-study's correlational signal toward a defensible causal reading, a team needs concrete, pre-registered artifacts: a runbook, a pre-registration form committed before any data, a source-labeled raw-data template, and a blinded reviewer rubric. This plan packages those so the comparison is runnable and auditable — without running it.
+
+## Goal
+
+Turn the text-only A/B protocol into an executable, pre-registered pilot packet — a step-by-step runbook, a commit-before-data pre-registration template, a source-labeled raw-data template, and a blinded reviewer rubric, plus an optional read-only `osc ab check` validator — while recording explicitly that no controlled outcome data has been collected and no causal claim is made.
+
+## Constraints / Out of scope
+
+- Do not run the experiment or collect outcome data: this slice ships the harness only; running it is separate future work gated on having enough matched tasks and participants.
+- Do not make or imply any causal or marketing claim such as "Open Scaffold wins"; the packet is a pre-registered measurement instrument, and any public claim remains a separate owner gate.
+- No new canonical state and no runtime dependency: the optional validator is read-only and never writes results, scores data, or mutates files.
+- Keep all wording public-safe and neutral; the artifacts are templates an external adopter copies into their own repo.
+- Reuse the existing protocol rather than restating it; the runbook links to `docs/AB_COMPARISON_PROTOCOL.md` for rationale and threats to validity.
+
+## Files to touch
+
+- `docs/AB_COMPARISON_PILOT.md` — operational runbook that turns the protocol into ordered, runnable steps.
+- `docs/examples/ab-comparison/README.md` — index of the pilot packet artifacts and how they fit together.
+- `docs/examples/ab-comparison/pre-registration.md` — fill-before-data template: hypotheses, metrics, analysis plan, arms, attestation.
+- `docs/examples/ab-comparison/raw-data-template.csv` — one row per task with source-labeled columns, arm, and metric fields.
+- `docs/examples/ab-comparison/reviewer-rubric.md` — blinded reconstruction-scoring rubric for the reviewer (H4).
+- `docs/examples/README.md` — link the new pilot packet from the examples index.
+- `src/ab.ts`, `src/cli.ts` — optional read-only `osc ab check <path>` validator over the pre-registration and raw-data files.
+- `tests/ab.test.ts` — prove the validator accepts a well-formed packet and rejects malformed cases.
+
+## Implementation Architecture Coverage
+
+- Strengthens: evaluation and audit-trail honesty — pre-registration plus source-labeled raw data make the comparison falsifiable and reproducible.
+- Audit envelope: the pre-registration file (committed before data), the raw-data CSV, and the reviewer rubric scores.
+- Evaluation envelope: `osc ab check` validates structure (required columns, declared arms, pre-registration completeness); human coding and blinded review evaluate outcomes against the rubric.
+- Feedback routing: a malformed or incomplete packet fails `osc ab check` with explicit messages; missing data is reported as missing, never imputed.
+- Boundary: this slice does not run the experiment, compute effect sizes, collect data, or make any causal claim; those remain out of scope and owner-gated.
+
+## Acceptance criteria
+
+- [x] `docs/AB_COMPARISON_PILOT.md` exists as an ordered runbook that links to `docs/AB_COMPARISON_PROTOCOL.md` and states up front that no data has been collected and that the packet proves nothing about outcomes on its own.
+- [x] `docs/examples/ab-comparison/` contains a pre-registration template, a source-labeled raw-data template (CSV), and a blinded reviewer rubric, indexed by a README and linked from `docs/examples/README.md`.
+- [x] The pre-registration template requires hypotheses, metrics with source labels, the analysis plan, and an explicit "committed before any data" attestation line.
+- [x] Optional `osc ab check <path>` runs read-only and reports whether the pre-registration and raw-data files are structurally well-formed, exiting nonzero on a malformed packet and zero on a well-formed one.
+- [x] Tests prove `osc ab check` accepts the well-formed example packet and rejects at least one malformed case (missing required column or unlabeled metric); no test asserts any outcome, effect, or winner.
+
+## Verification steps
+
+1. Run `npm test -- --run tests/ab.test.ts` — expect green.
+2. Run `osc ab check docs/examples/ab-comparison` — expect exit 0 with a "well-formed" report.
+3. Run `osc ab check` against a copy of the raw-data template with the `source` column dropped — expect a nonzero exit with an explicit message.
+4. Run `npm run build` and `./verify.sh --strict` — expect pass.
+5. Read `docs/AB_COMPARISON_PILOT.md` and the packet README and confirm both state, prominently, that no data has been collected and no causal claim is made.
+
+## Open questions
+
+- Should `osc ab check` also assert that the pre-registration file's commit predates the first raw-data row (a true "registered before data" time check), or is that more than a pre-data pilot harness needs before any data exists?
+- Is a single CSV the right raw-data shape for the template, or would one source-labeled file per task be easier for an adopter to audit?

--- a/.osc/releases/2026-05-29-126-pr-native-evidence-surface.md
+++ b/.osc/releases/2026-05-29-126-pr-native-evidence-surface.md
@@ -1,0 +1,49 @@
+# Release / Evidence Note: 126-pr-native-evidence-surface
+
+## Summary
+
+Added a read-only `osc pr-summary <plan-slug> [--format markdown|json]` renderer that surfaces a plan's goal, acceptance-criteria checklist state, evidence-note status, plan-validation results, and open questions for reviewers. Added an optional, opt-in GitHub Action that mirrors that rendering onto a pull request as a single, idempotently-updated comment, plus tests and a documented read-only mirror boundary.
+
+## Traceability
+
+- Roadmap / issue / task: plan `126-pr-native-evidence-surface` (PR-native evidence surface, glass-cockpit review-surface line following done `062`/`096`/`063`).
+- Plan: `.osc/plans/done/126-pr-native-evidence-surface.md`.
+- Run ID / run packet: N/A — direct repository implementation slice, no external runtime packet.
+- Branch / PR: review branch `cli/ab-protocol-and-pr-summary`; PR review and merge remain owner gates.
+
+## Pre-work coverage check
+
+Per acceptance-criterion 1, confirmed before writing code that this surface was not already delivered elsewhere:
+
+- `docs/GITHUB_WORKFLOW.md` documented the issue/PR/run chain, CI guardrails, and build-in-public operator events, but carried no PR-native plan + acceptance-criteria + evidence summary.
+- Done `063` (`github-actions-ci-templates`) added plan-validate, evidence-validate, stale-plans, and publish-npm guardrails — none renders a reviewer summary comment.
+- Done `062`/`096` (glass-cockpit webhooks) emit push-only operator events; the only PR-related event is a `pr_link` ("pull request ready") notification, not a rendered plan/AC/evidence comment.
+
+Decision: not substantially covered — proceed with new code as a read-only renderer plus an optional thin workflow wrapper, staying inside the existing "operator surfaces mirror, they are not canonical" boundary. No downgrade to a docs-only task.
+
+## Verification
+
+- `npx vitest run tests/cli-pr-summary.test.ts` — passed, 22 tests (renderer output, checkbox-state count, evidence/skeleton detection, validator reuse, graceful missing/unsafe-slug paths, idempotent upsert selector, CLI exit codes, and workflow marker-drift / opt-in / no-`actions/checkout` guards).
+- `npm run build` — passed (core and runtime-omx TypeScript builds).
+- `npm test -- --run` (full suite) — passed, 50 files / 479 tests after the combined plan-126 and plan-127 tree.
+- `git diff --check` — clean, no whitespace errors.
+- Smoke: `osc pr-summary 125-methodology-evidence-harness --format markdown` — rendered stage `done`, goal, `Acceptance criteria (6/6 checked)` matching the plan file, evidence note present + `approved`, plan validation passed, and open questions; first line carried the `<!-- osc-pr-summary -->` upsert marker.
+- Smoke: `osc pr-summary 999-missing` and `osc pr-summary ../outside` — both exited `0` with an explicit "no plan found" body rather than failing the check.
+
+## Outcome
+
+The PR-native evidence surface slice is implemented and the plan is closed; all five acceptance criteria are met:
+
+1. Pre-work coverage check recorded (above) with a proceed decision.
+2. `osc pr-summary <slug>` renders goal, acceptance-criteria checklist with checked/unchecked state, evidence-note presence, and open questions.
+3. The renderer reuses the existing `parsePlanFile`/`parseChecklist` plan readers, `findEvidenceNote` + `evidenceApprovalStatus`, and `validatePlanFile` rather than re-parsing plans independently.
+4. The optional `pr-summary.yml` workflow is opt-in (gated on `vars.OSC_PR_SUMMARY == 'true'`), reads repository contents with `contents: read`, and upserts exactly one PR comment by finding the marker — re-runs update in place.
+5. Tests prove idempotent comment content (single comment, no duplication) and a graceful "no/invalid plan" path.
+
+This note is not a merge, publication, GitHub Release, deployment, or npm publish approval; those remain owner gates.
+
+## Follow-up
+
+- Owner gate: review the PR and decide whether to merge.
+- Owner gate: decide separately on any npm publication or GitHub Release; this slice does not change the package version.
+- The optional mirror stays disabled until an owner sets `OSC_PR_SUMMARY=true` and `OSC_PR_SUMMARY_PLAN`.

--- a/.osc/releases/2026-05-29-126-pr-native-evidence-surface.md
+++ b/.osc/releases/2026-05-29-126-pr-native-evidence-surface.md
@@ -25,7 +25,7 @@ Decision: not substantially covered — proceed with new code as a read-only ren
 
 - `npx vitest run tests/cli-pr-summary.test.ts` — passed, 22 tests (renderer output, checkbox-state count, evidence/skeleton detection, validator reuse, graceful missing/unsafe-slug paths, idempotent upsert selector, CLI exit codes, and workflow marker-drift / opt-in / no-`actions/checkout` guards).
 - `npm run build` — passed (core and runtime-omx TypeScript builds).
-- `npm test -- --run` (full suite) — passed, 50 files / 479 tests after the combined plan-126 and plan-127 tree.
+- `npm test -- --run` (full suite) — passed, 50 files / 480 tests after the combined plan-126 and plan-127 tree plus the post-Codex raw-data preference regression.
 - `git diff --check` — clean, no whitespace errors.
 - Smoke: `osc pr-summary 125-methodology-evidence-harness --format markdown` — rendered stage `done`, goal, `Acceptance criteria (6/6 checked)` matching the plan file, evidence note present + `approved`, plan validation passed, and open questions; first line carried the `<!-- osc-pr-summary -->` upsert marker.
 - Smoke: `osc pr-summary 999-missing` and `osc pr-summary ../outside` — both exited `0` with an explicit "no plan found" body rather than failing the check.

--- a/.osc/releases/2026-05-29-126-pr-native-evidence-surface.md
+++ b/.osc/releases/2026-05-29-126-pr-native-evidence-surface.md
@@ -23,9 +23,9 @@ Decision: not substantially covered — proceed with new code as a read-only ren
 
 ## Verification
 
-- `npx vitest run tests/cli-pr-summary.test.ts` — passed, 22 tests (renderer output, checkbox-state count, evidence/skeleton detection, validator reuse, graceful missing/unsafe-slug paths, idempotent upsert selector, CLI exit codes, and workflow marker-drift / opt-in / no-`actions/checkout` guards).
+- `npx vitest run tests/cli-pr-summary.test.ts` — passed, 23 tests (renderer output, checkbox-state count, evidence/skeleton detection, validator reuse, graceful missing/unsafe-slug paths, idempotent upsert selector, CLI exit codes, workflow marker-drift / opt-in / no-`actions/checkout` guards, and fork/Dependabot comment-upsert guard).
 - `npm run build` — passed (core and runtime-omx TypeScript builds).
-- `npm test -- --run` (full suite) — passed, 50 files / 480 tests after the combined plan-126 and plan-127 tree plus the post-Codex raw-data preference regression.
+- `npm test -- --run` (full suite) — passed, 50 files / 481 tests after the combined plan-126 and plan-127 tree plus the post-Codex raw-data preference and workflow-permission regressions.
 - `git diff --check` — clean, no whitespace errors.
 - Smoke: `osc pr-summary 125-methodology-evidence-harness --format markdown` — rendered stage `done`, goal, `Acceptance criteria (6/6 checked)` matching the plan file, evidence note present + `approved`, plan validation passed, and open questions; first line carried the `<!-- osc-pr-summary -->` upsert marker.
 - Smoke: `osc pr-summary 999-missing` and `osc pr-summary ../outside` — both exited `0` with an explicit "no plan found" body rather than failing the check.
@@ -37,7 +37,7 @@ The PR-native evidence surface slice is implemented and the plan is closed; all 
 1. Pre-work coverage check recorded (above) with a proceed decision.
 2. `osc pr-summary <slug>` renders goal, acceptance-criteria checklist with checked/unchecked state, evidence-note presence, and open questions.
 3. The renderer reuses the existing `parsePlanFile`/`parseChecklist` plan readers, `findEvidenceNote` + `evidenceApprovalStatus`, and `validatePlanFile` rather than re-parsing plans independently.
-4. The optional `pr-summary.yml` workflow is opt-in (gated on `vars.OSC_PR_SUMMARY == 'true'`), reads repository contents with `contents: read`, and upserts exactly one PR comment by finding the marker — re-runs update in place.
+4. The optional `pr-summary.yml` workflow is opt-in (gated on `vars.OSC_PR_SUMMARY == 'true'`), reads repository contents with `contents: read`, upserts exactly one PR comment by finding the marker on same-repo PRs, and skips the comment-write step for forked or Dependabot PRs so the mirror stays non-blocking — re-runs update in place where comment permissions are available.
 5. Tests prove idempotent comment content (single comment, no duplication) and a graceful "no/invalid plan" path.
 
 This note is not a merge, publication, GitHub Release, deployment, or npm publish approval; those remain owner gates.

--- a/.osc/releases/2026-05-29-127-ab-comparison-pilot-harness.md
+++ b/.osc/releases/2026-05-29-127-ab-comparison-pilot-harness.md
@@ -1,0 +1,46 @@
+# Release / Evidence Note: 127-ab-comparison-pilot-harness
+
+## Summary
+
+Turned the text-only A/B comparison protocol into an executable, pre-registered
+pilot packet: an ordered runbook (`docs/AB_COMPARISON_PILOT.md`), a
+commit-before-data pre-registration template, a source-labeled raw-data
+template, a blinded reviewer rubric (all under `docs/examples/ab-comparison/`),
+and an optional read-only `osc ab check` validator. **No controlled outcome
+data was collected and no causal claim is made** — this slice ships the
+instrument only; running the experiment remains separate, owner-gated work.
+
+## Traceability
+
+- Roadmap / issue / task: extends the A/B protocol authored under plan `125`; no separate issue.
+- Plan: .osc/plans/done/127-ab-comparison-pilot-harness.md
+- Run ID / run packet: N/A — no runtime lane was launched; all work was local edits and read-only validation.
+- Branch / PR: review branch `cli/ab-protocol-and-pr-summary`; PR review and merge remain owner gates.
+
+## Verification
+
+- `npm test -- --run tests/ab.test.ts` — 14 passed (validator unit + CLI + honesty-guard tests).
+- `osc ab check docs/examples/ab-comparison` — exit 0, "A/B pilot packet is well-formed"; report states this is not evidence any experiment was run.
+- `osc ab check` on a raw-data file with the `source` column dropped — exit 1, "Raw-data file is missing required column: source."
+- `npm run build` — pass (build:core + build:runtime-omx, no tsc errors).
+- `./verify.sh --strict` — 9 pass, 0 fail, 1 warn (plan-immutability check skipped because this checkout is a git worktree; environmental, not a defect).
+- Read-through of `docs/AB_COMPARISON_PILOT.md` and `docs/examples/ab-comparison/README.md` — both state up front that no data has been collected and the packet proves nothing about outcomes.
+
+## Outcome
+
+All five acceptance criteria are met:
+
+1. `docs/AB_COMPARISON_PILOT.md` ships as an ordered runbook that links to `docs/AB_COMPARISON_PROTOCOL.md` and opens with a no-data / no-claim banner.
+2. `docs/examples/ab-comparison/` holds the pre-registration template, source-labeled raw-data CSV, and blinded reviewer rubric, indexed by a README and linked from `docs/examples/README.md`.
+3. The pre-registration template requires hypotheses, metrics with source labels, an analysis plan, and an explicit "committed before any data" attestation.
+4. `osc ab check <path>` runs read-only, reporting structural well-formedness with exit 0, and exits nonzero with explicit messages on a malformed packet.
+5. Tests prove the validator accepts the well-formed example packet and rejects malformed cases (missing column, invalid arm, invalid source, honesty-rule violations); no test asserts any outcome, effect, or winner.
+
+The raw-data template ships only blank, `unavailable`-sourced illustrative rows — no fabricated numbers. The validator is strictly read-only: it never writes, scores, interprets, or imputes.
+
+This is not a merge, publication, release, or approval; those remain owner gates.
+
+## Follow-up
+
+- Running the pilot — building a matched task pool, randomizing arms, collecting and source-labeling real data — is separate, owner-gated work. Until then the packet remains an instrument, not evidence.
+- Open question carried from the plan: whether `osc ab check` should later assert that the pre-registration commit predates the first raw-data row (a true time-ordering check), versus keeping the validator purely structural before any data exists.

--- a/.osc/releases/2026-05-29-127-ab-comparison-pilot-harness.md
+++ b/.osc/releases/2026-05-29-127-ab-comparison-pilot-harness.md
@@ -19,7 +19,7 @@ instrument only; running the experiment remains separate, owner-gated work.
 
 ## Verification
 
-- `npm test -- --run tests/ab.test.ts` — 14 passed (validator unit + CLI + honesty-guard tests).
+- `npm test -- --run tests/ab.test.ts` — 15 passed (validator unit + CLI + honesty-guard tests, including preference for filled `raw-data.csv` over the blank template when both are present).
 - `osc ab check docs/examples/ab-comparison` — exit 0, "A/B pilot packet is well-formed"; report states this is not evidence any experiment was run.
 - `osc ab check` on a raw-data file with the `source` column dropped — exit 1, "Raw-data file is missing required column: source."
 - `npm run build` — pass (build:core + build:runtime-omx, no tsc errors).

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,8 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-29: closed 126-pr-native-evidence-surface — PR-native read-only osc pr-summary renderer plus optional opt-in single-comment mirror
+- 2026-05-29: closed 127-ab-comparison-pilot-harness — Pre-registered A/B pilot packet (runbook, pre-registration, raw-data template, reviewer rubric) plus read-only osc ab check validator; no data collected and no causal claim
 - 2026-05-28: closed 125-methodology-evidence-harness — Close methodology evidence harness
 - 2026-05-28: closed 124-trace-package-release-sync — Close trace package release sync after npm and GitHub Release proof
 - 2026-05-28: closed 117-osc-trace-work-record-replay — added read-only work-record trace command

--- a/docs/AB_COMPARISON_PILOT.md
+++ b/docs/AB_COMPARISON_PILOT.md
@@ -1,0 +1,49 @@
+# A/B Comparison — Pilot Runbook
+
+> **Status: harness only. No data has been collected and no causal claim is
+> made.** This runbook turns the text-only [`AB_COMPARISON_PROTOCOL.md`](AB_COMPARISON_PROTOCOL.md)
+> into ordered, runnable steps and points at the templates in
+> [`examples/ab-comparison/`](examples/ab-comparison/README.md). Following it
+> produces a *pre-registered instrument and, later, source-labeled raw data* —
+> it does not, on its own, show that Open Scaffold improves any outcome. Read
+> the protocol's "Threats to validity" and "Sample size and statistical
+> honesty" sections before trusting any pilot you run.
+
+## What this runbook is for
+
+The observational self-study (`osc study`, plan `125`) can show correlation but
+not cause. A controlled comparison is the honest way to ask whether the scaffold
+*made* work go better. This runbook is the operational recipe for a small
+**within-subjects pilot** — descriptive and hypothesis-generating only. It exists
+so that the comparison, if anyone runs it, is pre-registered, source-labeled,
+blinded where it matters, and reproducible.
+
+## Before you start
+
+- Read [`AB_COMPARISON_PROTOCOL.md`](AB_COMPARISON_PROTOCOL.md) end to end. The design choices (within- vs between-subjects, controls held constant, threats to validity) are decided there; this runbook assumes them.
+- Copy the packet templates from [`examples/ab-comparison/`](examples/ab-comparison/README.md) into your own repository. You will fill them in; the shipped copies stay as blank-able examples.
+
+## Steps
+
+1. **Pre-register.** Fill `pre-registration.md` completely: hypotheses with nulls, the two arms, each metric with its source label, the randomization and cold-resume definitions, and the analysis plan. Commit it. Record the commit sha in the attestation block. **Commit this before collecting any data** — that ordering is the whole point.
+2. **Validate the instrument.** Run `osc ab check <your-packet-dir>` and confirm it reports the packet well-formed (exit `0`). This checks structure only; it does not run or interpret anything.
+3. **Build a task pool.** Assemble tasks matched on size and difficulty, of comparable, scoped, multi-session shape. Write down how you judged difficulty.
+4. **Randomize.** Assign tasks to Arm A (scaffolded) or Arm B (control) by the recorded random procedure. For a within-subjects pilot, counterbalance ordering and keep a washout gap between tasks.
+5. **Run each task** to its defined stopping point under its arm's rules. Arm A uses the full Open Scaffold loop; Arm B is the documented "no repo record" baseline. Keep the held-constant controls identical across arms (same model, tool access, time budget, definition of done).
+6. **Force a cold gap**, then resume. At the moment of resume, measure resume time (H1) and the human-typed context cost (H3). "Cold" means at least 24 hours, a fresh session, and no prior scrollback.
+7. **Code incidents (H2)** from the work trail against a fixed rubric: count reversals and redos attributable to a forgotten or re-litigated decision.
+8. **Blind-review (H4).** Strip arm labels, then have the reviewer score reconstruction with [`reviewer-rubric.md`](examples/ab-comparison/reviewer-rubric.md). The experimenter fills the `arm` column afterward from the blinding key.
+9. **Record raw data.** Add one source-labeled row per task per metric to your copy of `raw-data-template.csv`. Unmeasured figures are `source: unavailable` with a blank value — never imputed. Re-run `osc ab check` and commit the data.
+10. **Analyze descriptively.** Report per-arm descriptive statistics with confidence intervals for every metric and every hypothesis, including null and negative results. State plainly that a pilot cannot establish significance.
+
+## What a finished pilot can and cannot say
+
+- **Can:** estimate effect sizes, surface measurement problems, and tell you whether a larger, powered, between-subjects confirmatory study is worth the cost.
+- **Cannot:** establish statistical significance, prove causation from a handful of tasks, or justify a public "the scaffold works" claim. Any README or MISSION claim drawn from a pilot remains a separate, explicit owner gate.
+
+## Relationship to `osc study`
+
+Where a metric is computable by `osc study` (plan `125`), reuse that computation
+so the observational and controlled views stay consistent. `osc study`
+deliberately reports resume time as `unavailable`; the controlled pilot measures
+it directly at the cold resume instead of approximating it from commit gaps.

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -100,8 +100,29 @@ Open Scaffold projects should keep repository truth mechanically checked in GitH
 - `evidence-validate.yml` runs strict evidence checks for `.osc/releases/**/*.md` changes.
 - `stale-plans.yml` runs weekly and opens a GitHub Issue for stale active plans instead of mutating plan state automatically.
 - `publish-npm.yml` is the only active npm publish path and uses manual trusted publishing. Version tags and GitHub Releases are release markers only; publication, release, and deployment remain owner gates.
+- `pr-summary.yml` is an optional, opt-in, read-only mirror that renders a plan summary onto its PR as a single comment. It is disabled by default and is not a quality gate; see [PR summary mirror](#pr-summary-mirror-optional).
 
 CI failures should be resolved before merge unless the failure is explicitly classified as external infrastructure. CI does not replace Codex review or human approval.
+
+## PR summary mirror (optional)
+
+`osc pr-summary <plan-slug> [--format markdown|json]` renders a reviewer-ready summary of a plan from the `.osc/` artifacts already in the repository:
+
+- the plan goal and stage,
+- the acceptance-criteria checklist with checked/unchecked state and a count,
+- evidence-note presence, approval status, path, and whether it is still a TODO skeleton,
+- plan-validation results (reusing `osc plan validate`, not a second parser),
+- open questions.
+
+The command is read-only and reuses the same plan, evidence, and validation readers the rest of the CLI uses, so the summary cannot drift from canonical state. For a missing or unsafe plan slug it still exits `0` and renders an explicit "no plan found" body rather than failing, so it is safe to wire into a PR check.
+
+`pr-summary.yml` is an optional workflow that mirrors this rendering onto a pull request as exactly one comment:
+
+- **Opt-in.** It does nothing unless the repository variable `OSC_PR_SUMMARY` is set to `true`. The plan to summarize comes from `OSC_PR_SUMMARY_PLAN` (or the `plan` input on a manual `workflow_dispatch` run).
+- **Read-only.** It requests `contents: read` and only writes a PR comment via `pull-requests: write`. It never edits plan, evidence, or release files.
+- **Idempotent.** The rendered markdown carries a hidden marker on its first line; the workflow finds the one comment bearing that marker and updates it in place, so re-runs update a single comment instead of posting duplicates. The render is deterministic (no wall-clock timestamp), so an unchanged plan produces an identical body.
+
+This PR comment is an operator-surface mirror, the same class of surface as the build-in-public events below. It is **not canonical state**: the `.osc/` plan and evidence files remain the source of truth, and nothing reads the comment back. If the mirror is disabled or fails, the canonical chain is unaffected.
 
 ## Codex review connector
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-Five worked example paths a fresh user or agent can read end-to-end. The first four are operating modes; the fifth shows the evolution-ledger comparison wedge directly. Each path links to existing protocol docs and shipped fixtures rather than inventing new machinery.
+Six worked example paths a fresh user or agent can read end-to-end. The first four are operating modes; the fifth shows the evolution-ledger comparison wedge directly; the sixth is a pre-registered measurement instrument. Each path links to existing protocol docs and shipped fixtures rather than inventing new machinery.
 
 The example paths:
 
@@ -10,6 +10,7 @@ The example paths:
 4. [Runtime harness handoff](#4-runtime-harness-handoff) — packaging work for an external runtime lane to execute.
 5. [Evolution loop compare](evolution-loop-compare.md) — two attempts → `osc evolve compare` → frontier rationale.
    - [`examples/evolution-ledger-demo/`](../../examples/evolution-ledger-demo/) — runnable fixture: checked-in loop, attempts, evaluations, a promoted frontier, and committed expected compare output. Verified by the evolution CLI tests.
+6. [A/B comparison pilot packet](ab-comparison/README.md) — pre-registered templates to measure whether the scaffold helps. **Ships no data and proves no outcome.**
 
 If you want one complete non-recursive example first, start with [`downstream-walkthrough.md`](downstream-walkthrough.md). It shows the full mission → plan → optional `run.json` work package → evidence → close loop on a tiny shell CLI that is not Open Scaffold itself, then shows how a second session reconstructs the current state from files alone.
 

--- a/docs/examples/ab-comparison/README.md
+++ b/docs/examples/ab-comparison/README.md
@@ -1,0 +1,47 @@
+# A/B Comparison — Pilot Packet
+
+> **No data has been collected. This packet proves nothing about outcomes.**
+> It is a *pre-registered measurement instrument* — the templates an adopting
+> team copies to run the controlled comparison described in
+> [`docs/AB_COMPARISON_PROTOCOL.md`](../../AB_COMPARISON_PROTOCOL.md) on their own
+> work. It does not claim, and cannot show, that Open Scaffold improves any
+> outcome. Running the comparison and interpreting results is separate future
+> work, gated on having enough matched tasks and participants.
+
+## What is in this packet
+
+| File | Purpose |
+|------|---------|
+| [`pre-registration.md`](pre-registration.md) | Fill-before-data form: hypotheses, arms, metrics (source-labeled), assignment, analysis plan, and a commit-before-data attestation. |
+| [`raw-data-template.csv`](raw-data-template.csv) | One row per task per metric. Every figure carries a `source` label; unmeasured figures are `unavailable`, never imputed. Ships with illustrative `unavailable` rows only. |
+| [`reviewer-rubric.md`](reviewer-rubric.md) | Blinded 0–12 rubric for the reviewer-reconstruction hypothesis (H4). |
+
+The step-by-step runbook that ties these together is
+[`docs/AB_COMPARISON_PILOT.md`](../../AB_COMPARISON_PILOT.md).
+
+## Raw-data schema
+
+`raw-data-template.csv` uses a long format — one figure per row — so that every
+number is independently source-labeled:
+
+- `task_id` — identifier for the task.
+- `arm` — `A` (scaffolded) or `B` (control). No other value is valid.
+- `metric` — what is measured, e.g. `resume_time_seconds`, `rework_incidents`, `context_reexplanation_words`, `reconstruction_score`.
+- `value` — the measurement, or blank when unavailable.
+- `source` — one of `git`, `osc-artifact`, `metrics`, `manual`, `unavailable`. This is a superset of the `osc study` source enum (`git`/`osc-artifact`/`metrics`/`unavailable`); `manual` covers figures coded by hand under the rubric, which `osc study` cannot produce.
+- `notes` — free text (optional).
+
+## Checking the packet
+
+The optional read-only validator confirms the packet is structurally
+well-formed before you trust it — it never writes, scores, or interprets data:
+
+```bash
+osc ab check docs/examples/ab-comparison
+```
+
+It exits `0` when the pre-registration and raw-data files are well-formed, and
+nonzero with an explicit message when a required column is missing, an `arm` is
+not `A`/`B`, a `source` is not in the allowed set, or the pre-registration is
+missing its attestation. A passing check means "the instrument is well-formed,"
+**not** "the experiment was run" or "the scaffold works."

--- a/docs/examples/ab-comparison/pre-registration.md
+++ b/docs/examples/ab-comparison/pre-registration.md
@@ -1,0 +1,66 @@
+# A/B Comparison — Pre-Registration (template)
+
+> **This is a template, not a result.** Copy it into your own repo, fill every
+> section with your specifics, and commit it **before collecting any data**.
+> Nothing in this file is evidence about Open Scaffold; it is the instrument you
+> commit to in advance so the analysis cannot be reshaped to fit the outcome.
+> See `docs/AB_COMPARISON_PROTOCOL.md` for the rationale, design options, and
+> threats to validity that this form operationalizes.
+
+## Study identity
+
+- Title: `<short name for this comparison>`
+- Owner / experimenter: `<name>`
+- Design: within-subjects pilot (descriptive, hypothesis-generating only) — see protocol for the between-subjects confirmatory form.
+- Participant pool: `<who runs the tasks>`
+- Planned task count: `<e.g. 6–10 for a pilot>`
+
+## Hypotheses
+
+Each hypothesis is a falsifiable prediction with an explicit null. Report every
+arm and every metric, including null and negative results.
+
+- **H1 (resume time).** Arm A resumes a cold, multi-session task faster than Arm B. Null: no difference.
+- **H2 (rework / drift).** Arm A has fewer scope-drift and rework incidents. Null: no difference in incident count.
+- **H3 (context re-explanation cost).** Arm A requires less human-typed context to re-establish state at resume. Null: no difference.
+- **H4 (reviewer reconstruction).** A blinded reviewer can more completely reconstruct what/why/changed/verified for Arm A than Arm B. Null: no difference in reconstruction score.
+
+## Arms
+
+- **Arm A — scaffolded.** The full Open Scaffold loop: `MISSION.md`, an immutable plan, amendments on scope change, evidence notes, and `verify.sh`.
+- **Arm B — control.** AI-assisted work with no repo record (chat/context only). Document the actual Arm B behavior; it is not a clean zero.
+
+## Metrics
+
+Every figure is source-labeled. Allowed `source` values, recorded per row in the
+raw-data file: `git`, `osc-artifact`, `metrics`, `manual`, `unavailable`. A metric
+that cannot be measured for a task is recorded with `source: unavailable` and a
+blank value — never imputed or estimated.
+
+| Hypothesis | Metric (raw-data `metric` value) | Unit | Typical source |
+|-----------|----------------------------------|------|----------------|
+| H1 | `resume_time_seconds` | seconds | manual (stopwatch at cold resume) |
+| H2 | `rework_incidents` | count | manual (coded from history + notes) |
+| H3 | `context_reexplanation_words` | words | manual or `metrics` if `114` usage data present |
+| H4 | `reconstruction_score` | 0–12 rubric points | manual (blinded reviewer, see `reviewer-rubric.md`) |
+
+## Assignment
+
+- Randomization procedure: `<recorded random method, e.g. seeded coin flip>`.
+- Counterbalancing / washout (within-subjects): `<ordering rule and the gap between tasks>`.
+- "Cold" definition for resume: at least a 24-hour gap, a fresh session, and no access to prior scrollback.
+
+## Analysis plan
+
+- Primary report: per-arm descriptive statistics for each metric with confidence intervals, not just point estimates.
+- A pilot is descriptive and hypothesis-generating only; it cannot establish significance and the writeup must say so.
+- No dropping inconvenient tasks. No post-hoc metric selection. All four hypotheses are reported even when null.
+- Where a metric is computable by `osc study` (plan `125`), reuse that computation so observational and controlled views stay consistent.
+
+## Pre-registration attestation
+
+- [ ] These hypotheses, metrics, rubric, and analysis plan were committed to version control **before any data** was collected.
+- Pre-registration commit: `<git sha, filled in when committed>`
+- First data-collection commit: `<git sha, filled in later — must come after the line above>`
+
+No public README or MISSION claim is drawn from this work without a separate, explicit owner gate.

--- a/docs/examples/ab-comparison/raw-data-template.csv
+++ b/docs/examples/ab-comparison/raw-data-template.csv
@@ -1,0 +1,9 @@
+task_id,arm,metric,value,source,notes
+EXAMPLE-01,A,resume_time_seconds,,unavailable,illustrative row — replace with real measurements; no data collected yet
+EXAMPLE-01,A,rework_incidents,,unavailable,illustrative row — replace with real measurements; no data collected yet
+EXAMPLE-01,A,context_reexplanation_words,,unavailable,illustrative row — replace with real measurements; no data collected yet
+EXAMPLE-01,A,reconstruction_score,,unavailable,illustrative row — blinded reviewer score; no data collected yet
+EXAMPLE-02,B,resume_time_seconds,,unavailable,illustrative row — replace with real measurements; no data collected yet
+EXAMPLE-02,B,rework_incidents,,unavailable,illustrative row — replace with real measurements; no data collected yet
+EXAMPLE-02,B,context_reexplanation_words,,unavailable,illustrative row — replace with real measurements; no data collected yet
+EXAMPLE-02,B,reconstruction_score,,unavailable,illustrative row — blinded reviewer score; no data collected yet

--- a/docs/examples/ab-comparison/reviewer-rubric.md
+++ b/docs/examples/ab-comparison/reviewer-rubric.md
@@ -1,0 +1,50 @@
+# A/B Comparison — Blinded Reviewer Rubric (H4)
+
+> **Template, not a result.** This rubric scores how completely a cold reviewer
+> can reconstruct a task from its record alone. It is used in the controlled
+> comparison described in `docs/AB_COMPARISON_PROTOCOL.md`. No scores in this
+> repository have been collected.
+
+## How to use this rubric
+
+1. The experimenter **strips arm labels** from each task's record before review:
+   the reviewer must not know whether a task was Arm A (scaffolded) or Arm B
+   (control). Blinding is what keeps experimenter bias out of H4.
+2. The reviewer reads only the durable record left behind for a task (repo
+   files, commits, evidence notes, and/or chat transcript — whatever that arm
+   produced) and answers the four questions below from that record alone.
+3. The reviewer records points per dimension in the raw-data file as the
+   `reconstruction_score` metric (sum, 0–12), with `source: manual`.
+
+## Scoring dimensions
+
+Score each dimension independently. Do not let a strong record on one dimension
+inflate another.
+
+| Dimension | 0 — absent | 1 — partial | 2 — mostly | 3 — complete |
+|-----------|-----------|-------------|------------|--------------|
+| **What was asked** (the goal/scope) | Cannot tell what the task was | Vague sense of the goal | Goal clear, scope fuzzy | Goal and scope both unambiguous |
+| **Why** (intent / decisions) | No rationale recoverable | One decision explained | Most decisions explained | Intent and key decisions traceable |
+| **What changed** (the diff/work) | Cannot tell what was done | Some changes identifiable | Most changes identifiable | Full change set reconstructable |
+| **How it was verified** | No verification evidence | A claim of testing, no detail | Partial verification record | Verification commands/results present |
+
+Maximum score: **12**.
+
+## Recording the score
+
+For each task, add one row to the raw-data file:
+
+```text
+task_id,arm,metric,value,source,notes
+T07,A,reconstruction_score,11,manual,"blinded review; verification fully reconstructable"
+```
+
+The `arm` is filled in by the experimenter **after** scoring, from the blinding
+key — never by the reviewer. A task the reviewer could not score is recorded
+with a blank value and `source: unavailable`, not a zero.
+
+## Honesty rules (inherited from the project)
+
+Report every task's score, including ties and reversals where the control arm
+scored as well as or better than the scaffolded arm. A pilot is descriptive
+only. No public claim is drawn from these scores without a separate owner gate.

--- a/src/ab.ts
+++ b/src/ab.ts
@@ -1,0 +1,176 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+// Structural validator for an A/B comparison pilot packet
+// (docs/examples/ab-comparison). It is strictly read-only: it parses the
+// pre-registration and raw-data files, reports whether they are well-formed,
+// and never writes, scores, interprets, or imputes anything. A passing check
+// means "the instrument is well-formed", not "the experiment was run".
+
+export const AB_RAW_DATA_REQUIRED_COLUMNS = ['task_id', 'arm', 'metric', 'value', 'source'] as const;
+export const AB_ALLOWED_ARMS = ['A', 'B'] as const;
+// Superset of the osc study source enum: adds `manual` for figures coded by
+// hand under the rubric, which osc study cannot produce.
+export const AB_ALLOWED_SOURCES = ['git', 'osc-artifact', 'metrics', 'manual', 'unavailable'] as const;
+export const AB_PREREG_REQUIRED_SECTIONS = ['Hypotheses', 'Arms', 'Metrics', 'Analysis plan', 'Attestation'] as const;
+export const AB_PREREG_ATTESTATION_PHRASE = 'before any data';
+export const AB_PREREG_FILENAME = 'pre-registration.md';
+
+export interface AbCheckIssue {
+  file: string;
+  line: number; // 1-based; 0 means file-level
+  message: string;
+}
+
+export interface AbCheckReport {
+  ok: boolean;
+  preRegistration: string | null;
+  rawData: string | null;
+  issues: AbCheckIssue[];
+}
+
+function label(path: string, root: string): string {
+  const rel = relative(root, path);
+  return rel && !rel.startsWith('..') ? rel : path;
+}
+
+function checkPreRegistration(path: string, file: string, issues: AbCheckIssue[]): void {
+  const text = readFileSync(path, 'utf8');
+  const headings = text.split(/\r?\n/).filter((line) => /^#{1,6}\s/.test(line.trim()));
+  for (const section of AB_PREREG_REQUIRED_SECTIONS) {
+    const found = headings.some((heading) => heading.toLowerCase().includes(section.toLowerCase()));
+    if (!found) {
+      issues.push({ file, line: 0, message: `Pre-registration is missing a "${section}" heading.` });
+    }
+  }
+  if (!text.toLowerCase().includes(AB_PREREG_ATTESTATION_PHRASE)) {
+    issues.push({
+      file,
+      line: 0,
+      message: `Pre-registration is missing the commit-before-data attestation (expected the phrase "${AB_PREREG_ATTESTATION_PHRASE}").`,
+    });
+  }
+}
+
+function splitCsvLine(line: string): string[] {
+  return line.split(',').map((cell) => cell.trim());
+}
+
+function checkRawData(path: string, file: string, issues: AbCheckIssue[]): void {
+  const lines = readFileSync(path, 'utf8').split(/\r?\n/);
+  const headerIndex = lines.findIndex((line) => line.trim() !== '');
+  if (headerIndex < 0) {
+    issues.push({ file, line: 0, message: 'Raw-data file is empty (expected a header row).' });
+    return;
+  }
+
+  const header = splitCsvLine(lines[headerIndex]);
+  const columnIndex = new Map<string, number>();
+  header.forEach((name, index) => {
+    if (!columnIndex.has(name)) columnIndex.set(name, index);
+  });
+
+  const missing = AB_RAW_DATA_REQUIRED_COLUMNS.filter((column) => !columnIndex.has(column));
+  for (const column of missing) {
+    issues.push({ file, line: headerIndex + 1, message: `Raw-data file is missing required column: ${column}.` });
+  }
+  // Without the required columns the row coordinates are meaningless, so stop.
+  if (missing.length > 0) return;
+
+  const armCol = columnIndex.get('arm')!;
+  const sourceCol = columnIndex.get('source')!;
+  const valueCol = columnIndex.get('value')!;
+
+  for (let i = headerIndex + 1; i < lines.length; i += 1) {
+    const raw = lines[i];
+    if (raw.trim() === '') continue;
+    const cells = splitCsvLine(raw);
+    const lineNumber = i + 1;
+    const arm = (cells[armCol] ?? '').trim();
+    const source = (cells[sourceCol] ?? '').trim();
+    const value = (cells[valueCol] ?? '').trim();
+
+    if (!(AB_ALLOWED_ARMS as readonly string[]).includes(arm)) {
+      issues.push({ file, line: lineNumber, message: `Invalid arm "${arm}" (expected one of: ${AB_ALLOWED_ARMS.join(', ')}).` });
+    }
+
+    if (!(AB_ALLOWED_SOURCES as readonly string[]).includes(source)) {
+      issues.push({ file, line: lineNumber, message: `Invalid source "${source}" (expected one of: ${AB_ALLOWED_SOURCES.join(', ')}).` });
+      continue;
+    }
+
+    // Honesty rule: unavailable means no value; any other source means a real number.
+    if (source === 'unavailable') {
+      if (value !== '') {
+        issues.push({ file, line: lineNumber, message: 'Value is present but source is "unavailable"; clear the value or label its real source.' });
+      }
+    } else if (value === '') {
+      issues.push({ file, line: lineNumber, message: `Value is blank but source is "${source}"; use source "unavailable" for an unmeasured figure.` });
+    } else if (!Number.isFinite(Number(value))) {
+      issues.push({ file, line: lineNumber, message: `Value "${value}" is not numeric.` });
+    }
+  }
+}
+
+function findRawDataFile(dir: string): string | null {
+  const csvFiles = readdirSync(dir).filter((name) => name.toLowerCase().endsWith('.csv'));
+  if (csvFiles.length === 0) return null;
+  const preferred = ['raw-data-template.csv', 'raw-data.csv'];
+  for (const name of preferred) {
+    if (csvFiles.includes(name)) return join(dir, name);
+  }
+  return join(dir, csvFiles.sort()[0]);
+}
+
+export function checkAbPacket(targetPath: string, root: string = process.cwd()): AbCheckReport {
+  const issues: AbCheckIssue[] = [];
+  let preRegistration: string | null = null;
+  let rawData: string | null = null;
+
+  if (!existsSync(targetPath)) {
+    issues.push({ file: label(targetPath, root), line: 0, message: 'Path does not exist.' });
+    return { ok: false, preRegistration, rawData, issues };
+  }
+
+  const stats = statSync(targetPath);
+  if (stats.isDirectory()) {
+    const preRegPath = join(targetPath, AB_PREREG_FILENAME);
+    if (existsSync(preRegPath)) {
+      preRegistration = label(preRegPath, root);
+      checkPreRegistration(preRegPath, preRegistration, issues);
+    } else {
+      issues.push({ file: label(targetPath, root), line: 0, message: `Missing pre-registration file: ${AB_PREREG_FILENAME}.` });
+    }
+    const rawDataPath = findRawDataFile(targetPath);
+    if (rawDataPath) {
+      rawData = label(rawDataPath, root);
+      checkRawData(rawDataPath, rawData, issues);
+    } else {
+      issues.push({ file: label(targetPath, root), line: 0, message: 'No raw-data .csv file found in the packet directory.' });
+    }
+  } else if (targetPath.toLowerCase().endsWith('.csv')) {
+    rawData = label(targetPath, root);
+    checkRawData(targetPath, rawData, issues);
+  } else if (targetPath.toLowerCase().endsWith('.md')) {
+    preRegistration = label(targetPath, root);
+    checkPreRegistration(targetPath, preRegistration, issues);
+  } else {
+    issues.push({ file: label(targetPath, root), line: 0, message: 'Unsupported target; expected a packet directory, a .md pre-registration, or a .csv raw-data file.' });
+  }
+
+  return { ok: issues.length === 0, preRegistration, rawData, issues };
+}
+
+export function formatAbCheckReport(report: AbCheckReport): string {
+  const checked = [report.preRegistration, report.rawData].filter((path): path is string => Boolean(path));
+  if (report.ok) {
+    const what = checked.length > 0 ? checked.join(', ') : 'packet';
+    return `A/B pilot packet is well-formed: ${what}.\nThis confirms the instrument is structurally valid — not that any experiment was run or that the scaffold improves any outcome.`;
+  }
+  const lines = [`A/B pilot packet is not well-formed (${report.issues.length} issue(s)):`];
+  for (const issue of report.issues) {
+    const where = issue.line > 0 ? `${issue.file}:${issue.line}` : issue.file;
+    lines.push(`  - ${where}: ${issue.message}`);
+  }
+  return lines.join('\n');
+}

--- a/src/ab.ts
+++ b/src/ab.ts
@@ -115,7 +115,11 @@ function checkRawData(path: string, file: string, issues: AbCheckIssue[]): void 
 function findRawDataFile(dir: string): string | null {
   const csvFiles = readdirSync(dir).filter((name) => name.toLowerCase().endsWith('.csv'));
   if (csvFiles.length === 0) return null;
-  const preferred = ['raw-data-template.csv', 'raw-data.csv'];
+  // Prefer actual collected data over the shipped blank template. Teams may keep
+  // `raw-data-template.csv` next to a filled `raw-data.csv`; the directory check
+  // must not report success by validating the untouched template while ignoring
+  // malformed collected rows.
+  const preferred = ['raw-data.csv', 'raw-data-template.csv'];
   for (const name of preferred) {
     if (csvFiles.includes(name)) return join(dir, name);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,8 @@ import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, compareEvolutionLoop, record
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { computeMetrics, formatMetrics, parseSinceDate } from './metrics.js';
 import { computeStudy, renderStudyMarkdown, validateStudyReport, writeStudyOutput } from './study.js';
+import { computePrSummary, renderPrSummaryMarkdown } from './pr-summary.js';
+import { checkAbPacket, formatAbCheckReport } from './ab.js';
 import { runMcpCommand } from './mcp-server.js';
 import { loadRuntimeProfiles, resolveRuntimeProfile } from './runtimes.js';
 import { closePlan, createEvidenceNoteSkeleton, createPlanAmendment, createPlanSkeleton, inspectScaffold, listPlanTemplates, movePlan, parsePlanFile, planToJson, PLAN_CREATION_STAGES, type PlanCreationStage } from './scaffold.js';
@@ -92,6 +94,8 @@ Diagnostics and advanced:
   osc mcp serve [--repo <path>] [--allow-write] [--validate]
   osc metrics [--json] [--since <date>] [--lookback <weeks>] [--table] [--verbose]
   osc study [--json] [--since <date>] [--out <path>]
+  osc pr-summary <plan-slug> [--format <markdown|json>]
+  osc ab check <path>
   osc doctor [--fix] [--dry-run] [--severity <info|warn|error>] [--check <name>]
   osc runtimes list [--json]
   osc runtimes show <id>
@@ -2238,6 +2242,96 @@ function studyCommand(args: string[]): void {
   }
 }
 
+function printPrSummaryUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc pr-summary <plan-slug> [--format <markdown|json>]
+
+Renders a read-only, reviewer-ready summary of a plan — goal, acceptance-criteria
+checklist state, evidence-note status, plan-validation result, and open questions —
+for mirroring into a pull request. Reuses the plan/evidence readers and the same
+checks as \`osc plan validate\`; it makes no network calls and is never a source of
+truth. A missing or unsafe plan reference renders an explicit "no plan found"
+summary and still exits 0 so it cannot break a PR check.
+
+Options:
+  --format <markdown|json>   Output format (default: markdown). JSON emits the open-scaffold.pr_summary.v1 report.`, stream);
+}
+
+function prSummaryCommand(args: string[]): void {
+  if (isHelpArg(args[0])) {
+    printPrSummaryUsage('stdout');
+    return;
+  }
+  const slug = requireArg(args, 'plan-slug');
+
+  let format: 'markdown' | 'json' = 'markdown';
+  for (let i = 1; i < args.length; i += 1) {
+    const flag = args[i];
+    switch (flag) {
+      case '--format':
+        format = parseChoice(takeMetricsValue(args, i, flag), ['markdown', 'json'] as const, '--format');
+        i += 1;
+        break;
+      default:
+        console.error(`Unknown option for pr-summary: ${flag}`);
+        printPrSummaryUsage();
+        process.exit(2);
+    }
+  }
+
+  try {
+    const report = computePrSummary(slug, { root: process.cwd() });
+    if (format === 'json') console.log(JSON.stringify(report, null, 2));
+    else console.log(renderPrSummaryMarkdown(report));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+function printAbUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage(`Usage: osc ab check <path>
+
+Read-only structural validator for an A/B comparison pilot packet (see
+docs/AB_COMPARISON_PILOT.md). Pass the packet directory (containing
+pre-registration.md and a raw-data .csv), or a single .md or .csv file.
+
+It confirms the pre-registration has its required sections and commit-before-data
+attestation, and that every raw-data row has a valid arm (A/B) and a source-labeled,
+source-consistent value. It never writes, scores, or interprets data. Exit 0 when
+well-formed, 1 when malformed. A pass means the instrument is well-formed — not that
+any experiment was run or that the scaffold improves any outcome.`, stream);
+}
+
+function abCommand(args: string[]): void {
+  const [subcommand, ...rest] = args;
+  if (isHelpArg(subcommand) || subcommand === undefined) {
+    printAbUsage('stdout');
+    return;
+  }
+  if (subcommand !== 'check') {
+    console.error(`Unknown subcommand for ab: ${subcommand}`);
+    printAbUsage();
+    process.exit(2);
+  }
+  if (isHelpArg(rest[0])) {
+    printAbUsage('stdout');
+    return;
+  }
+  const target = requireArg(rest, 'path');
+  if (rest.length > 1) {
+    console.error(`Unknown option for ab check: ${rest[1]}`);
+    printAbUsage();
+    process.exit(2);
+  }
+  const report = checkAbPacket(target, process.cwd());
+  if (report.ok) {
+    console.log(formatAbCheckReport(report));
+  } else {
+    console.error(formatAbCheckReport(report));
+    process.exit(1);
+  }
+}
+
 function printTaskUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
   printUsage(`Usage: osc task new <title> [--priority <${TASK_PRIORITIES.join('|')}>] [--plan <slug>]
   osc task list [--status <${TASK_STATUSES.join('|')}>] [--priority <${TASK_PRIORITIES.join('|')}>] [--plan <slug>] [--json]
@@ -2801,6 +2895,12 @@ async function main(): Promise<void> {
       return;
     case 'study':
       studyCommand(args);
+      return;
+    case 'pr-summary':
+      prSummaryCommand(args);
+      return;
+    case 'ab':
+      abCommand(args);
       return;
     case 'cockpit':
       await cockpitCommand(args);

--- a/src/evidence.ts
+++ b/src/evidence.ts
@@ -95,7 +95,7 @@ function findPlanPath(root: string, slug: string): string | null {
   return null;
 }
 
-function findEvidenceNote(root: string, slug: string): string | null {
+export function findEvidenceNote(root: string, slug: string): string | null {
   const releasesDir = join(root, '.osc', 'releases');
   if (!existsSync(releasesDir)) return null;
   const pattern = new RegExp(`^\\d{4}-\\d{2}-\\d{2}-${escapeRegex(slug)}\\.md$`);

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -8,7 +8,7 @@ const DEFAULT_LOOKBACK_WEEKS = 12;
 const STALE_DAYS = 30;
 const APPROVAL_STATUSES = ['approved', 'weak_approved', 'rejected', 'blocked'] as const;
 
-type ApprovalStatus = typeof APPROVAL_STATUSES[number] | 'unknown';
+export type ApprovalStatus = typeof APPROVAL_STATUSES[number] | 'unknown';
 
 export interface MetricsOptions {
   root?: string;
@@ -277,9 +277,8 @@ function evidenceForPlan(notes: EvidenceNote[], slug: string): EvidenceNote | nu
   return newestEvidence(textMatches);
 }
 
-function approvalFromEvidence(note: EvidenceNote | null): ApprovalStatus {
-  if (!note || !note.text.trim()) return 'unknown';
-  const text = note.text;
+export function evidenceApprovalStatus(text: string): ApprovalStatus {
+  if (!text.trim()) return 'unknown';
   const explicit = text.match(/approval\.status\s*[:=]\s*(approved|weak_approved|rejected|blocked)\b/i);
   if (explicit) return explicit[1].toLowerCase() as ApprovalStatus;
   const ownerDecision = text.match(/owner decision\s*:\s*(approved|weak_approved|rejected|blocked)\b/i);
@@ -288,6 +287,10 @@ function approvalFromEvidence(note: EvidenceNote | null): ApprovalStatus {
   if (decision) return decision[1].toLowerCase() as ApprovalStatus;
   if (/\bweak approval\b|\bweak_approved\b/i.test(text)) return 'weak_approved';
   return 'unknown';
+}
+
+function approvalFromEvidence(note: EvidenceNote | null): ApprovalStatus {
+  return evidenceApprovalStatus(note?.text ?? '');
 }
 
 function percentile(values: number[], p: number): number | null {

--- a/src/pr-summary.ts
+++ b/src/pr-summary.ts
@@ -1,0 +1,245 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import {
+  findScaffoldRoot,
+  parseChecklist,
+  parsePlanFile,
+  PLAN_STAGES,
+  type ChecklistItem,
+  type PlanStage,
+} from './scaffold.js';
+import { resolvePlanValidationPath, validatePlanFile, type PlanValidationIssue } from './plan-validate.js';
+import { findEvidenceNote } from './evidence.js';
+import { evidenceApprovalStatus, type ApprovalStatus } from './metrics.js';
+
+export const PR_SUMMARY_SCHEMA = 'open-scaffold.pr_summary.v1';
+
+// Hidden HTML comment placed on the first line of the rendered markdown so an
+// automated mirror (the optional pr-summary workflow) can find and update its
+// own single comment instead of posting a new one each run.
+export const PR_SUMMARY_MARKER = '<!-- osc-pr-summary -->';
+
+export interface PrSummaryEvidence {
+  present: boolean;
+  path: string | null;
+  approval_status: ApprovalStatus;
+  is_skeleton: boolean;
+}
+
+export interface PrSummaryValidationIssue {
+  severity: PlanValidationIssue['severity'];
+  rule: string;
+  line: number;
+  message: string;
+}
+
+export interface PrSummaryValidation {
+  ok: boolean;
+  error_count: number;
+  warning_count: number;
+  issues: PrSummaryValidationIssue[];
+}
+
+export interface PrSummaryReport {
+  schemaVersion: typeof PR_SUMMARY_SCHEMA;
+  computed_at: string;
+  slug: string;
+  plan_found: boolean;
+  plan_path: string | null;
+  stage: PlanStage | null;
+  goal: string | null;
+  acceptance_criteria: ChecklistItem[];
+  evidence: PrSummaryEvidence;
+  open_questions: string[];
+  validation: PrSummaryValidation;
+  notes: string[];
+}
+
+export interface PrSummaryOptions {
+  root?: string;
+  now?: Date;
+}
+
+function resolveRoot(root?: string): string {
+  const start = root ?? process.cwd();
+  const scaffoldRoot = findScaffoldRoot(start);
+  if (!scaffoldRoot) {
+    throw new Error(`No Open Scaffold root found from ${resolve(start)}. Run this inside a repo with .osc/plans and .osc/releases.`);
+  }
+  return scaffoldRoot;
+}
+
+function stageFromPath(path: string): PlanStage | null {
+  const normalized = path.replace(/\\/g, '/');
+  for (const stage of PLAN_STAGES) {
+    if (normalized.includes(`/.osc/plans/${stage}/`)) return stage;
+  }
+  return null;
+}
+
+function emptyEvidence(): PrSummaryEvidence {
+  return { present: false, path: null, approval_status: 'unknown', is_skeleton: false };
+}
+
+function notFoundReport(slug: string, now: Date, reason: string): PrSummaryReport {
+  return {
+    schemaVersion: PR_SUMMARY_SCHEMA,
+    computed_at: now.toISOString(),
+    slug,
+    plan_found: false,
+    plan_path: null,
+    stage: null,
+    goal: null,
+    acceptance_criteria: [],
+    evidence: emptyEvidence(),
+    open_questions: [],
+    validation: { ok: false, error_count: 0, warning_count: 0, issues: [] },
+    notes: [reason],
+  };
+}
+
+export function computePrSummary(slug: string, options: PrSummaryOptions = {}): PrSummaryReport {
+  const root = resolveRoot(options.root);
+  const now = options.now ?? new Date();
+
+  let planPath: string | null = null;
+  try {
+    planPath = resolvePlanValidationPath(slug, root);
+  } catch (error) {
+    // A missing or unsafe plan reference renders an explicit "no plan" summary
+    // rather than failing the PR check — the mirror must never break CI.
+    const reason = error instanceof Error ? error.message : String(error);
+    return notFoundReport(slug, now, reason);
+  }
+
+  const parsed = parsePlanFile(planPath);
+  const acceptanceCriteria = parseChecklist(parsed.sections.get('Acceptance criteria') ?? '');
+  const validation = validatePlanFile(planPath);
+  const issues = validation.issues.map((issue) => ({
+    severity: issue.severity,
+    rule: issue.rule,
+    line: issue.line,
+    message: issue.message,
+  }));
+
+  const evidencePath = findEvidenceNote(root, parsed.slug);
+  let evidence = emptyEvidence();
+  if (evidencePath && existsSync(evidencePath)) {
+    const evidenceText = readFileSync(evidencePath, 'utf8');
+    evidence = {
+      present: true,
+      path: relative(root, evidencePath),
+      approval_status: evidenceApprovalStatus(evidenceText),
+      is_skeleton: /(^|[\s>*-])TODO:\s*\S/m.test(evidenceText),
+    };
+  }
+
+  return {
+    schemaVersion: PR_SUMMARY_SCHEMA,
+    computed_at: now.toISOString(),
+    slug: parsed.slug,
+    plan_found: true,
+    plan_path: relative(root, planPath),
+    stage: stageFromPath(planPath),
+    goal: parsed.goal || null,
+    acceptance_criteria: acceptanceCriteria,
+    evidence,
+    open_questions: parsed.openQuestions,
+    validation: {
+      ok: !issues.some((issue) => issue.severity === 'error'),
+      error_count: issues.filter((issue) => issue.severity === 'error').length,
+      warning_count: issues.filter((issue) => issue.severity === 'warning').length,
+      issues,
+    },
+    notes: [],
+  };
+}
+
+const MIRROR_FOOTER =
+  '_Read-only mirror of `.osc/` artifacts, generated by `osc pr-summary`. ' +
+  'Not canonical state — the plan and evidence files in the repository are the source of truth._';
+
+// The rendered markdown is deterministic for a given repository state (no
+// wall-clock timestamp), so re-running against an unchanged plan produces an
+// identical comment body and the mirror updates one comment in place.
+export function renderPrSummaryMarkdown(report: PrSummaryReport): string {
+  const lines: string[] = [PR_SUMMARY_MARKER, `## Open Scaffold summary — \`${report.slug}\``, ''];
+
+  if (!report.plan_found) {
+    lines.push(
+      `No plan found for \`${report.slug}\` in \`.osc/plans/{active,backlog,blocked,done}\`. ` +
+        'This pull request has no Open Scaffold plan to summarize.',
+      '',
+      '---',
+      MIRROR_FOOTER,
+      '',
+    );
+    return lines.join('\n');
+  }
+
+  lines.push(`**Stage:** ${report.stage ?? 'unknown'}`, '');
+  lines.push('**Goal:** ' + (report.goal ?? '_No goal recorded._'), '');
+
+  const total = report.acceptance_criteria.length;
+  const checked = report.acceptance_criteria.filter((item) => item.checked).length;
+  lines.push(`### Acceptance criteria (${checked}/${total} checked)`, '');
+  if (total === 0) {
+    lines.push('_No acceptance-criteria checklist items found._', '');
+  } else {
+    for (const item of report.acceptance_criteria) {
+      lines.push(`- [${item.checked ? 'x' : ' '}] ${item.text}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('### Evidence note', '');
+  if (report.evidence.present) {
+    lines.push(`- Present: yes — \`${report.evidence.path}\``);
+    lines.push(`- Approval: ${report.evidence.approval_status}`);
+    if (report.evidence.is_skeleton) {
+      lines.push('- Status: skeleton (contains TODO placeholders — not yet filled in)');
+    }
+  } else {
+    lines.push('- Present: no evidence note found yet.');
+  }
+  lines.push('');
+
+  lines.push('### Plan validation', '');
+  if (report.validation.ok && report.validation.warning_count === 0) {
+    lines.push('- Passed: no issues from `osc plan validate`.');
+  } else {
+    lines.push(`- ${report.validation.error_count} error(s), ${report.validation.warning_count} warning(s) from \`osc plan validate\`.`);
+    for (const issue of report.validation.issues) {
+      lines.push(`  - ${issue.severity} (${issue.rule}, line ${issue.line}): ${issue.message}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('### Open questions', '');
+  if (report.open_questions.length === 0) {
+    lines.push('_None recorded._');
+  } else {
+    for (const question of report.open_questions) {
+      lines.push(`- ${question}`);
+    }
+  }
+  lines.push('', '---', MIRROR_FOOTER, '');
+
+  return lines.join('\n');
+}
+
+export interface CommentLike {
+  id: number | string;
+  body: string;
+}
+
+// Pure selector that makes the mirror idempotent: the optional workflow upserts
+// by finding the one existing comment that carries PR_SUMMARY_MARKER. If found,
+// it updates that comment; otherwise it creates one. Either way there is never
+// more than one summary comment on a PR.
+export function selectSummaryComment<T extends CommentLike>(comments: T[], marker: string = PR_SUMMARY_MARKER): T | null {
+  for (const comment of comments) {
+    if (typeof comment.body === 'string' && comment.body.includes(marker)) return comment;
+  }
+  return null;
+}

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -579,6 +579,23 @@ function bulletItems(text: string): string[] {
     .filter(Boolean);
 }
 
+export interface ChecklistItem {
+  text: string;
+  checked: boolean;
+}
+
+export function parseChecklist(text: string): ChecklistItem[] {
+  const items: ChecklistItem[] = [];
+  for (const raw of text.split(/\r?\n/)) {
+    const match = raw.trim().match(/^[-*]\s+\[([ xX])\]\s*(.*)$/);
+    if (!match) continue;
+    const body = match[2].trim();
+    if (!body) continue;
+    items.push({ text: body, checked: match[1].toLowerCase() === 'x' });
+  }
+  return items;
+}
+
 function numberedItems(text: string): string[] {
   return text
     .split(/\r?\n/)

--- a/tests/ab.test.ts
+++ b/tests/ab.test.ts
@@ -73,6 +73,18 @@ describe('checkAbPacket', () => {
     expect(report.issues.some((issue) => /missing required column: source/i.test(issue.message))).toBe(true);
   });
 
+  it('prefers filled raw-data.csv over the shipped raw-data-template.csv when both exist', () => {
+    const dir = tempDir();
+    writePacket(dir, VALID_PREREG, VALID_CSV);
+    writeFileSync(join(dir, 'raw-data.csv'), 'task_id,arm,metric,value\nT01,A,resume_time_seconds,12\n');
+
+    const report = checkAbPacket(dir, dir);
+
+    expect(report.rawData).toBe('raw-data.csv');
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((issue) => /missing required column: source/i.test(issue.message))).toBe(true);
+  });
+
   it('rejects a row whose arm is not A or B', () => {
     const dir = tempDir();
     writePacket(dir, VALID_PREREG, 'task_id,arm,metric,value,source,notes\nT01,C,resume_time_seconds,,unavailable,x\n');

--- a/tests/ab.test.ts
+++ b/tests/ab.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { checkAbPacket } from '../src/ab.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+const shippedPacket = join(repoRoot, 'docs/examples/ab-comparison');
+
+function tempDir(prefix = 'osc-ab-') {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+const VALID_PREREG = [
+  '# Pre-Registration',
+  '',
+  '## Hypotheses',
+  '- H1: arm A resumes faster. Null: no difference.',
+  '',
+  '## Arms',
+  '- Arm A scaffolded; Arm B control.',
+  '',
+  '## Metrics',
+  '- resume_time_seconds, source-labeled.',
+  '',
+  '## Analysis plan',
+  '- Descriptive only; report every arm.',
+  '',
+  '## Attestation',
+  '- These were committed before any data was collected.',
+  '',
+].join('\n');
+
+const VALID_CSV = [
+  'task_id,arm,metric,value,source,notes',
+  'T01,A,resume_time_seconds,42,manual,ok',
+  'T02,B,resume_time_seconds,,unavailable,no data',
+  '',
+].join('\n');
+
+function writePacket(dir: string, prereg: string, csv: string) {
+  writeFileSync(join(dir, 'pre-registration.md'), prereg);
+  writeFileSync(join(dir, 'raw-data-template.csv'), csv);
+}
+
+describe('checkAbPacket', () => {
+  it('accepts the shipped example packet as well-formed', () => {
+    const report = checkAbPacket(shippedPacket, repoRoot);
+
+    expect(report.ok).toBe(true);
+    expect(report.issues).toEqual([]);
+    expect(report.preRegistration).toBe('docs/examples/ab-comparison/pre-registration.md');
+    expect(report.rawData).toBe('docs/examples/ab-comparison/raw-data-template.csv');
+  });
+
+  it('accepts a header-only raw-data file (an empty template with no data rows)', () => {
+    const dir = tempDir();
+    writePacket(dir, VALID_PREREG, 'task_id,arm,metric,value,source,notes\n');
+
+    expect(checkAbPacket(dir, dir).ok).toBe(true);
+  });
+
+  it('rejects a raw-data file missing the required source column', () => {
+    const dir = tempDir();
+    writePacket(dir, VALID_PREREG, 'task_id,arm,metric,value\nT01,A,resume_time_seconds,12\n');
+
+    const report = checkAbPacket(dir, dir);
+
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((issue) => /missing required column: source/i.test(issue.message))).toBe(true);
+  });
+
+  it('rejects a row whose arm is not A or B', () => {
+    const dir = tempDir();
+    writePacket(dir, VALID_PREREG, 'task_id,arm,metric,value,source,notes\nT01,C,resume_time_seconds,,unavailable,x\n');
+
+    const report = checkAbPacket(dir, dir);
+
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((issue) => /invalid arm "C"/i.test(issue.message))).toBe(true);
+  });
+
+  it('rejects a row whose source label is outside the allowed set', () => {
+    const dir = tempDir();
+    writePacket(dir, VALID_PREREG, 'task_id,arm,metric,value,source,notes\nT01,A,resume_time_seconds,12,guess,x\n');
+
+    const report = checkAbPacket(dir, dir);
+
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((issue) => /invalid source "guess"/i.test(issue.message))).toBe(true);
+  });
+
+  it('enforces the honesty rule that unavailable means blank and a real source means a number', () => {
+    const dir = tempDir();
+    writePacket(
+      dir,
+      VALID_PREREG,
+      [
+        'task_id,arm,metric,value,source,notes',
+        'T01,A,resume_time_seconds,99,unavailable,value-but-unavailable',
+        'T02,A,resume_time_seconds,,manual,blank-but-measured',
+        'T03,A,resume_time_seconds,lots,manual,not-numeric',
+        '',
+      ].join('\n'),
+    );
+
+    const report = checkAbPacket(dir, dir);
+
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((issue) => /source is "unavailable"/i.test(issue.message))).toBe(true);
+    expect(report.issues.some((issue) => /blank but source is "manual"/i.test(issue.message))).toBe(true);
+    expect(report.issues.some((issue) => /not numeric/i.test(issue.message))).toBe(true);
+  });
+
+  it('rejects a pre-registration missing the commit-before-data attestation', () => {
+    const dir = tempDir();
+    writePacket(dir, VALID_PREREG.replace('These were committed before any data was collected.', 'Filled in.'), VALID_CSV);
+
+    const report = checkAbPacket(dir, dir);
+
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((issue) => /attestation/i.test(issue.message))).toBe(true);
+  });
+
+  it('rejects a pre-registration missing a required section', () => {
+    const dir = tempDir();
+    writePacket(dir, VALID_PREREG.replace('## Hypotheses', '## Guesses'), VALID_CSV);
+
+    const report = checkAbPacket(dir, dir);
+
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((issue) => /missing a "Hypotheses" heading/i.test(issue.message))).toBe(true);
+  });
+
+  it('reports a missing packet directory without throwing', () => {
+    const report = checkAbPacket(join(tempDir(), 'does-not-exist'));
+
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((issue) => /does not exist/i.test(issue.message))).toBe(true);
+  });
+});
+
+describe('osc ab check CLI', () => {
+  it('exits 0 and reports well-formed for the shipped packet', () => {
+    const result = spawnSync(tsx, [cli, 'ab', 'check', 'docs/examples/ab-comparison'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('well-formed');
+    expect(result.stdout).toContain('not that any experiment was run');
+  });
+
+  it('exits 1 with an explicit message for a malformed raw-data file', () => {
+    const dir = tempDir();
+    const csv = join(dir, 'no-source.csv');
+    writeFileSync(csv, 'task_id,arm,metric,value\nT01,A,resume_time_seconds,12\n');
+
+    const result = spawnSync(tsx, [cli, 'ab', 'check', csv], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('missing required column: source');
+  });
+
+  it('treats a missing path as a usage error (exit 2)', () => {
+    const result = spawnSync(tsx, [cli, 'ab', 'check'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Missing required argument: path');
+  });
+
+  it('prints usage under --help at exit 0', () => {
+    const result = spawnSync(tsx, [cli, 'ab', '--help'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: osc ab check');
+  });
+});
+
+describe('A/B packet honesty guard', () => {
+  it('keeps the no-data / no-claim disclaimer prominent in the runbook and packet readme', () => {
+    const runbook = readFileSync(join(repoRoot, 'docs/AB_COMPARISON_PILOT.md'), 'utf8');
+    const packetReadme = readFileSync(join(repoRoot, 'docs/examples/ab-comparison/README.md'), 'utf8');
+
+    expect(runbook).toContain('No data has been collected');
+    expect(packetReadme).toContain('No data has been collected');
+    expect(packetReadme).toContain('proves nothing about outcomes');
+  });
+});

--- a/tests/cli-pr-summary.test.ts
+++ b/tests/cli-pr-summary.test.ts
@@ -327,4 +327,9 @@ describe('pr-summary mirror workflow', () => {
   it('checks out without the forbidden actions/checkout helper', () => {
     expect(workflow).not.toContain('actions/checkout');
   });
+
+  it('keeps the PR-comment upsert non-blocking for forked and Dependabot PRs', () => {
+    expect(workflow).toContain('github.event.pull_request.head.repo.full_name == github.repository');
+    expect(workflow).toContain("github.actor != 'dependabot[bot]'");
+  });
 });

--- a/tests/cli-pr-summary.test.ts
+++ b/tests/cli-pr-summary.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  PR_SUMMARY_MARKER,
+  PR_SUMMARY_SCHEMA,
+  computePrSummary,
+  renderPrSummaryMarkdown,
+  selectSummaryComment,
+  type PrSummaryReport,
+} from '../src/pr-summary.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+const now = new Date('2026-06-15T00:00:00.000Z');
+
+function tempScaffold(prefix = 'osc-pr-summary-') {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  for (const stage of ['active', 'backlog', 'blocked', 'done']) mkdirSync(join(root, `.osc/plans/${stage}`), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nTest pr-summary.\n\n## Changelog\n\n<!-- append YYYY-MM-DD entries below this line -->\n');
+  writeFileSync(join(root, '.osc/releases/README.md'), '# Releases\n');
+  return root;
+}
+
+interface PlanParts {
+  goal?: string;
+  context?: string;
+  ac?: string[];
+  openQuestions?: string[];
+}
+
+function planText(slug: string, status: string, parts: PlanParts = {}): string {
+  const goal = parts.goal ?? `Provide a reviewer-ready summary for ${slug} in pull requests.`;
+  const context = parts.context ?? `We need ${slug} so reviewers see the plan state in the PR.`;
+  const ac = parts.ac ?? ['- [x] First criterion is testable and complete.', '- [ ] Second criterion is still open for review.'];
+  const openQuestions = parts.openQuestions ?? ['- None.'];
+  return [
+    `# Plan: ${slug}`, '',
+    '## Status', '', status, '',
+    '## Context', '', context, '',
+    '## Goal', '', goal, '',
+    '## Constraints / Out of scope', '', '- Stay read-only.', '',
+    '## Files to touch', '', '- `README.md` — example.', '',
+    '## Acceptance criteria', '', ...ac, '',
+    '## Verification steps', '', '1. Run the tests.', '',
+    '## Open questions', '', ...openQuestions, '',
+  ].join('\n');
+}
+
+function writePlan(root: string, stage: 'active' | 'backlog' | 'blocked' | 'done', slug: string, parts: PlanParts = {}) {
+  const path = join(root, `.osc/plans/${stage}/${slug}.md`);
+  writeFileSync(path, planText(slug, stage, parts));
+  return path;
+}
+
+function writeEvidence(root: string, date: string, slug: string, approval: string, body = `Evidence for ${slug}.`) {
+  writeFileSync(join(root, `.osc/releases/${date}-${slug}.md`), [
+    `# Release / Evidence Note: ${slug}`,
+    '',
+    '## Summary',
+    '',
+    body,
+    '',
+    '## Outcome',
+    '',
+    `approval.status: ${approval}`,
+    '',
+  ].join('\n'));
+}
+
+describe('computePrSummary', () => {
+  it('reads goal, acceptance-criteria checkbox state, evidence, and open questions from the plan', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '010-sample', {
+      goal: 'Ship a reviewer summary that mirrors plan state into the PR.',
+      ac: ['- [x] Done item one.', '- [ ] Open item two.', '- [x] Done item three.'],
+      openQuestions: ['- Should the mirror also post to Discord?'],
+    });
+    writeEvidence(root, '2026-06-10', '010-sample', 'weak_approved');
+
+    const report = computePrSummary('010-sample', { root, now });
+
+    expect(report.schemaVersion).toBe(PR_SUMMARY_SCHEMA);
+    expect(report.plan_found).toBe(true);
+    expect(report.stage).toBe('active');
+    expect(report.goal).toBe('Ship a reviewer summary that mirrors plan state into the PR.');
+    expect(report.acceptance_criteria).toEqual([
+      { text: 'Done item one.', checked: true },
+      { text: 'Open item two.', checked: false },
+      { text: 'Done item three.', checked: true },
+    ]);
+    expect(report.evidence.present).toBe(true);
+    expect(report.evidence.path).toBe('.osc/releases/2026-06-10-010-sample.md');
+    expect(report.evidence.approval_status).toBe('weak_approved');
+    expect(report.evidence.is_skeleton).toBe(false);
+    expect(report.open_questions).toEqual(['Should the mirror also post to Discord?']);
+    expect(report.validation.ok).toBe(true);
+  });
+
+  it('reports a missing evidence note without inventing one', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '011-noevidence');
+
+    const report = computePrSummary('011-noevidence', { root, now });
+
+    expect(report.plan_found).toBe(true);
+    expect(report.evidence.present).toBe(false);
+    expect(report.evidence.path).toBeNull();
+    expect(report.evidence.approval_status).toBe('unknown');
+  });
+
+  it('flags an evidence skeleton that still carries TODO placeholders', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '012-skeleton');
+    writeEvidence(root, '2026-06-10', '012-skeleton', 'approved', 'TODO: summarize what changed.');
+
+    const report = computePrSummary('012-skeleton', { root, now });
+
+    expect(report.evidence.present).toBe(true);
+    expect(report.evidence.is_skeleton).toBe(true);
+  });
+
+  it('surfaces plan-validation issues by reusing the plan validator rather than re-parsing', () => {
+    const root = tempScaffold();
+    // A TODO marker trips the plan validator's no-todos rule (error severity).
+    writePlan(root, 'active', '013-invalid', { context: 'TODO: explain why this plan exists.' });
+
+    const report = computePrSummary('013-invalid', { root, now });
+
+    expect(report.plan_found).toBe(true);
+    expect(report.validation.ok).toBe(false);
+    expect(report.validation.error_count).toBeGreaterThan(0);
+    expect(report.validation.issues.some((issue) => issue.rule === 'no-todos')).toBe(true);
+  });
+
+  it('returns a graceful not-found report for a missing plan and never throws', () => {
+    const root = tempScaffold();
+
+    const report = computePrSummary('999-missing', { root, now });
+
+    expect(report.plan_found).toBe(false);
+    expect(report.plan_path).toBeNull();
+    expect(report.acceptance_criteria).toEqual([]);
+    expect(report.notes.join(' ')).toContain('Plan not found');
+  });
+
+  it('returns a graceful not-found report for an unsafe slug instead of resolving a path', () => {
+    const root = tempScaffold();
+
+    const report = computePrSummary('../outside', { root, now });
+
+    expect(report.plan_found).toBe(false);
+    expect(report.plan_path).toBeNull();
+  });
+});
+
+describe('renderPrSummaryMarkdown', () => {
+  it('places the upsert marker on the first line and renders checkbox state with a count', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '020-render', {
+      ac: ['- [x] Done one.', '- [ ] Open two.'],
+    });
+    const markdown = renderPrSummaryMarkdown(computePrSummary('020-render', { root, now }));
+
+    expect(markdown.split('\n')[0]).toBe(PR_SUMMARY_MARKER);
+    expect(markdown).toContain('### Acceptance criteria (1/2 checked)');
+    expect(markdown).toContain('- [x] Done one.');
+    expect(markdown).toContain('- [ ] Open two.');
+    expect(markdown).toContain('Read-only mirror of `.osc/` artifacts');
+  });
+
+  it('is deterministic across compute times so the mirrored comment is stable', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '021-stable');
+
+    const early = renderPrSummaryMarkdown(computePrSummary('021-stable', { root, now: new Date('2026-01-01T00:00:00.000Z') }));
+    const late = renderPrSummaryMarkdown(computePrSummary('021-stable', { root, now: new Date('2026-12-31T23:59:59.000Z') }));
+
+    expect(early).toBe(late);
+  });
+
+  it('renders an explicit no-plan body that still carries the marker', () => {
+    const root = tempScaffold();
+    const markdown = renderPrSummaryMarkdown(computePrSummary('999-missing', { root, now }));
+
+    expect(markdown.split('\n')[0]).toBe(PR_SUMMARY_MARKER);
+    expect(markdown).toContain('No plan found for `999-missing`');
+  });
+});
+
+describe('selectSummaryComment (idempotent upsert)', () => {
+  it('finds the single comment carrying the marker among unrelated comments', () => {
+    const comments = [
+      { id: 1, body: 'CI passed.' },
+      { id: 2, body: `${PR_SUMMARY_MARKER}\n## Open Scaffold summary` },
+      { id: 3, body: 'LGTM' },
+    ];
+
+    expect(selectSummaryComment(comments)?.id).toBe(2);
+  });
+
+  it('returns null when no comment carries the marker so the mirror creates one', () => {
+    expect(selectSummaryComment([{ id: 1, body: 'unrelated' }])).toBeNull();
+    expect(selectSummaryComment([])).toBeNull();
+  });
+
+  it('updates in place on re-run rather than duplicating the comment', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '030-idem');
+    const body = renderPrSummaryMarkdown(computePrSummary('030-idem', { root, now }));
+
+    // Model the workflow's upsert: select existing -> update, else create.
+    let comments: Array<{ id: number; body: string }> = [];
+    let nextId = 1;
+    const upsert = (newBody: string) => {
+      const existing = selectSummaryComment(comments);
+      if (existing) existing.body = newBody;
+      else comments.push({ id: nextId++, body: newBody });
+    };
+
+    upsert(body); // first run: creates
+    upsert(body); // second run: updates the same comment
+
+    expect(comments).toHaveLength(1);
+    expect(comments.filter((c) => c.body.includes(PR_SUMMARY_MARKER))).toHaveLength(1);
+    expect(comments[0].id).toBe(1);
+  });
+});
+
+describe('osc pr-summary CLI', () => {
+  it('renders a markdown summary for a real plan at exit 0', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '040-cli', { ac: ['- [x] Done.', '- [ ] Open.'] });
+    writeEvidence(root, '2026-06-10', '040-cli', 'approved');
+
+    const result = spawnSync(tsx, [cli, 'pr-summary', '040-cli'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout.split('\n')[0]).toBe(PR_SUMMARY_MARKER);
+    expect(result.stdout).toContain('### Acceptance criteria (1/2 checked)');
+    expect(result.stdout).toContain('Provide a reviewer-ready summary for 040-cli');
+    expect(result.stdout).toContain('.osc/releases/2026-06-10-040-cli.md');
+  });
+
+  it('emits a valid JSON report under --format json', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '041-json');
+
+    const result = spawnSync(tsx, [cli, 'pr-summary', '041-json', '--format', 'json'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout) as PrSummaryReport;
+    expect(parsed.schemaVersion).toBe(PR_SUMMARY_SCHEMA);
+    expect(parsed.plan_found).toBe(true);
+    expect(parsed.acceptance_criteria.length).toBeGreaterThan(0);
+  });
+
+  it('exits 0 with an explicit no-plan summary for a missing plan rather than failing the check', () => {
+    const root = tempScaffold();
+
+    const result = spawnSync(tsx, [cli, 'pr-summary', '999-missing'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('No plan found for `999-missing`');
+  });
+
+  it('exits 0 with a graceful no-plan summary for an unsafe slug', () => {
+    const root = tempScaffold();
+
+    const result = spawnSync(tsx, [cli, 'pr-summary', '../outside'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('No plan found');
+  });
+
+  it('rejects an unknown --format value as a usage error', () => {
+    const root = tempScaffold();
+    writePlan(root, 'active', '042-bad');
+
+    const result = spawnSync(tsx, [cli, 'pr-summary', '042-bad', '--format', 'yaml'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Invalid value for --format');
+  });
+
+  it('requires a plan slug', () => {
+    const root = tempScaffold();
+
+    const result = spawnSync(tsx, [cli, 'pr-summary'], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Missing required argument: plan-slug');
+  });
+
+  it('documents pr-summary flags in command help', () => {
+    const result = spawnSync(tsx, [cli, 'pr-summary', '--help'], { cwd: repoRoot, encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: osc pr-summary');
+    expect(result.stdout).toContain('--format');
+  });
+});
+
+describe('pr-summary mirror workflow', () => {
+  const workflow = readFileSync(join(repoRoot, '.github/workflows/pr-summary.yml'), 'utf8');
+
+  it('embeds the exact PR_SUMMARY_MARKER so the upsert never drifts from the renderer', () => {
+    // The workflow re-implements the find-by-marker upsert inline in github-script.
+    // If this literal ever drifts from PR_SUMMARY_MARKER the mirror would post a
+    // second comment instead of updating in place, so pin them together here.
+    expect(workflow).toContain(PR_SUMMARY_MARKER);
+  });
+
+  it('is gated opt-in and runs read-only against contents', () => {
+    expect(workflow).toContain("vars.OSC_PR_SUMMARY == 'true'");
+    expect(workflow).toContain('contents: read');
+    expect(workflow).toContain('issues: write');
+  });
+
+  it('checks out without the forbidden actions/checkout helper', () => {
+    expect(workflow).not.toContain('actions/checkout');
+  });
+});


### PR DESCRIPTION
## Summary

This PR completes the two remaining original-document follow-ups before package/public-surface sync:

1. **Plan 126 — PR-native evidence surface**
   - Adds `osc pr-summary <plan-slug> [--format markdown|json]`.
   - Renders plan goal, AC checklist state, evidence-note status, plan validation, and open questions.
   - Adds an opt-in GitHub Action (`OSC_PR_SUMMARY=true`) that upserts one PR comment by marker; the comment is a mirror, not canonical state.

2. **Plan 127 — A/B comparison pilot harness**
   - Converts `docs/AB_COMPARISON_PROTOCOL.md` into an executable pre-registered pilot packet.
   - Adds runbook, pre-registration template, source-labeled raw-data CSV template, and blinded reviewer rubric.
   - Adds read-only `osc ab check <path>` structural validator.
   - Does **not** collect data and makes **no causal claim**.

## Post-Codex fixes

Codex flagged two valid P2s; both are fixed:

1. `e600f98` — `osc ab check <packet-dir>` now prefers a filled `raw-data.csv` over `raw-data-template.csv`, so malformed collected rows cannot be masked by a valid template. Regression added.
2. `8aa146c` — opt-in PR-summary comment upsert now skips forked and Dependabot PRs where `GITHUB_TOKEN` can be read-only, keeping the mirror non-blocking. Regression added.

## Verification

- `npm test -- --run tests/cli-pr-summary.test.ts tests/ab.test.ts` — 38 passed
- `npm run build` — passed
- `./verify.sh --strict` — 9 pass, 0 fail, 1 warn (`.git` worktree pointer skips immutability check)
- `git diff --check` — clean
- `npm run osc -- plan validate .osc/plans/done/126-pr-native-evidence-surface.md` — 0 issues
- `npm run osc -- plan validate .osc/plans/done/127-ab-comparison-pilot-harness.md` — 0 issues
- `npm run osc -- pr-summary 126-pr-native-evidence-surface` — renders stage done, 5/5 AC, evidence present
- `npm run osc -- pr-summary 127-ab-comparison-pilot-harness` — renders stage done, 5/5 AC, evidence present
- `npm run osc -- ab check docs/examples/ab-comparison` — well-formed
- `npm test -- --run` — 50 files, 481 tests passed

## Non-goals / gates

- No npm publish.
- No GitHub Release.
- No package version bump.
- No actual A/B experiment run yet.
- No public claim that Open Scaffold improves outcomes.
- Merge remains owner-gated.
