### PR TITLE
Prove zero-context resume from repo state

### DIFF
--- a/.osc/plans/active/129-zero-context-resume-proof.md
+++ b/.osc/plans/active/129-zero-context-resume-proof.md
@@ -1,0 +1,159 @@
+# Plan: 129-zero-context-resume-proof
+
+## Status
+
+active
+
+
+**Approval state:** approved for execution by owner. AC-7 interpretation approved: feature the zero-context-resume narrative prominently in the README first screen, immediately after the locked work-record promise paragraph, without displacing existing positioning tokens. Consensus-approved by `/ralplan --consensus` (Planner → Architect → Critic, 2 iterations: Architect **SOUND**, Critic **APPROVE**). No commit, push, publish, release, merge, or PR without a separate owner gate.
+
+## Context
+
+The deep-interview spec `.omc/specs/deep-interview-improve-open-scaffold.md` (run `deep-interview-improve-open-scaffold-20260529-100813`, final ambiguity 16%) crystallized Open Scaffold's headline promise — *a fresh AI agent (or its solo-dev operator) can resume bounded work straight from the repo after total chat-context loss, with no re-explaining* — into one provable slice. Today that promise is asserted in prose but never demonstrated by a committed, deterministic artifact, and several first-contact frictions undercut trust: the `npx open-scaffold compare` "30-second" demo fails because `examples/` is not in `package.json` `files`; the version story is split (git tag `v1.0.5` vs `package.json` `0.20.2`); ~40 flat docs have no single front door; and `.osc`/`.omc`/`.omx`/`.osc-dev` + run packet / glass cockpit / OMC / OMX / Codex / operator surface are unexplained. This plan turns the promise into proof and removes the friction, without growing the CLI surface or the core protocol.
+
+## Goal
+
+Ship one slice that makes zero-context resume **provable and legible**: a committed sample repo-state fixture, a deterministic golden-snapshot resume test, a fixed `npx` compare demo, and four docs/positioning deliverables — without adding a new stable `osc` command, changing the core protocol, adding a runtime dependency, or overclaiming.
+
+## Constraints / Out of scope
+
+- **No new stable `osc` command** (`osc resume`/`osc next` are out). Reconstruction reuses existing library internals and/or a test-only helper; nothing is registered in `cli.ts` dispatch, `osc --help`, or the `docs/STABILITY.md` stable-command list. This is CI-enforced (see AC-10 / the CLI-absence guard), not left to intent — note `dist/resume.js` ships publicly via `files: ["dist"]`, so the guard is the test.
+- **No core protocol-contract change; core stays non-spawning.**
+- **Zero new runtime dependencies.** The resume test is deterministic with **no LLM/model call in default CI**.
+- **Do not break existing `osc` commands;** `./verify.sh --strict`, `npm test`, `npm run build` must stay green; `tests/public-positioning.test.ts` and `tests/first-run-docs.test.ts` must stay green.
+- **No enterprise/compliance/regulator-ready overclaim.**
+- **Out of scope:** a real LLM-agent resume in default CI (documented walkthrough or optional manual/key-gated eval only); a user-facing `osc resume`/`osc next` command (backlog); telemetry/adoption analytics; any commit/push/publish/release (separate owner-gated step).
+
+## Files to touch
+
+- `examples/resume-demo/**` (new) — committed mid-flight `.osc`-shaped fixture: exactly **1** active plan (7-section handoff-schema-conformant, ≥1 unchecked acceptance criterion), exactly **1** amendment to that plan (must **not** re-scope acceptance criteria), ≥1 done/closed slice, ≥1 evidence/release note, and a mini `MISSION.md` so mission reads as defined. (AC-1)
+- `examples/resume-demo/expected-resume-summary.json` (new) — the committed **golden file**: the normalized expected `ResumeSummary` (relative-to-fixture paths, stable key order, no timestamps, `root` stripped). (AC-3)
+- `src/resume.ts` (new) — **test-only** library composer. Exported for vitest, **NOT** wired to `cli.ts` dispatch/help/STABILITY. Builds the `ResumeSummary` (schema below) by reusing `inspectScaffold`, `parsePlanFile`/`splitSections`, the `buildTrace` report builder, `parseChecklist`, and amendment-sibling enumeration. (AC-2, AC-4)
+- `tests/resume-snapshot.test.ts` (new) — golden-diff test (reconstructed summary vs golden file; fails on drift), determinism check, next-bounded-action check, single-active assertion, and the amendment-present assertion. Deterministic; no LLM; no new dep. (AC-3, AC-4)
+- `package.json` (`files` field **only**) — ship the compare-demo payload and the resume-demo fixture: add `examples/attempt-compare` and `examples/resume-demo` explicitly (not the whole `examples/`, to avoid shipping unrelated heavy fixtures). **`dependencies` unchanged.** (AC-5; AC-10)
+- `tests/package-payload.test.ts` — extend: assert the compare-demo inputs (`examples/attempt-compare/attempt-a`, `attempt-b` and their files) appear in `npm pack --dry-run --json` output. (AC-5)
+- `docs/START_HERE.md` (new) — single authoritative front door routing a solo-dev + their agent to the one first action; contains the literal adopter first command and links the resume demo + walkthrough. (AC-6)
+- `README.md` + `docs/index.html` — add the zero-context-resume narrative **immediately after** the locked work-record promise paragraph (no positioning-token displacement, forbidden vocabulary avoided); link the resume demo + golden-snapshot walkthrough. (AC-7)
+- `docs/VERSION_TRUTH.md` (new) — canonical reconciliation page: git tag `v1.0.5` (historical) vs `package.json` `0.20.2` (current/pre-1.0), stable vs experimental. (AC-8)
+- `docs/GLOSSARY.md` (new) — jargon + boundary glossary: run packet, glass cockpit, OMC / OMX / Codex, operator surface, `.osc` / `.omc` / `.omx` / `.osc-dev`, plus a one-line core-vs-adapter boundary statement. (AC-9)
+- `docs/RESUME_WALKTHROUGH.md` (new) — narrated real-agent resume showing the **actual** `osc status` / `osc trace` output and stating the consolidated summary is reconstructed by the project's tooling/test, not emitted by one shipped command today (future `osc resume` noted as backlog). Documented, **not** run in CI. Its displayed next-action must equal the golden file's `next_bounded_action`. (AC-7)
+- `tests/resume-docs.test.ts` (new) — self-checks (AC-6–AC-9, AC-10): START_HERE exists + linked from README first 80 lines + contains the literal first command; resume-hook placement (after the promise paragraph, within the first screen, no token displacement); VERSION_TRUTH positive-token reconciliation across README/STABILITY/CHANGELOG; GLOSSARY defines all 6 term groups; the no-overclaim **disclaimer sentence is present**; and the **CLI-absence guard** (`resume`/`next` absent from `osc --help`, the dispatch switch, and the STABILITY stable-command-list block).
+
+### `ResumeSummary` schema (`open-scaffold.resume.v1`)
+
+```jsonc
+{
+  "schema": "open-scaffold.resume.v1",
+  "mission": { "defined": true },
+  "active_plan": {
+    "slug": "...", "stage": "active", "status": "...", "goal": "...",
+    "acceptance_criteria": [ { "text": "...", "checked": false } ]   // from parseChecklist on the raw "Acceptance criteria" section
+  },
+  "amendments": { "count": 1, "ids": ["<slug>-amendment-1"] },        // enumerated from <slug>-amendment-<n>.md siblings; REPORTED, not used in derivation
+  "work_done": {
+    "done_slices": ["..."],                                          // inspectScaffold plans.done
+    "evidence": ["..."]                                              // buildTrace links: release_note / evidence_reference (fixture-relative)
+  },
+  "status": "active plan <slug>; N/M acceptance criteria complete",
+  "next_bounded_action": "<text of first unchecked AC>"               // first unchecked from the SAME parseChecklist list; ∈ acceptance_criteria by construction
+}
+```
+
+Determinism rules: one shared normalization helper strips `TraceReport.root` and rebases `path`/`target_path`/`source_path` to the **fixture** root; arrays sorted deterministically (by slug/filename); no `Date`/env-derived fields. The same helper is used by both the golden test and the walkthrough↔golden comparison so path-shapes cannot mismatch. Derivation pins **`scaffold.ts:parseChecklist`** as the single AC parser for both `acceptance_criteria` and `next_bounded_action`. The composer **asserts exactly one active plan** (throws if `active.length !== 1`). Amendments are **reported** in the payload but **excluded** from next-action derivation (acknowledged v1 limitation; fixture amendment must not re-scope ACs).
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|-------------|----------------|
+| T1 | Build `examples/resume-demo/` fixture (1 active plan w/ ≥1 unchecked AC, 1 amendment, ≥1 done slice, evidence note, mini MISSION.md) — AC-1 | None | A |
+| T2 | `docs/GLOSSARY.md` (6 term groups + core-vs-adapter line) — AC-9 | None | A |
+| T3 | `docs/VERSION_TRUTH.md` + reconcile version tokens — AC-8 | None | A |
+| T4 | `package.json` `files` add + extend `tests/package-payload.test.ts` — AC-5 | None | A |
+| T7 | `docs/START_HERE.md` front door — AC-6 | None | A |
+| T5 | `src/resume.ts` test-only composer (schema above) — AC-2, AC-4 | T1 | B |
+| T6 | `tests/resume-snapshot.test.ts` + `examples/resume-demo/expected-resume-summary.json` golden — AC-3, AC-4 | T5 | B |
+| T8 | README + `docs/index.html` resume narrative + `docs/RESUME_WALKTHROUGH.md` (real output; walkthrough↔golden) — AC-7 | T1, T6 | C |
+| T9 | `tests/resume-docs.test.ts` self-checks + CLI-absence guard — AC-6–AC-9, AC-10 | T2, T3, T7, T8 | D |
+| T10 | Full gate: `npm run build`, `npm test`, `./verify.sh --strict` — AC-10 | all | D |
+
+### Parallel groups
+
+- **Group A** (independent authoring; distinct files, no shared edits): T1, T2, T3, T4, T7.
+- **Group B** (resume engine; depends on the fixture): T5 → T6.
+- **Group C** (positioning; depends on fixture + golden so the walkthrough shows real, golden-consistent output): T8.
+- **Group D** (verification): T9 → T10.
+
+### Dependencies
+
+- T5/T6 depend on T1 (composer + golden need the fixture).
+- T8 depends on T1 (links the demo path) and T6 (walkthrough's displayed next-action must equal the golden `next_bounded_action`).
+- T9 depends on the docs it checks (T2, T3, T7, T8); T10 depends on everything.
+
+### Delegation notes / conflict flags
+
+- **Single-owner files** (no two parallel tasks edit the same file): `README.md` (T8), `package.json` (T4), `docs/index.html` (T8).
+- **AC-7 inner gate:** T8 must run `npm test -- public-positioning` before finishing — the README's first 80 lines are contract-locked (exact promise string + tokens `goal`/`plan`/`handoff`/`evidence`/`approval`/`lessons`; forbidden vocabulary `agent OS`/`control plane`/`compliance-grade`/`operating system`/`tamper-proof`). The resume narrative lands after the promise paragraph and must not displace those tokens.
+- **Fixture/scanner interaction (verified safe):** `./verify.sh` is strictly root-anchored (literal `"$ROOT/.osc/..."` paths, no recursive descent), and `tests/package-payload.test.ts`'s forbidden-path regex is anchored at the package root (`startsWith('.osc/plans/active/')`), so the fixture's `examples/resume-demo/.osc/plans/active/*.md` is invisible to both. Documented exemption: the fixture's active-plan files **ship to npm** via `examples/resume-demo` in `files` (harmless; do **not** later tighten the payload regex to scan all `.osc/` subtrees without re-checking this).
+
+## Implementation Architecture Coverage
+
+- **Strengthens:** evaluation (acceptance criteria become a deterministic, committed proof) and recovery/ownership (resume-from-repo demonstrated end-to-end).
+- **Audit envelope:** spec run `deep-interview-improve-open-scaffold-20260529-100813`; plan `129-zero-context-resume-proof`; the fixture + golden file + vitest tests are the durable evidence; an `.osc/releases/` note at close.
+- **Evaluation envelope:** AC-1…AC-10 are checked by `npm test` (`resume-snapshot`, extended `package-payload`, `resume-docs`) + `./verify.sh --strict`; every AC maps to a named verification step below.
+- **Feedback routing:** drift in the resume summary fails CI; doc/version drift fails the self-check tests; new learnings become an amendment to this plan.
+- **Boundary (out of this slice):** no runtime execution, no credentials, no new command surface, no compliance certification; real-LLM resume stays a walkthrough/optional eval; a user-facing `osc resume` is a separate, explicitly-approved future plan.
+
+## Acceptance criteria
+
+- [ ] **AC-1** A committed `examples/resume-demo/` fixture exists representing a mid-flight project: exactly 1 active plan (≥1 unchecked AC), exactly 1 amendment, ≥1 done/closed slice, and evidence signals.
+- [ ] **AC-2** A deterministic reconstruction (test-only helper reusing existing library internals — **no new stable command**) builds a `ResumeSummary` containing at minimum: active plan, work-done/evidence signals, **amendments applied/acknowledged** (explicit `amendments` field), current status, and next bounded action.
+- [ ] **AC-3** A vitest test compares the reconstructed summary against the committed golden file and fails on drift. No LLM/model call in default CI; no new runtime dependency.
+- [ ] **AC-4** The summary's `next_bounded_action` deterministically matches the fixture's single unambiguous next slice (first unchecked AC of the single active plan via `parseChecklist`; `next_bounded_action ∈ acceptance_criteria`; composer throws if `active.length !== 1`).
+- [ ] **AC-5** `npx open-scaffold compare …` works from a fresh install (its payload ships); a payload test asserts the demo inputs are present in the published package.
+- [ ] **AC-6** A single authoritative `docs/START_HERE.md` routes a solo-dev + agent to the first action in one hop (exists + linked from README's first 80 lines + contains the literal first command).
+- [ ] **AC-7** README + `docs/index.html` feature the zero-context-resume narrative in the first screen (immediately after the locked promise paragraph) and link the resume demo + golden-snapshot walkthrough; the walkthrough shows real `osc status`/`osc trace` output with the no-overclaim disclaimer.
+- [ ] **AC-8** One version/release-truth page reconciles git tag `v1.0.5` (historical) vs `package.json` `0.20.2` (current) and states stable vs experimental, with no contradictions across README / `docs/STABILITY.md` / `docs/CHANGELOG.md` (positive-token assertions).
+- [ ] **AC-9** A jargon + boundary glossary defines run packet, glass cockpit, OMC / OMX / Codex, operator surface, `.osc` / `.omc` / `.omx` / `.osc-dev`, plus a one-line core-vs-adapter boundary statement.
+- [ ] **AC-10** No new stable `osc` command (CLI-absence guard green), no core protocol change, no new runtime dependency, no overclaim; existing `osc` commands unchanged; `./verify.sh --strict`, `npm test`, `npm run build` pass.
+
+## Verification steps
+
+1. `npm run build` → exits 0.
+2. `npm test` → all vitest pass, including new `tests/resume-snapshot.test.ts`, extended `tests/package-payload.test.ts`, and new `tests/resume-docs.test.ts`. (AC-3, AC-5, AC-6–AC-9)
+3. **Determinism (AC-3):** run `resume-snapshot.test.ts` twice and on a clean checkout → identical; intentionally mutate the fixture → the test fails (drift caught).
+4. **Next-action (AC-4):** in a scratch copy, flip the active plan's first unchecked AC → `next_bounded_action` changes accordingly; assert the composer throws when `active.length !== 1`; assert `next_bounded_action ∈ acceptance_criteria`.
+5. **Amendments (AC-2):** assert the golden summary has `amendments.count === 1` and contains the fixture's amendment id.
+6. **Demo (AC-5):** `npm pack --dry-run --json` lists `examples/attempt-compare/**`; extract the tarball and run `node dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` → exits 0.
+7. **No new command (AC-10):** `osc --help` and the `cli.ts` dispatch contain no `resume`/`next` subcommand; the `docs/STABILITY.md` stable-command-list block contains no `resume`; `git diff package.json` shows no change under `dependencies`.
+8. **Glossary (AC-9):** `resume-docs.test.ts` asserts all 6 term groups (run packet; glass cockpit; OMC/OMX/Codex; operator surface; `.osc`/`.omc`/`.omx`/`.osc-dev`; core-vs-adapter boundary line) are present.
+9. **Version truth (AC-8):** `resume-docs.test.ts` asserts positive reconciliation tokens (`v0.20.x` current/pre-1.0, `v1.0.5` historical) in README + STABILITY + CHANGELOG.
+10. **Walkthrough consistency (AC-7):** the displayed next-action in `docs/RESUME_WALKTHROUGH.md` equals the golden file's `next_bounded_action`; the disclaimer sentence is present.
+11. **No regression:** `tests/public-positioning.test.ts` and `tests/first-run-docs.test.ts` still pass.
+12. `./verify.sh --strict` → exits 0 (the nested fixture `.osc/` does not trip amendment/changelog checks).
+
+## Open questions
+
+- **AC-7 "lead with" interpretation (decision needed at approval):** the README's first 80 lines are contract-locked by `tests/public-positioning.test.ts` (exact promise string at the top), so literal "resume narrative as the first content" is **impossible** without breaking that test. This plan commits to *"prominently featured in the first screen, immediately after the locked promise paragraph, no positioning-token displacement."* **Confirm this interpretation is acceptable, or relax the public-positioning lock.** (Surfaced by the Critic; both reviewers agree this is a human decision.)
+- **`next_bounded_action` null-handling (backlog):** if a future fixture leaves all ACs checked, the derivation yields no next action. The committed fixture is mid-flight (≥1 unchecked) so the golden snapshot is unaffected; the schema should later state whether `next_bounded_action` is nullable and what the summary says when work is complete.
+- **`dist/resume.js` public-import surface (backlog):** the test-only composer ships in `dist` (via `files: ["dist"]`) and is guarded only by the CLI-absence test. A follow-up may exclude it from `dist` via tsconfig so an external importer of `open-scaffold/dist/resume.js` does not silently depend on a test-only internal.
+
+## ADR
+
+- **Decision:** Implement the AC-2 reconstruction as a **test-only library composer** (`src/resume.ts`) that reuses existing library internals (`inspectScaffold`, `parsePlanFile`/`splitSections`, `buildTrace`, `parseChecklist`, amendment-sibling enumeration), exported for the vitest golden test and **not** registered as an `osc` subcommand.
+- **Drivers:** determinism + zero-dep; reuse existing surfaces; honor "no new stable command"; avoid acceptance-criteria parser drift (the codebase already has three divergent AC extractors — `parseChecklist`, `parseAcceptanceCriteria`, `parsePlanFile`→`bulletItems`).
+- **Alternatives considered:** **(B)** a pure `tests/` helper reading fixture files directly — strongest no-core-change guarantee, but would re-implement parsing and **institutionalize the existing parser drift into a fourth path**. **(C)** compose `osc status --json` + `osc trace --json` stdout in the test — most literal "reuse existing surfaces," but neither command emits a consolidated `next_bounded_action`, and merging two CLI outputs is brittle.
+- **Why chosen:** Option A is deterministic, reuses the canonical parsers (no new drift), pins a single AC parser so the summary's AC list and next-action cannot diverge, and adds **zero new stable-command surface** — satisfying the moat constraint while still producing the full structured summary (including amendments and next-action). The "test-only" boundary is converted from intent into a CI-guarded invariant (CLI-absence guard).
+- **Consequences:** `src/resume.ts` exists as library code reachable only from tests; `dist/resume.js` is published but undocumented/unwired and guarded by the absence test. A real user-facing `osc resume`/`osc next` would be a separate, explicitly-approved command plan.
+- **Follow-ups:** optional `osc resume`/`osc next` stable command (backlog); optional key-gated real-LLM resume eval (backlog); `dist` exclusion for `resume.ts` (backlog); `next_bounded_action` null-handling schema (backlog).
+
+<!--
+Consensus provenance (ralplan --consensus --direct):
+- Planner: drafted plan + RALPLAN-DR (principles/drivers/options) + ADR.
+- Architect iter 1: SOUND-WITH-CHANGES (5 changes) — disproved the nested-.osc top risk (verify.sh root-anchored), confirmed AC-5 root cause empirically.
+- Critic iter 1: ITERATE (6 bounded spec-precision items, no CRITICAL).
+- Architect iter 2: SOUND ("ship to executor"); endorsed the C4 cross-check deviation.
+- Critic iter 2: APPROVE — all 6 items resolved; C4 deviation accepted on merits.
+RALPLAN-DR principles: (1) prove-don't-claim, (2) reuse surfaces / no new stable command, (3) determinism over fidelity in CI, (4) single front door, (5) truth without overclaim.
+-->

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Open Scaffold gives AI-assisted work a durable repo record.
 
 It keeps the goal, plan, handoff, evidence, approval trail, and lessons from repeated attempts in git-tracked files that a human, agent, runtime, or future session can inspect cold.
 
+Any agent or operator can **resume bounded work straight from the repo after total chat-context loss** — no re-explaining needed. Start at [`docs/START_HERE.md`](docs/START_HERE.md), try the committed mid-flight fixture at [`examples/resume-demo/`](examples/resume-demo/), or read the narrated path in [`docs/RESUME_WALKTHROUGH.md`](docs/RESUME_WALKTHROUGH.md).
+
 Use it when AI-assisted work needs **control**, **clarity**, **reviewability**, **handoff**, or **improvement over time**.
 
 It does not replace your agent, IDE, task tracker, CI, or compliance process. Those tools do the work or run the program. Open Scaffold records what was asked, what was handed off, what came back, what was checked, and what humans approved. For the boundary between structural evidence and process assurance, see [`docs/AUDITABILITY.md`](docs/AUDITABILITY.md).
@@ -300,7 +302,7 @@ Use cases the current contract supports today:
 - teams that want PRs to carry intent, evidence, and approval state;
 - consulting or audit-sensitive delivery where later readers need to reconstruct what happened.
 
-Publication truth lives outside git, and the two public surfaces move separately. Check `npm view open-scaffold version dist-tags --json` to see which package `npx open-scaffold@latest` installs. Check the GitHub Release marked **Latest** to see which release note GitHub highlights. The historical `v1.0.x` tags remain published history; the current forward-moving line is `v0.20.x` until the protocol and product surface earn a real 1.0 again. See [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
+Publication truth lives outside git, and the two public surfaces move separately. Check `npm view open-scaffold version dist-tags --json` to see which package `npx open-scaffold@latest` installs. Check the GitHub Release marked **Latest** to see which release note GitHub highlights. The historical `v1.0.5` / `v1.0.x` tags remain published history; the current forward-moving line is `v0.20.x` until the protocol and product surface earn a real 1.0 again. See [`docs/VERSION_TRUTH.md`](docs/VERSION_TRUTH.md), [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
 
 ---
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,40 @@
+# Glossary
+
+Definitions for terms that appear across Open Scaffold docs, plans, and runtime harness documentation. Each entry states what the term means in this project's context.
+
+---
+
+## run packet
+
+A repo-native handoff package stored at `.osc/runs/<run_id>/run.json`. It captures the plan, task, executor lane, runtime preset, operator surface, and any binding constraints needed for a worker (agent, human, or runtime) to begin bounded work without re-reading the full chat history. The core scaffold creates run packets; external agents or adapters do the work and return receipts or evidence. See [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md) for the full `task_id` / `run_id` / `question_id` identity model.
+
+## glass cockpit
+
+An event stream protocol for real-time status broadcasting. A glass cockpit transport relays structured events — status updates, blockers, questions, approvals, evidence receipts, and PR links — to a human-facing channel such as Discord, Slack, or a local dashboard. It is an opt-in lab/experimental surface: the core work-record loop does not require it. See [`docs/GLASS_COCKPIT_PROTOCOL.md`](GLASS_COCKPIT_PROTOCOL.md) for the event vocabulary.
+
+## OMC / OMX / Codex
+
+Runtime harnesses that extend a base agent with workflow modes.
+
+- **OMC** (Oh-My-ClaudeCode): a runtime harness for Claude Code. It provides workflow skills (`/team`, `/ralph`, `/ultrawork`, `/ralplan`) and orchestration tooling on top of the Claude Code CLI. OMC is not itself an orchestrator; it is a harness that routes work to specialized sub-agents.
+- **OMX** (Oh-My-Codex): the equivalent harness for OpenAI Codex. It provides parallel workflow commands (`$team`, `$ralph`, `$ultrawork`, `$ralplan`) on top of the Codex CLI.
+- **Codex**: OpenAI's coding agent. In this project, "Codex" refers to the CLI agent, not to the historical Codex language model.
+
+OMC and OMX are **not** orchestrators in the same sense as Hermes or Claw/OpenClaw. They are harnesses that add workflow modes to a base agent. See [`docs/OPEN_SCAFFOLD_SYSTEM.md`](OPEN_SCAFFOLD_SYSTEM.md) for the ontology.
+
+## operator surface
+
+The human-facing side of a run. An operator surface is where a human receives questions from the agent (`question_id`), approves or rejects decisions, and feeds back corrections. In a typical run, the operator surface is a chat thread, a Discord channel, or a CLI session. The glass cockpit protocol is the formalized event vocabulary for the operator surface; the run packet's `operator_surface` field identifies which surface is active for a given run. See [`docs/TASK_RUN_MODEL.md`](TASK_RUN_MODEL.md).
+
+## Directory namespaces
+
+| Path | What lives there |
+|---|---|
+| `.osc/` | Open Scaffold core: `plans/`, `runs/`, `releases/`, `specs/`, and state. The repo-native work record. Ships with the npm package. |
+| `.omc/` | OMC runtime harness state: session state, notepad, plans managed by the OMC layer, research, logs. Not shipped in the public package. |
+| `.omx/` | OMX runtime harness state: equivalent of `.omc/` for the Codex/OMX harness. |
+| `.osc-dev/` | Owner workspace: full internal decision history, ADRs, specs, and snapshots for the open-scaffold project itself. Gitignored; not present in cloned templates or published packages. |
+
+## Core-vs-adapter boundary
+
+**Open Scaffold core is non-spawning.** Core creates and reads repo artifacts (plans, run packets, evidence notes, trace reports) and exposes a CLI for the work-record loop. It does not launch agents, call provider APIs, or execute work on its own. Work execution is adapter-owned: an external agent or runtime harness (OMC, OMX, a custom adapter) receives a run packet, does the work, and returns receipts or evidence to the scaffold.

--- a/docs/RESUME_WALKTHROUGH.md
+++ b/docs/RESUME_WALKTHROUGH.md
@@ -1,0 +1,155 @@
+# Zero-Context Resume Walkthrough
+
+This walkthrough shows how a fresh AI agent, or its solo-developer operator, can resume bounded work straight from the repo after total chat-context loss — no re-explaining needed.
+
+The example uses the committed mid-flight fixture at `examples/resume-demo/`. The command output below is taken from that fixture with the local CLI build.
+
+> **Disclaimer:** The consolidated resume summary shown at the end is reconstructed by test tooling (`src/resume.ts` + `tests/resume-snapshot.test.ts`). It is not emitted by a shipped stable command today, and Open Scaffold core still does not spawn an agent.
+
+---
+
+## The scenario
+
+You open a repo you have not touched in a week. There is no open chat context. The agent has no memory of previous discussion. The only source of truth is the repository.
+
+The repo contains:
+
+- one active plan: `demo-add-greeting`;
+- one amendment: `demo-add-greeting-amendment-1`;
+- one closed slice: `scaffold-init`;
+- one evidence note under `.osc/releases/`.
+
+---
+
+## Step 1 — Check what is in flight
+
+Run `osc status` from the fixture root:
+
+```text
+$ cd examples/resume-demo
+$ node ../../dist/cli.js status
+Open Scaffold status
+Namespace: .osc
+Mission: defined
+active: 1
+  - demo-add-greeting
+backlog: 0
+blocked: 0
+done: 1
+  - scaffold-init
+```
+
+The repo tells the fresh reader that there is exactly one active slice and one completed setup slice.
+
+---
+
+## Step 2 — Replay the work-record chain
+
+Run `osc trace demo-add-greeting` to inspect the active plan:
+
+```text
+$ node ../../dist/cli.js trace demo-add-greeting
+Open Scaffold trace: demo-add-greeting
+Status: active
+Stage: active
+Path: .osc/plans/active/demo-add-greeting.md
+Goal: Implement a greeting module that returns "Hello, <name>!" and records each greeting to the releases folder.
+
+Acceptance criteria:
+  - AC1 [x] Greeting module exports a greet function that returns the string "Hello, <name>!".
+  - AC2 [ ] Greeting history is written to the releases folder as an evidence note on each run.
+  - AC3 [ ] All greeting tests pass (npm test exits 0).
+
+Links:
+  [local] plan_file: .osc/plans/active/demo-add-greeting.md — Plan file found in local scaffold stage.
+  [local] acceptance_criterion: AC1 — Greeting module exports a greet function that returns the string "Hello, <name>!".
+  [local] acceptance_criterion: AC2 — Greeting history is written to the releases folder as an evidence note on each run. (unchecked)
+  [local] acceptance_criterion: AC3 — All greeting tests pass (npm test exits 0). (unchecked)
+  [missing] run_packet: .osc/runs/*/run.json — No local run packet found for demo-add-greeting.
+  [missing] release_note: .osc/releases/*-demo-add-greeting.md — No local release/evidence note found for demo-add-greeting.
+
+Summary: local=4, external=0, missing=2, unverified=0
+```
+
+The next bounded action is the first unchecked acceptance criterion:
+
+```text
+Greeting history is written to the releases folder as an evidence note on each run.
+```
+
+---
+
+## Step 3 — Reconstructed resume summary
+
+The resume summary below is reconstructed by `src/resume.ts`, a test-only helper that reuses existing scaffold/trace internals, and verified deterministically by `tests/resume-snapshot.test.ts` against `examples/resume-demo/expected-resume-summary.json`.
+
+```json
+{
+  "schema": "open-scaffold.resume.v1",
+  "mission": {
+    "defined": true
+  },
+  "active_plan": {
+    "slug": "demo-add-greeting",
+    "stage": "active",
+    "status": "active",
+    "goal": "Implement a greeting module that returns \"Hello, <name>!\" and records each greeting to the releases folder.",
+    "acceptance_criteria": [
+      {
+        "text": "Greeting module exports a greet function that returns the string \"Hello, <name>!\".",
+        "checked": true
+      },
+      {
+        "text": "Greeting history is written to the releases folder as an evidence note on each run.",
+        "checked": false
+      },
+      {
+        "text": "All greeting tests pass (npm test exits 0).",
+        "checked": false
+      }
+    ]
+  },
+  "amendments": {
+    "count": 1,
+    "ids": [
+      "demo-add-greeting-amendment-1"
+    ]
+  },
+  "work_done": {
+    "done_slices": [
+      "scaffold-init"
+    ],
+    "evidence": [
+      ".osc/releases/2026-05-10-scaffold-init.md"
+    ]
+  },
+  "status": "active plan demo-add-greeting; 1/3 acceptance criteria complete",
+  "next_bounded_action": "Greeting history is written to the releases folder as an evidence note on each run."
+}
+```
+
+The `next_bounded_action` value is derived deterministically from the first unchecked acceptance criterion of the single active plan. The snapshot test asserts it does not drift.
+
+---
+
+## What the agent does next
+
+With this summary, a fresh agent knows:
+
+1. **Mission:** defined — no need to ask what the project is for.
+2. **Active work:** one plan, `demo-add-greeting`, with a scope clarification in `demo-add-greeting-amendment-1`.
+3. **Progress:** one of three criteria is done; the greeting export does not need to be repeated.
+4. **Next step:** implement evidence-note writing: `Greeting history is written to the releases folder as an evidence note on each run.`
+5. **Prior art:** the closed `scaffold-init` slice and its evidence note show the starting structure already exists.
+
+No chat history. No re-explaining. The repo is the context.
+
+---
+
+## Links
+
+- Fixture: [`examples/resume-demo/`](../examples/resume-demo/)
+- Golden file: [`examples/resume-demo/expected-resume-summary.json`](../examples/resume-demo/expected-resume-summary.json)
+- Resume composer (test-only): [`src/resume.ts`](../src/resume.ts)
+- Snapshot test: [`tests/resume-snapshot.test.ts`](../tests/resume-snapshot.test.ts)
+- Front door: [`docs/START_HERE.md`](START_HERE.md)

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -9,7 +9,7 @@ The historical `v1.0.x` packages and GitHub Releases remain available for proven
 ## Release status
 
 - Current cadence: pre-1.0 hardening on the `v0.20.x` line.
-- Historical note: `v1.0.x` exists as a previously published launch line and remains immutable package/release history.
+- Historical note: `v1.0.x` exists as a previously published launch line (most recent tag: `v1.0.5`) and remains immutable package/release history.
 - Current repository package version: check `package.json`.
 - Live npm package truth: check `npm view open-scaffold version dist-tags --json`.
 - Live GitHub release truth: check the GitHub Releases page and the release marked **Latest**.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,0 +1,47 @@
+# Start Here
+
+The single first action for a solo developer or their AI agent entering this repository cold.
+
+## What is Open Scaffold?
+
+Open Scaffold gives AI-assisted work a durable repo record. It keeps the goal, plan, handoff, evidence, approval trail, and lessons in git-tracked files — so any agent or future session can pick up work without relying on vanished chat context.
+
+- **Version info:** see [`docs/VERSION_TRUTH.md`](VERSION_TRUTH.md) for the current package line and historical tags.
+- **Jargon:** see [`docs/GLOSSARY.md`](GLOSSARY.md) for run packet, glass cockpit, OMC/OMX, operator surface, and namespace definitions.
+
+## The one first action
+
+```bash
+npx open-scaffold init --tier min --target .
+```
+
+Run it from the repo you want to scaffold. This adds the minimal scaffold to the current directory: `MISSION.md`, `.osc/plans/`, and `.osc/releases/`.
+
+After that: define your mission in `MISSION.md`, create a plan with `osc plan new <slug> --stage active`, hand it off with a run packet or amendment, capture evidence, verify, and close the slice.
+
+## See the core idea before adopting
+
+From this repository checkout, run the 30-second demo — no runtime, no provider account needed:
+
+```bash
+npx open-scaffold@latest compare \
+  examples/attempt-compare/attempt-a \
+  examples/attempt-compare/attempt-b
+```
+
+To see what zero-context resume looks like in practice, explore `examples/resume-demo/`. It is a committed mid-flight project snapshot: one active plan with unchecked acceptance criteria, one amendment, one closed slice, and an evidence note — everything a new agent or session needs to reconstruct bounded next work without any chat history.
+
+See [`docs/RESUME_WALKTHROUGH.md`](RESUME_WALKTHROUGH.md) for the narrated walkthrough and the no-overclaim disclaimer about what is and is not a shipped stable command today.
+
+## Where to go next
+
+| I want to… | Go to |
+|---|---|
+| Understand the project mission and goals | [`MISSION.md`](../MISSION.md) |
+| See the current roadmap | [`ROADMAP.md`](../ROADMAP.md) |
+| Learn the core work-record loop | [`README.md`](../README.md) |
+| Understand the version story | [`docs/VERSION_TRUTH.md`](VERSION_TRUTH.md) |
+| Look up unfamiliar terms | [`docs/GLOSSARY.md`](GLOSSARY.md) |
+| Understand the system boundary map | [`docs/OPEN_SCAFFOLD_SYSTEM.md`](OPEN_SCAFFOLD_SYSTEM.md) |
+| Try the resume fixture | `examples/resume-demo/` |
+| Read the zero-context resume walkthrough | [`docs/RESUME_WALKTHROUGH.md`](RESUME_WALKTHROUGH.md) |

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -1,0 +1,33 @@
+# Version Truth
+
+This page is the canonical reconciliation between the current package version and the historical git tag line. Check it when the numbers look contradictory.
+
+## Current line: `v0.20.x` (pre-1.0 hardening)
+
+- **Current `package.json` version:** `0.20.2`
+- **npm latest:** check `npm view open-scaffold version dist-tags --json` for live truth.
+- **GitHub Release latest:** check the GitHub Releases page for the release marked **Latest**.
+- **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
+
+Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.
+
+## Historical line: `v1.0.x` (including `v1.0.5`)
+
+- **Most recent historical tag:** `v1.0.5` — published as `open-scaffold@1.0.5` on the historical `v1.0.x` launch line.
+- **Status:** immutable historical artifacts. The `v1.0.x` packages remain available on npm for provenance; they are not erased.
+- **Why it is not the current line:** the `v1.0.x` launch was premature. The project reset to a pre-1.0 `v0.20.x` hardening cadence at `v0.20.0` to earn the long-term stable contract honestly. A future real 1.0 requires the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives to feel durable enough to sustain that promise.
+
+## Stable vs experimental in the current line
+
+The `v0.20.x` line defines a stable-enough core (the repo-native work-record loop, the 7-section plan schema, lifecycle helpers, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). See [`docs/STABILITY.md`](STABILITY.md) for the full listing.
+
+## Summary
+
+| Surface | Value |
+|---|---|
+| `package.json` version | `0.20.2` |
+| Current package line | `v0.20.x` (pre-1.0) |
+| Most recent historical tag | `v1.0.5` |
+| Historical package line | `v1.0.x` (over-eager launch; not current) |
+| npm live truth | `npm view open-scaffold version` |
+| GitHub live truth | GitHub Releases → Latest |

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,6 +122,7 @@
         <div>
           <h1>AI work needs a repo record.</h1>
           <p class="lead">Open Scaffold keeps the goal, plan, handoff package, evidence, approval trail, and lessons from repeated AI-assisted attempts in files your team can review.</p>
+          <p>Any agent or operator can <strong>resume bounded work straight from the repo after total chat-context loss</strong> — no re-explaining needed. See the <a href="../examples/resume-demo/">resume demo fixture</a> and the <a href="RESUME_WALKTHROUGH.md">resume walkthrough</a>.</p>
         </div>
         <aside class="panel">
           <h2>First command</h2>

--- a/examples/resume-demo/.osc/plans/active/demo-add-greeting-amendment-1.md
+++ b/examples/resume-demo/.osc/plans/active/demo-add-greeting-amendment-1.md
@@ -1,0 +1,21 @@
+# Amendment 1: demo-add-greeting
+
+## Parent
+
+demo-add-greeting
+
+## Date
+
+2026-05-15
+
+## Learning
+
+After reviewing the initial approach, the greeting module should use a factory function pattern instead of a plain function export, to make future extension easier. This does not change any acceptance criterion.
+
+## New direction
+
+Use `createGreeter()` returning an object with a `greet` method instead of a bare function export. The module interface changes internally but the acceptance criteria describe observable outcomes, not the internal structure.
+
+## Impact on acceptance criteria
+
+None — all acceptance criteria remain unchanged. The observable behavior (greet function returns "Hello, <name>!", history written to releases, tests pass) is unaffected by the internal factory pattern change.

--- a/examples/resume-demo/.osc/plans/active/demo-add-greeting-amendment-1.md
+++ b/examples/resume-demo/.osc/plans/active/demo-add-greeting-amendment-1.md
@@ -10,11 +10,11 @@ demo-add-greeting
 
 ## Learning
 
-After reviewing the initial approach, the greeting module should use a factory function pattern instead of a plain function export, to make future extension easier. This does not change any acceptance criterion.
+After reviewing the initial approach, the greeting module should use a factory function pattern internally while keeping the public `greet` export required by the parent plan. This does not change any acceptance criterion.
 
 ## New direction
 
-Use `createGreeter()` returning an object with a `greet` method instead of a bare function export. The module interface changes internally but the acceptance criteria describe observable outcomes, not the internal structure.
+Add `createGreeter()` returning an object with a `greet` method, then export a `greet(name)` wrapper that delegates to the default greeter. The internal structure changes, but the public API and observable acceptance criteria remain unchanged.
 
 ## Impact on acceptance criteria
 

--- a/examples/resume-demo/.osc/plans/active/demo-add-greeting.md
+++ b/examples/resume-demo/.osc/plans/active/demo-add-greeting.md
@@ -1,0 +1,39 @@
+# Plan: demo-add-greeting
+
+## Status
+
+active
+
+## Context
+
+The demo project needs a greeting module so the resume fixture has a meaningful active slice to demonstrate zero-context resume.
+
+## Goal
+
+Implement a greeting module that returns "Hello, <name>!" and records each greeting to the releases folder.
+
+## Constraints / Out of scope
+
+- No web server or external service calls.
+- Greeting history is append-only; no editing past entries.
+
+## Files to touch
+
+- `src/greet.ts` — the greeting function.
+- `tests/greet.test.ts` — tests for the greeting function.
+- `.osc/releases/` — evidence note on completion.
+
+## Acceptance criteria
+
+- [x] Greeting module exports a greet function that returns the string "Hello, <name>!".
+- [ ] Greeting history is written to the releases folder as an evidence note on each run.
+- [ ] All greeting tests pass (npm test exits 0).
+
+## Verification steps
+
+1. `node -e "import('./src/greet.js').then(m => console.log(m.greet('World')))"` → prints `Hello, World!`
+2. `npm test` → exits 0 with greeting tests green.
+
+## Open questions
+
+- None.

--- a/examples/resume-demo/.osc/plans/done/scaffold-init.md
+++ b/examples/resume-demo/.osc/plans/done/scaffold-init.md
@@ -1,0 +1,39 @@
+# Plan: scaffold-init
+
+## Status
+
+done
+
+## Context
+
+Initial scaffold setup for the demo project before active feature work begins.
+
+## Goal
+
+Bootstrap the project with MISSION.md, the .osc folder structure, and a minimal README so the repo is ready for a first feature plan.
+
+## Constraints / Out of scope
+
+- No feature code yet — structure only.
+- No external dependencies.
+
+## Files to touch
+
+- `MISSION.md` — project mission.
+- `.osc/plans/` — plan stage folders.
+- `.osc/releases/` — releases folder.
+
+## Acceptance criteria
+
+- [x] MISSION.md exists and has a defined mission (no unset marker).
+- [x] `.osc/plans/{active,backlog,blocked,done}/` stage folders exist.
+- [x] `.osc/releases/` exists and is ready for evidence notes.
+
+## Verification steps
+
+1. `ls MISSION.md .osc/plans/ .osc/releases/` → exits 0.
+2. Mission check: `grep -v "mission:unset" MISSION.md` → exits 0.
+
+## Open questions
+
+- None.

--- a/examples/resume-demo/.osc/releases/2026-05-10-scaffold-init.md
+++ b/examples/resume-demo/.osc/releases/2026-05-10-scaffold-init.md
@@ -1,0 +1,25 @@
+# Release / Evidence Note: scaffold-init
+
+## Summary
+
+Scaffold initialized. MISSION.md defined, .osc plan folders created, releases folder ready. This done slice closes the bootstrap work and unblocks the first feature plan.
+
+## Traceability
+
+- Roadmap / issue / task: N/A — initial bootstrap.
+- Plan: .osc/plans/done/scaffold-init.md
+- Run ID / run packet: N/A.
+- Branch / PR: N/A — direct commit.
+
+## Verification
+
+- `ls MISSION.md .osc/plans/ .osc/releases/` — exits 0.
+- Mission check: `grep -v "mission:unset" MISSION.md` — exits 0.
+
+## Outcome
+
+Scaffold structure in place. Active feature work (demo-add-greeting) can begin.
+
+## Follow-up
+
+- Implement demo-add-greeting as the first feature slice.

--- a/examples/resume-demo/MISSION.md
+++ b/examples/resume-demo/MISSION.md
@@ -1,0 +1,20 @@
+# Mission
+
+Build a demo greeting project to serve as an Open Scaffold resume-proof fixture.
+
+## Goals
+
+- Provide a self-contained mid-flight project state that demonstrates zero-context resume.
+- Show a realistic active plan with mixed acceptance criteria, one amendment, a done slice, and evidence.
+
+## Non-goals
+
+- No production deployment; this is a demo fixture only.
+- No external dependencies or cloud services.
+
+## Changelog
+
+<!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-01: bootstrap — mission defined for demo greeting project
+- 2026-05-10: closed scaffold-init — initial scaffold structure in place
+- 2026-05-15: amendment 1 to demo-add-greeting — switched to factory function pattern (approach change; ACs unchanged)

--- a/examples/resume-demo/expected-resume-summary.json
+++ b/examples/resume-demo/expected-resume-summary.json
@@ -1,0 +1,42 @@
+{
+  "schema": "open-scaffold.resume.v1",
+  "mission": {
+    "defined": true
+  },
+  "active_plan": {
+    "slug": "demo-add-greeting",
+    "stage": "active",
+    "status": "active",
+    "goal": "Implement a greeting module that returns \"Hello, <name>!\" and records each greeting to the releases folder.",
+    "acceptance_criteria": [
+      {
+        "text": "Greeting module exports a greet function that returns the string \"Hello, <name>!\".",
+        "checked": true
+      },
+      {
+        "text": "Greeting history is written to the releases folder as an evidence note on each run.",
+        "checked": false
+      },
+      {
+        "text": "All greeting tests pass (npm test exits 0).",
+        "checked": false
+      }
+    ]
+  },
+  "amendments": {
+    "count": 1,
+    "ids": [
+      "demo-add-greeting-amendment-1"
+    ]
+  },
+  "work_done": {
+    "done_slices": [
+      "scaffold-init"
+    ],
+    "evidence": [
+      ".osc/releases/2026-05-10-scaffold-init.md"
+    ]
+  },
+  "status": "active plan demo-add-greeting; 1/3 acceptance criteria complete",
+  "next_bounded_action": "Greeting history is written to the releases folder as an evidence note on each run."
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     ".osc/plans/templates",
     ".osc/releases/README.md",
     ".osc/specs/.gitkeep",
+    "examples/attempt-compare",
+    "examples/resume-demo",
     "docs",
     "python",
     "README.md",

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,6 +1,6 @@
-import { readdirSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { inspectScaffold, parsePlanFile, parseChecklist } from './scaffold.js';
+import { inspectScaffold, parsePlanFile, parseChecklist, splitSections } from './scaffold.js';
 import { buildTrace } from './trace.js';
 
 export interface ResumeSummary {
@@ -26,6 +26,29 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function amendmentKeepsAcceptanceCriteriaUnchanged(markdown: string): boolean {
+  const sections = splitSections(markdown);
+  const impact = (sections.get('Impact on acceptance criteria') ?? '').trim();
+  if (!impact) return false;
+  if (/\bnone\b/i.test(impact) && /\bunchanged\b|\bno\s+change\b|\bdoes\s+not\s+change\b/i.test(impact)) {
+    return true;
+  }
+  if (/acceptance criteria remain unchanged/i.test(impact)) return true;
+  return false;
+}
+
+function assertAmendmentsDoNotChangeAcceptanceCriteria(planDir: string, amendmentFiles: string[]): void {
+  for (const file of amendmentFiles) {
+    const text = readFileSync(join(planDir, file), 'utf8');
+    if (!amendmentKeepsAcceptanceCriteriaUnchanged(text)) {
+      throw new Error(
+        `Resume composer does not support amendments that change or supersede acceptance criteria: ${file}. ` +
+        'Fold amendment impacts into a future resume schema before deriving next_bounded_action.'
+      );
+    }
+  }
+}
+
 export function buildResumeSummary(root: string): ResumeSummary {
   const scaffold = inspectScaffold(root);
 
@@ -42,10 +65,11 @@ export function buildResumeSummary(root: string): ResumeSummary {
 
   const planDir = join(root, '.osc', 'plans', planSummary.stage);
   const amendmentRe = new RegExp(`^${escapeRegex(planSummary.slug)}-amendment-(\\d+)\\.md$`);
-  const amendmentIds = readdirSync(planDir)
+  const amendmentFiles = readdirSync(planDir)
     .filter((f) => amendmentRe.test(f))
-    .sort()
-    .map((f) => f.slice(0, -3));
+    .sort();
+  assertAmendmentsDoNotChangeAcceptanceCriteria(planDir, amendmentFiles);
+  const amendmentIds = amendmentFiles.map((f) => f.slice(0, -3));
 
   const doneSlices = scaffold.plans.done.map((p) => p.slug).sort();
   const evidenceSet = new Set<string>();

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -62,6 +62,11 @@ function assertAmendmentsDoNotChangeAcceptanceCriteria(planDir: string, amendmen
   }
 }
 
+function getAmendmentNumber(file: string, amendmentRe: RegExp): number {
+  const match = file.match(amendmentRe);
+  return Number.parseInt(match?.[1] ?? '0', 10);
+}
+
 export function buildResumeSummary(root: string): ResumeSummary {
   const scaffold = inspectScaffold(root);
 
@@ -80,7 +85,7 @@ export function buildResumeSummary(root: string): ResumeSummary {
   const amendmentRe = new RegExp(`^${escapeRegex(planSummary.slug)}-amendment-(\\d+)\\.md$`);
   const amendmentFiles = readdirSync(planDir)
     .filter((f) => amendmentRe.test(f))
-    .sort();
+    .sort((a, b) => getAmendmentNumber(a, amendmentRe) - getAmendmentNumber(b, amendmentRe));
   assertAmendmentsDoNotChangeAcceptanceCriteria(planDir, amendmentFiles);
   const amendmentIds = amendmentFiles.map((f) => f.slice(0, -3));
 

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,0 +1,88 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { inspectScaffold, parsePlanFile, parseChecklist } from './scaffold.js';
+import { buildTrace } from './trace.js';
+
+export interface ResumeSummary {
+  schema: 'open-scaffold.resume.v1';
+  mission: { defined: boolean };
+  active_plan: {
+    slug: string;
+    stage: 'active';
+    status: string;
+    goal: string;
+    acceptance_criteria: Array<{ text: string; checked: boolean }>;
+  };
+  amendments: { count: number; ids: string[] };
+  work_done: {
+    done_slices: string[];
+    evidence: string[];
+  };
+  status: string;
+  next_bounded_action: string | null;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function buildResumeSummary(root: string): ResumeSummary {
+  const scaffold = inspectScaffold(root);
+
+  if (scaffold.plans.active.length !== 1) {
+    throw new Error(
+      `Resume composer requires exactly one active plan; found ${scaffold.plans.active.length}.`
+    );
+  }
+
+  const planSummary = scaffold.plans.active[0];
+  const plan = parsePlanFile(join(root, planSummary.path));
+  const acSection = plan.sections.get('Acceptance criteria') ?? '';
+  const checklist = parseChecklist(acSection);
+
+  const planDir = join(root, '.osc', 'plans', planSummary.stage);
+  const amendmentRe = new RegExp(`^${escapeRegex(planSummary.slug)}-amendment-(\\d+)\\.md$`);
+  const amendmentIds = readdirSync(planDir)
+    .filter((f) => amendmentRe.test(f))
+    .sort()
+    .map((f) => f.slice(0, -3));
+
+  const doneSlices = scaffold.plans.done.map((p) => p.slug).sort();
+  const evidenceSet = new Set<string>();
+  for (const doneSlug of doneSlices) {
+    try {
+      const report = buildTrace(root, doneSlug);
+      for (const link of report.links) {
+        if (
+          (link.type === 'release_note' || link.type === 'evidence_reference') &&
+          link.status === 'local'
+        ) {
+          evidenceSet.add(link.reference);
+        }
+      }
+    } catch {
+      // skip done slices whose trace fails
+    }
+  }
+  const evidence = [...evidenceSet].sort();
+
+  const checkedCount = checklist.filter((c) => c.checked).length;
+  const totalCount = checklist.length;
+  const firstUnchecked = checklist.find((c) => !c.checked) ?? null;
+
+  return {
+    schema: 'open-scaffold.resume.v1',
+    mission: { defined: scaffold.mission.defined },
+    active_plan: {
+      slug: planSummary.slug,
+      stage: 'active',
+      status: plan.status,
+      goal: plan.goal,
+      acceptance_criteria: checklist.map((c) => ({ text: c.text, checked: c.checked })),
+    },
+    amendments: { count: amendmentIds.length, ids: amendmentIds },
+    work_done: { done_slices: doneSlices, evidence },
+    status: `active plan ${planSummary.slug}; ${checkedCount}/${totalCount} acceptance criteria complete`,
+    next_bounded_action: firstUnchecked?.text ?? null,
+  };
+}

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -30,10 +30,23 @@ function amendmentKeepsAcceptanceCriteriaUnchanged(markdown: string): boolean {
   const sections = splitSections(markdown);
   const impact = (sections.get('Impact on acceptance criteria') ?? '').trim();
   if (!impact) return false;
-  if (/\bnone\b/i.test(impact) && /\bunchanged\b|\bno\s+change\b|\bdoes\s+not\s+change\b/i.test(impact)) {
+  const normalized = impact.toLowerCase().replace(/\s+/g, ' ');
+  const changedSignals = [
+    /\bnone\s+of\b/,
+    /\bexcept\b/,
+    /\bsupersed(?:e|es|ed|ing)\b/,
+    /\breplac(?:e|es|ed|ing)\b/,
+    /\brevis(?:e|es|ed|ing)\b/,
+    /\bmodif(?:y|ies|ied|ying)\b/,
+    /\bac\s*\d+\b/,
+    /\bcriterion\s+\d+\b/,
+    /\bcriteria\s+\d+\b/,
+  ];
+  if (changedSignals.some((pattern) => pattern.test(normalized))) return false;
+  if (/^none\b/.test(normalized) && /\bunchanged\b|\bno\s+change\b|\bdoes\s+not\s+change\b/.test(normalized)) {
     return true;
   }
-  if (/acceptance criteria remain unchanged/i.test(impact)) return true;
+  if (/\bacceptance criteria remain unchanged\b/.test(normalized)) return true;
   return false;
 }
 

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -50,6 +50,36 @@ describe('npm package payload', () => {
     expect(forbidden).toEqual([]);
   }, 20_000);
 
+  it('ships compare-demo and resume-demo example fixtures in the published package', () => {
+    const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const [pack] = JSON.parse(output) as PackResult[];
+    const paths = pack.files.map((file) => file.path).sort();
+
+    // compare-demo inputs must ship so `npx open-scaffold compare` works from a fresh install
+    expect(paths).toContain('examples/attempt-compare/attempt-a/ac-status.json');
+    expect(paths).toContain('examples/attempt-compare/attempt-a/diff.patch');
+    expect(paths).toContain('examples/attempt-compare/attempt-a/rationale.txt');
+    expect(paths).toContain('examples/attempt-compare/attempt-a/transcript.md');
+    expect(paths).toContain('examples/attempt-compare/attempt-b/ac-status.json');
+    expect(paths).toContain('examples/attempt-compare/attempt-b/diff.patch');
+    expect(paths).toContain('examples/attempt-compare/attempt-b/rationale.txt');
+    expect(paths).toContain('examples/attempt-compare/attempt-b/transcript.md');
+
+    // resume-demo fixture must ship so the zero-context-resume demo works from a fresh install
+    if (existsSync(join(repoRoot, 'examples', 'resume-demo'))) {
+      expect(paths).toContain('examples/resume-demo/MISSION.md');
+      expect(paths).toContain('examples/resume-demo/.osc/plans/active/demo-add-greeting.md');
+      expect(paths).toContain('examples/resume-demo/.osc/plans/active/demo-add-greeting-amendment-1.md');
+      expect(paths).toContain('examples/resume-demo/.osc/plans/done/scaffold-init.md');
+      expect(paths).toContain('examples/resume-demo/.osc/releases/2026-05-10-scaffold-init.md');
+      expect(paths).toContain('examples/resume-demo/expected-resume-summary.json');
+    }
+  }, 20_000);
+
   it('runs init successfully from an extracted npm tarball', () => {
     const packDir = mkdtempSync(join(tmpdir(), 'open-scaffold-pack-'));
     const extractDir = mkdtempSync(join(tmpdir(), 'open-scaffold-extract-'));

--- a/tests/resume-docs.test.ts
+++ b/tests/resume-docs.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(process.cwd());
+
+function read(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf8');
+}
+
+function exists(path: string): boolean {
+  return existsSync(join(repoRoot, path));
+}
+
+function firstLines(text: string, count: number): string {
+  return text.split('\n').slice(0, count).join('\n');
+}
+
+describe('resume docs self-checks (AC-6 through AC-10)', () => {
+  describe('AC-6: START_HERE front door', () => {
+    it('docs/START_HERE.md exists', () => {
+      expect(exists('docs/START_HERE.md')).toBe(true);
+    });
+
+    it('README first 80 lines link to START_HERE.md', () => {
+      const first80 = firstLines(read('README.md'), 80);
+      expect(first80).toMatch(/START_HERE\.md/);
+    });
+
+    it('START_HERE.md contains the literal first command', () => {
+      const content = read('docs/START_HERE.md');
+      expect(content).toContain('npx open-scaffold init --tier min --target .');
+    });
+  });
+
+  describe('AC-7: zero-context-resume narrative placement', () => {
+    it('README first screen features resume narrative after the locked promise paragraph', () => {
+      const readme = read('README.md');
+      const lines = readme.split('\n');
+      const first80 = lines.slice(0, 80).join('\n');
+
+      expect(first80).toContain('It keeps the goal, plan, handoff, evidence, approval trail, and lessons');
+      expect(first80).toMatch(/zero.context.resum|resume.*from.*repo|resume.*without.re.explain/i);
+
+      const promiseIdx = lines.findIndex(l =>
+        l.includes('It keeps the goal, plan, handoff, evidence, approval trail, and lessons'),
+      );
+      const resumeIdx = lines.findIndex(l =>
+        /zero.context.resum|resume.*from.*repo|resume.*without.re.explain/i.test(l),
+      );
+      expect(promiseIdx).toBeGreaterThanOrEqual(0);
+      expect(resumeIdx).toBeGreaterThan(promiseIdx);
+      expect(resumeIdx).toBeLessThan(80);
+    });
+
+    it('README first 80 lines preserve all locked positioning tokens', () => {
+      const first80 = firstLines(read('README.md'), 80);
+      expect(first80).toContain('goal');
+      expect(first80).toContain('plan');
+      expect(first80).toContain('handoff');
+      expect(first80).toContain('evidence');
+      expect(first80).toContain('approval');
+      expect(first80).toContain('lessons');
+    });
+
+    it('README first 80 lines avoid forbidden vocabulary', () => {
+      const first80 = firstLines(read('README.md'), 80);
+      expect(first80).not.toMatch(/agent OS|control plane|compliance-grade|operating system|tamper-proof/i);
+    });
+
+    it('README links to resume demo fixture', () => {
+      const readme = read('README.md');
+      expect(readme).toMatch(/examples\/resume-demo/);
+    });
+
+    it('README links to RESUME_WALKTHROUGH.md', () => {
+      const readme = read('README.md');
+      expect(readme).toMatch(/RESUME_WALKTHROUGH\.md/);
+    });
+
+    it('docs/index.html features zero-context-resume narrative', () => {
+      const html = read('docs/index.html');
+      expect(html).toMatch(/zero.context.resum|resume.*from.*repo|resume.*without.re.explain/i);
+    });
+
+    it('docs/RESUME_WALKTHROUGH.md exists', () => {
+      expect(exists('docs/RESUME_WALKTHROUGH.md')).toBe(true);
+    });
+
+    it('walkthrough shows osc status and osc trace commands', () => {
+      const walkthrough = read('docs/RESUME_WALKTHROUGH.md');
+      expect(walkthrough).toContain('osc status');
+      expect(walkthrough).toContain('osc trace');
+    });
+
+    it('walkthrough contains the no-overclaim disclaimer sentence', () => {
+      const walkthrough = read('docs/RESUME_WALKTHROUGH.md');
+      expect(walkthrough).toMatch(/reconstructed by.*tooling|reconstructed by.*test/i);
+      expect(walkthrough).toMatch(/not.*emitted by.*stable command|not.*shipped.*stable command/i);
+    });
+
+    it('walkthrough next_bounded_action matches golden file when Task 1 fixture is ready', () => {
+      const goldenPath = join(repoRoot, 'examples/resume-demo/expected-resume-summary.json');
+      if (!existsSync(goldenPath)) {
+        // Golden file not yet committed by Task 1; check deferred
+        return;
+      }
+      const golden = JSON.parse(readFileSync(goldenPath, 'utf8')) as { next_bounded_action: string };
+      const walkthrough = read('docs/RESUME_WALKTHROUGH.md');
+      expect(walkthrough).toContain(golden.next_bounded_action);
+    });
+  });
+
+  describe('AC-8: version truth reconciliation', () => {
+    it('docs/VERSION_TRUTH.md exists', () => {
+      expect(exists('docs/VERSION_TRUTH.md')).toBe(true);
+    });
+
+    it('README contains both v0.20.x current and v1.0.5 historical version tokens', () => {
+      const readme = read('README.md');
+      expect(readme).toMatch(/v0\.20\.x|v0\.20\.\d/);
+      expect(readme).toMatch(/v1\.0\.5/);
+    });
+
+    it('STABILITY.md contains v0.20.x current line and v1.0.x historical reference', () => {
+      const stability = read('docs/STABILITY.md');
+      expect(stability).toMatch(/v0\.20\.x/);
+      expect(stability).toMatch(/v1\.0\.[x5]/);
+    });
+
+    it('CHANGELOG.md contains v0.20.x entries and v1.0.5 historical entry', () => {
+      const changelog = read('docs/CHANGELOG.md');
+      expect(changelog).toMatch(/v0\.20\.\d/);
+      expect(changelog).toMatch(/v1\.0\.5/);
+    });
+  });
+
+  describe('AC-9: glossary term coverage', () => {
+    it('docs/GLOSSARY.md exists', () => {
+      expect(exists('docs/GLOSSARY.md')).toBe(true);
+    });
+
+    it('GLOSSARY defines run packet', () => {
+      expect(read('docs/GLOSSARY.md')).toMatch(/run packet/i);
+    });
+
+    it('GLOSSARY defines glass cockpit', () => {
+      expect(read('docs/GLOSSARY.md')).toMatch(/glass cockpit/i);
+    });
+
+    it('GLOSSARY defines OMC, OMX, and Codex', () => {
+      const glossary = read('docs/GLOSSARY.md');
+      expect(glossary).toMatch(/\bOMC\b/);
+      expect(glossary).toMatch(/\bOMX\b/);
+      expect(glossary).toMatch(/\bCodex\b/);
+    });
+
+    it('GLOSSARY defines operator surface', () => {
+      expect(read('docs/GLOSSARY.md')).toMatch(/operator surface/i);
+    });
+
+    it('GLOSSARY defines .osc, .omc, .omx, .osc-dev directories', () => {
+      const glossary = read('docs/GLOSSARY.md');
+      expect(glossary).toContain('.osc');
+      expect(glossary).toContain('.omc');
+      expect(glossary).toContain('.omx');
+      expect(glossary).toContain('.osc-dev');
+    });
+
+    it('GLOSSARY contains a core-vs-adapter boundary statement', () => {
+      const glossary = read('docs/GLOSSARY.md');
+      expect(glossary).toMatch(/core.*adapter|adapter.*core/i);
+    });
+  });
+
+  describe('AC-10: CLI-absence guard', () => {
+    it('src/cli.ts dispatch does not register resume or next subcommands', () => {
+      const cli = read('src/cli.ts');
+      expect(cli).not.toMatch(/case ['"]resume['"]/);
+      expect(cli).not.toMatch(/case ['"]next['"]/);
+    });
+
+    it('docs/STABILITY.md stable-command-list block does not contain resume', () => {
+      const stability = read('docs/STABILITY.md');
+      const cliSection = stability.split('### CLI and shell floor')[1]?.split('###')[0] ?? '';
+      expect(cliSection).not.toMatch(/\bresume\b/i);
+    });
+
+    it('osc --help does not list resume or next as subcommands', () => {
+      let helpOutput = '';
+      try {
+        helpOutput = execSync('node dist/cli.js --help', {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+      } catch (e: unknown) {
+        const err = e as { stdout?: string; stderr?: string };
+        helpOutput = err.stdout ?? err.stderr ?? '';
+      }
+      const resumeLines = helpOutput.split('\n').filter(l => /^\s*osc\s+(resume|next)\b/.test(l));
+      expect(resumeLines).toHaveLength(0);
+    });
+  });
+});

--- a/tests/resume-snapshot.test.ts
+++ b/tests/resume-snapshot.test.ts
@@ -10,6 +10,31 @@ function loadGolden() {
   return JSON.parse(readFileSync(join(fixtureRoot, 'expected-resume-summary.json'), 'utf8'));
 }
 
+function renderUnchangedAmendment(number: number) {
+  return `# Amendment ${number}: demo-add-greeting
+
+## Parent
+
+demo-add-greeting
+
+## Date
+
+2026-05-15
+
+## Learning
+
+Additional internal implementation note ${number}; no observable behavior changes.
+
+## New direction
+
+Keep the existing public API and continue with the documented active plan.
+
+## Impact on acceptance criteria
+
+None — all acceptance criteria remain unchanged.
+`;
+}
+
 describe('resume-snapshot', () => {
   it('matches the committed golden file', () => {
     const summary = buildResumeSummary(fixtureRoot);
@@ -47,6 +72,24 @@ describe('resume-snapshot', () => {
     const { work_done } = buildResumeSummary(fixtureRoot);
     expect(work_done.done_slices).toContain('scaffold-init');
     expect(work_done.evidence).toContain('.osc/releases/2026-05-10-scaffold-init.md');
+  });
+
+  it('sorts amendment ids by numeric amendment order', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'osc-resume-amendment-order-'));
+    try {
+      cpSync(fixtureRoot, tempRoot, { recursive: true });
+      const activeDir = join(tempRoot, '.osc', 'plans', 'active');
+      writeFileSync(join(activeDir, 'demo-add-greeting-amendment-2.md'), renderUnchangedAmendment(2), 'utf8');
+      writeFileSync(join(activeDir, 'demo-add-greeting-amendment-10.md'), renderUnchangedAmendment(10), 'utf8');
+
+      expect(buildResumeSummary(tempRoot).amendments.ids).toEqual([
+        'demo-add-greeting-amendment-1',
+        'demo-add-greeting-amendment-2',
+        'demo-add-greeting-amendment-10',
+      ]);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it('fails loudly when amendment impact text changes or negates unchanged criteria', () => {

--- a/tests/resume-snapshot.test.ts
+++ b/tests/resume-snapshot.test.ts
@@ -49,20 +49,28 @@ describe('resume-snapshot', () => {
     expect(work_done.evidence).toContain('.osc/releases/2026-05-10-scaffold-init.md');
   });
 
-  it('fails loudly when an amendment changes acceptance criteria', () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'osc-resume-amendment-'));
-    try {
-      cpSync(fixtureRoot, tempRoot, { recursive: true });
-      const amendmentPath = join(tempRoot, '.osc', 'plans', 'active', 'demo-add-greeting-amendment-1.md');
-      const amendment = readFileSync(amendmentPath, 'utf8').replace(
-        'None — all acceptance criteria remain unchanged. The observable behavior (greet function returns "Hello, <name>!", history written to releases, tests pass) is unaffected by the internal factory pattern change.',
-        'Criterion 1 is superseded: the greeting must return "Hi, <name>!" instead of the original text.'
-      );
-      writeFileSync(amendmentPath, amendment, 'utf8');
+  it('fails loudly when amendment impact text changes or negates unchanged criteria', () => {
+    const changingImpacts = [
+      'Criterion 1 is superseded: the greeting must return "Hi, <name>!" instead of the original text.',
+      'None of the original acceptance criteria remain unchanged; AC1 is superseded.',
+      'Acceptance criteria remain unchanged except AC2 is replaced.',
+    ];
 
-      expect(() => buildResumeSummary(tempRoot)).toThrow(/amendments that change or supersede acceptance criteria/);
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
+    for (const impact of changingImpacts) {
+      const tempRoot = mkdtempSync(join(tmpdir(), 'osc-resume-amendment-'));
+      try {
+        cpSync(fixtureRoot, tempRoot, { recursive: true });
+        const amendmentPath = join(tempRoot, '.osc', 'plans', 'active', 'demo-add-greeting-amendment-1.md');
+        const amendment = readFileSync(amendmentPath, 'utf8').replace(
+          'None — all acceptance criteria remain unchanged. The observable behavior (greet function returns "Hello, <name>!", history written to releases, tests pass) is unaffected by the internal factory pattern change.',
+          impact
+        );
+        writeFileSync(amendmentPath, amendment, 'utf8');
+
+        expect(() => buildResumeSummary(tempRoot)).toThrow(/amendments that change or supersede acceptance criteria/);
+      } finally {
+        rmSync(tempRoot, { recursive: true, force: true });
+      }
     }
   });
 });

--- a/tests/resume-snapshot.test.ts
+++ b/tests/resume-snapshot.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { buildResumeSummary } from '../src/resume.js';
+
+const fixtureRoot = join(resolve(process.cwd()), 'examples/resume-demo');
+
+function loadGolden() {
+  return JSON.parse(readFileSync(join(fixtureRoot, 'expected-resume-summary.json'), 'utf8'));
+}
+
+describe('resume-snapshot', () => {
+  it('matches the committed golden file', () => {
+    const summary = buildResumeSummary(fixtureRoot);
+    expect(summary).toEqual(loadGolden());
+  });
+
+  it('is deterministic — second call equals first', () => {
+    expect(buildResumeSummary(fixtureRoot)).toEqual(buildResumeSummary(fixtureRoot));
+  });
+
+  it('next_bounded_action is a member of acceptance_criteria', () => {
+    const { next_bounded_action, active_plan } = buildResumeSummary(fixtureRoot);
+    expect(next_bounded_action).not.toBeNull();
+    const acTexts = active_plan.acceptance_criteria.map((c) => c.text);
+    expect(acTexts).toContain(next_bounded_action);
+  });
+
+  it('reports exactly the fixture active plan slug', () => {
+    expect(buildResumeSummary(fixtureRoot).active_plan.slug).toBe('demo-add-greeting');
+  });
+
+  it('composer throws when active plan count != 1', () => {
+    expect(() => buildResumeSummary(join(fixtureRoot, '.osc', 'plans', 'active'))).toThrow(
+      /exactly one active plan/
+    );
+  });
+
+  it('reports amendments count 1 and correct id', () => {
+    const { amendments } = buildResumeSummary(fixtureRoot);
+    expect(amendments.count).toBe(1);
+    expect(amendments.ids).toContain('demo-add-greeting-amendment-1');
+  });
+
+  it('reports done slices and evidence links', () => {
+    const { work_done } = buildResumeSummary(fixtureRoot);
+    expect(work_done.done_slices).toContain('scaffold-init');
+    expect(work_done.evidence).toContain('.osc/releases/2026-05-10-scaffold-init.md');
+  });
+});

--- a/tests/resume-snapshot.test.ts
+++ b/tests/resume-snapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { buildResumeSummary } from '../src/resume.js';
 
@@ -46,5 +47,22 @@ describe('resume-snapshot', () => {
     const { work_done } = buildResumeSummary(fixtureRoot);
     expect(work_done.done_slices).toContain('scaffold-init');
     expect(work_done.evidence).toContain('.osc/releases/2026-05-10-scaffold-init.md');
+  });
+
+  it('fails loudly when an amendment changes acceptance criteria', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'osc-resume-amendment-'));
+    try {
+      cpSync(fixtureRoot, tempRoot, { recursive: true });
+      const amendmentPath = join(tempRoot, '.osc', 'plans', 'active', 'demo-add-greeting-amendment-1.md');
+      const amendment = readFileSync(amendmentPath, 'utf8').replace(
+        'None — all acceptance criteria remain unchanged. The observable behavior (greet function returns "Hello, <name>!", history written to releases, tests pass) is unaffected by the internal factory pattern change.',
+        'Criterion 1 is superseded: the greeting must return "Hi, <name>!" instead of the original text.'
+      );
+      writeFileSync(amendmentPath, amendment, 'utf8');
+
+      expect(() => buildResumeSummary(tempRoot)).toThrow(/amendments that change or supersede acceptance criteria/);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds a committed `examples/resume-demo/` fixture that represents a mid-flight project with one active plan, one amendment, one done slice, and evidence.
- Adds deterministic zero-context resume reconstruction via `src/resume.ts` and a golden snapshot test, without adding a stable `osc resume` or `osc next` command.
- Fails loudly when an amendment changes or supersedes acceptance criteria before deriving completion counts and the next bounded action.
- Sorts amendment IDs by numeric amendment suffix so double-digit amendment histories preserve scaffold layering order.
- Adds the adoption docs needed for first contact: `START_HERE`, `VERSION_TRUTH`, `GLOSSARY`, and a resume walkthrough.
- Updates README/docs landing copy to put the zero-context resume proof in the first screen while preserving the existing positioning contract.
- Ships `examples/attempt-compare` and `examples/resume-demo` in the npm package payload and tests that they are present.

## Verification

- `git diff --check`
- `npm run build`
- `npm test` — 52 files / 518 tests passed
- `./verify.sh --strict` — 10 pass, 0 fail, 0 warn
- `node dist/cli.js plan validate .osc/plans/active/129-zero-context-resume-proof.md` — 0 issues found
- `npm pack --dry-run --json` confirms compare-demo and resume-demo fixture files are included
- Extracted tarball smoke: `node package/dist/cli.js compare package/examples/attempt-compare/attempt-a package/examples/attempt-compare/attempt-b` exits 0

## Risk / gates

- No package publish, GitHub Release, merge, or runtime execution is included in this PR.
- `src/resume.ts` is intentionally test-only for this slice and is guarded by CLI-absence tests so no new stable `osc` command is introduced.
- The version-truth page clarifies that `v1.0.5` is historical and `v0.20.x` is the current pre-1.0 hardening line.
