### PR TITLE
Prepare 0.20.3 section parser package sync

### DIFF
--- a/.osc/releases/2026-05-29-130-section-parser-canonical-contract.md
+++ b/.osc/releases/2026-05-29-130-section-parser-canonical-contract.md
@@ -22,7 +22,7 @@ It adds no runtime dependency, no agent spawning, no MCP surface expansion, and 
 - Source Pull Request: https://github.com/graphanov/open-scaffold/pull/150.
 - Source merge commit: `d4866bba7e83ae8e9f4d710f4696fdf759a7cc2c`.
 - Package-sync branch: `release/section-parser-0203`.
-- Package-sync Pull Request: pending.
+- Package-sync Pull Request: https://github.com/graphanov/open-scaffold/pull/151.
 - Trusted publishing workflow: pending after merge.
 - npm package: pending `open-scaffold@0.20.3` with dist-tag `latest`.
 - GitHub Release: pending `v0.20.3`.

--- a/.osc/releases/2026-05-29-130-section-parser-canonical-contract.md
+++ b/.osc/releases/2026-05-29-130-section-parser-canonical-contract.md
@@ -1,0 +1,64 @@
+# Release / Evidence Note: 130-section-parser-canonical-contract
+
+## Summary
+
+Prepares `open-scaffold@0.20.3` as the package/public-surface sync for the canonical Markdown section-parser contract merged in PR #150.
+
+This release publishes the parser and validation hardening now on `main`:
+
+- canonical dependency-free H2 section parsing for plans and release/evidence notes;
+- fenced-code-block safety so `## ...` lines inside column-0 backtick/tilde fences do not become section boundaries;
+- optional trailing ATX closing hash normalization such as `## Status ##`;
+- CRLF-tolerant section parsing;
+- strict verifier parity for exact, fence-aware plan and release-note section checks;
+- Python reference parser parity; and
+- canonical status-update behavior for plan templates and plan movement.
+
+It adds no runtime dependency, no agent spawning, no MCP surface expansion, and no new dynamic-runtime claim.
+
+## Traceability
+
+- Source plan: `.osc/plans/active/130-section-parser-canonical-contract.md`.
+- Source Pull Request: https://github.com/graphanov/open-scaffold/pull/150.
+- Source merge commit: `d4866bba7e83ae8e9f4d710f4696fdf759a7cc2c`.
+- Package-sync branch: `release/section-parser-0203`.
+- Package-sync Pull Request: pending.
+- Trusted publishing workflow: pending after merge.
+- npm package: pending `open-scaffold@0.20.3` with dist-tag `latest`.
+- GitHub Release: pending `v0.20.3`.
+- Run ID / run packet: N/A for release-sync.
+
+## Verification
+
+Candidate gates before PR-ready:
+
+- [x] `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `0.20.3 / 0.20.3 / 0.20.3`.
+- [x] `npm view open-scaffold version dist-tags versions --json --prefer-online` — PASS: live npm remains `0.20.2`, `latest: 0.20.2`, and `0.20.3` is not yet published.
+- [x] `npm run build` — PASS.
+- [x] `node dist/cli.js --help` — PASS.
+- [x] `node dist/cli.js plan validate .osc/plans/active/130-section-parser-canonical-contract.md` — PASS: source plan validates before final closeout.
+- [x] `npm test -- --run` — PASS: 53 files / 530 tests.
+- [x] `python3 -m unittest discover python/tests` — PASS.
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
+- [x] `npm pack --dry-run --json` — PASS for `open-scaffold@0.20.3` (203 files); includes the parser/verifier/Python parser/docs/release assets.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.20.3`.
+- [x] `git diff --check` — PASS.
+- [ ] PR CI and latest-head review are clean before merge.
+
+Post-merge/publication gates after owner-preapproved follow-through:
+
+- [ ] Sync clean `main` after merge.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.20.3` with workflow input `npm-tag=latest`.
+- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.20.3` and `latest: 0.20.3`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` resolves to the published package.
+- [ ] Fresh isolated-cache smoke proves package-visible parser behavior through CLI validation on a temporary scaffold fixture with `## Status ##` and fenced `## Example` text.
+- [ ] GitHub Release `v0.20.3` exists and is marked Latest.
+- [ ] Source plan 130 is closed to `done/` with final public proof.
+
+## Outcome
+
+Pending: candidate package sync prepared for PR review/merge before trusted publishing and GitHub Release follow-through.
+
+## Follow-up
+
+- Next slice after 130 closeout: `.osc/plans/backlog/131-mcp-integration-surface-readiness.md`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.20.3 — Canonical section parser package sync
+
+Status: candidate prepared for `open-scaffold@0.20.3`; npm publication and GitHub Release follow-through are pending the package-sync PR merge.
+
+Highlights:
+
+- Publishes the PR #150 canonical Markdown H2 section parser across plan parsing, plan validation, release-note validation, strict shell verification, Python reference parsing, and template status updates.
+- Ignores fenced `## ...` lines inside column-0 backtick/tilde code fences, tolerates CRLF, and normalizes optional trailing ATX closing hashes such as `## Status ##`.
+- Tightens strict verifier section checks to exact, fence-aware plan and release-note headings while preserving the no-new-runtime-dependency boundary.
+- Keeps Open Scaffold core non-spawning: no runtime execution, no MCP surface expansion, and no new dynamic-runtime claim.
+
+Evidence:
+
+- Source plan: `.osc/plans/active/130-section-parser-canonical-contract.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/150
+- Release-sync evidence note: `.osc/releases/2026-05-29-130-section-parser-canonical-contract.md`
+
 ## v0.20.2 — Methodology and reviewer evidence package sync
 
 Status: published to npm as `open-scaffold@0.20.2`; GitHub Release `v0.20.2` is Latest after owner-approved trusted publishing and release follow-through.

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -4,7 +4,7 @@ This page is the canonical reconciliation between the current package version an
 
 ## Current line: `v0.20.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.20.2`
+- **Current `package.json` version:** `0.20.3`
 - **npm latest:** check `npm view open-scaffold version dist-tags --json` for live truth.
 - **GitHub Release latest:** check the GitHub Releases page for the release marked **Latest**.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
@@ -25,7 +25,7 @@ The `v0.20.x` line defines a stable-enough core (the repo-native work-record loo
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.20.2` |
+| `package.json` version | `0.20.3` |
 | Current package line | `v0.20.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.20.2",
+      "version": "0.20.3",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -246,7 +246,7 @@ This sample must not count as the real section.
 
     expect(hash(planIssueSnapshot)).toBe('70c8b00da0fe9631cb08a421d893b702ab8ceacad4dfa332d23c9a1e3fed320b');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('d61c996b0583801c07591071031318066b42b2929861e6b155324d1449710a2c');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('d6ca29a5d2141f51b5d5425d52fcb0691143adeb1c8799638e64653f6c8d22d4');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Prepares `open-scaffold@0.20.3` as the package/public-surface sync for PR #150's canonical Markdown section parser hardening.

This makes the merged parser/validator/verifier/Python parity work available through the public npm install path once the PR is merged and trusted publishing is run.

## Traceability

- Source plan: `.osc/plans/active/130-section-parser-canonical-contract.md`
- Source PR: https://github.com/graphanov/open-scaffold/pull/150
- Source merge commit: `d4866bba7e83ae8e9f4d710f4696fdf759a7cc2c`
- Release/evidence note: `.osc/releases/2026-05-29-130-section-parser-canonical-contract.md`

## Verification

- [x] Version alignment: `0.20.3 / 0.20.3 / 0.20.3`
- [x] `npm view open-scaffold version dist-tags versions --json --prefer-online` — live npm remains `0.20.2`; `0.20.3` unpublished
- [x] `npm run build`
- [x] `node dist/cli.js --help`
- [x] `node dist/cli.js plan validate .osc/plans/active/130-section-parser-canonical-contract.md`
- [x] `npm test -- --run` — 53 files / 530 tests
- [x] `python3 -m unittest discover python/tests`
- [x] `./verify.sh --strict` — 10 pass / 0 fail / 0 warn
- [x] `npm pack --dry-run --json` — `open-scaffold@0.20.3`, 203 files
- [x] `npm publish --dry-run --tag latest`
- [x] `git diff --check`

## Risk / gates

- No new runtime dependency.
- No runtime/spawning/MCP surface expansion.
- This PR only prepares the package candidate. After merge, the pre-approved follow-through is trusted npm publish with `npm-tag=latest`, fresh isolated-cache `npx` proof, GitHub Release `v0.20.3`, then a final evidence closeout PR moving plan 130 to `done/`.
