### PR TITLE
Repair fresh npx compare demo

### DIFF
--- a/.osc/releases/2026-05-30-129-npx-compare-demo-repair.md
+++ b/.osc/releases/2026-05-30-129-npx-compare-demo-repair.md
@@ -1,0 +1,57 @@
+# Release / Evidence Note: 129-npx-compare-demo-repair
+
+## Summary
+
+Prepares `open-scaffold@0.20.4` as the package-visible repair for plan `129-zero-context-resume-proof` AC-5: the advertised first-read `npx open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` command must work from a fresh external directory after publication, not only from the repository root.
+
+This candidate keeps `osc compare` local and read-only. It does not add runtime spawning, model scoring, frontier promotion, approval automation, or a new stable command.
+
+## Traceability
+
+- Roadmap / issue / task: Open Scaffold self-dogfood package/adoption repair for active plan 129; Hermes Kanban card `t_4ff11e15`.
+- Plan: `.osc/plans/active/129-zero-context-resume-proof.md` remains active until merge, npm publication, fresh `npx`, GitHub Release Latest, and final closeout proof are complete.
+- Branch: `fix/129-npx-compare-demo`.
+- Pull Request: pending; this note is the candidate evidence for the repair PR.
+- Run ID / run packet: N/A for this scoped package repair.
+
+## Verification
+
+Reproduced pre-fix failure from a fresh temp directory and isolated npm cache against current published `open-scaffold@latest` (`0.20.3`):
+
+```text
+npx --yes open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b
+attempt-a: attempt folder does not exist: examples/attempt-compare/attempt-a
+```
+
+Candidate gates before PR-ready:
+
+- [x] Fresh published-package failure reproduced from external temp directory with isolated npm cache — PASS: current `open-scaffold@latest` exits 1 with `attempt folder does not exist`.
+- [x] `npm test -- tests/package-payload.test.ts` — PASS: 1 file / 4 tests after adding extracted-package external-cwd compare regression.
+- [x] `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `0.20.4 / 0.20.4 / 0.20.4`.
+- [x] `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before publish: live npm remains `0.20.3`, `latest: 0.20.3`, and `0.20.4` is not yet published.
+- [x] `npm run build` — PASS.
+- [x] `npm test` — PASS after updating the live-corpus hash for this new evidence note: 53 files / 531 tests.
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
+- [x] `npm pack --dry-run --json` — PASS for `open-scaffold@0.20.4` (204 files); includes compare-demo inputs, resume-demo fixture, and `dist/cli.js`.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.20.4`.
+- [x] Extracted-package compare smoke from a fresh external cwd — PASS: `node <extracted>/package/dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` renders `# Attempt comparison: attempt-a → attempt-b`.
+- [x] `git diff --check` — PASS.
+- [ ] PR CI and latest-head Codex review loop — pending after PR creation.
+
+Post-merge/publication gates after owner merge approval:
+
+- [ ] Sync clean `main` after merge.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.20.4` with dist-tag `latest`.
+- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.20.4` and `latest: 0.20.4`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` succeeds from a fresh external directory.
+- [ ] GitHub Release `v0.20.4` exists and is marked Latest.
+- [ ] Source plan 129 is closed to `done/` with final public proof.
+
+## Outcome
+
+Candidate prepared; not merged, not published, not released, and not closed yet. The repair changes packaged example-path resolution and adds regression coverage so the zero-context demo can be proven after trusted publication.
+
+## Follow-up
+
+- Owner/merge gate: merge the repair PR only after local verification, CI, and latest-head Codex are clean.
+- After merge: publish `open-scaffold@0.20.4` through trusted publishing, verify fresh isolated-cache `npx`, create GitHub Release `v0.20.4` as Latest, then close plan 129 with final evidence.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,22 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.20.4 — Fresh npx compare demo repair candidate
+
+Status: release candidate prepared in the repository. It is not published until the repair PR is merged, trusted npm publishing succeeds, fresh isolated-cache `npx` proves the zero-context command, and GitHub Release `v0.20.4` is created and marked Latest.
+
+Highlights:
+
+- Repairs the advertised first-read command so `npx open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` can run from a fresh external directory after publication.
+- Keeps `osc compare` local and read-only: no runtime spawning, no model scoring, no frontier promotion, and no approval automation.
+- Adds extracted-package regression coverage proving the packaged demo resolves from outside the package directory.
+- Keeps plan `129-zero-context-resume-proof` active until merge, npm publication, fresh `npx`, GitHub Release Latest, and final closeout evidence are complete.
+
+Evidence:
+
+- Source plan: `.osc/plans/active/129-zero-context-resume-proof.md`
+- Candidate evidence note: `.osc/releases/2026-05-30-129-npx-compare-demo-repair.md`
+
 ## v0.20.3 — Canonical section parser package sync
 
 Status: published to npm as `open-scaffold@0.20.3`; GitHub Release `v0.20.3` is Latest after owner-preapproved trusted publishing and release follow-through.

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -4,7 +4,7 @@ This page is the canonical reconciliation between the current package version an
 
 ## Current line: `v0.20.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.20.3`
+- **Current `package.json` version:** `0.20.4` (release candidate in this repository until npm/GitHub Release follow-through proves publication)
 - **npm latest:** check `npm view open-scaffold version dist-tags --json` for live truth.
 - **GitHub Release latest:** check the GitHub Releases page for the release marked **Latest**.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
@@ -25,7 +25,7 @@ The `v0.20.x` line defines a stable-enough core (the repo-native work-record loo
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.20.3` |
+| `package.json` version | `0.20.4` candidate |
 | Current package line | `v0.20.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.20.3",
+      "version": "0.20.4",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { basename, resolve } from 'node:path';
+import { basename, isAbsolute, join, normalize, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const ATTEMPT_COMPARISON_SCHEMA = 'open-scaffold.attempt-comparison.v1';
 
@@ -102,6 +103,28 @@ function readOptionalFile(dir: string, name: AttemptFileName, readContent = true
   return { present: true, bytes: stat.size, content };
 }
 
+const packageRoot = fileURLToPath(new URL('..', import.meta.url));
+const packagedCompareExamplePrefix = 'examples/attempt-compare/';
+
+function normalizeRelativePath(pathArg: string): string {
+  return normalize(pathArg).split(sep).join('/').replace(/^\.\/+/, '');
+}
+
+function resolveAttemptDirectory(pathArg: string): string {
+  const callerRelative = resolve(pathArg);
+  if (existsSync(callerRelative)) return callerRelative;
+  if (isAbsolute(pathArg)) return callerRelative;
+
+  const normalized = normalizeRelativePath(pathArg);
+  if (normalized === '..' || normalized.startsWith('../')) return callerRelative;
+  if (normalized === 'examples/attempt-compare' || normalized.startsWith(packagedCompareExamplePrefix)) {
+    const packagedPath = join(packageRoot, ...normalized.split('/'));
+    if (existsSync(packagedPath)) return packagedPath;
+  }
+
+  return callerRelative;
+}
+
 function normalizeChangedFile(value: string): string | null {
   const withoutTimestamp = value.split('\t', 1)[0];
   const trimmed = withoutTimestamp.trim();
@@ -167,7 +190,7 @@ function parseAcStatus(content: string): { score: number | null; scoreLabel: str
 }
 
 function loadBareAttempt(pathArg: string, label: 'attempt-a' | 'attempt-b'): BareAttemptSummary {
-  const absolute = resolve(pathArg);
+  const absolute = resolveAttemptDirectory(pathArg);
   if (!existsSync(absolute)) throw new Error(`${label}: attempt folder does not exist: ${pathArg}`);
   if (!statSync(absolute).isDirectory()) throw new Error(`${label}: attempt path must be a directory: ${pathArg}`);
 

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -80,6 +80,46 @@ describe('npm package payload', () => {
     }
   }, 20_000);
 
+  it('runs compare demo from an extracted npm tarball while invoked from a fresh external cwd', () => {
+    const packDir = mkdtempSync(join(tmpdir(), 'open-scaffold-pack-'));
+    const extractDir = mkdtempSync(join(tmpdir(), 'open-scaffold-extract-'));
+    const freshCwd = mkdtempSync(join(tmpdir(), 'open-scaffold-fresh-cwd-'));
+
+    try {
+      const output = execFileSync('npm', ['pack', '--json', '--pack-destination', packDir], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const [pack] = JSON.parse(output) as PackResult[];
+      const tarball = resolve(packDir, pack.filename);
+
+      execFileSync('tar', ['-xzf', tarball, '-C', extractDir], {
+        cwd: repoRoot,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const packageDir = join(extractDir, 'package');
+      const compareOutput = execFileSync('node', [
+        join(packageDir, 'dist/cli.js'),
+        'compare',
+        'examples/attempt-compare/attempt-a',
+        'examples/attempt-compare/attempt-b',
+      ], {
+        cwd: freshCwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      expect(compareOutput).toContain('# Attempt comparison: attempt-a → attempt-b');
+      expect(compareOutput).toContain('This command reads local files only. It does not spawn runtimes, promote a frontier, or approve work.');
+    } finally {
+      rmSync(packDir, { recursive: true, force: true });
+      rmSync(extractDir, { recursive: true, force: true });
+      rmSync(freshCwd, { recursive: true, force: true });
+    }
+  }, 40_000);
+
   it('runs init successfully from an extracted npm tarball', () => {
     const packDir = mkdtempSync(join(tmpdir(), 'open-scaffold-pack-'));
     const extractDir = mkdtempSync(join(tmpdir(), 'open-scaffold-extract-'));

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -246,7 +246,7 @@ This sample must not count as the real section.
 
     expect(hash(planIssueSnapshot)).toBe('0750ffde60e42d9a61d4fc92694cd956e9183957268dae514f55980994bcc45c');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('d6ca29a5d2141f51b5d5425d52fcb0691143adeb1c8799638e64653f6c8d22d4');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('da7338c8aecb0720c157e57366521f856eb5e26417aaf1c4fc858f1df35bf0b6');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- repair `osc compare` so the shipped `examples/attempt-compare/...` demo resolves from the installed package when the command is invoked from a fresh external directory
- add extracted-package regression coverage for the advertised zero-context `npx open-scaffold@latest compare ...` path
- prepare `open-scaffold@0.20.4` candidate docs/evidence while keeping plan 129 active until merge + npm publish + GitHub Release + final closeout proof

## Traceability

- Plan: `.osc/plans/active/129-zero-context-resume-proof.md`
- Evidence: `.osc/releases/2026-05-30-129-npx-compare-demo-repair.md`
- Kanban: `t_4ff11e15`
- Branch: `fix/129-npx-compare-demo`

## Verification

- `npm test -- tests/package-payload.test.ts` — PASS, 1 file / 4 tests
- `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS, `0.20.4 / 0.20.4 / 0.20.4`
- `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before publish, npm latest remains `0.20.3`
- `npm run build` — PASS
- `npm test` — PASS, 53 files / 531 tests
- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn
- `npm pack --dry-run --json` — PASS, `open-scaffold@0.20.4` / 204 files
- `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.20.4`
- extracted package smoke from a fresh external cwd — PASS: `node <extracted>/package/dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b`
- `git diff --check` — PASS

## Owner gates

Stop before merge. After merge, the approved follow-through for this same scoped plan is: trusted npm publish for `open-scaffold@0.20.4`, fresh isolated-cache `npx open-scaffold@latest compare ...` verification, GitHub Release `v0.20.4` marked Latest, then plan 129 closeout with final evidence.
