### PR TITLE
Close plan 129 after package release

### DIFF
--- a/.osc/plans/done/129-zero-context-resume-proof.md
+++ b/.osc/plans/done/129-zero-context-resume-proof.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 
 **Approval state:** approved for execution by owner. AC-7 interpretation approved: feature the zero-context-resume narrative prominently in the README first screen, immediately after the locked work-record promise paragraph, without displacing existing positioning tokens. Consensus-approved by `/ralplan --consensus` (Planner → Architect → Critic, 2 iterations: Architect **SOUND**, Critic **APPROVE**). No commit, push, publish, release, merge, or PR without a separate owner gate.

--- a/.osc/releases/2026-05-30-129-npx-compare-demo-repair.md
+++ b/.osc/releases/2026-05-30-129-npx-compare-demo-repair.md
@@ -2,21 +2,25 @@
 
 ## Summary
 
-Prepares `open-scaffold@0.20.4` as the package-visible repair for plan `129-zero-context-resume-proof` AC-5: the advertised first-read `npx open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` command must work from a fresh external directory after publication, not only from the repository root.
+Published `open-scaffold@0.20.4` as the package-visible repair for plan `129-zero-context-resume-proof` AC-5: the advertised first-read `npx open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` command now works from a fresh external directory, not only from the repository root.
 
-This candidate keeps `osc compare` local and read-only. It does not add runtime spawning, model scoring, frontier promotion, approval automation, or a new stable command.
+This release keeps `osc compare` local and read-only. It does not add runtime spawning, model scoring, frontier promotion, approval automation, or a new stable command.
 
 ## Traceability
 
-- Roadmap / issue / task: Open Scaffold self-dogfood package/adoption repair for active plan 129; Hermes Kanban card `t_4ff11e15`.
-- Plan: `.osc/plans/active/129-zero-context-resume-proof.md` remains active until merge, npm publication, fresh `npx`, GitHub Release Latest, and final closeout proof are complete.
-- Branch: `fix/129-npx-compare-demo`.
-- Pull Request: pending; this note is the candidate evidence for the repair PR.
+- Roadmap / issue / task: Open Scaffold self-dogfood package/adoption repair for plan 129; Hermes Kanban card `t_4ff11e15`.
+- Plan: `.osc/plans/done/129-zero-context-resume-proof.md` after closeout; `.osc/plans/active/129-zero-context-resume-proof.md` during implementation and package/release follow-through.
+- Repair branch: `fix/129-npx-compare-demo`.
+- Repair Pull Request: https://github.com/graphanov/open-scaffold/pull/155.
+- Repair merge commit: `2c8c81f973c500f43a7796645a92d7f790c7194e`.
+- Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/26689646203.
+- npm package: `open-scaffold@0.20.4` with dist-tag `latest`.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.20.4.
 - Run ID / run packet: N/A for this scoped package repair.
 
 ## Verification
 
-Reproduced pre-fix failure from a fresh temp directory and isolated npm cache against current published `open-scaffold@latest` (`0.20.3`):
+Reproduced pre-fix failure from a fresh temp directory and isolated npm cache against published `open-scaffold@latest` before the repair (`0.20.3`):
 
 ```text
 npx --yes open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b
@@ -25,33 +29,33 @@ attempt-a: attempt folder does not exist: examples/attempt-compare/attempt-a
 
 Candidate gates before PR-ready:
 
-- [x] Fresh published-package failure reproduced from external temp directory with isolated npm cache — PASS: current `open-scaffold@latest` exits 1 with `attempt folder does not exist`.
+- [x] Fresh published-package failure reproduced from external temp directory with isolated npm cache — PASS: pre-fix `open-scaffold@latest` exited 1 with `attempt folder does not exist`.
 - [x] `npm test -- tests/package-payload.test.ts` — PASS: 1 file / 4 tests after adding extracted-package external-cwd compare regression.
 - [x] `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `0.20.4 / 0.20.4 / 0.20.4`.
-- [x] `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before publish: live npm remains `0.20.3`, `latest: 0.20.3`, and `0.20.4` is not yet published.
+- [x] `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before publish: live npm remained `0.20.3`, `latest: 0.20.3`, and `0.20.4` was not yet published.
 - [x] `npm run build` — PASS.
 - [x] `npm test` — PASS after updating the live-corpus hash for this new evidence note: 53 files / 531 tests.
 - [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
 - [x] `npm pack --dry-run --json` — PASS for `open-scaffold@0.20.4` (204 files); includes compare-demo inputs, resume-demo fixture, and `dist/cli.js`.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.20.4`.
-- [x] Extracted-package compare smoke from a fresh external cwd — PASS: `node <extracted>/package/dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` renders `# Attempt comparison: attempt-a → attempt-b`.
+- [x] Extracted-package compare smoke from a fresh external cwd — PASS: `node <extracted>/package/dist/cli.js compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` rendered `# Attempt comparison: attempt-a → attempt-b`.
 - [x] `git diff --check` — PASS.
-- [ ] PR CI and latest-head Codex review loop — pending after PR creation.
+- [x] PR CI and latest-head Codex review loop — PASS: PR #155 checks green, Codex clean, unresolved review threads zero.
 
-Post-merge/publication gates after owner merge approval:
+Post-merge/publication gates after owner-approved follow-through:
 
-- [ ] Sync clean `main` after merge.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.20.4` with dist-tag `latest`.
-- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.20.4` and `latest: 0.20.4`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` succeeds from a fresh external directory.
-- [ ] GitHub Release `v0.20.4` exists and is marked Latest.
-- [ ] Source plan 129 is closed to `done/` with final public proof.
+- [x] Sync clean `main` after merge — PASS at `2c8c81f973c500f43a7796645a92d7f790c7194e`.
+- [x] Trusted publishing workflow published `open-scaffold@0.20.4` with dist-tag `latest` — PASS: run `26689646203` succeeded.
+- [x] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.20.4` and `latest: 0.20.4`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --version` reports `0.20.4`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` succeeds from a fresh external directory.
+- [x] GitHub Release `v0.20.4` exists and is marked Latest.
+- [x] Source plan 129 is closed to `done/` with final public proof in this closeout branch.
 
 ## Outcome
 
-Candidate prepared; not merged, not published, not released, and not closed yet. The repair changes packaged example-path resolution and adds regression coverage so the zero-context demo can be proven after trusted publication.
+Completed. PR #155 merged the package-path repair, trusted publishing succeeded, npm `open-scaffold@latest` resolves to `0.20.4`, fresh isolated-cache `npx` proves the zero-context compare demo from an external directory, GitHub Release `v0.20.4` is Latest, and plan 129 is closed to `done/` by the closeout branch.
 
 ## Follow-up
 
-- Owner/merge gate: merge the repair PR only after local verification, CI, and latest-head Codex are clean.
-- After merge: publish `open-scaffold@0.20.4` through trusted publishing, verify fresh isolated-cache `npx`, create GitHub Release `v0.20.4` as Latest, then close plan 129 with final evidence.
+- Next roadmap decision can move to the next active/backlog slice only after this closeout branch lands on `main`.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-30: closed 129-zero-context-resume-proof — published open-scaffold@0.20.4, verified fresh npx compare demo, and created GitHub Release v0.20.4
 - 2026-05-29: closed 131-mcp-integration-surface-readiness — closed 131-mcp-integration-surface-readiness after PR #153 MCP posture ADR merge
 - 2026-05-29: record MCP posture ADR and readiness proof — see .osc/plans/done/131-mcp-integration-surface-readiness-amendment-1.md
 - 2026-05-29: closed 130-section-parser-canonical-contract — published open-scaffold@0.20.3 and aligned canonical section parser public surfaces

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,21 +4,22 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
-## v0.20.4 — Fresh npx compare demo repair candidate
+## v0.20.4 — Fresh npx compare demo repair
 
-Status: release candidate prepared in the repository. It is not published until the repair PR is merged, trusted npm publishing succeeds, fresh isolated-cache `npx` proves the zero-context command, and GitHub Release `v0.20.4` is created and marked Latest.
+Status: published to npm as `open-scaffold@0.20.4`; GitHub Release `v0.20.4` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
 - Repairs the advertised first-read command so `npx open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` can run from a fresh external directory after publication.
 - Keeps `osc compare` local and read-only: no runtime spawning, no model scoring, no frontier promotion, and no approval automation.
 - Adds extracted-package regression coverage proving the packaged demo resolves from outside the package directory.
-- Keeps plan `129-zero-context-resume-proof` active until merge, npm publication, fresh `npx`, GitHub Release Latest, and final closeout evidence are complete.
+- Closes plan `129-zero-context-resume-proof` after merge, npm publication, fresh `npx`, GitHub Release Latest, and final closeout evidence are complete.
 
 Evidence:
 
-- Source plan: `.osc/plans/active/129-zero-context-resume-proof.md`
-- Candidate evidence note: `.osc/releases/2026-05-30-129-npx-compare-demo-repair.md`
+- Source plan: `.osc/plans/done/129-zero-context-resume-proof.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/155
+- Release-sync evidence note: `.osc/releases/2026-05-30-129-npx-compare-demo-repair.md`
 
 ## v0.20.3 — Canonical section parser package sync
 

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -4,9 +4,9 @@ This page is the canonical reconciliation between the current package version an
 
 ## Current line: `v0.20.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.20.4` (release candidate in this repository until npm/GitHub Release follow-through proves publication)
-- **npm latest:** check `npm view open-scaffold version dist-tags --json` for live truth.
-- **GitHub Release latest:** check the GitHub Releases page for the release marked **Latest**.
+- **Current `package.json` version:** `0.20.4`
+- **npm latest:** `0.20.4` with dist-tag `latest` after trusted publishing run `26689646203`; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** `v0.20.4` is marked **Latest** after the fresh npx compare-demo repair release.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.
@@ -25,7 +25,7 @@ The `v0.20.x` line defines a stable-enough core (the repo-native work-record loo
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.20.4` candidate |
+| `package.json` version | `0.20.4` |
 | Current package line | `v0.20.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('0750ffde60e42d9a61d4fc92694cd956e9183957268dae514f55980994bcc45c');
+    expect(hash(planIssueSnapshot)).toBe('1fe1f4f315168d2ccddff3261fc081bc46a6695df1f388763d4115ea1f43705d');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('da7338c8aecb0720c157e57366521f856eb5e26417aaf1c4fc858f1df35bf0b6');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary
- Closes plan 129 after the repair PR, npm publish, fresh `npx` compare smoke, and GitHub Release `v0.20.4` are complete.
- Updates release evidence, changelog, and version-truth docs from candidate wording to published/Latest truth.
- Updates the live-corpus section-parser hash after moving the plan from active to done.

## Verification
- `git diff --check`
- `./verify.sh --strict`
- `npm test`
- `npm run build`

## Public surface proof
- Repair PR: https://github.com/graphanov/open-scaffold/pull/155
- Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/26689646203
- npm: `open-scaffold@0.20.4` / `latest`
- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.20.4
- Fresh isolated-cache `npx --yes open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` succeeded from an external temp directory.

## Risk / gates
- Docs/evidence/plan-state closeout only.
- No package code, runtime behavior, workflow permissions, publish action, or release side effect in this PR.
