### PR TITLE
Add tally downstream proof example

### DIFF
--- a/.osc/plans/done/115-downstream-example-proof.md
+++ b/.osc/plans/done/115-downstream-example-proof.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+done
 
 ## Context
 

--- a/.osc/releases/2026-05-30-115-downstream-example-proof.md
+++ b/.osc/releases/2026-05-30-115-downstream-example-proof.md
@@ -1,0 +1,30 @@
+# Release / Evidence Note: 115-downstream-example-proof
+
+## Summary
+
+Added a downstream proof page documenting [`graphanov/tally`](https://github.com/graphanov/tally), a small standalone CLI built outside this repository where one real feature was planned, executed, verified, and closed as an Open Scaffold work record. README links the proof from the Dogfooded section. Documentation only; no Open Scaffold product code changed.
+
+## Traceability
+
+- Roadmap / issue / task: `.osc/plans/active/115-downstream-example-proof.md` (this slice); strategy direction from `references/adoption-wedge-strategy-swarm-2026-05-27.md` ("one external/downstream example before broad launch").
+- Plan: `.osc/plans/done/115-downstream-example-proof.md` after closeout; `.osc/plans/active/115-downstream-example-proof.md` during implementation.
+- Run ID / run packet: N/A — documentation slice.
+- Branch / PR: branch `docs/downstream-proof-tally`; PR pending.
+
+## Verification
+
+- `git diff --check` — PASS.
+- `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
+- `npm test` — PASS (no product code changed; suite stays green).
+- Private-marker scan over the new docs page — PASS: no private operating-workshop, assistant-internal, private-workspace, or raw-agent-log markers.
+- All links in `docs/examples/downstream-proof.md` verified against the live public `graphanov/tally` repository, including `MISSION.md`, `.osc/plans/done/streak-and-json.md`, `src/streak.ts`, `tests/streak.test.ts`, the evidence note, and PR #1.
+- Downstream reproduction verified in the tally repo: `npm test` (2 files / 15 tests), `./verify.sh --standard` (6 pass / 0 fail / 0 warn), and `osc trace streak-and-json` reconstructs the slice.
+
+## Outcome
+
+Shipped: `docs/examples/downstream-proof.md` plus a README proof link. The example is honestly labeled owner-created, demonstrates reconstructability rather than certification, and uses CLI/package names matching npm latest (`open-scaffold@0.20.4`). Pending owner PR review and merge.
+
+## Follow-up
+
+- Owner gate: review and merge the PR for `docs/downstream-proof-tally`.
+- Optional later: a collaborator- or third-party-built example would strengthen the proof beyond owner-created dogfood.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-30: closed 115-downstream-example-proof — Add tally downstream proof example
 - 2026-05-30: closed 129-zero-context-resume-proof — published open-scaffold@0.20.4, verified fresh npx compare demo, and created GitHub Release v0.20.4
 - 2026-05-29: closed 131-mcp-integration-surface-readiness — closed 131-mcp-integration-surface-readiness after PR #153 MCP posture ADR merge
 - 2026-05-29: record MCP posture ADR and readiness proof — see .osc/plans/done/131-mcp-integration-surface-readiness-amendment-1.md

--- a/README.md
+++ b/README.md
@@ -380,3 +380,5 @@ Translations for agent entry files: Chinese, Japanese, Korean, Spanish, Portugue
 ## Dogfooded
 
 Open Scaffold is built with Open Scaffold. This repo contains its own roadmap, plans, evidence notes, decisions, releases, and PR history so the method can be inspected instead of merely claimed.
+
+For proof of use **outside** this repo, see [`docs/examples/downstream-proof.md`](docs/examples/downstream-proof.md): [`tally`](https://github.com/graphanov/tally), a small standalone CLI where one real feature was planned, executed, verified, and closed as an Open Scaffold work record.

--- a/docs/examples/downstream-proof.md
+++ b/docs/examples/downstream-proof.md
@@ -1,0 +1,51 @@
+# Downstream proof: tally
+
+Open Scaffold is heavily dogfooded — this repository keeps its own plans, evidence, and releases under `.osc/`. A fair skeptic still asks: *does anything outside this repo actually use it?*
+
+This page answers that with one small, inspectable example you can read in a couple of minutes.
+
+> Provenance: **owner-created**. `tally` was built by the same owner as Open Scaffold as an honest reference example. It is dogfood outside the core repo, not third-party adoption.
+
+## What tally is
+
+[`tally`](https://github.com/graphanov/tally) is a tiny habit/streak tracker CLI (TypeScript, zero runtime dependencies). It is a real, standalone tool — not an `example-` folder inside this repo. Open Scaffold was added to it the same way any adopter would: from a fresh `npx open-scaffold@latest` against an existing project.
+
+## The chain you can reconstruct
+
+One real feature — a `tally streak <habit>` command plus `tally list --json` — was carried through the full Open Scaffold lifecycle in the tally repo:
+
+```text
+brownfield init  ->  MISSION.md  ->  plan  ->  code change + tests  ->  evidence note  ->  close  ->  PR
+```
+
+Every step left a durable artifact you can open:
+
+| Step | Artifact (in `graphanov/tally`) |
+|---|---|
+| Added Open Scaffold to an existing repo | `npx open-scaffold@latest init --from-existing --tier min --target .` |
+| Mission | [`MISSION.md`](https://github.com/graphanov/tally/blob/main/MISSION.md) |
+| Plan | [`.osc/plans/done/streak-and-json.md`](https://github.com/graphanov/tally/blob/main/.osc/plans/done/streak-and-json.md) |
+| Code change | [`src/streak.ts`](https://github.com/graphanov/tally/blob/main/src/streak.ts) + [`tests/streak.test.ts`](https://github.com/graphanov/tally/blob/main/tests/streak.test.ts) |
+| Evidence note | [`.osc/releases/2026-05-30-streak-and-json.md`](https://github.com/graphanov/tally/blob/main/.osc/releases/2026-05-30-streak-and-json.md) |
+| Closeout (plan → `done/`, mission changelog stamp) | `./close.sh streak-and-json` |
+| Pull request | [`graphanov/tally#1`](https://github.com/graphanov/tally/pull/1) |
+
+## Reproduce the inspection
+
+```bash
+git clone https://github.com/graphanov/tally
+cd tally
+npm install
+npm test            # 2 files / 15 tests
+./verify.sh --standard
+npx open-scaffold@latest trace streak-and-json
+```
+
+The `trace` output reconstructs the slice — goal, acceptance criteria, and the evidence note that cites the plan — straight from the repo, with no chat history.
+
+## What this proves (and what it does not)
+
+- **Proves:** Open Scaffold can be added to an existing, unrelated project and used to plan, execute, verify, and close a real change, leaving a reconstructable work record.
+- **Does not prove:** automatic correctness, third-party endorsement, or that every future change is right. It demonstrates *reconstructability*, not certification.
+
+Friction discovered while building tally is recorded as follow-up backlog in this repo rather than hidden, keeping the example honest.

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('1fe1f4f315168d2ccddff3261fc081bc46a6695df1f388763d4115ea1f43705d');
+    expect(hash(planIssueSnapshot)).toBe('070ce8bdc287f22d91fedce6badf268f5b3ab6824f261ae7d28f1ac97faff347');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('da7338c8aecb0720c157e57366521f856eb5e26417aaf1c4fc858f1df35bf0b6');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('74e4ca830a2b8bc52100d106fc8f193926ae2427fd24b1f98683aca174f826a2');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Adds a downstream proof page documenting [`graphanov/tally`](https://github.com/graphanov/tally) — a small standalone CLI, built outside this repository, where one real feature (`tally streak` + `tally list --json`) was planned, executed, verified, and closed as an Open Scaffold work record. This answers the "only the maintainer's own repo uses it" objection with an external, inspectable example.

Closes plan `115-downstream-example-proof`.

## What landed

- `docs/examples/downstream-proof.md` — the proof page: what tally is, the reconstructable `init → mission → plan → change → evidence → close → PR` chain (with links to the live tally artifacts), a clone-and-inspect reproduction, and an explicit "proves reconstructability, not certification" boundary.
- `README.md` — one proof link from the Dogfooded section.
- `.osc/plans/done/115-downstream-example-proof.md` — plan closed.
- `.osc/releases/2026-05-30-115-downstream-example-proof.md` — evidence note.

## Honesty

The example is labeled **owner-created** dogfood, not third-party adoption. It demonstrates that Open Scaffold can be added to an existing, unrelated project and used end to end — not that any future change is automatically correct.

## Verification

- `git diff --check` — PASS.
- `./verify.sh --strict` — 10 pass / 0 fail / 0 warn.
- `npm test` — 53 files / 531 tests PASS (live-corpus hashes updated for the new done plan + release note).
- `npm run build` — PASS.
- All `graphanov/tally` links in the proof page verified resolving (HTTP 200) on `main` after tally's own first PR merged.

## Out of scope

No Open Scaffold product code changed. No npm publish or release in this slice (docs-only).
