### PR TITLE
Add osc plan stats portfolio summary command

### DIFF
--- a/.osc/plans/done/132-plan-stats-command.md
+++ b/.osc/plans/done/132-plan-stats-command.md
@@ -1,0 +1,65 @@
+# Plan: 132-plan-stats-command
+
+## Status
+
+done
+
+## Context
+
+Open Scaffold repos accumulate plans across four stages (`active`, `backlog`,
+`blocked`, `done`). On a mature repo there can be well over a hundred plans, and
+a maintainer currently has no quick way to see the shape of that portfolio or to
+spot in-flight work that has gone stale. The lifecycle commands (`plan new`,
+`plan move`, `plan validate`, `close`) all operate on a single plan; there is no
+summary view.
+
+## Goal
+
+Add an `osc plan stats` command that prints a portfolio summary: a count of
+plans in each stage, the total, and the oldest active plan (least recently
+modified) so a maintainer can spot stale in-flight work. Provide a `--json`
+mode emitting the same data for scripting, with a clear non-error message when
+there are no active plans.
+
+## Constraints / Out of scope
+
+- Do not change unrelated workflows or other `osc plan` subcommands.
+- Do not add hidden network calls or runtime spawning.
+- Do not add new runtime dependencies.
+- Do not modify `MISSION.md`, `ROADMAP.md`, or committed plan bodies.
+- Stage counts must be read from the real `.osc/plans/` structure, never hardcoded.
+
+## Files to touch
+
+- `src/plan-stats.ts` — stats computation (`computePlanStats`) and text rendering (`formatPlanStats`); reads the scaffold via the existing `inspectScaffold()` helper.
+- `src/cli.ts` — register a `stats` branch in `planCommand()` with help/usage text mirroring `plan move` / `plan validate`.
+- `tests/cli-plan-stats.test.ts` — unit + CLI coverage: per-stage counts, total, oldest-active-by-mtime (not alphabetical), no-active message, `--json` parseability, and bad-flag exit code.
+- `tests/cli-lifecycle-help.test.ts` — extend help-parity coverage so the new command is locked into `--help`.
+
+## Acceptance criteria
+
+- [ ] `osc plan stats` prints a count of plans in each stage (active, backlog, blocked, done) plus the total.
+- [ ] `osc plan stats` identifies the oldest active plan by modification time, and prints a clear non-error message when there are no active plans.
+- [ ] `osc plan stats --json` prints valid, parseable JSON containing the same counts, total, and oldest-active data.
+- [ ] Invalid input (unknown flag) fails with an actionable error and a non-zero exit code.
+- [ ] Documentation/help lists `osc plan stats [--json]`, and a help-parity test covers it.
+- [ ] Existing behavior remains backwards-compatible: build, full test suite, and `./verify.sh --strict` all pass.
+
+## Verification steps
+
+1. `npm test -- tests/cli-plan-stats.test.ts tests/cli-lifecycle-help.test.ts`
+2. `npm test`
+3. `npm run build && ./verify.sh --strict`
+4. CLI smoke: `node dist/cli.js plan stats` and `node dist/cli.js plan stats --json`
+
+## Open questions
+
+- None.
+
+## Provenance
+
+This implementation was selected through a real two-agent `osc compare` run:
+Codex CLI and Claude Code each implemented this feature from an identical brief
+in isolated worktrees. Both passed all gates; the Claude attempt was adopted
+because it added a help-parity regression guard and broader test coverage. The
+comparison artifacts are operator-local scratch and are not part of this PR.

--- a/.osc/releases/2026-05-30-132-plan-stats-command.md
+++ b/.osc/releases/2026-05-30-132-plan-stats-command.md
@@ -1,0 +1,53 @@
+# Release / Evidence Note: 132-plan-stats-command
+
+## Summary
+
+Added `osc plan stats`, a portfolio-summary command for the plan lifecycle. It
+prints per-stage counts (active/backlog/blocked/done), the total, and the oldest
+active plan by modification time, with a clear non-error message when there are
+no active plans. A `--json` mode emits the same data for scripting.
+
+## Traceability
+
+- Plan: `.osc/plans/done/132-plan-stats-command.md` (after closeout); `.osc/plans/active/132-plan-stats-command.md` during implementation.
+- Branch / PR: branch `cli/plan-stats`; PR pending.
+- Run ID / run packet: N/A — direct CLI feature slice.
+
+## Implementation
+
+- `src/plan-stats.ts` — `computePlanStats()` reads the scaffold via the existing `inspectScaffold()` helper (counts never hardcoded); `formatPlanStats()` renders the aligned text summary.
+- `src/cli.ts` — `stats` branch registered in `planCommand()` with `--json` handling, an actionable unknown-flag error (exit 2), and help/usage text alongside `plan move` / `plan validate` / `plan graph`.
+- `tests/cli-plan-stats.test.ts` — unit + CLI coverage: per-stage counts, total, oldest-active selection by mtime (proven against alphabetical order via controlled mtimes), no-active message in both text and JSON, `--json` parseability, and unknown-flag exit code 2.
+- `tests/cli-lifecycle-help.test.ts` — extended help-parity coverage so the new command stays in `--help`.
+- `tests/section-parser.test.ts` — live-corpus plan-validation hash pin refreshed for the new done plan + this evidence note.
+
+## Verification
+
+- `npm test -- tests/cli-plan-stats.test.ts tests/cli-lifecycle-help.test.ts` — PASS (16 tests).
+- `npm test` — PASS, 54 files / 538 tests.
+- `npm run build` — PASS.
+- `./verify.sh --strict` — 10 pass / 0 fail / 0 warn.
+- `git diff --check` — clean.
+- CLI smoke (real repo): `node dist/cli.js plan stats` → per-stage counts + total + oldest-active line; `node dist/cli.js plan stats --json` → valid parseable JSON.
+
+## Provenance
+
+The implementation was selected through a real two-agent comparison: Codex CLI
+and Claude Code each implemented this feature from an identical brief in isolated
+git worktrees off the same base commit. Both passed all gates independently; the
+Claude attempt was adopted via `osc compare` because it added a help-parity
+regression guard and broader test coverage (including the unknown-flag error
+path). The comparison artifacts are operator-local scratch and are intentionally
+not part of this PR.
+
+## Outcome
+
+Shipped: `osc plan stats` with text and `--json` output, wired into `planCommand()`
+and `--help`, covered by unit + CLI tests and a help-parity guard. All gates pass
+(538 tests, build clean, `verify.sh --strict` clean). Pending owner PR review and
+merge; no npm publish or release in this slice.
+
+## Follow-up
+
+- Owner gate: review and merge the PR for `cli/plan-stats`.
+- After merge, this command surface is package-visible; a package/release sync may be warranted before advertising it externally (npm latest currently predates this command).

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-05-30: closed 132-plan-stats-command — Add osc plan stats portfolio summary command
 - 2026-05-30: closed 129-zero-context-resume-proof — published open-scaffold@0.20.4, verified fresh npx compare demo, and created GitHub Release v0.20.4
 - 2026-05-29: closed 131-mcp-integration-surface-readiness — closed 131-mcp-integration-surface-readiness after PR #153 MCP posture ADR merge
 - 2026-05-29: record MCP posture ADR and readiness proof — see .osc/plans/done/131-mcp-integration-surface-readiness-amendment-1.md

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ import { addTaskComment, createTask, formatTaskDetails, formatTaskSummary, forma
 import { validateScaffold } from './validation.js';
 import { formatPlanValidationIssues, hasBlockingIssues, resolvePlanValidationPath, validatePlanFile } from './plan-validate.js';
 import { buildPlanGraph, normalizePlanReference, renderPlanGraphAscii, renderPlanGraphMermaid, type PlanGraphDirection, type PlanGraphFormat, type PlanGraphStageFilter } from './plan-graph.js';
+import { computePlanStats, formatPlanStats } from './plan-stats.js';
 import { askInteractiveAnswers, assertWizardReady, createWizardPlan, loadAnswersFile, type PlanWizardAnswers } from './wizard.js';
 import { buildWorkDryRunPreview, formatWorkDryRunPreview } from './work.js';
 import { buildTrace, formatTraceReport, TraceUsageError } from './trace.js';
@@ -51,6 +52,7 @@ Stable core protocol:
   osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]
   osc plan move <slug> --to <active|backlog|blocked>
   osc plan graph [--format <ascii|mermaid|json>] [--stage <active|backlog|all>] [--direction <downstream|upstream|both>] [--plan <slug>]
+  osc plan stats [--json]
   osc amend <plan-slug> [--message <text>]
   osc evidence new <slug>
   osc evidence collect <slug> [--ci] [--dry-run] [--verbose]
@@ -514,7 +516,8 @@ function printPlanUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
   osc plan validate <slug-or-path> [--json] [--strict]
   osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]
   osc plan move <slug> --to <active|backlog|blocked>
-  osc plan graph [--format <ascii|mermaid|json>] [--stage <active|backlog|all>] [--direction <downstream|upstream|both>] [--plan <slug>]`, stream);
+  osc plan graph [--format <ascii|mermaid|json>] [--stage <active|backlog|all>] [--direction <downstream|upstream|both>] [--plan <slug>]
+  osc plan stats [--json]`, stream);
 }
 
 function printPlanNewUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
@@ -531,6 +534,10 @@ function printPlanMoveUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
 
 function printPlanGraphUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
   printUsage('Usage: osc plan graph [--format <ascii|mermaid|json>] [--stage <active|backlog|all>] [--direction <downstream|upstream|both>] [--plan <slug>]', stream);
+}
+
+function printPlanStatsUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc plan stats [--json]', stream);
 }
 
 function parsePlanGraphOptions(args: string[]): { format: PlanGraphFormat; stage?: PlanGraphStageFilter; direction: PlanGraphDirection; plan?: string } {
@@ -874,6 +881,33 @@ async function planCommand(args: string[]): Promise<void> {
       console.log(`From: ${result.fromStage}`);
       console.log(`To: ${result.toStage}`);
       console.log(`Moved files: ${result.movedFiles.join(', ')}`);
+      return;
+    } catch (error) {
+      exitForScaffoldHelperError(error);
+    }
+  }
+
+  if (subcommand === 'stats') {
+    if (isHelpArg(rest[0])) {
+      printPlanStatsUsage('stdout');
+      return;
+    }
+    let json = false;
+    for (const flag of rest) {
+      if (flag === '--json') json = true;
+      else {
+        console.error(`Unknown option for plan stats: ${flag}`);
+        printPlanStatsUsage();
+        process.exit(2);
+      }
+    }
+    try {
+      const stats = computePlanStats(process.cwd());
+      if (json) {
+        console.log(JSON.stringify(stats, null, 2));
+      } else {
+        console.log(formatPlanStats(stats));
+      }
       return;
     } catch (error) {
       exitForScaffoldHelperError(error);

--- a/src/plan-stats.ts
+++ b/src/plan-stats.ts
@@ -1,0 +1,69 @@
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+import { findScaffoldRoot, inspectScaffold, PLAN_STAGES, type PlanStage } from './scaffold.js';
+
+export type PlanStageCounts = Record<PlanStage, number>;
+
+export interface OldestActivePlan {
+  slug: string;
+  path: string;
+  modifiedMs: number;
+  modifiedIso: string;
+}
+
+export interface PlanStats {
+  counts: PlanStageCounts;
+  total: number;
+  oldestActive: OldestActivePlan | null;
+}
+
+/**
+ * Portfolio summary of the plans under .osc/plans/. Counts are read from the
+ * real stage folders via inspectScaffold (which already filters READMEs,
+ * WORKFLOW.md, the handoff template, and amendment files), so they are never
+ * hardcoded. "Oldest active" means the active plan with the smallest
+ * filesystem modification time — the least recently touched in-flight work.
+ */
+export function computePlanStats(start = process.cwd()): PlanStats {
+  const root = findScaffoldRoot(start) ?? start;
+  const state = inspectScaffold(root);
+
+  const counts: PlanStageCounts = { active: 0, backlog: 0, blocked: 0, done: 0 };
+  let total = 0;
+  for (const stage of PLAN_STAGES) {
+    counts[stage] = state.plans[stage].length;
+    total += counts[stage];
+  }
+
+  // inspectScaffold returns active plans sorted by filename; the strict `<`
+  // comparison keeps the first-by-name plan on an mtime tie, so the result is
+  // deterministic.
+  let oldestActive: OldestActivePlan | null = null;
+  for (const plan of state.plans.active) {
+    const modifiedMs = Math.round(statSync(join(state.root, plan.path)).mtimeMs);
+    if (!oldestActive || modifiedMs < oldestActive.modifiedMs) {
+      oldestActive = { slug: plan.slug, path: plan.path, modifiedMs, modifiedIso: new Date(modifiedMs).toISOString() };
+    }
+  }
+
+  return { counts, total, oldestActive };
+}
+
+export function formatPlanStats(stats: PlanStats): string {
+  const lines = [
+    'Plan portfolio stats',
+    '',
+    `active:  ${stats.counts.active}`,
+    `backlog: ${stats.counts.backlog}`,
+    `blocked: ${stats.counts.blocked}`,
+    `done:    ${stats.counts.done}`,
+    `total:   ${stats.total}`,
+    '',
+  ];
+  if (stats.oldestActive) {
+    lines.push(`Oldest active plan: ${stats.oldestActive.slug} (least recently modified ${stats.oldestActive.modifiedIso.slice(0, 10)})`);
+  } else {
+    lines.push('Oldest active plan: none (no active plans)');
+  }
+  return lines.join('\n');
+}

--- a/src/plan-stats.ts
+++ b/src/plan-stats.ts
@@ -25,7 +25,10 @@ export interface PlanStats {
  * filesystem modification time — the least recently touched in-flight work.
  */
 export function computePlanStats(start = process.cwd()): PlanStats {
-  const root = findScaffoldRoot(start) ?? start;
+  const root = findScaffoldRoot(start);
+  if (!root) {
+    throw new Error(`No Open Scaffold root found from ${start}. Run this inside a repo with .osc/plans and .osc/releases.`);
+  }
   const state = inspectScaffold(root);
 
   const counts: PlanStageCounts = { active: 0, backlog: 0, blocked: 0, done: 0 };

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -34,6 +34,7 @@ const topLevelHelpCommands = [
   'osc plan wizard <slug> [--stage <active|backlog|blocked>] [--non-interactive --answers <answers.json>]',
   'osc plan move <slug> --to <active|backlog|blocked>',
   'osc plan graph [--format <ascii|mermaid|json>] [--stage <active|backlog|all>] [--direction <downstream|upstream|both>] [--plan <slug>]',
+  'osc plan stats [--json]',
   'osc amend <plan-slug> [--message <text>]',
   'osc evidence new <slug>',
   'osc evidence collect <slug> [--ci] [--dry-run] [--verbose]',
@@ -106,6 +107,12 @@ const cases: HelpCase[] = [
     args: ['plan', 'move', '--help'],
     expected: 'Usage: osc plan move <slug> --to <active|backlog|blocked>',
     forbidden: 'Missing required option',
+  },
+  {
+    name: 'plan stats',
+    args: ['plan', 'stats', '--help'],
+    expected: 'Usage: osc plan stats [--json]',
+    forbidden: 'Unknown option',
   },
   {
     name: 'amend',

--- a/tests/cli-plan-stats.test.ts
+++ b/tests/cli-plan-stats.test.ts
@@ -80,6 +80,16 @@ describe('osc plan stats logic', () => {
     expect(stats.oldestActive).toBeNull();
     expect(formatPlanStats(stats)).toContain('Oldest active plan: none (no active plans)');
   }, 20_000);
+
+  it('throws (rather than reporting an all-zero portfolio) when run outside an Open Scaffold root', () => {
+    // A bare temp dir with no .osc/plans is NOT a scaffold. Reporting total: 0
+    // here would be indistinguishable from a real empty scaffold and would give
+    // misleading data in a wrong-directory CI/scripting context, so the command
+    // must fail the same way other plan-scoped commands (plan graph/validate) do.
+    const notAScaffold = tempDir('osc-plan-stats-noroot-');
+
+    expect(() => computePlanStats(notAScaffold)).toThrow(/No Open Scaffold root found/);
+  }, 20_000);
 });
 
 describe('osc plan stats CLI', () => {
@@ -142,5 +152,14 @@ describe('osc plan stats CLI', () => {
     const result = spawnSync(tsx, [cli, 'plan', 'stats', '--bogus'], { cwd: target, encoding: 'utf8' });
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('Unknown option for plan stats');
+  }, 20_000);
+
+  it('fails with a non-zero exit and the scaffold-root error when run outside a scaffold', () => {
+    const notAScaffold = tempDir('osc-plan-stats-cli-noroot-');
+
+    const result = spawnSync(tsx, [cli, 'plan', 'stats'], { cwd: notAScaffold, encoding: 'utf8' });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('No Open Scaffold root found');
+    expect(result.stdout).not.toContain('total:');
   }, 20_000);
 });

--- a/tests/cli-plan-stats.test.ts
+++ b/tests/cli-plan-stats.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { computePlanStats, formatPlanStats } from '../src/plan-stats.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempDir(prefix = 'osc-cli-plan-stats-') {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function defineMission(target: string) {
+  writeFileSync(join(target, 'MISSION.md'), [
+    '# Mission',
+    '',
+    'Test project mission.',
+    '',
+    '## Goals',
+    '',
+    '- Test plan stats.',
+    '',
+    '## Non-Goals',
+    '',
+    '- Do not execute runtime work.',
+    '',
+    '## Changelog',
+    '',
+    '<!-- append YYYY-MM-DD entries below this line -->',
+    '',
+  ].join('\n'));
+}
+
+function initializedScaffold() {
+  const target = tempDir();
+  execFileSync(tsx, [cli, 'init', '--tier', 'min', '--target', target], { encoding: 'utf8' });
+  defineMission(target);
+  return target;
+}
+
+function newPlan(target: string, slug: string, stage: string) {
+  execFileSync(tsx, [cli, 'plan', 'new', slug, '--stage', stage], { cwd: target, encoding: 'utf8' });
+}
+
+function setMtime(target: string, stage: string, slug: string, when: Date) {
+  const path = join(target, '.osc/plans', stage, `${slug}.md`);
+  utimesSync(path, when, when);
+}
+
+describe('osc plan stats logic', () => {
+  it('identifies the oldest active plan by modification time, not by slug order', () => {
+    const target = initializedScaffold();
+    newPlan(target, '010-recent', 'active');
+    newPlan(target, '020-stale', 'active');
+    // 020-stale sorts AFTER 010-recent alphabetically but is older by mtime, so a
+    // correct "least recently modified" result must pick 020-stale.
+    setMtime(target, 'active', '010-recent', new Date('2024-06-01T00:00:00Z'));
+    setMtime(target, 'active', '020-stale', new Date('2021-06-01T00:00:00Z'));
+
+    const stats = computePlanStats(target);
+
+    expect(stats.counts.active).toBe(2);
+    expect(stats.total).toBe(2);
+    expect(stats.oldestActive?.slug).toBe('020-stale');
+    expect(stats.oldestActive?.path).toBe('.osc/plans/active/020-stale.md');
+    expect(formatPlanStats(stats)).toContain('Oldest active plan: 020-stale');
+  }, 20_000);
+
+  it('reports no oldest active plan when there are no active plans', () => {
+    const target = initializedScaffold();
+    newPlan(target, '030-backlog', 'backlog');
+
+    const stats = computePlanStats(target);
+
+    expect(stats.counts.active).toBe(0);
+    expect(stats.counts.backlog).toBe(1);
+    expect(stats.oldestActive).toBeNull();
+    expect(formatPlanStats(stats)).toContain('Oldest active plan: none (no active plans)');
+  }, 20_000);
+});
+
+describe('osc plan stats CLI', () => {
+  it('prints per-stage counts, the total, and the oldest active plan', () => {
+    const target = initializedScaffold();
+    newPlan(target, '010-active-one', 'active');
+    newPlan(target, '020-active-two', 'active');
+    newPlan(target, '030-backlog', 'backlog');
+    newPlan(target, '040-blocked', 'blocked');
+    newPlan(target, '050-doomed', 'active');
+    execFileSync(tsx, [cli, 'close', '050-doomed'], { cwd: target, encoding: 'utf8' });
+    setMtime(target, 'active', '010-active-one', new Date('2024-06-01T00:00:00Z'));
+    setMtime(target, 'active', '020-active-two', new Date('2021-06-01T00:00:00Z'));
+
+    const output = execFileSync(tsx, [cli, 'plan', 'stats'], { cwd: target, encoding: 'utf8' });
+
+    expect(output).toMatch(/^active:\s+2$/m);
+    expect(output).toMatch(/^backlog:\s+1$/m);
+    expect(output).toMatch(/^blocked:\s+1$/m);
+    expect(output).toMatch(/^done:\s+1$/m);
+    expect(output).toMatch(/^total:\s+5$/m);
+    expect(output).toContain('Oldest active plan: 020-active-two');
+  }, 20_000);
+
+  it('emits the same information as parseable JSON with --json', () => {
+    const target = initializedScaffold();
+    newPlan(target, '010-active-one', 'active');
+    newPlan(target, '020-active-two', 'active');
+    newPlan(target, '030-backlog', 'backlog');
+    setMtime(target, 'active', '010-active-one', new Date('2024-06-01T00:00:00Z'));
+    setMtime(target, 'active', '020-active-two', new Date('2021-06-01T00:00:00Z'));
+
+    const output = execFileSync(tsx, [cli, 'plan', 'stats', '--json'], { cwd: target, encoding: 'utf8' });
+    const parsed = JSON.parse(output);
+
+    expect(parsed.counts).toEqual({ active: 2, backlog: 1, blocked: 0, done: 0 });
+    expect(parsed.total).toBe(3);
+    expect(parsed.oldestActive.slug).toBe('020-active-two');
+    expect(parsed.oldestActive.path).toBe('.osc/plans/active/020-active-two.md');
+    expect(typeof parsed.oldestActive.modifiedIso).toBe('string');
+  }, 20_000);
+
+  it('says there are no active plans clearly instead of erroring (text and JSON)', () => {
+    const target = initializedScaffold();
+    newPlan(target, '030-backlog', 'backlog');
+
+    const text = execFileSync(tsx, [cli, 'plan', 'stats'], { cwd: target, encoding: 'utf8' });
+    expect(text).toMatch(/^active:\s+0$/m);
+    expect(text).toContain('Oldest active plan: none (no active plans)');
+
+    const json = execFileSync(tsx, [cli, 'plan', 'stats', '--json'], { cwd: target, encoding: 'utf8' });
+    const parsed = JSON.parse(json);
+    expect(parsed.oldestActive).toBeNull();
+    expect(parsed.total).toBe(1);
+  }, 20_000);
+
+  it('rejects unknown options with exit code 2', () => {
+    const target = initializedScaffold();
+
+    const result = spawnSync(tsx, [cli, 'plan', 'stats', '--bogus'], { cwd: target, encoding: 'utf8' });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Unknown option for plan stats');
+  }, 20_000);
+});

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('1fe1f4f315168d2ccddff3261fc081bc46a6695df1f388763d4115ea1f43705d');
+    expect(hash(planIssueSnapshot)).toBe('cf85e56fb787406636c45340be596146d9992c1c0973090363ea088177aa9d5f');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('da7338c8aecb0720c157e57366521f856eb5e26417aaf1c4fc858f1df35bf0b6');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('a5a74c468e765eb8565eed57aa36c0cace4b1315489b802cc673145e634960de');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Adds `osc plan stats`, a portfolio-summary command for the plan lifecycle. On a
mature Open Scaffold repo there can be 100+ plans across four stages with no quick
way to see the shape of the work or spot stale in-flight plans. This fills that gap.

- `osc plan stats` — per-stage counts (active/backlog/blocked/done), total, and the
  oldest active plan by modification time (a clear non-error message when there are none).
- `osc plan stats --json` — the same data as parseable JSON for scripting.
- Unknown flags fail with an actionable error and exit code 2.

## Closes

Plan `132-plan-stats-command` (closed in this branch; evidence note included).

## Implementation

- `src/plan-stats.ts` — `computePlanStats()` reads the scaffold via the existing
  `inspectScaffold()` helper (counts never hardcoded); `formatPlanStats()` renders
  the aligned text summary.
- `src/cli.ts` — `stats` branch in `planCommand()` with `--json`, unknown-flag error,
  and help/usage text alongside the other `osc plan` subcommands.
- `tests/cli-plan-stats.test.ts` — counts, total, oldest-active-by-mtime (proven
  against alphabetical order with controlled mtimes), no-active message (text + JSON),
  `--json` parseability, unknown-flag exit code.
- `tests/cli-lifecycle-help.test.ts` — help-parity coverage for the new command.

## Verification

- `npm test` — 54 files / 538 tests PASS.
- `npm run build` — PASS.
- `./verify.sh --strict` — 10 pass / 0 fail / 0 warn.
- `git diff --check` — clean.
- CLI smoke on the real repo: `plan stats` and `plan stats --json` both produce real output.

## Provenance (how this implementation was chosen)

This slice was selected through a real two-agent comparison: Codex CLI and Claude
Code each implemented the feature from an identical brief in isolated git worktrees
off the same base commit. Both passed all gates independently; `osc compare` was
used to adjudicate, and the Claude attempt was adopted because it added a
help-parity regression guard and broader test coverage (including the error path).
The comparison artifacts are operator-local scratch and are intentionally not part
of this PR.

## Out of scope

No package publish or release. No changes to other `osc plan` subcommands, runtime
behavior, or dependencies.
