### PR TITLE
feat: add evolve plateau analysis

### DIFF
--- a/.osc/plans/active/134-osc-evolve-analyze-plateau-and-impossible-ac.md
+++ b/.osc/plans/active/134-osc-evolve-analyze-plateau-and-impossible-ac.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+active
 
 ## Context
 

--- a/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
+++ b/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
@@ -1,0 +1,32 @@
+# Release / Evidence Note: 134-osc-evolve-analyze-plateau-and-impossible-ac
+
+## Summary
+
+Added `osc evolve analyze`, a read-only loop-analysis command for existing evolution directories. It reports plateau/stagnation, current-vs-previous and current-vs-frontier acceptance-criteria deltas, observed score sensitivity, probe-only/impossible criteria, and a bounded next-action recommendation without spawning runtimes, rerunning benchmarks, promoting frontiers, or approving work.
+
+## Traceability
+
+- Roadmap / issue / task: follow-up from the 2000m v1 two-lane benchmark reset; no separate GitHub issue in this slice.
+- Plan: `.osc/plans/active/134-osc-evolve-analyze-plateau-and-impossible-ac.md` during implementation.
+- Run ID / run packet: N/A — direct CLI feature slice; no runtime or benchmark rerun.
+- Branch / PR: branch `feat/evolve-analyze-plateau`; PR pending owner review.
+
+## Verification
+
+- RED focused tests first: `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` failed as expected before implementation because `analyzeEvolutionLoop` / `osc evolve analyze` did not exist.
+- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — PASS (35 tests).
+- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts tests/cli-lifecycle-help.test.ts` — PASS (45 tests).
+- `npm test` — PASS (54 files / 544 tests).
+- `npm run build` — PASS (core and runtime-omx TypeScript builds).
+- `git diff --check` — PASS.
+- `./verify.sh --strict` — PASS (10 pass / 0 fail / 0 warn).
+- Added-line public-safety scan — PASS; no blocking private identity/path/raw-score-win claims. Negated fixture guardrails such as `No raw benchmark win` were reviewed as intended non-claims.
+
+## Outcome
+
+Implemented a package-visible analysis surface only. The command inspects existing curated loop/evaluation evidence and can render terminal, Markdown, or JSON output; `--out` writes only the requested report file. Runtime spawning, benchmark reruns, benchmark-v2, external-scorer adapters, npm publication, GitHub Release changes, merge, and acceptance approval remain out of scope and owner-gated.
+
+## Follow-up
+
+- Owner gate: review the PR when opened; merge is not authorized by this note.
+- Next slices remain separate: external-scorer import for `osc eval`, compact evidence mode, and benchmark-v2 design outside this implementation slice.

--- a/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
+++ b/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
@@ -14,9 +14,9 @@ Added `osc evolve analyze`, a read-only loop-analysis command for existing evolu
 ## Verification
 
 - RED focused tests first: `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` failed as expected before implementation because `analyzeEvolutionLoop` / `osc evolve analyze` did not exist.
-- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — PASS (35 tests).
+- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — PASS (36 tests).
 - `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts tests/cli-lifecycle-help.test.ts` — PASS (45 tests).
-- `npm test` — PASS (54 files / 544 tests).
+- `npm test` — PASS (54 files / 545 tests).
 - `npm run build` — PASS (core and runtime-omx TypeScript builds).
 - `git diff --check` — PASS.
 - `./verify.sh --strict` — PASS (10 pass / 0 fail / 0 warn).

--- a/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
+++ b/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
@@ -14,9 +14,9 @@ Added `osc evolve analyze`, a read-only loop-analysis command for existing evolu
 ## Verification
 
 - RED focused tests first: `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` failed as expected before implementation because `analyzeEvolutionLoop` / `osc evolve analyze` did not exist.
-- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — PASS (36 tests).
+- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — PASS (37 tests).
 - `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts tests/cli-lifecycle-help.test.ts` — PASS (45 tests).
-- `npm test` — PASS (54 files / 545 tests).
+- `npm test` — PASS (54 files / 546 tests).
 - `npm run build` — PASS (core and runtime-omx TypeScript builds).
 - `git diff --check` — PASS.
 - `./verify.sh --strict` — PASS (10 pass / 0 fail / 0 warn).

--- a/docs/EVOLUTION_LOOP.md
+++ b/docs/EVOLUTION_LOOP.md
@@ -70,7 +70,19 @@ Check loop structure:
 osc evolve check .osc/evolution/demo-loop
 ```
 
-`osc evolve` does not create a run, launch a runtime, call an LLM, publish benchmark rankings, certify compliance, approve a merge, or decide product taste. It only records curated loop state.
+Analyze a stopped or in-flight loop without recording a new attempt:
+
+```bash
+osc evolve analyze .osc/evolution/demo-loop
+osc evolve analyze .osc/evolution/demo-loop --format json
+osc evolve analyze .osc/evolution/demo-loop --format markdown --out docs/evidence/evolution-analysis.md
+```
+
+`osc evolve analyze` reads `loop.json`, `attempts.jsonl`, `frontier.json`, and linked evaluation envelopes. It reports plateau/stagnation, current-vs-previous and current-vs-frontier acceptance-criteria deltas, observed score sensitivity, criteria flagged as probe-only / hardcoded non-pass / skipped / stale / impossible, and a next-action recommendation: `continue`, `stop`, `redesign`, or `inspect_scorer`. Criterion-level hints can come from evaluation/scorer metadata such as `analysis.score_sensitivity`, `analysis.impossible`, `analysis.reason`, and `analysis.source`, or from explicit evidence/rationale wording.
+
+The analysis command is a decision aid. It does not mutate loop files unless `--out` is supplied for a rendered report, and even then it writes only the requested report path. It does not spawn runtimes, rerun benchmarks, rank models, certify compliance, promote a frontier, or approve work.
+
+`osc evolve` does not create a run, launch a runtime, call an LLM, publish benchmark rankings, certify compliance, approve a merge, or decide product taste. It only records and analyzes curated loop state.
 
 ## See it in one screen
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { openDashboardUrl, serveDashboard, writeWebDashboard } from './dashboard
 import { collectEvidence } from './evidence.js';
 import { evidenceChainExitCode, formatEvidenceChainReport, verifyEvidenceChain } from './evidence-chain.js';
 import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
-import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, compareEvolutionLoop, recordEvolutionAttempt, renderEvolutionComparison, validateEvolutionLoopDir, writeEvolutionLoop, type EvolutionCompareFormat, type EvolutionDecision, type EvolutionStrategy } from './evolution.js';
+import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, analyzeEvolutionLoop, compareEvolutionLoop, recordEvolutionAttempt, renderEvolutionAnalysis, renderEvolutionComparison, validateEvolutionLoopDir, writeEvolutionLoop, type EvolutionAnalysisFormat, type EvolutionCompareFormat, type EvolutionDecision, type EvolutionStrategy } from './evolution.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { computeMetrics, formatMetrics, parseSinceDate } from './metrics.js';
 import { computeStudy, renderStudyMarkdown, validateStudyReport, writeStudyOutput } from './study.js';
@@ -84,6 +84,7 @@ Lab and experimental:
   osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>]
   osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text>
   osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>]
+  osc evolve analyze <loop-dir> [--format <terminal|markdown|json>] [--out <path>] [--plateau-threshold <n>]
   osc evolve check <loop-dir>
   osc cockpit config
   osc cockpit test [--dry-run]
@@ -1865,7 +1866,7 @@ function evalCommand(args: string[]): void {
 }
 
 function printEvolutionUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
-  printUsage('Usage: osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>] | osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text> | osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>] | osc evolve check <loop-dir>', stream);
+  printUsage('Usage: osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>] | osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text> | osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>] | osc evolve analyze <loop-dir> [--format <terminal|markdown|json>] [--out <path>] [--plateau-threshold <n>] | osc evolve check <loop-dir>', stream);
 }
 
 function takeEvolutionValue(args: string[], index: number, flag: string): string {
@@ -1896,6 +1897,10 @@ function parseEvolutionCompareFormat(value: string): EvolutionCompareFormat {
   console.error(`Invalid value for --format: ${value}. Expected one of: terminal, markdown, json`);
   printEvolutionUsage();
   process.exit(2);
+}
+
+function parseEvolutionAnalysisFormat(value: string): EvolutionAnalysisFormat {
+  return parseEvolutionCompareFormat(value);
 }
 
 function evolutionRootFor(path: string): string {
@@ -2084,6 +2089,62 @@ function evolutionCommand(args: string[]): void {
         const resolvedOut = resolve(outPath);
         writeFileSync(resolvedOut, rendered, 'utf8');
         console.log(`Wrote evolution comparison: ${resolvedOut}`);
+      } else {
+        process.stdout.write(rendered.endsWith('\n') ? rendered : `${rendered}\n`);
+      }
+      return;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  }
+
+  if (subcommand === 'analyze') {
+    if (!sourceOrPath) {
+      printEvolutionUsage();
+      process.exit(2);
+    }
+    let format: EvolutionAnalysisFormat = 'terminal';
+    let outPath: string | undefined;
+    let plateauThreshold: number | undefined;
+    for (let i = 0; i < rest.length; i += 1) {
+      const flag = rest[i];
+      switch (flag) {
+        case '--format':
+          format = parseEvolutionAnalysisFormat(takeEvolutionValue(rest, i, flag));
+          i += 1;
+          break;
+        case '--out':
+        case '--output':
+          outPath = takeEvolutionValue(rest, i, flag);
+          i += 1;
+          break;
+        case '--plateau-threshold': {
+          const raw = takeEvolutionValue(rest, i, flag);
+          const parsed = Number(raw);
+          if (!Number.isInteger(parsed) || parsed < 1) {
+            console.error(`Invalid value for --plateau-threshold: ${raw}. Expected a positive integer.`);
+            process.exit(2);
+          }
+          plateauThreshold = parsed;
+          i += 1;
+          break;
+        }
+        default:
+          console.error(`Unknown option for evolve analyze: ${flag}`);
+          printEvolutionUsage();
+          process.exit(2);
+      }
+    }
+    try {
+      const loopDir = resolve(sourceOrPath);
+      const root = evolutionRootFor(loopDir);
+      const analysis = analyzeEvolutionLoop(loopDir, { plateauThreshold }, root);
+      const rendered = renderEvolutionAnalysis(analysis, format);
+      if (outPath) {
+        const resolvedOut = resolve(outPath);
+        writeFileSync(resolvedOut, rendered, 'utf8');
+        console.log(`Wrote evolution analysis: ${resolvedOut}`);
       } else {
         process.stdout.write(rendered.endsWith('\n') ? rendered : `${rendered}\n`);
       }

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -105,6 +105,10 @@ function asNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
 function meaningfulString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0 && !/^(todo|tbd|n\/a|none)$/i.test(value.trim());
 }
@@ -818,6 +822,516 @@ export function renderEvolutionComparison(comparison: EvolutionCompareResult, fo
   }
   if (format === 'markdown') return renderMarkdownComparison(comparison);
   return renderTerminalComparison(comparison);
+}
+
+export type EvolutionAnalysisFormat = EvolutionCompareFormat;
+export type EvolutionAnalysisRecommendationAction = 'continue' | 'stop' | 'redesign' | 'inspect_scorer';
+
+type EvolutionPlateauStatus = 'insufficient_data' | 'improving' | 'stagnating' | 'plateau' | 'regressed';
+type EvolutionCriterionSensitivity = 'observed_positive' | 'observed_negative' | 'none' | 'unknown';
+
+interface EvolutionAnalysisCriterionSnapshot {
+  id: string;
+  text: string;
+  status: string | null;
+  reasons: string[];
+  evidence: string[];
+  impossible: boolean;
+  sensitivityOverride: EvolutionCriterionSensitivity | null;
+}
+
+export interface EvolutionAnalysisDeltaRow {
+  id: string;
+  text: string;
+  previousStatus?: string | null;
+  frontierStatus?: string | null;
+  currentStatus: string | null;
+}
+
+export interface EvolutionAnalysisCriterion {
+  id: string;
+  text: string;
+  currentStatus: string | null;
+  previousStatus: string | null;
+  frontierStatus: string | null;
+  sensitivity: EvolutionCriterionSensitivity;
+  impossible: boolean;
+  reasons: string[];
+  evidence: string[];
+}
+
+export interface EvolutionAnalysisResult {
+  kind: 'analysis';
+  loop: { loopDir: string; loopId: string | null; objective: string | null; strategy: string | null; attemptCount: number };
+  plateau: { status: EvolutionPlateauStatus; threshold: number; noImprovementCount: number; currentScore: number | null; bestScore: number | null; bestAttemptId: string | null };
+  currentAttempt: { attemptId: string | null; runId: string | null; decision: string | null; score: number | null; evaluation: string | null };
+  previousAttempt: { attemptId: string | null; runId: string | null; decision: string | null; score: number | null; evaluation: string | null };
+  frontierAttempt: { attemptId: string | null; runId: string | null; decision: string | null; score: number | null; evaluation: string | null };
+  acceptanceSummary: { currentPass: number; currentTotal: number; frontierPass: number; frontierTotal: number; remainingFailures: string[] };
+  criteria: EvolutionAnalysisCriterion[];
+  currentVsPrevious: { present: boolean; previousAttemptId: string | null; currentAttemptId: string | null; rows: EvolutionAnalysisDeltaRow[] };
+  currentVsFrontier: { present: boolean; frontierAttemptId: string | null; currentAttemptId: string | null; rows: EvolutionAnalysisDeltaRow[] };
+  recommendation: { action: EvolutionAnalysisRecommendationAction; summary: string; reasons: string[] };
+  notes: string[];
+}
+
+export interface EvolutionAnalyzeOptions {
+  plateauThreshold?: number;
+}
+
+function normalizeReason(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  if (normalized === 'probe_only_criterion') return 'probe_only';
+  if (normalized === 'hardcoded_pass_false' || normalized === 'pass_false' || normalized === 'hardcoded_non_pass') return 'hardcoded_non_pass';
+  if (normalized === 'artifact_type' || normalized === 'current_artifact_type') return 'artifact_type_mismatch';
+  return normalized || 'impossible';
+}
+
+function normalizeSensitivity(value: string | null): EvolutionCriterionSensitivity | null {
+  if (!value) return null;
+  const normalized = normalizeReason(value);
+  if (['none', 'no', 'no_score_movement', 'no_score_sensitivity', 'zero', 'low', 'probe_only'].includes(normalized)) return 'none';
+  if (['observed_positive', 'positive', 'score_moving', 'score_sensitive'].includes(normalized)) return 'observed_positive';
+  if (['observed_negative', 'negative', 'inverse'].includes(normalized)) return 'observed_negative';
+  if (normalized === 'unknown') return 'unknown';
+  return null;
+}
+
+const BLOCKING_IMPOSSIBLE_REASONS = new Set(['probe_only', 'hardcoded_non_pass', 'skipped', 'stale', 'impossible', 'artifact_type_mismatch']);
+
+function isAnalysisRefSafe(ref: string): boolean {
+  if (/^file:/i.test(ref)) return false;
+  if (/^https?:\/\//i.test(ref)) return true;
+  const normalized = toPosix(ref).replace(/^\.\//, '');
+  if (isAbsolute(ref) || win32.isAbsolute(ref) || normalized.startsWith('/') || normalized.startsWith('~')) return false;
+  if (isPrivatePath(normalized)) return false;
+  return true;
+}
+
+function addReasonFromText(text: string, reasons: Set<string>): void {
+  const lower = text.toLowerCase();
+  if (/probe[- ]only|probe only/.test(lower)) reasons.add('probe_only');
+  if (/hardcoded[^\n.]*(pass\s*=\s*false|non[- ]pass|fail)|pass\s*=\s*false|pass-false|always fail/.test(lower)) reasons.add('hardcoded_non_pass');
+  if (/\bskipped\b|\bskip-only\b/.test(lower)) reasons.add('skipped');
+  if (/\bstale\b|out[- ]of[- ]date/.test(lower)) reasons.add('stale');
+  if (/impossible|cannot pass|can't pass|no attempt can|unreachable/.test(lower)) reasons.add('impossible');
+  if (/current artifact type|artifact type mismatch|headless json driver/.test(lower)) reasons.add('artifact_type_mismatch');
+}
+
+function collectEvidenceRefsFromCriterion(criterion: Record<string, unknown>, analysis: Record<string, unknown>): string[] {
+  const refs = [
+    asString(analysis.source),
+    asString(analysis.evidence_source),
+    asString(analysis.ref),
+    asString(criterion.source),
+  ];
+  const evaluator = isRecord(criterion.evaluator) ? criterion.evaluator : null;
+  refs.push(evaluator ? asString(evaluator.ref) : null);
+  const evidence = Array.isArray(criterion.evidence) ? criterion.evidence.filter(isRecord) : [];
+  for (const item of evidence) refs.push(asString(item.ref));
+  return uniqueRefs(refs.filter((ref): ref is string => Boolean(ref && ref.trim() && isAnalysisRefSafe(ref))));
+}
+
+function metadataForCriterion(criterion: Record<string, unknown>): { impossible: boolean; reasons: string[]; evidence: string[]; sensitivityOverride: EvolutionCriterionSensitivity | null } {
+  const analysis = isRecord(criterion.analysis) ? criterion.analysis : {};
+  const reasons = new Set<string>();
+  for (const value of [analysis.reason, criterion.reason]) {
+    if (typeof value === 'string') reasons.add(normalizeReason(value));
+  }
+  for (const value of [analysis.reasons, criterion.reasons]) {
+    for (const reason of asStringArray(value)) reasons.add(normalizeReason(reason));
+  }
+  if (asBoolean(analysis.impossible) === true || asBoolean(criterion.impossible) === true) reasons.add('impossible');
+  if (asBoolean(analysis.probe_only) === true || asBoolean(criterion.probe_only) === true) reasons.add('probe_only');
+  if (asBoolean(analysis.hardcoded_non_pass) === true || asBoolean(criterion.hardcoded_non_pass) === true) reasons.add('hardcoded_non_pass');
+  if (asBoolean(analysis.skipped) === true || asBoolean(criterion.skipped) === true) reasons.add('skipped');
+  if (asBoolean(analysis.stale) === true || asBoolean(criterion.stale) === true) reasons.add('stale');
+
+  const evidence = Array.isArray(criterion.evidence) ? criterion.evidence.filter(isRecord) : [];
+  const textParts = [
+    asString(criterion.text),
+    asString(criterion.rationale),
+    asString(analysis.rationale),
+    asString(analysis.notes),
+    ...asStringArray(criterion.gaps),
+    ...asStringArray(analysis.gaps),
+    ...evidence.flatMap((item) => [asString(item.summary), asString(item.ref)]),
+  ].filter((value): value is string => Boolean(value));
+  addReasonFromText(textParts.join('\n'), reasons);
+
+  const sensitivityOverride = normalizeSensitivity(asString(analysis.score_sensitivity) ?? asString(criterion.score_sensitivity) ?? asString(analysis.sensitivity) ?? asString(criterion.sensitivity));
+  const impossible = asBoolean(analysis.impossible) === true
+    || asBoolean(criterion.impossible) === true
+    || [...reasons].some((reason) => BLOCKING_IMPOSSIBLE_REASONS.has(reason));
+  return {
+    impossible,
+    reasons: [...reasons].sort(),
+    evidence: collectEvidenceRefsFromCriterion(criterion, analysis),
+    sensitivityOverride,
+  };
+}
+
+function readEvaluationCriteriaForAnalysis(root: string, evaluationRef: string | null): EvolutionAnalysisCriterionSnapshot[] {
+  if (!evaluationRef) return [];
+  const evaluationPath = isAbsolute(evaluationRef) || win32.isAbsolute(evaluationRef) ? evaluationRef : resolve(root, evaluationRef);
+  try {
+    const parsed = readJson(evaluationPath);
+    if (!isRecord(parsed) || parsed.schema !== EVALUATION_SCHEMA) return [];
+    const criteria = Array.isArray(parsed.acceptance_criteria) ? parsed.acceptance_criteria.filter(isRecord) : [];
+    return criteria.map((criterion, index) => {
+      const metadata = metadataForCriterion(criterion);
+      const id = asString(criterion.id) ?? `AC${index + 1}`;
+      return {
+        id,
+        text: asString(criterion.text) ?? id,
+        status: asString(criterion.status),
+        reasons: metadata.reasons,
+        evidence: metadata.evidence,
+        impossible: metadata.impossible,
+        sensitivityOverride: metadata.sensitivityOverride,
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+function criterionStatusRank(status: string | null): number {
+  switch (status) {
+    case 'pass':
+      return 4;
+    case 'partial':
+      return 3;
+    case 'blocked':
+      return 2;
+    case 'fail':
+      return 1;
+    case 'not_evaluated':
+      return 0;
+    default:
+      return -1;
+  }
+}
+
+function analyzePlateau(attempts: EvolutionCompareAttempt[], threshold: number) {
+  const scored = attempts.filter((attempt) => attempt.score !== null);
+  if (scored.length < 2) {
+    return { status: 'insufficient_data' as const, threshold, noImprovementCount: 0, currentScore: scored.at(-1)?.score ?? null, bestScore: scored.at(-1)?.score ?? null, bestAttemptId: scored.at(-1)?.attemptId ?? null };
+  }
+  let bestScore = scored[0].score ?? null;
+  let bestAttemptId = scored[0].attemptId;
+  let lastImprovementIndex = 0;
+  const epsilon = 1e-9;
+  for (let index = 1; index < scored.length; index += 1) {
+    const score = scored[index].score;
+    if (score !== null && bestScore !== null && score > bestScore + epsilon) {
+      bestScore = score;
+      bestAttemptId = scored[index].attemptId;
+      lastImprovementIndex = index;
+    }
+  }
+  const currentScore = scored[scored.length - 1].score;
+  const noImprovementCount = Math.max(0, scored.length - lastImprovementIndex - 1);
+  let status: EvolutionPlateauStatus = 'improving';
+  if (currentScore !== null && bestScore !== null && currentScore < bestScore - epsilon) status = 'regressed';
+  else if (noImprovementCount >= threshold) status = 'plateau';
+  else if (noImprovementCount > 0) status = 'stagnating';
+  return { status, threshold, noImprovementCount, currentScore, bestScore, bestAttemptId };
+}
+
+function snapshotById(snapshots: EvolutionAnalysisCriterionSnapshot[]): Map<string, EvolutionAnalysisCriterionSnapshot> {
+  return new Map(snapshots.map((snapshot) => [snapshot.id, snapshot]));
+}
+
+function buildCurrentPreviousRows(ids: string[], textById: Map<string, string>, previous: Map<string, EvolutionAnalysisCriterionSnapshot>, current: Map<string, EvolutionAnalysisCriterionSnapshot>): EvolutionAnalysisDeltaRow[] {
+  return ids.map((id) => ({
+    id,
+    text: textById.get(id) ?? id,
+    previousStatus: previous.get(id)?.status ?? null,
+    currentStatus: current.get(id)?.status ?? null,
+  }));
+}
+
+function buildCurrentFrontierRows(ids: string[], textById: Map<string, string>, frontier: Map<string, EvolutionAnalysisCriterionSnapshot>, current: Map<string, EvolutionAnalysisCriterionSnapshot>): EvolutionAnalysisDeltaRow[] {
+  return ids.map((id) => ({
+    id,
+    text: textById.get(id) ?? id,
+    frontierStatus: frontier.get(id)?.status ?? null,
+    currentStatus: current.get(id)?.status ?? null,
+  }));
+}
+
+function countPassing(snapshots: EvolutionAnalysisCriterionSnapshot[]): { pass: number; total: number; remainingFailures: string[] } {
+  return {
+    pass: snapshots.filter((snapshot) => snapshot.status === 'pass').length,
+    total: snapshots.length,
+    remainingFailures: snapshots.filter((snapshot) => snapshot.status !== 'pass').map((snapshot) => snapshot.id),
+  };
+}
+
+function inferObservedSensitivity(id: string, attempts: EvolutionCompareAttempt[], criteriaByAttempt: Map<string, Map<string, EvolutionAnalysisCriterionSnapshot>>): EvolutionCriterionSensitivity | null {
+  let observedPositive = false;
+  let observedNegative = false;
+  for (let index = 1; index < attempts.length; index += 1) {
+    const previous = attempts[index - 1];
+    const current = attempts[index];
+    if (previous.score === null || current.score === null) continue;
+    const previousStatus = criteriaByAttempt.get(previous.attemptId)?.get(id)?.status ?? null;
+    const currentStatus = criteriaByAttempt.get(current.attemptId)?.get(id)?.status ?? null;
+    if (previousStatus === currentStatus) continue;
+    const scoreDelta = current.score - previous.score;
+    const statusDelta = criterionStatusRank(currentStatus) - criterionStatusRank(previousStatus);
+    if (Math.abs(scoreDelta) < 1e-9 || statusDelta === 0) continue;
+    if ((scoreDelta > 0 && statusDelta > 0) || (scoreDelta < 0 && statusDelta < 0)) observedPositive = true;
+    if ((scoreDelta > 0 && statusDelta < 0) || (scoreDelta < 0 && statusDelta > 0)) observedNegative = true;
+  }
+  if (observedPositive) return 'observed_positive';
+  if (observedNegative) return 'observed_negative';
+  return null;
+}
+
+function attemptSummary(attempt: EvolutionCompareAttempt | null) {
+  return {
+    attemptId: attempt?.attemptId ?? null,
+    runId: attempt?.runId ?? null,
+    decision: attempt?.decision ?? null,
+    score: attempt?.score ?? null,
+    evaluation: attempt?.evaluation ?? null,
+  };
+}
+
+function recommendAnalysis(plateau: EvolutionAnalysisResult['plateau'], criteria: EvolutionAnalysisCriterion[], currentTotal: number): EvolutionAnalysisResult['recommendation'] {
+  if (currentTotal === 0) {
+    return { action: 'inspect_scorer', summary: 'No current acceptance-criteria evidence is available; inspect the scorer or evaluation envelope before retrying.', reasons: ['no_current_acceptance_criteria'] };
+  }
+  const remaining = criteria.filter((criterion) => criterion.currentStatus !== 'pass');
+  if (remaining.length === 0) {
+    return { action: 'stop', summary: 'Current evaluation has all criteria passing; stop retrying and route to human approval/closeout.', reasons: ['all_current_criteria_pass'] };
+  }
+  const plateaued = plateau.status === 'plateau' || plateau.status === 'stagnating';
+  const remainingNonMoving = remaining.every((criterion) => criterion.impossible || criterion.sensitivity === 'none');
+  if (plateaued && remainingNonMoving) {
+    return {
+      action: 'redesign',
+      summary: `Plateaued with ${remaining.length} remaining failing criteria that are impossible or not moving the score; redesign the criterion, scorer, artifact shape, or benchmark instead of retrying.`,
+      reasons: ['plateau', 'remaining_failures_non_score_moving'],
+    };
+  }
+  if (plateaued) {
+    return { action: 'inspect_scorer', summary: 'Scores have stopped improving while failures remain; inspect scorer sensitivity and evaluation evidence before another attempt.', reasons: ['plateau', 'remaining_failures'] };
+  }
+  if (plateau.status === 'regressed') {
+    return { action: 'inspect_scorer', summary: 'Latest score is below the best recorded score; inspect scorer/evidence before continuing.', reasons: ['score_regressed'] };
+  }
+  return { action: 'continue', summary: 'Score or acceptance-criteria evidence is still moving; one more bounded attempt may be useful.', reasons: ['still_moving'] };
+}
+
+export function analyzeEvolutionLoop(loopDir: string, options: EvolutionAnalyzeOptions = {}, root = process.cwd()): EvolutionAnalysisResult {
+  const absoluteLoopDir = isAbsolute(loopDir) ? loopDir : resolve(root, loopDir);
+  const analysisRoot = findScaffoldRoot(absoluteLoopDir) ?? inferScaffoldRootFromLoopDir(absoluteLoopDir) ?? root;
+  const loopPath = join(absoluteLoopDir, 'loop.json');
+  const attemptsPath = join(absoluteLoopDir, 'attempts.jsonl');
+  const frontierPath = join(absoluteLoopDir, 'frontier.json');
+  const loop = readJson(loopPath);
+  if (!isRecord(loop) || loop.schema !== EVOLUTION_LOOP_SCHEMA) {
+    throw new Error(`Evolution loop must declare schema: ${EVOLUTION_LOOP_SCHEMA}`);
+  }
+  const frontier = readJson(frontierPath);
+  if (!isRecord(frontier) || frontier.schema !== EVOLUTION_FRONTIER_SCHEMA) {
+    throw new Error(`Evolution frontier must declare schema: ${EVOLUTION_FRONTIER_SCHEMA}`);
+  }
+  const attempts = readAttempts(attemptsPath).map(normalizeCompareAttempt);
+  const strategy = isRecord(loop.strategy) ? asString(loop.strategy.name) : null;
+  const loopInfo = {
+    loopDir: basename(absoluteLoopDir),
+    loopId: asString(loop.loop_id),
+    objective: asString(loop.objective),
+    strategy,
+    attemptCount: attempts.length,
+  };
+  const currentAttempt = attempts.at(-1) ?? null;
+  const previousAttempt = attempts.length > 1 ? attempts[attempts.length - 2] : null;
+  const frontierIds = frontierAttemptIds(frontier);
+  const frontierAttempt = frontierIds.current ? attempts.find((attempt) => attempt.attemptId === frontierIds.current) ?? null : null;
+  const criteriaByAttempt = new Map<string, Map<string, EvolutionAnalysisCriterionSnapshot>>();
+  const textById = new Map<string, string>();
+  for (const attempt of attempts) {
+    const snapshots = readEvaluationCriteriaForAnalysis(analysisRoot, attempt.evaluation);
+    const mapped = snapshotById(snapshots);
+    criteriaByAttempt.set(attempt.attemptId, mapped);
+    for (const snapshot of snapshots) {
+      if (!textById.has(snapshot.id) || snapshot.text !== snapshot.id) textById.set(snapshot.id, snapshot.text);
+    }
+  }
+  const currentMap = currentAttempt ? criteriaByAttempt.get(currentAttempt.attemptId) ?? new Map() : new Map<string, EvolutionAnalysisCriterionSnapshot>();
+  const previousMap = previousAttempt ? criteriaByAttempt.get(previousAttempt.attemptId) ?? new Map() : new Map<string, EvolutionAnalysisCriterionSnapshot>();
+  const frontierMap = frontierAttempt ? criteriaByAttempt.get(frontierAttempt.attemptId) ?? new Map() : new Map<string, EvolutionAnalysisCriterionSnapshot>();
+  const ids = [...new Set([...textById.keys(), ...currentMap.keys(), ...previousMap.keys(), ...frontierMap.keys()])].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const plateau = analyzePlateau(attempts, Math.max(1, options.plateauThreshold ?? 2));
+  const criteria = ids.map((id) => {
+    const current = currentMap.get(id);
+    const previous = previousMap.get(id);
+    const frontierSnapshot = frontierMap.get(id);
+    const metadataSources = [current, previous, frontierSnapshot].filter((snapshot): snapshot is EvolutionAnalysisCriterionSnapshot => Boolean(snapshot));
+    const impossible = metadataSources.some((snapshot) => snapshot.impossible);
+    const reasons = uniqueRefs(metadataSources.flatMap((snapshot) => snapshot.reasons)).sort();
+    const evidence = uniqueRefs(metadataSources.flatMap((snapshot) => snapshot.evidence));
+    const sensitivityOverride = metadataSources.map((snapshot) => snapshot.sensitivityOverride).find((value): value is EvolutionCriterionSensitivity => value !== null) ?? null;
+    const observed = inferObservedSensitivity(id, attempts, criteriaByAttempt);
+    const sensitivity = sensitivityOverride ?? (impossible ? 'none' : observed ?? 'unknown');
+    return {
+      id,
+      text: textById.get(id) ?? id,
+      currentStatus: current?.status ?? null,
+      previousStatus: previous?.status ?? null,
+      frontierStatus: frontierSnapshot?.status ?? null,
+      sensitivity,
+      impossible,
+      reasons,
+      evidence,
+    };
+  });
+  const currentCounts = countPassing([...currentMap.values()]);
+  const frontierCounts = countPassing([...frontierMap.values()]);
+  const acceptanceSummary = {
+    currentPass: currentCounts.pass,
+    currentTotal: currentCounts.total,
+    frontierPass: frontierCounts.pass,
+    frontierTotal: frontierCounts.total,
+    remainingFailures: currentCounts.remainingFailures,
+  };
+  const recommendation = recommendAnalysis(plateau, criteria, currentCounts.total);
+  return {
+    kind: 'analysis',
+    loop: loopInfo,
+    plateau,
+    currentAttempt: attemptSummary(currentAttempt),
+    previousAttempt: attemptSummary(previousAttempt),
+    frontierAttempt: attemptSummary(frontierAttempt),
+    acceptanceSummary,
+    criteria,
+    currentVsPrevious: {
+      present: Boolean(currentAttempt && previousAttempt),
+      previousAttemptId: previousAttempt?.attemptId ?? null,
+      currentAttemptId: currentAttempt?.attemptId ?? null,
+      rows: buildCurrentPreviousRows(ids, textById, previousMap, currentMap),
+    },
+    currentVsFrontier: {
+      present: Boolean(currentAttempt && frontierAttempt),
+      frontierAttemptId: frontierAttempt?.attemptId ?? null,
+      currentAttemptId: currentAttempt?.attemptId ?? null,
+      rows: buildCurrentFrontierRows(ids, textById, frontierMap, currentMap),
+    },
+    recommendation,
+    notes: [
+      'This analysis is read-only and does not spawn runtimes, rerun benchmarks, mutate loop state, rank models, or approve work.',
+      'Score-frontier promotion is not acceptance approval; use human/maintainer review for closeout decisions.',
+    ],
+  };
+}
+
+function impossibleLabel(criterion: EvolutionAnalysisCriterion): string {
+  if (!criterion.impossible) return '—';
+  if (criterion.reasons.length === 0) return 'yes';
+  const priority = ['probe_only', 'hardcoded_non_pass', 'skipped', 'stale', 'artifact_type_mismatch', 'impossible'];
+  const ordered = [
+    ...priority.filter((reason) => criterion.reasons.includes(reason)),
+    ...criterion.reasons.filter((reason) => !priority.includes(reason)),
+  ];
+  return ordered.join(',');
+}
+
+function renderAnalysisTerminal(analysis: EvolutionAnalysisResult): string {
+  const lines = [
+    `Evolution Analysis: ${analysis.loop.loopDir}`,
+    `Objective: ${analysis.loop.objective ?? '—'}`,
+    `Strategy: ${analysis.loop.strategy ?? '—'}`,
+    `Attempts: ${analysis.loop.attemptCount} recorded`,
+    '',
+    `Plateau: ${analysis.plateau.status} — ${analysis.plateau.noImprovementCount} attempt(s) since last score improvement (current=${formatScore(analysis.plateau.currentScore)}, best=${formatScore(analysis.plateau.bestScore)})`,
+    `Acceptance: current=${analysis.acceptanceSummary.currentPass}/${analysis.acceptanceSummary.currentTotal} pass | frontier=${analysis.acceptanceSummary.frontierPass}/${analysis.acceptanceSummary.frontierTotal} pass`,
+    '',
+    'Score sensitivity',
+    ...(analysis.criteria.length > 0 ? analysis.criteria.map((criterion) => {
+      const evidence = criterion.evidence.length > 0 ? ` | evidence=${criterion.evidence.join(', ')}` : '';
+      return `  ${criterion.id}: ${criterion.currentStatus ?? '—'} | sensitivity=${criterion.sensitivity} | impossible=${impossibleLabel(criterion)} — ${criterion.text}${evidence}`;
+    }) : ['  —']),
+    '',
+    'Current vs previous AC delta',
+    ...(analysis.currentVsPrevious.rows.length > 0 ? analysis.currentVsPrevious.rows.map((row) => `  ${row.id}: previous=${formatPlainCriterionStatus(row.previousStatus ?? null)} | current=${formatPlainCriterionStatus(row.currentStatus)}${criterionDeltaMarker(row.previousStatus ?? null, row.currentStatus)} — ${row.text}`) : ['  —']),
+    '',
+    'Current vs frontier AC delta',
+    ...(analysis.currentVsFrontier.rows.length > 0 ? analysis.currentVsFrontier.rows.map((row) => `  ${row.id}: frontier=${formatPlainCriterionStatus(row.frontierStatus ?? null)} | current=${formatPlainCriterionStatus(row.currentStatus)}${criterionDeltaMarker(row.frontierStatus ?? null, row.currentStatus)} — ${row.text}`) : ['  —']),
+    '',
+    `Recommendation: ${analysis.recommendation.action}`,
+    `  ${analysis.recommendation.summary}`,
+    '',
+    'Notes',
+    ...analysis.notes.map((note) => `  ${note}`),
+    '',
+    'Use --format markdown --out <path> to export this analysis for a PR or review thread.',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function renderAnalysisMarkdown(analysis: EvolutionAnalysisResult): string {
+  const lines = [
+    `# Evolution analysis: ${analysis.loop.loopDir}`,
+    '',
+    `**Attempts:** ${analysis.loop.attemptCount} recorded`,
+    `**Current attempt:** ${analysis.currentAttempt.attemptId ?? '—'}`,
+    `**Frontier attempt:** ${analysis.frontierAttempt.attemptId ?? '—'}`,
+    '',
+    '## Plateau / stagnation',
+    '',
+    `- Status: \`${analysis.plateau.status}\``,
+    `- Attempts since last score improvement: ${analysis.plateau.noImprovementCount}`,
+    `- Current score: ${formatScore(analysis.plateau.currentScore)}`,
+    `- Best score: ${formatScore(analysis.plateau.bestScore)}${analysis.plateau.bestAttemptId ? ` (\`${analysis.plateau.bestAttemptId}\`)` : ''}`,
+    '',
+    '## Score sensitivity and impossible criteria',
+    '',
+    '| Criterion | Current | Sensitivity | Impossible / blocked evidence |',
+    '|---|---|---|---|',
+    ...(analysis.criteria.length > 0 ? analysis.criteria.map((criterion) => {
+      const criterionLabel = `${criterion.id} — ${criterion.text}`;
+      const impossible = criterion.impossible ? `${impossibleLabel(criterion)}${criterion.evidence.length > 0 ? ` (${criterion.evidence.map((ref) => `\`${ref}\``).join(', ')})` : ''}` : '—';
+      return `| ${escapeMarkdownTableCell(criterionLabel)} | ${formatCriterionStatus(criterion.currentStatus)} | ${criterion.sensitivity} | ${escapeMarkdownTableCell(impossible)} |`;
+    }) : ['| — | — | — | — |']),
+    '',
+    '## Current vs previous AC delta',
+    '',
+    '| Criterion | Previous | Current |',
+    '|---|---|---|',
+    ...(analysis.currentVsPrevious.rows.length > 0 ? analysis.currentVsPrevious.rows.map((row) => {
+      const criterion = `${row.id} — ${row.text}`;
+      return `| ${escapeMarkdownTableCell(criterion)} | ${formatCriterionStatus(row.previousStatus ?? null)} | ${formatCriterionStatus(row.currentStatus)}${criterionDeltaMarker(row.previousStatus ?? null, row.currentStatus)} |`;
+    }) : ['| — | — | — |']),
+    '',
+    '## Current vs frontier AC delta',
+    '',
+    '| Criterion | Frontier | Current |',
+    '|---|---|---|',
+    ...(analysis.currentVsFrontier.rows.length > 0 ? analysis.currentVsFrontier.rows.map((row) => {
+      const criterion = `${row.id} — ${row.text}`;
+      return `| ${escapeMarkdownTableCell(criterion)} | ${formatCriterionStatus(row.frontierStatus ?? null)} | ${formatCriterionStatus(row.currentStatus)}${criterionDeltaMarker(row.frontierStatus ?? null, row.currentStatus)} |`;
+    }) : ['| — | — | — |']),
+    '',
+    '## Recommendation',
+    '',
+    `\`${analysis.recommendation.action}\` — ${analysis.recommendation.summary}`,
+    '',
+    '## Boundaries',
+    '',
+    ...analysis.notes.map((note) => `- ${note}`),
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderEvolutionAnalysis(analysis: EvolutionAnalysisResult, format: EvolutionAnalysisFormat = 'terminal'): string {
+  if (format === 'json') return `${JSON.stringify(analysis, null, 2)}\n`;
+  if (format === 'markdown') return renderAnalysisMarkdown(analysis);
+  return renderAnalysisTerminal(analysis);
 }
 
 export function recordEvolutionAttempt(loopDir: string, options: RecordEvolutionAttemptOptions, root = process.cwd()): RecordEvolutionAttemptResult {

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -1172,10 +1172,14 @@ export function analyzeEvolutionLoop(loopDir: string, options: EvolutionAnalyzeO
     const previous = previousMap.get(id);
     const frontierSnapshot = frontierMap.get(id);
     const metadataSources = [current, previous, frontierSnapshot].filter((snapshot): snapshot is EvolutionAnalysisCriterionSnapshot => Boolean(snapshot));
-    const impossible = metadataSources.some((snapshot) => snapshot.impossible);
-    const reasons = uniqueRefs(metadataSources.flatMap((snapshot) => snapshot.reasons)).sort();
-    const evidence = uniqueRefs(metadataSources.flatMap((snapshot) => snapshot.evidence));
-    const sensitivityOverride = metadataSources.map((snapshot) => snapshot.sensitivityOverride).find((value): value is EvolutionCriterionSensitivity => value !== null) ?? null;
+    const currentMetadataSources = current ? [current] : metadataSources;
+    const impossible = current?.impossible ?? false;
+    const reasons = uniqueRefs(currentMetadataSources.flatMap((snapshot) => snapshot.reasons)).sort();
+    const evidence = uniqueRefs(currentMetadataSources.flatMap((snapshot) => snapshot.evidence));
+    let sensitivityOverride = current?.sensitivityOverride ?? null;
+    if (!current && sensitivityOverride === null) {
+      sensitivityOverride = metadataSources.map((snapshot) => snapshot.sensitivityOverride).find((value): value is EvolutionCriterionSensitivity => value !== null) ?? null;
+    }
     const observed = inferObservedSensitivity(id, attempts, criteriaByAttempt);
     const sensitivity = sensitivityOverride ?? (impossible ? 'none' : observed ?? 'unknown');
     return {

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -956,7 +956,7 @@ function metadataForCriterion(criterion: Record<string, unknown>): { impossible:
     asString(analysis.notes),
     ...asStringArray(criterion.gaps),
     ...asStringArray(analysis.gaps),
-    ...evidence.flatMap((item) => [asString(item.summary), asString(item.ref)]),
+    ...evidence.map((item) => asString(item.summary)),
   ].filter((value): value is string => Boolean(value));
   addReasonFromText(textParts.join('\n'), reasons);
 

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -1103,13 +1103,17 @@ function recommendAnalysis(plateau: EvolutionAnalysisResult['plateau'], criteria
   if (currentTotal === 0) {
     return { action: 'inspect_scorer', summary: 'No current acceptance-criteria evidence is available; inspect the scorer or evaluation envelope before retrying.', reasons: ['no_current_acceptance_criteria'] };
   }
-  const remaining = criteria.filter((criterion) => criterion.currentStatus !== 'pass');
+  const missingCurrent = criteria.filter((criterion) => criterion.currentStatus === null && (criterion.previousStatus !== null || criterion.frontierStatus !== null));
+  const remaining = criteria.filter((criterion) => criterion.currentStatus !== null && criterion.currentStatus !== 'pass');
   if (remaining.length === 0) {
+    if (missingCurrent.length > 0) {
+      return { action: 'inspect_scorer', summary: 'Current evaluation omits criteria seen in earlier attempts; inspect the scorer or evaluation envelope before stopping.', reasons: ['missing_current_acceptance_criteria'] };
+    }
     return { action: 'stop', summary: 'Current evaluation has all criteria passing; stop retrying and route to human approval/closeout.', reasons: ['all_current_criteria_pass'] };
   }
   const plateaued = plateau.status === 'plateau' || plateau.status === 'stagnating';
   const remainingNonMoving = remaining.every((criterion) => criterion.impossible || criterion.sensitivity === 'none');
-  if (plateaued && remainingNonMoving) {
+  if (plateaued && missingCurrent.length === 0 && remainingNonMoving) {
     return {
       action: 'redesign',
       summary: `Plateaued with ${remaining.length} remaining failing criteria that are impossible or not moving the score; redesign the criterion, scorer, artifact shape, or benchmark instead of retrying.`,
@@ -1171,15 +1175,11 @@ export function analyzeEvolutionLoop(loopDir: string, options: EvolutionAnalyzeO
     const current = currentMap.get(id);
     const previous = previousMap.get(id);
     const frontierSnapshot = frontierMap.get(id);
-    const metadataSources = [current, previous, frontierSnapshot].filter((snapshot): snapshot is EvolutionAnalysisCriterionSnapshot => Boolean(snapshot));
-    const currentMetadataSources = current ? [current] : metadataSources;
+    const currentMetadataSources = current ? [current] : [];
     const impossible = current?.impossible ?? false;
     const reasons = uniqueRefs(currentMetadataSources.flatMap((snapshot) => snapshot.reasons)).sort();
     const evidence = uniqueRefs(currentMetadataSources.flatMap((snapshot) => snapshot.evidence));
-    let sensitivityOverride = current?.sensitivityOverride ?? null;
-    if (!current && sensitivityOverride === null) {
-      sensitivityOverride = metadataSources.map((snapshot) => snapshot.sensitivityOverride).find((value): value is EvolutionCriterionSensitivity => value !== null) ?? null;
-    }
+    const sensitivityOverride = current?.sensitivityOverride ?? null;
     const observed = inferObservedSensitivity(id, attempts, criteriaByAttempt);
     const sensitivity = sensitivityOverride ?? (impossible ? 'none' : observed ?? 'unknown');
     return {

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -900,10 +900,12 @@ function normalizeSensitivity(value: string | null): EvolutionCriterionSensitivi
 const BLOCKING_IMPOSSIBLE_REASONS = new Set(['probe_only', 'hardcoded_non_pass', 'skipped', 'stale', 'impossible', 'artifact_type_mismatch']);
 
 function isAnalysisRefSafe(ref: string): boolean {
-  if (/^file:/i.test(ref)) return false;
-  if (/^https?:\/\//i.test(ref)) return true;
-  const normalized = toPosix(ref).replace(/^\.\//, '');
-  if (isAbsolute(ref) || win32.isAbsolute(ref) || normalized.startsWith('/') || normalized.startsWith('~')) return false;
+  const clean = ref.trim();
+  if (/^file:/i.test(clean)) return false;
+  if (/^https?:\/\//i.test(clean)) return true;
+  const normalized = toPosix(clean).replace(/^\.\//, '');
+  if (isAbsolute(clean) || win32.isAbsolute(clean) || normalized.startsWith('/') || normalized.startsWith('~')) return false;
+  if (normalized.split('/').some((segment) => segment === '..')) return false;
   if (isPrivatePath(normalized)) return false;
   return true;
 }

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -949,7 +949,6 @@ function metadataForCriterion(criterion: Record<string, unknown>): { impossible:
 
   const evidence = Array.isArray(criterion.evidence) ? criterion.evidence.filter(isRecord) : [];
   const textParts = [
-    asString(criterion.text),
     asString(criterion.rationale),
     asString(analysis.rationale),
     asString(analysis.notes),

--- a/tests/cli-evolution.test.ts
+++ b/tests/cli-evolution.test.ts
@@ -112,6 +112,64 @@ Improve the run contract.
   return { root, planPath, runPath, evalPath, receiptPath, adapterEvidencePath, adapterLogPath };
 }
 
+function writePlateauCliEvaluation(root: string, runId: string, ac2Status: 'pass' | 'fail') {
+  const evalPath = join(root, `docs/evidence/${runId}-evaluation.json`);
+  writeFileSync(evalPath, JSON.stringify({
+    schema: 'open-scaffold.evaluation.v1',
+    evaluation_id: `eval-${runId}`,
+    subject: { source: 'run', plan: '.osc/plans/active/087-demo.md', plan_slug: '087-demo', task_id: 'task-123', run_id: runId, run_packet: `.osc/runs/${runId}/run.json` },
+    acceptance_criteria: [
+      {
+        id: 'AC1',
+        text: 'Loop state is created.',
+        status: 'pass',
+        evaluator: { kind: 'human', name: 'reviewer', ref: null },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/demo-run-proof.md', summary: 'Synthetic CLI evidence.' }],
+        rationale: 'Loop state exists.',
+      },
+      {
+        id: 'AC2',
+        text: 'Frontier promotion is explicit.',
+        status: ac2Status,
+        evaluator: { kind: 'human', name: 'reviewer', ref: null },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/demo-run-proof.md', summary: 'Synthetic CLI evidence.' }],
+        rationale: ac2Status === 'pass' ? 'Reachable criterion fixed.' : 'Reachable criterion failed.',
+      },
+      {
+        id: 'AC28',
+        text: 'Renderer probe returns a playable visual artifact.',
+        status: 'fail',
+        evaluator: { kind: 'domain-tool', name: 'synthetic-scorer', ref: 'docs/evidence/scorer.md' },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/scorer.md', summary: 'Probe-only criterion is hardcoded pass=false for headless JSON drivers.' }],
+        rationale: 'Probe-only and impossible for the current artifact type.',
+        analysis: { score_sensitivity: 'none', impossible: true, reason: 'probe_only', source: 'docs/evidence/scorer.md#AC28' },
+      },
+    ],
+    decision: { status: 'rejected', approver: 'human', rationale: 'Score frontier is not acceptance approval.' },
+    improvement: { route: 'create_next_slice', target: null, carried_forward: [], do_not_assume: ['No raw benchmark win.'] },
+  }, null, 2));
+  return evalPath;
+}
+
+function writePlateauCliLoop() {
+  const { root, planPath } = tempRepo();
+  const outDir = join(root, '.osc/evolution/plateau-loop');
+  writeFileSync(join(root, 'docs/evidence/scorer.md'), 'AC28 is probe-only/pass-false for this synthetic driver.');
+  execFileSync(tsx, [cli, 'evolve', 'init', planPath, '--out', outDir, '--strategy', 'greedy'], { cwd: root, encoding: 'utf8' });
+  const attempts = [
+    { runId: 'attempt-a', score: '0.9', ac2Status: 'fail' as const, decision: 'promote', rationale: 'First score frontier.' },
+    { runId: 'attempt-b', score: '0.944893', ac2Status: 'pass' as const, decision: 'promote', rationale: 'Improved reachable AC2.' },
+    { runId: 'attempt-c', score: '0.944893', ac2Status: 'pass' as const, decision: 'retry', rationale: 'Retry plateaued.' },
+    { runId: 'attempt-d', score: '0.944893', ac2Status: 'pass' as const, decision: 'retry', rationale: 'Remaining failure is probe-only.' },
+  ];
+  for (const attempt of attempts) {
+    const runPath = writeRunPacket(root, attempt.runId);
+    const evalPath = writePlateauCliEvaluation(root, attempt.runId, attempt.ac2Status);
+    execFileSync(tsx, [cli, 'evolve', 'record', outDir, '--run', runPath, '--evaluation', evalPath, '--decision', attempt.decision, '--score', attempt.score, '--rationale', attempt.rationale], { cwd: root, encoding: 'utf8' });
+  }
+  return { root, outDir };
+}
+
 describe('checked-in evolution ledger demo fixture through the CLI', () => {
   it('checks the committed fixture and renders the expected markdown exactly', () => {
     const check = execFileSync(tsx, [cli, 'evolve', 'check', evolutionDemoLoop], { cwd: repoRoot, encoding: 'utf8' });
@@ -306,6 +364,37 @@ describe('osc evolve CLI', () => {
     expect(report).toContain('**B (promote):** Better frontier.');
     expect(report).toContain('## Acceptance criteria delta');
     expect(report).toContain('| AC2 — Frontier promotion is explicit. | ✗ fail | ✓ pass ▲ |');
+  });
+
+  it('analyzes a plateau loop in terminal, markdown, and JSON without mutating evidence unless --out is supplied', () => {
+    const { root, outDir } = writePlateauCliLoop();
+    const before = {
+      loop: readFileSync(join(outDir, 'loop.json'), 'utf8'),
+      attempts: readFileSync(join(outDir, 'attempts.jsonl'), 'utf8'),
+      frontier: readFileSync(join(outDir, 'frontier.json'), 'utf8'),
+    };
+    const reportPath = join(root, 'docs/evidence/evolution-analysis.md');
+
+    const terminal = execFileSync(tsx, [cli, 'evolve', 'analyze', outDir], { cwd: root, encoding: 'utf8' });
+    expect(terminal).toContain('Evolution Analysis: plateau-loop');
+    expect(terminal).toContain('Plateau: plateau — 2 attempt(s) since last score improvement');
+    expect(terminal).toContain('Recommendation: redesign');
+    expect(existsSync(reportPath)).toBe(false);
+
+    const json = JSON.parse(execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--format', 'json'], { cwd: root, encoding: 'utf8' }));
+    expect(json.recommendation.action).toBe('redesign');
+    expect(json.criteria.find((criterion: { id: string }) => criterion.id === 'AC28')).toMatchObject({ impossible: true, sensitivity: 'none' });
+
+    const output = execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--format', 'markdown', '--out', reportPath], { cwd: root, encoding: 'utf8' });
+    expect(output).toContain('Wrote evolution analysis:');
+    const report = readFileSync(reportPath, 'utf8');
+    expect(report).toContain('# Evolution analysis: plateau-loop');
+    expect(report).toContain('## Current vs frontier AC delta');
+    expect(report).toContain('`redesign`');
+
+    expect(readFileSync(join(outDir, 'loop.json'), 'utf8')).toBe(before.loop);
+    expect(readFileSync(join(outDir, 'attempts.jsonl'), 'utf8')).toBe(before.attempts);
+    expect(readFileSync(join(outDir, 'frontier.json'), 'utf8')).toBe(before.frontier);
   });
 
   it('rejects unknown strategies and prints evolve usage', () => {

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -63,6 +63,7 @@ const topLevelHelpCommands = [
   'osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>]',
   'osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text>',
   'osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>]',
+  'osc evolve analyze <loop-dir> [--format <terminal|markdown|json>] [--out <path>] [--plateau-threshold <n>]',
   'osc evolve check <loop-dir>',
   'osc cockpit config',
   'osc cockpit test [--dry-run]',

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -4,9 +4,11 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
   EVOLUTION_LOOP_SCHEMA,
+  analyzeEvolutionLoop,
   compareEvolutionLoop,
   loadEvolutionSource,
   recordEvolutionAttempt,
+  renderEvolutionAnalysis,
   renderEvolutionComparison,
   renderEvolutionLoopFiles,
   validateEvolutionLoopDir,
@@ -131,6 +133,135 @@ function writeDispatchReceipt(root: string, runId = 'demo-run') {
   writeFileSync(evidencePath, 'runtime omx evidence');
   writeFileSync(logPath, 'runtime omx log');
   return { receiptPath, evidencePath, logPath };
+}
+
+function writePlateauEvaluation(root: string, runId: string, ac2Status: 'pass' | 'fail' = 'fail') {
+  const evalPath = join(root, `docs/evidence/${runId}-evaluation.json`);
+  writeFileSync(evalPath, JSON.stringify({
+    schema: 'open-scaffold.evaluation.v1',
+    evaluation_id: `eval-${runId}`,
+    subject: {
+      source: 'run',
+      plan: '.osc/plans/active/087-demo.md',
+      plan_slug: '087-demo',
+      task_id: 'task-123',
+      run_id: runId,
+      run_packet: `.osc/runs/${runId}/run.json`,
+    },
+    acceptance_criteria: [
+      {
+        id: 'AC1',
+        text: 'Deterministic driver output is produced.',
+        status: 'pass',
+        evaluator: { kind: 'automated-check', name: 'synthetic-scorer', ref: 'docs/evidence/scorer.md' },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Determinism probe passed.' }],
+        rationale: 'Stable deterministic output.',
+      },
+      {
+        id: 'AC2',
+        text: 'Frontier promotion improves one reachable criterion.',
+        status: ac2Status,
+        evaluator: { kind: 'automated-check', name: 'synthetic-scorer', ref: 'docs/evidence/scorer.md' },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: ac2Status === 'pass' ? 'Reachable criterion passed.' : 'Reachable criterion still failed.' }],
+        rationale: ac2Status === 'pass' ? 'Fixed by the second attempt.' : 'Not fixed yet.',
+      },
+      {
+        id: 'AC28',
+        text: 'Renderer probe returns a playable visual artifact.',
+        status: 'fail',
+        evaluator: { kind: 'domain-tool', name: 'synthetic-2000m-scorer', ref: 'docs/evidence/scorer.md' },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/scorer.md', summary: 'Probe-only criterion is hardcoded pass=false for headless JSON drivers.' }],
+        rationale: 'The scorer marks this criterion probe-only and impossible for the current artifact type.',
+        analysis: {
+          score_sensitivity: 'none',
+          impossible: true,
+          reason: 'probe_only',
+          source: 'docs/evidence/scorer.md#AC28',
+        },
+      },
+    ],
+    decision: { status: 'rejected', approver: 'human', rationale: 'Score frontier is not acceptance approval.' },
+    improvement: { route: 'create_next_slice', target: null, carried_forward: ['AC28 requires benchmark redesign.'], do_not_assume: ['No raw benchmark win.'] },
+  }, null, 2));
+  return evalPath;
+}
+
+function writePlateauLoop() {
+  const root = tempRepo();
+  const planPath = writePlan(root);
+  const outDir = join(root, '.osc/evolution/plateau-loop');
+  writeFileSync(join(root, 'docs/evidence/scorer.md'), 'Synthetic scorer metadata: AC28 is probe-only/pass-false for headless JSON drivers.');
+  writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-31T08:00:00.000Z'), strategy: 'greedy' });
+  const attempts = [
+    { runId: 'attempt-a', score: 0.9, ac2Status: 'fail' as const, decision: 'promote' as const, rationale: 'First score frontier.' },
+    { runId: 'attempt-b', score: 0.944893, ac2Status: 'pass' as const, decision: 'promote' as const, rationale: 'Improved reachable AC2 but AC28 remains scorer-blocked.' },
+    { runId: 'attempt-c', score: 0.944893, ac2Status: 'pass' as const, decision: 'retry' as const, rationale: 'Retry plateaued at the same score.' },
+    { runId: 'attempt-d', score: 0.944893, ac2Status: 'pass' as const, decision: 'retry' as const, rationale: 'Another retry plateaued; remaining failure is probe-only.' },
+  ];
+  for (const [index, attempt] of attempts.entries()) {
+    const runPath = writeRunPacket(root, attempt.runId);
+    const evalPath = writePlateauEvaluation(root, attempt.runId, attempt.ac2Status);
+    recordEvolutionAttempt(outDir, {
+      runPath,
+      evaluationPath: evalPath,
+      decision: attempt.decision,
+      score: attempt.score,
+      rationale: attempt.rationale,
+      now: new Date(`2026-05-31T08:${String(10 + index).padStart(2, '0')}:00.000Z`),
+    }, root);
+  }
+  return { root, outDir };
+}
+
+function writeOrdinaryFailureEvaluation(root: string, runId: string, privateRefs = false) {
+  const evalPath = join(root, `docs/evidence/${runId}-ordinary-evaluation.json`);
+  writeFileSync(evalPath, JSON.stringify({
+    schema: 'open-scaffold.evaluation.v1',
+    evaluation_id: `eval-${runId}`,
+    subject: { source: 'run', plan: '.osc/plans/active/087-demo.md', plan_slug: '087-demo', task_id: 'task-123', run_id: runId, run_packet: `.osc/runs/${runId}/run.json` },
+    acceptance_criteria: [
+      {
+        id: 'AC1',
+        text: 'Loop state is created.',
+        status: 'pass',
+        evaluator: { kind: 'human', name: 'reviewer', ref: 'docs/evidence/proof.md' },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Synthetic evidence.' }],
+        rationale: 'Loop state exists.',
+      },
+      {
+        id: 'AC2',
+        text: 'Tests cover the remaining reachable behavior.',
+        status: 'fail',
+        evaluator: { kind: 'human', name: 'reviewer', ref: privateRefs ? '/private/scorer.md' : 'docs/evidence/proof.md' },
+        evidence: [{ kind: 'path', ref: privateRefs ? '.osc/research/private-scorer.md' : 'docs/evidence/proof.md', summary: 'Reachable work remains incomplete.' }],
+        rationale: 'Missing tests for a reachable behavior; another implementation or scorer inspection can still help.',
+        analysis: { reason: 'missing_tests', source: privateRefs ? 'file:///private/scorer.md' : 'docs/evidence/proof.md' },
+      },
+    ],
+    decision: { status: 'rejected', approver: 'human', rationale: 'Reachable behavior remains incomplete.' },
+    improvement: { route: 'retry_run', target: null, carried_forward: ['AC2 needs tests.'], do_not_assume: ['No model benchmark claim.'] },
+  }, null, 2));
+  return evalPath;
+}
+
+function writeOrdinaryFailureLoop(privateRefs = false) {
+  const root = tempRepo();
+  const planPath = writePlan(root);
+  const outDir = join(root, '.osc/evolution/ordinary-failure-loop');
+  writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-31T09:00:00.000Z'), strategy: 'greedy' });
+  for (const [index, runId] of ['attempt-a', 'attempt-b', 'attempt-c'].entries()) {
+    const runPath = writeRunPacket(root, runId);
+    const evalPath = writeOrdinaryFailureEvaluation(root, runId, privateRefs);
+    recordEvolutionAttempt(outDir, {
+      runPath,
+      evaluationPath: evalPath,
+      decision: index === 0 ? 'promote' : 'retry',
+      score: 0.7,
+      rationale: index === 0 ? 'Initial score frontier.' : 'Retry did not move score, but remaining failure is reachable.',
+      now: new Date(`2026-05-31T09:${String(10 + index).padStart(2, '0')}:00.000Z`),
+    }, root);
+  }
+  return { root, outDir };
 }
 
 describe('checked-in evolution ledger demo fixture', () => {
@@ -399,6 +530,94 @@ describe('evolution attempt recording and validation', () => {
     expect(result.failures.map((failure) => failure.code)).toContain('evolution.boundary.unsupported_true');
     expect(result.failures.map((failure) => failure.code)).toContain('evolution.source_ref.private_path');
     expect(result.failures.map((failure) => failure.code)).toContain('evolution.attempt.duplicate_id');
+  });
+});
+
+describe('evolution analysis', () => {
+  it('reports plateau, impossible probe-only criteria, AC deltas, sensitivity, and redesign recommendation without mutating loop state', () => {
+    const { root, outDir } = writePlateauLoop();
+    const before = {
+      loop: readFileSync(join(outDir, 'loop.json'), 'utf8'),
+      attempts: readFileSync(join(outDir, 'attempts.jsonl'), 'utf8'),
+      frontier: readFileSync(join(outDir, 'frontier.json'), 'utf8'),
+      evaluation: readFileSync(join(root, 'docs/evidence/attempt-d-evaluation.json'), 'utf8'),
+    };
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+
+    expect(analysis.loop).toMatchObject({ loopDir: 'plateau-loop', attemptCount: 4 });
+    expect(analysis.plateau).toMatchObject({ status: 'plateau', noImprovementCount: 2, currentScore: 0.944893 });
+    expect(analysis.acceptanceSummary).toMatchObject({ currentPass: 2, currentTotal: 3, frontierPass: 2, frontierTotal: 3 });
+    expect(analysis.currentVsPrevious.rows.find((row) => row.id === 'AC28')).toMatchObject({ previousStatus: 'fail', currentStatus: 'fail' });
+    expect(analysis.currentVsFrontier.rows.find((row) => row.id === 'AC2')).toMatchObject({ frontierStatus: 'pass', currentStatus: 'pass' });
+    const ac2 = analysis.criteria.find((criterion) => criterion.id === 'AC2');
+    expect(ac2).toMatchObject({ currentStatus: 'pass', sensitivity: 'observed_positive' });
+    const ac28 = analysis.criteria.find((criterion) => criterion.id === 'AC28');
+    expect(ac28).toMatchObject({
+      currentStatus: 'fail',
+      sensitivity: 'none',
+      impossible: true,
+      evidence: expect.arrayContaining(['docs/evidence/scorer.md#AC28']),
+      reasons: expect.arrayContaining(['probe_only']),
+    });
+    expect(analysis.recommendation).toMatchObject({ action: 'redesign' });
+    expect(analysis.recommendation.summary).toContain('remaining failing criteria');
+    expect(analysis.notes.join('\n')).toContain('Score-frontier promotion is not acceptance approval');
+
+    const terminal = renderEvolutionAnalysis(analysis, 'terminal');
+    expect(terminal).toContain('Plateau: plateau — 2 attempt(s) since last score improvement');
+    expect(terminal).toContain('AC28: fail | sensitivity=none | impossible=probe_only');
+    expect(terminal).toContain('Recommendation: redesign');
+
+    const markdown = renderEvolutionAnalysis(analysis, 'markdown');
+    expect(markdown).toContain('# Evolution analysis: plateau-loop');
+    expect(markdown).toContain('## Current vs frontier AC delta');
+    expect(markdown).toContain('| AC28 — Renderer probe returns a playable visual artifact. | ✗ fail | ✗ fail |');
+    expect(markdown).toContain('## Recommendation');
+    expect(markdown).toContain('`redesign`');
+
+    const json = JSON.parse(renderEvolutionAnalysis(analysis, 'json'));
+    expect(json.recommendation.action).toBe('redesign');
+    expect(json.criteria.find((criterion: { id: string }) => criterion.id === 'AC28').impossible).toBe(true);
+
+    expect(readFileSync(join(outDir, 'loop.json'), 'utf8')).toBe(before.loop);
+    expect(readFileSync(join(outDir, 'attempts.jsonl'), 'utf8')).toBe(before.attempts);
+    expect(readFileSync(join(outDir, 'frontier.json'), 'utf8')).toBe(before.frontier);
+    expect(readFileSync(join(root, 'docs/evidence/attempt-d-evaluation.json'), 'utf8')).toBe(before.evaluation);
+  });
+
+  it('does not classify ordinary reachable failure reasons as impossible redesign-only blockers', () => {
+    const { outDir, root } = writeOrdinaryFailureLoop();
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+    const ac2 = analysis.criteria.find((criterion) => criterion.id === 'AC2');
+
+    expect(analysis.plateau.status).toBe('plateau');
+    expect(ac2).toMatchObject({
+      currentStatus: 'fail',
+      sensitivity: 'unknown',
+      impossible: false,
+      reasons: expect.arrayContaining(['missing_tests']),
+    });
+    expect(analysis.recommendation.action).toBe('inspect_scorer');
+    expect(analysis.recommendation.summary).toContain('Scores have stopped improving');
+  });
+
+  it('suppresses private or internal criterion evidence refs from analysis reports', () => {
+    const { outDir, root } = writeOrdinaryFailureLoop(true);
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+    const ac2 = analysis.criteria.find((criterion) => criterion.id === 'AC2');
+    const terminal = renderEvolutionAnalysis(analysis, 'terminal');
+    const markdown = renderEvolutionAnalysis(analysis, 'markdown');
+
+    expect(ac2?.evidence).toEqual([]);
+    expect(terminal).not.toContain('/private/scorer.md');
+    expect(terminal).not.toContain('file:///private/scorer.md');
+    expect(terminal).not.toContain('.osc/research/private-scorer.md');
+    expect(markdown).not.toContain('/private/scorer.md');
+    expect(markdown).not.toContain('file:///private/scorer.md');
+    expect(markdown).not.toContain('.osc/research/private-scorer.md');
   });
 });
 

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -213,7 +213,7 @@ function writePlateauLoop() {
   return { root, outDir };
 }
 
-function writeStaleBlockerEvaluation(root: string, runId: string, hasBlocker: boolean) {
+function writeStaleBlockerEvaluation(root: string, runId: string, hasBlocker: boolean, omitAc28 = false) {
   const evalPath = join(root, `docs/evidence/${runId}-stale-blocker-evaluation.json`);
   const ac28: Record<string, unknown> = {
     id: 'AC28',
@@ -245,7 +245,7 @@ function writeStaleBlockerEvaluation(root: string, runId: string, hasBlocker: bo
         evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Synthetic evidence.' }],
         rationale: 'Loop state exists.',
       },
-      ac28,
+      ...(omitAc28 ? [] : [ac28]),
     ],
     decision: { status: 'rejected', approver: 'human', rationale: 'Current scorer still reports a reachable failure.' },
     improvement: { route: 'retry_run', target: null, carried_forward: ['AC28 still needs implementation work.'], do_not_assume: ['No raw benchmark win.'] },
@@ -259,13 +259,13 @@ function writeStaleBlockerLoop() {
   const outDir = join(root, '.osc/evolution/stale-blocker-loop');
   writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-31T10:00:00.000Z'), strategy: 'greedy' });
   const attempts = [
-    { runId: 'attempt-a', blocker: true, decision: 'promote' as const },
-    { runId: 'attempt-b', blocker: false, decision: 'retry' as const },
-    { runId: 'attempt-c', blocker: false, decision: 'retry' as const },
+    { runId: 'attempt-a', blocker: true, omitAc28: false, decision: 'promote' as const },
+    { runId: 'attempt-b', blocker: false, omitAc28: false, decision: 'retry' as const },
+    { runId: 'attempt-c', blocker: false, omitAc28: false, decision: 'retry' as const },
   ];
   for (const [index, attempt] of attempts.entries()) {
     const runPath = writeRunPacket(root, attempt.runId);
-    const evalPath = writeStaleBlockerEvaluation(root, attempt.runId, attempt.blocker);
+    const evalPath = writeStaleBlockerEvaluation(root, attempt.runId, attempt.blocker, attempt.omitAc28);
     recordEvolutionAttempt(outDir, {
       runPath,
       evaluationPath: evalPath,
@@ -273,6 +273,31 @@ function writeStaleBlockerLoop() {
       score: 0.7,
       rationale: index === 0 ? 'Initial frontier with old scorer metadata.' : 'Retry plateaued after scorer metadata changed.',
       now: new Date(`2026-05-31T10:${String(10 + index).padStart(2, '0')}:00.000Z`),
+    }, root);
+  }
+  return { root, outDir };
+}
+
+function writeMissingCurrentBlockerLoop() {
+  const root = tempRepo();
+  const planPath = writePlan(root);
+  const outDir = join(root, '.osc/evolution/missing-current-blocker-loop');
+  writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-31T11:00:00.000Z'), strategy: 'greedy' });
+  const attempts = [
+    { runId: 'attempt-a', blocker: true, omitAc28: false, decision: 'promote' as const },
+    { runId: 'attempt-b', blocker: false, omitAc28: true, decision: 'retry' as const },
+    { runId: 'attempt-c', blocker: false, omitAc28: true, decision: 'retry' as const },
+  ];
+  for (const [index, attempt] of attempts.entries()) {
+    const runPath = writeRunPacket(root, attempt.runId);
+    const evalPath = writeStaleBlockerEvaluation(root, attempt.runId, attempt.blocker, attempt.omitAc28);
+    recordEvolutionAttempt(outDir, {
+      runPath,
+      evaluationPath: evalPath,
+      decision: attempt.decision,
+      score: 0.7,
+      rationale: index === 0 ? 'Initial frontier with old scorer metadata.' : 'Retry plateaued after current scorer omitted AC28.',
+      now: new Date(`2026-05-31T11:${String(10 + index).padStart(2, '0')}:00.000Z`),
     }, root);
   }
   return { root, outDir };
@@ -666,6 +691,27 @@ describe('evolution analysis', () => {
     });
     expect(ac28?.reasons).not.toContain('probe_only');
     expect(analysis.recommendation.action).toBe('inspect_scorer');
+  });
+
+  it('treats missing current criterion metadata as scorer-inspection instead of stale blocker evidence', () => {
+    const { outDir, root } = writeMissingCurrentBlockerLoop();
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+    const ac28 = analysis.criteria.find((criterion) => criterion.id === 'AC28');
+
+    expect(analysis.acceptanceSummary).toMatchObject({ currentPass: 1, currentTotal: 1 });
+    expect(ac28).toMatchObject({
+      currentStatus: null,
+      frontierStatus: 'fail',
+      sensitivity: 'unknown',
+      impossible: false,
+      reasons: [],
+      evidence: [],
+    });
+    expect(analysis.recommendation).toMatchObject({
+      action: 'inspect_scorer',
+      reasons: expect.arrayContaining(['missing_current_acceptance_criteria']),
+    });
   });
 
   it('does not classify ordinary reachable failure reasons as impossible redesign-only blockers', () => {

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -324,7 +324,7 @@ function writeOrdinaryFailureEvaluation(root: string, runId: string, privateRefs
         status: 'fail',
         source: privateRefs ? 'docs/../../.osc-dev/notes.md' : undefined,
         evaluator: { kind: 'human', name: 'reviewer', ref: privateRefs ? '/private/scorer.md' : 'docs/evidence/proof.md' },
-        evidence: [{ kind: 'path', ref: privateRefs ? '.osc/research/private-scorer.md' : 'docs/evidence/proof.md', summary: 'Reachable work remains incomplete.' }],
+        evidence: [{ kind: 'path', ref: privateRefs ? '.osc/research/private-scorer.md' : 'docs/evidence/skipped-rows-report.md', summary: 'Reachable work remains incomplete.' }],
         rationale: 'Missing tests for a reachable behavior; another implementation or scorer inspection can still help.',
         analysis: {
           reason: 'missing_tests',

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -230,7 +230,7 @@ function writeOrdinaryFailureEvaluation(root: string, runId: string, privateRefs
       },
       {
         id: 'AC2',
-        text: 'Tests cover the remaining reachable behavior.',
+        text: 'Skipped rows are listed in the report while tests cover the remaining reachable behavior.',
         status: 'fail',
         evaluator: { kind: 'human', name: 'reviewer', ref: privateRefs ? '/private/scorer.md' : 'docs/evidence/proof.md' },
         evidence: [{ kind: 'path', ref: privateRefs ? '.osc/research/private-scorer.md' : 'docs/evidence/proof.md', summary: 'Reachable work remains incomplete.' }],
@@ -599,6 +599,7 @@ describe('evolution analysis', () => {
       impossible: false,
       reasons: expect.arrayContaining(['missing_tests']),
     });
+    expect(ac2?.reasons).not.toContain('skipped');
     expect(analysis.recommendation.action).toBe('inspect_scorer');
     expect(analysis.recommendation.summary).toContain('Scores have stopped improving');
   });

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -322,10 +322,15 @@ function writeOrdinaryFailureEvaluation(root: string, runId: string, privateRefs
         id: 'AC2',
         text: 'Skipped rows are listed in the report while tests cover the remaining reachable behavior.',
         status: 'fail',
+        source: privateRefs ? 'docs/../../.osc-dev/notes.md' : undefined,
         evaluator: { kind: 'human', name: 'reviewer', ref: privateRefs ? '/private/scorer.md' : 'docs/evidence/proof.md' },
         evidence: [{ kind: 'path', ref: privateRefs ? '.osc/research/private-scorer.md' : 'docs/evidence/proof.md', summary: 'Reachable work remains incomplete.' }],
         rationale: 'Missing tests for a reachable behavior; another implementation or scorer inspection can still help.',
-        analysis: { reason: 'missing_tests', source: privateRefs ? 'file:///private/scorer.md' : 'docs/evidence/proof.md' },
+        analysis: {
+          reason: 'missing_tests',
+          source: privateRefs ? 'file:///private/scorer.md' : 'docs/evidence/proof.md',
+          evidence_source: privateRefs ? '../raw-scorer.log' : undefined,
+        },
       },
     ],
     decision: { status: 'rejected', approver: 'human', rationale: 'Reachable behavior remains incomplete.' },
@@ -744,9 +749,13 @@ describe('evolution analysis', () => {
     expect(terminal).not.toContain('/private/scorer.md');
     expect(terminal).not.toContain('file:///private/scorer.md');
     expect(terminal).not.toContain('.osc/research/private-scorer.md');
+    expect(terminal).not.toContain('../raw-scorer.log');
+    expect(terminal).not.toContain('docs/../../.osc-dev/notes.md');
     expect(markdown).not.toContain('/private/scorer.md');
     expect(markdown).not.toContain('file:///private/scorer.md');
     expect(markdown).not.toContain('.osc/research/private-scorer.md');
+    expect(markdown).not.toContain('../raw-scorer.log');
+    expect(markdown).not.toContain('docs/../../.osc-dev/notes.md');
   });
 });
 

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -213,6 +213,71 @@ function writePlateauLoop() {
   return { root, outDir };
 }
 
+function writeStaleBlockerEvaluation(root: string, runId: string, hasBlocker: boolean) {
+  const evalPath = join(root, `docs/evidence/${runId}-stale-blocker-evaluation.json`);
+  const ac28: Record<string, unknown> = {
+    id: 'AC28',
+    text: 'Renderer evidence is evaluated against the current scorer contract.',
+    status: 'fail',
+    evaluator: { kind: 'automated-check', name: 'synthetic-scorer', ref: 'docs/evidence/proof.md' },
+    evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Current scorer still reports a reachable failure.' }],
+    rationale: 'Current attempt still fails, but current scorer metadata now treats the criterion as reachable.',
+  };
+  if (hasBlocker) {
+    ac28.analysis = {
+      score_sensitivity: 'none',
+      impossible: true,
+      reason: 'probe_only',
+      source: 'docs/evidence/scorer.md#old-AC28',
+    };
+    ac28.rationale = 'Old scorer metadata marked this criterion probe-only.';
+  }
+  writeFileSync(evalPath, JSON.stringify({
+    schema: 'open-scaffold.evaluation.v1',
+    evaluation_id: `eval-${runId}`,
+    subject: { source: 'run', plan: '.osc/plans/active/087-demo.md', plan_slug: '087-demo', task_id: 'task-123', run_id: runId, run_packet: `.osc/runs/${runId}/run.json` },
+    acceptance_criteria: [
+      {
+        id: 'AC1',
+        text: 'Loop state is created.',
+        status: 'pass',
+        evaluator: { kind: 'human', name: 'reviewer', ref: 'docs/evidence/proof.md' },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Synthetic evidence.' }],
+        rationale: 'Loop state exists.',
+      },
+      ac28,
+    ],
+    decision: { status: 'rejected', approver: 'human', rationale: 'Current scorer still reports a reachable failure.' },
+    improvement: { route: 'retry_run', target: null, carried_forward: ['AC28 still needs implementation work.'], do_not_assume: ['No raw benchmark win.'] },
+  }, null, 2));
+  return evalPath;
+}
+
+function writeStaleBlockerLoop() {
+  const root = tempRepo();
+  const planPath = writePlan(root);
+  const outDir = join(root, '.osc/evolution/stale-blocker-loop');
+  writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-05-31T10:00:00.000Z'), strategy: 'greedy' });
+  const attempts = [
+    { runId: 'attempt-a', blocker: true, decision: 'promote' as const },
+    { runId: 'attempt-b', blocker: false, decision: 'retry' as const },
+    { runId: 'attempt-c', blocker: false, decision: 'retry' as const },
+  ];
+  for (const [index, attempt] of attempts.entries()) {
+    const runPath = writeRunPacket(root, attempt.runId);
+    const evalPath = writeStaleBlockerEvaluation(root, attempt.runId, attempt.blocker);
+    recordEvolutionAttempt(outDir, {
+      runPath,
+      evaluationPath: evalPath,
+      decision: attempt.decision,
+      score: 0.7,
+      rationale: index === 0 ? 'Initial frontier with old scorer metadata.' : 'Retry plateaued after scorer metadata changed.',
+      now: new Date(`2026-05-31T10:${String(10 + index).padStart(2, '0')}:00.000Z`),
+    }, root);
+  }
+  return { root, outDir };
+}
+
 function writeOrdinaryFailureEvaluation(root: string, runId: string, privateRefs = false) {
   const evalPath = join(root, `docs/evidence/${runId}-ordinary-evaluation.json`);
   writeFileSync(evalPath, JSON.stringify({
@@ -584,6 +649,23 @@ describe('evolution analysis', () => {
     expect(readFileSync(join(outDir, 'attempts.jsonl'), 'utf8')).toBe(before.attempts);
     expect(readFileSync(join(outDir, 'frontier.json'), 'utf8')).toBe(before.frontier);
     expect(readFileSync(join(root, 'docs/evidence/attempt-d-evaluation.json'), 'utf8')).toBe(before.evaluation);
+  });
+
+  it('uses current-attempt blocker metadata for recommendation instead of stale frontier metadata', () => {
+    const { outDir, root } = writeStaleBlockerLoop();
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+    const ac28 = analysis.criteria.find((criterion) => criterion.id === 'AC28');
+
+    expect(analysis.plateau.status).toBe('plateau');
+    expect(ac28).toMatchObject({
+      currentStatus: 'fail',
+      frontierStatus: 'fail',
+      sensitivity: 'unknown',
+      impossible: false,
+    });
+    expect(ac28?.reasons).not.toContain('probe_only');
+    expect(analysis.recommendation.action).toBe('inspect_scorer');
   });
 
   it('does not classify ordinary reachable failure reasons as impossible redesign-only blockers', () => {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('f511593bade87b6b65d455910e924869d1e649af7d6c8de64c71ad79d8d93903');
+    expect(hash(planIssueSnapshot)).toBe('826ec5790bb50145e7c3379130bf731fc1928fb949173208971575b26a738af7');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('a5a74c468e765eb8565eed57aa36c0cace4b1315489b802cc673145e634960de');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('d7f063e42ac54b6f289bf4e8ce2c2f58576016bcedd21ac1c05474be4ea6ecc5');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds read-only `osc evolve analyze <loop-dir>` with terminal, Markdown, and JSON output.
- Reports plateau/stagnation, current-vs-previous and current-vs-frontier AC deltas, score sensitivity, impossible/probe-only criteria, and a next-action recommendation.
- Activates plan 134 and documents the analysis boundary: no runtime spawning, benchmark rerun, frontier promotion, ranking, approval, npm publish, or GitHub Release action.

## Verification
- RED focused tests first: `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` failed before implementation because the analysis API/CLI did not exist.
- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — PASS (37 tests).
- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts tests/cli-lifecycle-help.test.ts` — PASS (45 tests).
- `npm test` — PASS (54 files / 546 tests).
- `npm run build` — PASS.
- `git diff --check` — PASS.
- `./verify.sh --strict` — PASS (10 pass / 0 fail / 0 warn).
- Added-line public-safety scan — PASS; no blocking private identity/path/raw-score-win claims.

## Risk / gates
- Analysis is read-only unless `--out` writes the requested report path.
- No npm publish, GitHub Release, benchmark-v2, runtime spawning, benchmark rerun, or merge is requested in this PR.
- Owner approval required before merge.