### PR TITLE
chore: close evolve analyze plan

### DIFF
--- a/.osc/plans/done/134-osc-evolve-analyze-plateau-and-impossible-ac.md
+++ b/.osc/plans/done/134-osc-evolve-analyze-plateau-and-impossible-ac.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 

--- a/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
+++ b/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
@@ -7,9 +7,9 @@ Added `osc evolve analyze`, a read-only loop-analysis command for existing evolu
 ## Traceability
 
 - Roadmap / issue / task: follow-up from the 2000m v1 two-lane benchmark reset; no separate GitHub issue in this slice.
-- Plan: `.osc/plans/active/134-osc-evolve-analyze-plateau-and-impossible-ac.md` during implementation.
+- Plan: `.osc/plans/done/134-osc-evolve-analyze-plateau-and-impossible-ac.md`.
 - Run ID / run packet: N/A — direct CLI feature slice; no runtime or benchmark rerun.
-- Branch / PR: branch `feat/evolve-analyze-plateau`; PR pending owner review.
+- Branch / PR: branch `feat/evolve-analyze-plateau`; PR #160 (`https://github.com/graphanov/open-scaffold/pull/160`), merged 2026-06-01.
 
 ## Verification
 
@@ -24,9 +24,9 @@ Added `osc evolve analyze`, a read-only loop-analysis command for existing evolu
 
 ## Outcome
 
-Implemented a package-visible analysis surface only. The command inspects existing curated loop/evaluation evidence and can render terminal, Markdown, or JSON output; `--out` writes only the requested report file. Runtime spawning, benchmark reruns, benchmark-v2, external-scorer adapters, npm publication, GitHub Release changes, merge, and acceptance approval remain out of scope and owner-gated.
+Implemented a package-visible analysis surface only. The command inspects existing curated loop/evaluation evidence and can render terminal, Markdown, or JSON output; `--out` writes only the requested report file. PR #160 merged this slice. Runtime spawning, benchmark reruns, benchmark-v2, external-scorer adapters, npm publication, GitHub Release changes, and acceptance approval remain out of scope and owner-gated.
 
 ## Follow-up
 
-- Owner gate: review the PR when opened; merge is not authorized by this note.
+- Release gate: this slice changed package-visible CLI/help, so npm publication and GitHub Release remain a separate owner-gated release-sync decision.
 - Next slices remain separate: external-scorer import for `osc eval`, compact evidence mode, and benchmark-v2 design outside this implementation slice.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-01: closed 134-osc-evolve-analyze-plateau-and-impossible-ac — shipped osc evolve analyze via PR #160
 - 2026-05-31: closed 133-2000m-postmortem-evolve-reset — Create 2000m benchmark postmortem and evolve reset package
 - 2026-05-30: closed 132-plan-stats-command — Add osc plan stats portfolio summary command
 - 2026-05-30: closed 129-zero-context-resume-proof — published open-scaffold@0.20.4, verified fresh npx compare demo, and created GitHub Release v0.20.4

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('826ec5790bb50145e7c3379130bf731fc1928fb949173208971575b26a738af7');
+    expect(hash(planIssueSnapshot)).toBe('8cdef46073122ccf22304341d028a6e1598f7bea70e6500468b243a986b3aae9');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('d7f063e42ac54b6f289bf4e8ce2c2f58576016bcedd21ac1c05474be4ea6ecc5');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary
- Moves plan 134 from `active/` to `done/` after PR #160 merged.
- Updates the plan status, MISSION changelog, evidence note traceability, and live-corpus plan hash.
- Records that npm publication and GitHub Release remain separate owner-gated release-sync work because #160 changed package-visible CLI/help.

## Verification
- `node dist/cli.js plan validate .osc/plans/done/134-osc-evolve-analyze-plateau-and-impossible-ac.md --strict` — PASS.
- `git diff --check` — PASS.
- `./verify.sh --strict` — PASS (10 pass / 0 fail / 0 warn).
- `npm test` — PASS (54 files / 546 tests).
- `npm run build` — PASS.
- Added-line public-safety scan — PASS.

## Risk / gates
- Closeout only; no product code changes.
- No npm publish or GitHub Release action in this PR.
- Owner approval required before merge.