### PR TITLE
feat: import external eval scorer output

### DIFF
--- a/.osc/plans/done/135-osc-eval-external-scorer-adapter.md
+++ b/.osc/plans/done/135-osc-eval-external-scorer-adapter.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+done
 
 ## Context
 

--- a/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
+++ b/.osc/releases/2026-06-01-134-osc-evolve-analyze-plateau-and-impossible-ac.md
@@ -28,5 +28,5 @@ Implemented a package-visible analysis surface only. The command inspects existi
 
 ## Follow-up
 
-- Release gate: this slice changed package-visible CLI/help, so npm publication and GitHub Release remain a separate owner-gated release-sync decision.
-- Next slices remain separate: external-scorer import for `osc eval`, compact evidence mode, and benchmark-v2 design outside this implementation slice.
+- Public package drift can be noted, but there is no automatic release-sync PR after this slice; npm publication and GitHub Release changes require an explicit release-train decision.
+- Next functional slices remain separate: external-scorer import for `osc eval`, compact evidence mode, and benchmark-v2 design outside this implementation slice.

--- a/.osc/releases/2026-06-01-135-osc-eval-external-scorer-adapter.md
+++ b/.osc/releases/2026-06-01-135-osc-eval-external-scorer-adapter.md
@@ -1,0 +1,31 @@
+# Release / Evidence Note: 135-osc-eval-external-scorer-adapter
+
+## Summary
+
+Adds `osc eval import`, a read-only external-scorer import path that maps structured 2000m v1 scorer JSON into an `open-scaffold.evaluation.v1` envelope. The adapter records scorer provenance, criterion status, correction routes, determinism/composite-score metadata, and analysis hints for `osc evolve analyze` without running the scorer or turning Open Scaffold into a domain judge.
+
+## Traceability
+
+- Roadmap / issue / task: follow-up from the 2000m v1 two-lane benchmark reset; no separate GitHub issue in this slice.
+- Plan: `.osc/plans/done/135-osc-eval-external-scorer-adapter.md`.
+- Run ID / run packet: N/A — direct CLI/evaluation-contract feature slice; no runtime or benchmark rerun.
+- Branch / PR: branch `feat/osc-eval-import-scorer`; PR pending.
+
+## Verification
+
+- Focused tests: `npm test -- --run tests/evaluation.test.ts tests/cli-eval.test.ts` — PASS (2 files / 32 tests) after fixing pre-commit and Codex review findings.
+- `npm test` — PASS (54 files / 558 tests).
+- `npm run build` — PASS (core and runtime-omx TypeScript builds).
+- `git diff --check` — PASS.
+- `./verify.sh --strict` — PASS (10 pass / 0 fail / 0 warn).
+- Added-line public-safety scan — PASS.
+- Built CLI smoke: `node dist/cli.js eval import ... --adapter 2000m-v1 --scorer <tmp>/scorer.json --out <tmp>/imported-evaluation.json` then `node dist/cli.js eval check <tmp>/imported-evaluation.json` — PASS; imported schema `open-scaffold.evaluation.v1`, decision `rejected`, 2 criteria.
+
+## Outcome
+
+Implemented and locally verified. The slice adds a package-visible CLI surface for importing already-produced scorer output only. It does not spawn runtimes, call APIs, rerun benchmarks, certify correctness/compliance/model quality, approve work, or claim Open Scaffold improved raw 2000m v1 score.
+
+## Follow-up
+
+- Continue with compact evidence mode only after this import path is coherent and verified.
+- No npm publish or GitHub Release work is included in this slice.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-01: closed 135-osc-eval-external-scorer-adapter — Close 135 after eval external scorer import
 - 2026-06-01: closed 134-osc-evolve-analyze-plateau-and-impossible-ac — shipped osc evolve analyze via PR #160
 - 2026-05-31: closed 133-2000m-postmortem-evolve-reset — Create 2000m benchmark postmortem and evolve reset package
 - 2026-05-30: closed 132-plan-stats-command — Add osc plan stats portfolio summary command

--- a/docs/EVOLUTION_LOOP.md
+++ b/docs/EVOLUTION_LOOP.md
@@ -82,6 +82,17 @@ osc evolve analyze .osc/evolution/demo-loop --format markdown --out docs/evidenc
 
 The analysis command is a decision aid. It does not mutate loop files unless `--out` is supplied for a rendered report, and even then it writes only the requested report path. It does not spawn runtimes, rerun benchmarks, rank models, certify compliance, promote a frontier, or approve work.
 
+Import structured external scorer output into an evaluation envelope when a domain tool already did the judging:
+
+```bash
+osc eval import .osc/runs/demo-run/run.json \
+  --adapter 2000m-v1 \
+  --scorer docs/evidence/2000m-v1-score.json \
+  --out docs/evidence/demo-evaluation.json
+```
+
+The first adapter maps 2000m v1 conformance JSON (`passCount`, `totalAcs`, `acs[].id`, `name`, `pass`, `skipped`, `quality`, `detail`, `breakdown`, determinism, and composite score) into `open-scaffold.evaluation.v1`. It records scorer provenance and routes non-pass or skipped/probe-only criteria to retry/block instead of approval. Composite score and determinism are verification metadata, not acceptance approval, and the import path does not run the scorer, call an API, rerun a benchmark, or embed raw/private logs.
+
 `osc evolve` does not create a run, launch a runtime, call an LLM, publish benchmark rankings, certify compliance, approve a merge, or decide product taste. It only records and analyzes curated loop state.
 
 ## See it in one screen

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import { doctorExitCode, formatDoctorReport, parseDoctorCheckName, runDoctor, ty
 import { openDashboardUrl, serveDashboard, writeWebDashboard } from './dashboard-web.js';
 import { collectEvidence } from './evidence.js';
 import { evidenceChainExitCode, formatEvidenceChainReport, verifyEvidenceChain } from './evidence-chain.js';
-import { loadEvaluationSource, renderEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope } from './evaluation.js';
+import { EXTERNAL_SCORER_ADAPTERS, loadEvaluationSource, renderEvaluationEnvelope, renderImportedEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope, writeImportedEvaluationEnvelope, type ExternalScorerAdapter } from './evaluation.js';
 import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, analyzeEvolutionLoop, compareEvolutionLoop, recordEvolutionAttempt, renderEvolutionAnalysis, renderEvolutionComparison, validateEvolutionLoopDir, writeEvolutionLoop, type EvolutionAnalysisFormat, type EvolutionCompareFormat, type EvolutionDecision, type EvolutionStrategy } from './evolution.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { computeMetrics, formatMetrics, parseSinceDate } from './metrics.js';
@@ -78,6 +78,7 @@ Lab and experimental:
   osc task comment <task-id> <comment>
   osc task link <task-id> --plan <slug>
   osc eval init <run-or-plan> [--out <path>]
+  osc eval import <run-or-plan> --adapter 2000m-v1 --scorer <scorer-json> [--out <path>]
   osc eval check <evaluation-path>
   osc audit init <run-or-plan> [--artifact <role> <path>]... [--out <path>]
   osc audit check <audit-manifest-path>
@@ -1752,7 +1753,7 @@ function auditCommand(args: string[]): void {
 }
 
 function printEvalUsage(): void {
-  console.error('Usage: osc eval init <run-or-plan> [--out <path>] | osc eval check <evaluation-path>');
+  console.error('Usage: osc eval init <run-or-plan> [--out <path>] | osc eval import <run-or-plan> --adapter 2000m-v1 --scorer <scorer-json> [--out <path>] | osc eval check <evaluation-path>');
 }
 
 function findScaffoldRoot(start: string): string | null {
@@ -1776,6 +1777,13 @@ function takeEvalValue(args: string[], index: number, flag: string): string {
     process.exit(2);
   }
   return value;
+}
+
+function parseExternalScorerAdapter(value: string): ExternalScorerAdapter {
+  if (EXTERNAL_SCORER_ADAPTERS.includes(value as ExternalScorerAdapter)) return value as ExternalScorerAdapter;
+  console.error(`Unsupported eval import adapter: ${value}`);
+  printEvalUsage();
+  process.exit(2);
 }
 
 function evalCommand(args: string[]): void {
@@ -1823,6 +1831,77 @@ function evalCommand(args: string[]): void {
       }
       console.log(`Created evaluation envelope: ${absoluteOut}`);
       console.log('Note: this is a structure/coverage template only; fill evidence, evaluator, decision, and routing before check/close.');
+      return;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  }
+
+  if (subcommand === 'import') {
+    if (!sourceOrPath) {
+      printEvalUsage();
+      process.exit(2);
+    }
+    let adapter: ExternalScorerAdapter | null = null;
+    let scorerPath: string | null = null;
+    let outPath: string | null = null;
+    let force = false;
+    for (let i = 0; i < rest.length; i += 1) {
+      const flag = rest[i];
+      switch (flag) {
+        case '--adapter':
+          adapter = parseExternalScorerAdapter(takeEvalValue(rest, i, flag));
+          i += 1;
+          break;
+        case '--scorer':
+        case '--scorer-json':
+          scorerPath = takeEvalValue(rest, i, flag);
+          i += 1;
+          break;
+        case '--out':
+        case '--output':
+          outPath = takeEvalValue(rest, i, flag);
+          i += 1;
+          break;
+        case '--force':
+          force = true;
+          break;
+        default:
+          console.error(`Unknown option for eval import: ${flag}`);
+          printEvalUsage();
+          process.exit(2);
+      }
+    }
+    if (!adapter) {
+      console.error('Missing required option for eval import: --adapter');
+      printEvalUsage();
+      process.exit(2);
+    }
+    if (!scorerPath) {
+      console.error('Missing required option for eval import: --scorer');
+      printEvalUsage();
+      process.exit(2);
+    }
+    try {
+      if (!outPath) {
+        const source = loadEvaluationSource(sourceOrPath, process.cwd());
+        process.stdout.write(renderImportedEvaluationEnvelope(source, scorerPath, process.cwd(), { adapter }));
+        return;
+      }
+      const absoluteOut = resolve(outPath);
+      if (existsSync(absoluteOut) && !force) {
+        console.error(`Refusing to overwrite existing evaluation envelope: ${absoluteOut}`);
+        process.exit(1);
+      }
+      if (force && existsSync(absoluteOut)) {
+        const source = loadEvaluationSource(sourceOrPath, process.cwd());
+        writeFileSync(absoluteOut, renderImportedEvaluationEnvelope(source, scorerPath, process.cwd(), { adapter }), 'utf8');
+      } else {
+        writeImportedEvaluationEnvelope(sourceOrPath, scorerPath, absoluteOut, process.cwd(), { adapter });
+      }
+      console.log(`Created imported evaluation envelope: ${absoluteOut}`);
+      console.log('Note: imported scorer evidence does not make Open Scaffold the scorer and does not certify correctness, compliance, production readiness, or model quality.');
       return;
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));

--- a/src/evaluation.ts
+++ b/src/evaluation.ts
@@ -30,6 +30,14 @@ export interface RenderEvaluationOptions {
   now?: Date;
 }
 
+export type ExternalScorerAdapter = '2000m-v1';
+
+export const EXTERNAL_SCORER_ADAPTERS: ExternalScorerAdapter[] = ['2000m-v1'];
+
+export interface RenderImportedEvaluationOptions extends RenderEvaluationOptions {
+  adapter?: ExternalScorerAdapter;
+}
+
 interface CriterionIdentity {
   id: string;
   idSource: 'explicit' | 'fallback';
@@ -51,6 +59,102 @@ function asString(value: unknown): string | null {
 
 function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function asBoolean(value: unknown): boolean | null {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', 'yes', 'y', 'pass', 'passed', 'ok', 'success'].includes(normalized)) return true;
+    if (['false', 'no', 'n', 'fail', 'failed', 'error', 'blocked'].includes(normalized)) return false;
+  }
+  return null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function valueFor(record: Record<string, unknown>, keys: string[]): unknown {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) return record[key];
+  }
+  return undefined;
+}
+
+function requiredNumber(record: Record<string, unknown>, keys: string[], label: string): number {
+  const value = asNumber(valueFor(record, keys));
+  if (value === null) throw new Error(`External scorer output is missing numeric ${label}.`);
+  return value;
+}
+
+function sanitizeScorerText(value: unknown, fallback = ''): string {
+  const raw = typeof value === 'string' ? value : fallback;
+  return raw
+    .replace(/\b[A-Za-z]:\\[^\s,;)\]]+/g, '[local-path omitted]')
+    .replace(/(^|[\s("'`=:])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
+    .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
+    .trim()
+    .slice(0, 1000);
+}
+
+function sanitizeScorerKey(key: string): string {
+  const sanitized = sanitizeScorerText(key)
+    .replace(/\[local-path omitted\]/g, 'local_path_omitted')
+    .replace(/[^A-Za-z0-9._:-]/g, '_')
+    .slice(0, 120);
+  return sanitized || 'omitted';
+}
+
+function sanitizeScorerId(value: unknown, index: number): string {
+  const raw = asString(value);
+  if (!meaningfulString(raw)) throw new Error(`External scorer AC ${index + 1} is missing id.`);
+  const sanitized = sanitizeScorerText(raw)
+    .replace(/\s+/g, '_')
+    .replace(/[^A-Za-z0-9._:-]/g, '_')
+    .slice(0, 80);
+  if (!meaningfulString(sanitized) || sanitized.includes('local-path') || sanitized.includes('local_path_omitted')) {
+    throw new Error(`External scorer AC ${index + 1} has an unsafe id.`);
+  }
+  const normalizedAcId = sanitized.match(/^AC[-_]?(\d+)$/i);
+  if (normalizedAcId) return `AC${normalizedAcId[1]}`;
+  return sanitized;
+}
+
+function sanitizeScorerJsonValue(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') return sanitizeScorerText(value);
+  if (depth > 4) return '[nested scorer data omitted]';
+  if (Array.isArray(value)) {
+    const items = value.slice(0, 50).map((item) => sanitizeScorerJsonValue(item, depth + 1));
+    if (value.length > 50) items.push(`[${value.length - 50} scorer item(s) omitted]`);
+    return items;
+  }
+  if (isRecord(value)) {
+    const entries = Object.entries(value).slice(0, 50).map(([key, nested]) => [sanitizeScorerKey(key), sanitizeScorerJsonValue(nested, depth + 1)]);
+    if (Object.keys(value).length > 50) entries.push(['omitted_keys', `${Object.keys(value).length - 50} scorer key(s) omitted`]);
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+function scorerInputEvidence(root: string, scorerPath: string) {
+  const absoluteScorer = isAbsolute(scorerPath) ? scorerPath : resolve(root, scorerPath);
+  const comparableRoot = existsSync(root) ? realpathSync(root) : resolve(root);
+  const comparableScorer = existsSync(absoluteScorer) ? realpathSync(absoluteScorer) : absoluteScorer;
+  const rel = relative(comparableRoot, comparableScorer);
+  if (rel && !rel.startsWith('..') && !isAbsolute(rel)) {
+    return { kind: 'path', ref: rel, summary: 'External scorer JSON imported into this evaluation envelope.' };
+  }
+  return { kind: 'other', ref: 'external-scorer:2000m-v1:input', summary: 'External scorer JSON imported without embedding a local absolute path.' };
 }
 
 function pathRelativeToRoot(root: string, path: string): string {
@@ -216,6 +320,246 @@ export function renderEvaluationEnvelope(source: EvaluationSource, options: Rend
     ],
   };
   return `${JSON.stringify(envelope, null, 2)}\n`;
+}
+
+function determinismVerdict(value: unknown): { pass: boolean | null; label: string | null } {
+  if (isRecord(value)) {
+    const pass = asBoolean(valueFor(value, ['pass', 'passed', 'ok', 'deterministic']));
+    const label = asString(valueFor(value, ['verdict', 'status', 'label', 'detail'])) ?? (pass === null ? null : pass ? 'PASS' : 'FAIL');
+    return { pass, label: sanitizeScorerText(label ?? '') || null };
+  }
+  const pass = asBoolean(value);
+  const label = typeof value === 'string' ? sanitizeScorerText(value) : pass === null ? null : pass ? 'PASS' : 'FAIL';
+  return { pass, label };
+}
+
+function normalizeScorerCriterion(raw: unknown, index: number) {
+  if (!isRecord(raw)) throw new Error(`External scorer AC ${index + 1} must be an object.`);
+  const id = sanitizeScorerId(valueFor(raw, ['id', 'ac', 'criterionId', 'criterion_id']), index);
+  const name = asString(valueFor(raw, ['name', 'text', 'title', 'criterion']));
+  if (!meaningfulString(name)) throw new Error(`External scorer AC ${id} is missing name/text.`);
+  const pass = asBoolean(valueFor(raw, ['pass', 'passed', 'ok', 'status']));
+  const skipped = asBoolean(valueFor(raw, ['skipped', 'skip', 'isSkipped'])) ?? (asString(valueFor(raw, ['status']))?.toLowerCase() === 'skipped');
+  if (pass === null && !skipped) throw new Error(`External scorer AC ${id} is missing pass/skipped state.`);
+  const detail = sanitizeScorerText(valueFor(raw, ['detail', 'details', 'message', 'summary', 'rationale']));
+  const quality = sanitizeScorerJsonValue(valueFor(raw, ['quality', 'qualityScore', 'quality_score']));
+  const breakdown = sanitizeScorerJsonValue(valueFor(raw, ['breakdown', 'scoreBreakdown', 'score_breakdown']));
+  const explicitSensitivity = asString(valueFor(raw, ['score_sensitivity', 'scoreSensitivity', 'sensitivity']));
+  const probeOnly = asBoolean(valueFor(raw, ['probe_only', 'probeOnly'])) === true;
+  return {
+    id,
+    name: sanitizeScorerText(name),
+    pass: pass === true,
+    skipped,
+    detail,
+    quality,
+    breakdown,
+    scoreSensitivity: explicitSensitivity ? sanitizeScorerText(explicitSensitivity) : skipped ? 'none' : 'unknown',
+    probeOnly,
+  };
+}
+
+function load2000mV1Scorer(path: string) {
+  const parsed = readJson(path);
+  if (!isRecord(parsed)) throw new Error('External scorer output must be a JSON object.');
+  const acsRaw = valueFor(parsed, ['acs', 'acceptance_criteria', 'acceptanceCriteria', 'criteria']);
+  if (!Array.isArray(acsRaw) || acsRaw.length === 0) {
+    throw new Error('2000m-v1 scorer output must include a non-empty acs array.');
+  }
+  const passCount = requiredNumber(parsed, ['passCount', 'pass_count', 'passedAcs', 'passed_acs'], 'passCount');
+  const totalAcs = requiredNumber(parsed, ['totalAcs', 'total_acs', 'totalACs'], 'totalAcs');
+  const acs = acsRaw.map((item, index) => normalizeScorerCriterion(item, index));
+  const computedPassCount = acs.filter((criterion) => criterion.pass).length;
+  if (totalAcs !== acs.length) {
+    throw new Error(`2000m-v1 scorer totalAcs (${totalAcs}) does not match acs length (${acs.length}).`);
+  }
+  if (passCount !== computedPassCount) {
+    throw new Error(`2000m-v1 scorer passCount (${passCount}) does not match passed AC count (${computedPassCount}).`);
+  }
+  const determinism = determinismVerdict(valueFor(parsed, ['determinism', 'determinismPass', 'determinism_pass', 'deterministic']));
+  const compositeScore = asNumber(valueFor(parsed, ['composite', 'compositeScore', 'composite_score', 'score']));
+  return {
+    passCount,
+    totalAcs,
+    acs,
+    determinism,
+    compositeScore,
+  };
+}
+
+function validateScorerCoverage(source: EvaluationSource, scorer: ReturnType<typeof load2000mV1Scorer>): void {
+  const expectedCriteria = criterionIdentities(source.acceptanceCriteria);
+  const expected = expectedCriteria.map((criterion) => criterion.id);
+  if (expected.length === 0) {
+    throw new Error('External scorer import requires source acceptance criteria to compare coverage.');
+  }
+  const actual = scorer.acs.map((criterion) => criterion.id);
+  const missing = expected.filter((id) => !actual.includes(id));
+  const extra = actual.filter((id) => !expected.includes(id));
+  if (actual.length !== expected.length || missing.length > 0 || extra.length > 0) {
+    const details = [
+      missing.length > 0 ? `missing ${missing.join(', ')}` : null,
+      extra.length > 0 ? `extra ${extra.join(', ')}` : null,
+    ].filter(Boolean).join('; ');
+    throw new Error(`External scorer AC coverage does not match source acceptance criteria${details ? ` (${details})` : ''}.`);
+  }
+  const normalized = (value: string) => value.trim().replace(/\s+/g, ' ').toLowerCase();
+  const expectedTextById = new Map(expectedCriteria.map((criterion) => [criterion.id, normalized(criterion.text)]));
+  const mismatched = scorer.acs
+    .filter((criterion) => expectedTextById.get(criterion.id) !== normalized(criterion.name))
+    .map((criterion) => criterion.id);
+  if (mismatched.length > 0) {
+    throw new Error(`External scorer AC text does not match source acceptance criteria (${mismatched.join(', ')}).`);
+  }
+}
+
+function importedCriterionStatus(criterion: ReturnType<typeof normalizeScorerCriterion>): 'pass' | 'fail' | 'not_evaluated' {
+  if (criterion.skipped || criterion.probeOnly) return 'not_evaluated';
+  if (criterion.pass) return 'pass';
+  return 'fail';
+}
+
+function correctionForImportedCriterion(criterion: ReturnType<typeof normalizeScorerCriterion>) {
+  if (criterion.skipped || criterion.probeOnly) {
+    return { route: 'block', target: null, rationale: 'External scorer did not evaluate or cannot mechanically pass this criterion; inspect the scorer, criterion, or artifact shape.' };
+  }
+  if (criterion.pass) return { route: null, target: null, rationale: '' };
+  return { route: 'retry_run', target: null, rationale: 'External scorer reported this criterion as not passed; retry or revise the run before approval.' };
+}
+
+export function renderImportedEvaluationEnvelope(source: EvaluationSource, scorerPath: string, root = process.cwd(), options: RenderImportedEvaluationOptions = {}): string {
+  const adapter = options.adapter ?? '2000m-v1';
+  if (adapter !== '2000m-v1') throw new Error(`Unsupported external scorer adapter: ${adapter}`);
+  const absoluteScorerPath = isAbsolute(scorerPath) ? scorerPath : resolve(root, scorerPath);
+  const scorer = load2000mV1Scorer(absoluteScorerPath);
+  validateScorerCoverage(source, scorer);
+  const now = options.now ?? new Date();
+  const createdAt = now.toISOString();
+  const stamp = timestampId(now);
+  const hasSkipped = scorer.acs.some((criterion) => criterion.skipped || criterion.probeOnly);
+  const hasFailed = scorer.acs.some((criterion) => !criterion.pass && !criterion.skipped && !criterion.probeOnly);
+  const allPass = scorer.acs.every((criterion) => criterion.pass && !criterion.skipped && !criterion.probeOnly);
+  const determinismFailed = scorer.determinism.pass === false;
+  const decisionStatus = allPass && !determinismFailed ? 'approved' : hasSkipped || determinismFailed ? 'blocked' : 'rejected';
+  const improvementRoute = decisionStatus === 'approved' ? 'close' : decisionStatus === 'blocked' ? 'block' : 'retry_run';
+  const scoreSummary = scorer.compositeScore === null ? 'composite score unavailable' : `composite ${scorer.compositeScore}`;
+  const determinismSummary = scorer.determinism.label ?? 'not reported';
+  const envelope = {
+    schema: EVALUATION_SCHEMA,
+    evaluation_id: `${stamp}-${source.runId ?? source.planSlug}-2000m-v1-eval`,
+    idempotency_key: `eval:import:${adapter}:${source.runId ?? source.planSlug}:${digest([JSON.stringify(scorer.acs), String(scorer.passCount), String(scorer.totalAcs), String(scorer.compositeScore ?? ''), String(scorer.determinism.pass ?? ''), scorer.determinism.label ?? ''])}`,
+    created_at: createdAt,
+    evaluated_at: createdAt,
+    subject: {
+      source: source.kind,
+      plan: source.planPath,
+      plan_slug: source.planSlug,
+      task_id: source.taskId,
+      run_id: source.runId,
+      run_packet: source.runPacketPath,
+    },
+    correlation: {
+      task_id: source.taskId,
+      run_id: source.runId,
+      evidence_receipt_ids: [],
+      feedback_ids: [],
+    },
+    inputs: {
+      run_packet: source.runPacketPath,
+      evidence: [scorerInputEvidence(root, scorerPath)],
+      feedback: [],
+    },
+    acceptance_criteria: scorer.acs.map((criterion, index) => {
+      const status = importedCriterionStatus(criterion);
+      const reason = criterion.skipped ? 'skipped' : criterion.probeOnly ? 'probe_only' : status === 'pass' ? 'passed' : 'failed';
+      return {
+        id: criterion.id,
+        id_source: 'external-scorer',
+        source_index: index + 1,
+        text: criterion.name,
+        status,
+        evaluator: {
+          kind: 'domain-tool',
+          name: '2000m-v1 scorer',
+          ref: 'external-scorer:2000m-v1',
+        },
+        evidence: [{ kind: 'other', ref: `external-scorer:2000m-v1:${criterion.id}`, summary: `Scorer result: ${reason}; ${scoreSummary}.` }],
+        rationale: criterion.detail || `External scorer reported ${criterion.id} as ${reason}.`,
+        confidence: 'medium',
+        gaps: status === 'pass' ? [] : [`External scorer reported ${criterion.id} as ${reason}.`],
+        feedback_refs: [],
+        correction: correctionForImportedCriterion(criterion),
+        analysis: {
+          source: 'external-scorer',
+          adapter,
+          pass: criterion.pass,
+          skipped: criterion.skipped,
+          probe_only: criterion.probeOnly,
+          quality: criterion.quality ?? null,
+          detail: criterion.detail || null,
+          breakdown: criterion.breakdown ?? null,
+          score_sensitivity: criterion.scoreSensitivity,
+          reasons: [
+            ...(criterion.skipped ? ['skipped'] : []),
+            ...(criterion.probeOnly ? ['probe_only'] : []),
+          ],
+          scorer_summary: {
+            pass_count: scorer.passCount,
+            total_acs: scorer.totalAcs,
+            composite_score: scorer.compositeScore,
+            determinism: determinismSummary,
+          },
+        },
+      };
+    }),
+    verification: [
+      {
+        id: 'external-scorer-2000m-v1-summary',
+        kind: 'external-scorer',
+        status: allPass ? 'pass' : 'fail',
+        summary: `2000m-v1 scorer reported ${scorer.passCount}/${scorer.totalAcs} ACs passed; ${scoreSummary}.`,
+        evidence: [{ kind: 'other', ref: 'external-scorer:2000m-v1:summary', summary: 'Structured scorer output was imported; raw scorer output is not embedded.' }],
+      },
+      {
+        id: 'external-scorer-2000m-v1-determinism',
+        kind: 'external-scorer',
+        status: scorer.determinism.pass === true ? 'pass' : scorer.determinism.pass === false ? 'fail' : 'not_evaluated',
+        summary: `Determinism verdict: ${determinismSummary}.`,
+        evidence: [{ kind: 'other', ref: 'external-scorer:2000m-v1:determinism', summary: 'Determinism is scorer metadata, not acceptance approval.' }],
+      },
+    ],
+    decision: {
+      status: decisionStatus,
+      approver: 'external-scorer-import',
+      rationale: decisionStatus === 'approved'
+        ? 'All imported mechanical criteria passed. This does not certify domain correctness beyond the external scorer output.'
+        : `Imported scorer evidence has non-pass criteria${determinismFailed ? ' or failed determinism metadata' : ''}; do not approve this evaluation.`,
+    },
+    improvement: {
+      route: improvementRoute,
+      target: null,
+      carried_forward: [
+        ...(hasFailed ? ['External scorer reported at least one failed criterion.'] : []),
+        ...(hasSkipped ? ['External scorer skipped or marked at least one criterion as probe-only/non-mechanical.'] : []),
+        ...(determinismFailed ? ['External scorer determinism metadata failed.'] : []),
+      ],
+      do_not_assume: [
+        'This imported envelope records external scorer evidence only; Open Scaffold does not become the scorer.',
+        'Do not treat composite score or determinism metadata as acceptance approval.',
+      ],
+    },
+    notes: [
+      'Imported from 2000m-v1 external scorer JSON. Open Scaffold maps scorer evidence into an evaluation envelope; it does not certify correctness, compliance, production readiness, or model quality.',
+    ],
+  };
+  return `${JSON.stringify(envelope, null, 2)}\n`;
+}
+
+export function writeImportedEvaluationEnvelope(sourcePath: string, scorerPath: string, outPath: string, root = process.cwd(), options: RenderImportedEvaluationOptions = {}): { path: string } {
+  const source = loadEvaluationSource(sourcePath, root);
+  const absoluteOut = isAbsolute(outPath) ? outPath : resolve(root, outPath);
+  writeFileSync(absoluteOut, renderImportedEvaluationEnvelope(source, scorerPath, root, options), { encoding: 'utf8', flag: 'wx' });
+  return { path: absoluteOut };
 }
 
 export function writeEvaluationEnvelope(sourcePath: string, outPath: string, root = process.cwd(), options: RenderEvaluationOptions = {}): { path: string } {

--- a/tests/cli-eval.test.ts
+++ b/tests/cli-eval.test.ts
@@ -86,6 +86,19 @@ function validEnvelope(root: string) {
   };
 }
 
+function scorer2000m() {
+  return {
+    passCount: 1,
+    totalAcs: 2,
+    determinism: 'PASS',
+    compositeScore: 94.4892857143,
+    acs: [
+      { id: 'AC1', name: 'First criterion passes with evidence.', pass: true, skipped: false, quality: 1, detail: 'Passed.' },
+      { id: 'AC2', name: 'Second criterion routes feedback.', pass: false, skipped: false, quality: 0, detail: 'Failed.' },
+    ],
+  };
+}
+
 describe('osc eval CLI', () => {
   it('prints an evaluation template for a plan without spawning runtimes', () => {
     const { root, planPath } = tempRepo();
@@ -110,6 +123,46 @@ describe('osc eval CLI', () => {
     const overwrite = spawnSync(tsx, [cli, 'eval', 'init', planPath, '--out', outPath], { cwd: root, encoding: 'utf8' });
     expect(overwrite.status).toBe(1);
     expect(overwrite.stderr).toContain('Refusing to overwrite');
+  });
+
+  it('imports external 2000m-v1 scorer output as an evaluation envelope and validates it', () => {
+    const { root, planPath } = tempRepo();
+    const scorerPath = join(root, 'docs/evidence/2000m-score.json');
+    const outPath = join(root, 'docs/evidence/imported-evaluation.json');
+    writeFileSync(scorerPath, JSON.stringify(scorer2000m(), null, 2));
+
+    const jsonOutput = execFileSync(tsx, [cli, 'eval', 'import', planPath, '--adapter', '2000m-v1', '--scorer', scorerPath], { cwd: root, encoding: 'utf8' });
+    const envelope = JSON.parse(jsonOutput);
+    expect(envelope.acceptance_criteria.map((criterion: any) => [criterion.id, criterion.status])).toEqual([
+      ['AC1', 'pass'],
+      ['AC2', 'fail'],
+    ]);
+    expect(envelope.decision.status).toBe('rejected');
+    expect(jsonOutput).not.toContain('/Users/');
+
+    const writeOutput = execFileSync(tsx, [cli, 'eval', 'import', planPath, '--adapter', '2000m-v1', '--scorer', scorerPath, '--out', outPath], { cwd: root, encoding: 'utf8' });
+    expect(writeOutput).toContain('Created imported evaluation envelope:');
+    expect(existsSync(outPath)).toBe(true);
+    const checkOutput = execFileSync(tsx, [cli, 'eval', 'check', outPath], { cwd: root, encoding: 'utf8' });
+    expect(checkOutput).toContain('PASS evaluation envelope structure valid');
+
+    const overwrite = spawnSync(tsx, [cli, 'eval', 'import', planPath, '--adapter', '2000m-v1', '--scorer', scorerPath, '--out', outPath], { cwd: root, encoding: 'utf8' });
+    expect(overwrite.status).toBe(1);
+    expect(overwrite.stderr).toContain('Refusing to overwrite');
+  });
+
+  it('rejects missing or unsupported eval import adapters as usage errors', () => {
+    const { root, planPath } = tempRepo();
+    const scorerPath = join(root, 'docs/evidence/2000m-score.json');
+    writeFileSync(scorerPath, JSON.stringify(scorer2000m(), null, 2));
+
+    const missing = spawnSync(tsx, [cli, 'eval', 'import', planPath, '--scorer', scorerPath], { cwd: root, encoding: 'utf8' });
+    expect(missing.status).toBe(2);
+    expect(missing.stderr).toContain('Missing required option for eval import: --adapter');
+
+    const unsupported = spawnSync(tsx, [cli, 'eval', 'import', planPath, '--adapter', 'toy', '--scorer', scorerPath], { cwd: root, encoding: 'utf8' });
+    expect(unsupported.status).toBe(2);
+    expect(unsupported.stderr).toContain('Unsupported eval import adapter: toy');
   });
 
   it('checks a valid evaluation envelope with structure-only PASS wording', () => {
@@ -177,6 +230,6 @@ describe('osc eval CLI', () => {
     const result = spawnSync(tsx, [cli, 'eval', 'judge'], { cwd: root, encoding: 'utf8' });
 
     expect(result.status).toBe(2);
-    expect(result.stderr).toContain('Usage: osc eval init <run-or-plan> [--out <path>] | osc eval check <evaluation-path>');
+    expect(result.stderr).toContain('Usage: osc eval init <run-or-plan> [--out <path>] | osc eval import <run-or-plan> --adapter 2000m-v1 --scorer <scorer-json> [--out <path>] | osc eval check <evaluation-path>');
   });
 });

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -57,6 +57,7 @@ const topLevelHelpCommands = [
   'osc task link <task-id> --plan <slug>',
   'osc compare <attempt-a-dir> <attempt-b-dir> [--json] [--output <path>]',
   'osc eval init <run-or-plan> [--out <path>]',
+  'osc eval import <run-or-plan> --adapter 2000m-v1 --scorer <scorer-json> [--out <path>]',
   'osc eval check <evaluation-path>',
   'osc audit init <run-or-plan> [--artifact <role> <path>]... [--out <path>]',
   'osc audit check <audit-manifest-path>',

--- a/tests/evaluation.test.ts
+++ b/tests/evaluation.test.ts
@@ -6,6 +6,7 @@ import {
   EVALUATION_SCHEMA,
   loadEvaluationSource,
   renderEvaluationEnvelope,
+  renderImportedEvaluationEnvelope,
   validateEvaluationEnvelopeText,
 } from '../src/evaluation.js';
 
@@ -106,6 +107,38 @@ function validEnvelope(root: string, overrides: Record<string, unknown> = {}) {
   };
 }
 
+function scorer2000m(overrides: Record<string, unknown> = {}) {
+  return {
+    passCount: 1,
+    totalAcs: 2,
+    determinism: { verdict: 'PASS', pass: true },
+    composite: 94.4892857143,
+    acs: [
+      {
+        id: 'AC1',
+        name: 'First thing works.',
+        pass: true,
+        skipped: false,
+        quality: 1,
+        detail: 'Reached target checkpoint.',
+        breakdown: { checkpoint: 'reached' },
+      },
+      {
+        id: 'AC2',
+        name: 'Second thing routes feedback.',
+        pass: false,
+        skipped: true,
+        probe_only: true,
+        quality: 0.2,
+        detail: 'Probe-only metadata came from /Users/example/private/raw-log.json and key=/workspace/open-scaffold/.osc-dev/raw.log; path:/opt/project/trace.log cannot mechanically pass headless output.',
+        breakdown: { events: ['/Users/example/private/raw-log.json', 'path=/workspace/open-scaffold/.osc-dev/events.log'], 'log=/workspace/open-scaffold/.osc-dev/keyed-log.json': true },
+        score_sensitivity: 'none',
+      },
+    ],
+    ...overrides,
+  };
+}
+
 describe('evaluation envelope generation', () => {
   it('renders a JSON evaluation envelope template from a plan with deterministic fallback AC ids', () => {
     const root = tempRepo();
@@ -139,6 +172,177 @@ describe('evaluation envelope generation', () => {
     expect(envelope.subject).toMatchObject({ source: 'run', task_id: 'task-123', run_id: 'demo-run', run_packet: '.osc/runs/demo-run/run.json' });
     expect(envelope.inputs.evidence).toEqual([{ kind: 'path', ref: 'docs/evidence/run-proof.md', summary: 'Evidence from run packet.' }]);
     expect(envelope.acceptance_criteria[0].id).toBe('AC1');
+  });
+
+  it('imports 2000m-v1 scorer JSON into a valid evaluation envelope without approving non-pass criteria or leaking local paths', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const scorerPath = join(root, 'docs/evidence/2000m-score.json');
+    writeFileSync(scorerPath, JSON.stringify(scorer2000m(), null, 2));
+
+    const output = renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root, { now: new Date('2026-06-01T08:00:00.000Z') });
+    const envelope = JSON.parse(output);
+    const validation = validateEvaluationEnvelopeText(output, join(root, 'docs/evidence/imported-eval.json'), root);
+
+    expect(validation.ok).toBe(true);
+    expect(envelope.schema).toBe(EVALUATION_SCHEMA);
+    expect(envelope.acceptance_criteria.map((criterion: any) => [criterion.id, criterion.status])).toEqual([
+      ['AC1', 'pass'],
+      ['AC2', 'not_evaluated'],
+    ]);
+    expect(envelope.acceptance_criteria[1].analysis).toMatchObject({ adapter: '2000m-v1', skipped: true, probe_only: true, score_sensitivity: 'none' });
+    expect(envelope.decision.status).toBe('blocked');
+    expect(envelope.improvement.route).toBe('block');
+    expect(output).not.toContain('/Users/example');
+    expect(output).not.toContain('/workspace/open-scaffold');
+    expect(output).not.toContain('/opt/project');
+    expect(output).toContain('[local-path omitted]');
+    expect(output).toContain('Open Scaffold maps scorer evidence into an evaluation envelope');
+  });
+
+  it('rejects malformed scorer output before creating empty acceptance criteria', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const scorerPath = join(root, 'docs/evidence/bad-score.json');
+    writeFileSync(scorerPath, JSON.stringify({ passCount: 0, totalAcs: 0, acs: [] }, null, 2));
+
+    expect(() => renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root)).toThrow(/non-empty acs array/);
+  });
+
+  it('rejects scorer files that do not cover the source acceptance criteria', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const scorerPath = join(root, 'docs/evidence/stale-score.json');
+    writeFileSync(scorerPath, JSON.stringify({
+      passCount: 1,
+      totalAcs: 1,
+      determinism: 'PASS',
+      composite: 100,
+      acs: [{ id: 'AC1', name: 'Only one stale criterion.', pass: true }],
+    }, null, 2));
+
+    expect(() => renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root)).toThrow(/coverage does not match source acceptance criteria/);
+  });
+
+  it('rejects scorer files that reuse fallback ids for different acceptance criteria text', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const scorerPath = join(root, 'docs/evidence/wrong-text-score.json');
+    writeFileSync(scorerPath, JSON.stringify({
+      passCount: 2,
+      totalAcs: 2,
+      determinism: 'PASS',
+      composite: 100,
+      acs: [
+        { id: 'AC1', name: 'Unrelated stale criterion one.', pass: true },
+        { id: 'AC2', name: 'Unrelated stale criterion two.', pass: true },
+      ],
+    }, null, 2));
+
+    expect(() => renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root)).toThrow(/AC text does not match source acceptance criteria/);
+  });
+
+  it('normalizes scorer AC ids the same way as explicit source criteria ids', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root, ['AC-1: Explicit dash id works.', 'AC_2: Explicit underscore id works.']);
+    const scorerPath = join(root, 'docs/evidence/explicit-id-score.json');
+    writeFileSync(scorerPath, JSON.stringify({
+      passCount: 2,
+      totalAcs: 2,
+      determinism: 'PASS',
+      composite: 100,
+      acs: [
+        { id: 'AC-1', name: 'Explicit dash id works.', pass: true },
+        { id: 'AC_2', name: 'Explicit underscore id works.', pass: true },
+      ],
+    }, null, 2));
+
+    const envelope = JSON.parse(renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root));
+
+    expect(envelope.acceptance_criteria.map((criterion: any) => [criterion.id, criterion.status])).toEqual([
+      ['AC1', 'pass'],
+      ['AC2', 'pass'],
+    ]);
+    expect(envelope.decision.status).toBe('approved');
+  });
+
+  it('rejects scorer imports when the source has no acceptance criteria', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root, []);
+    const scorerPath = join(root, 'docs/evidence/source-empty-score.json');
+    writeFileSync(scorerPath, JSON.stringify({
+      passCount: 1,
+      totalAcs: 1,
+      determinism: 'PASS',
+      composite: 100,
+      acs: [{ id: 'AC1', name: 'Scorer-only criterion.', pass: true }],
+    }, null, 2));
+
+    expect(() => renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root)).toThrow(/requires source acceptance criteria/);
+  });
+
+  it('includes determinism metadata in imported evaluation idempotency keys', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root, ['Deterministic all-pass criterion.']);
+    const passScorerPath = join(root, 'docs/evidence/determinism-pass-score.json');
+    const failScorerPath = join(root, 'docs/evidence/determinism-fail-score.json');
+    const baseScorer = {
+      passCount: 1,
+      totalAcs: 1,
+      composite: 100,
+      acs: [{ id: 'AC1', name: 'Deterministic all-pass criterion.', pass: true }],
+    };
+    writeFileSync(passScorerPath, JSON.stringify({ ...baseScorer, determinism: { verdict: 'PASS', pass: true } }, null, 2));
+    writeFileSync(failScorerPath, JSON.stringify({ ...baseScorer, determinism: { verdict: 'FAIL', pass: false } }, null, 2));
+
+    const source = loadEvaluationSource(planPath, root);
+    const passEnvelope = JSON.parse(renderImportedEvaluationEnvelope(source, passScorerPath, root));
+    const failEnvelope = JSON.parse(renderImportedEvaluationEnvelope(source, failScorerPath, root));
+
+    expect(passEnvelope.decision.status).toBe('approved');
+    expect(failEnvelope.decision.status).toBe('blocked');
+    expect(passEnvelope.idempotency_key).not.toBe(failEnvelope.idempotency_key);
+  });
+
+  it('blocks skipped or probe-only criteria even if the scorer also marks them pass', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root, ['Probe-only passed flag should not approve.']);
+    const scorerPath = join(root, 'docs/evidence/skipped-pass-score.json');
+    writeFileSync(scorerPath, JSON.stringify({
+      passCount: 1,
+      totalAcs: 1,
+      determinism: 'PASS',
+      composite: 100,
+      acs: [{ id: 'AC1', name: 'Probe-only passed flag should not approve.', pass: true, skipped: true, probe_only: true, detail: 'Skipped/probe-only.' }],
+    }, null, 2));
+
+    const envelope = JSON.parse(renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root));
+
+    expect(envelope.acceptance_criteria[0]).toMatchObject({ status: 'not_evaluated', correction: { route: 'block' } });
+    expect(envelope.decision.status).toBe('blocked');
+    expect(envelope.improvement.route).toBe('block');
+  });
+
+  it('rejects unsafe scorer criterion ids instead of echoing private paths', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const scorerPath = join(root, 'docs/evidence/unsafe-id-score.json');
+    writeFileSync(scorerPath, JSON.stringify({
+      passCount: 1,
+      totalAcs: 1,
+      acs: [{ id: '/Users/example/private/raw-log.json', name: 'Unsafe id.', pass: true }],
+    }, null, 2));
+
+    expect(() => renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root)).toThrow(/unsafe id/);
+  });
+
+  it('rejects scorer pass counts that do not match imported AC states', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const scorerPath = join(root, 'docs/evidence/mismatched-score.json');
+    writeFileSync(scorerPath, JSON.stringify(scorer2000m({ passCount: 2 }), null, 2));
+
+    expect(() => renderImportedEvaluationEnvelope(loadEvaluationSource(planPath, root), scorerPath, root)).toThrow(/passCount/);
   });
 });
 

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('8cdef46073122ccf22304341d028a6e1598f7bea70e6500468b243a986b3aae9');
+    expect(hash(planIssueSnapshot)).toBe('916c935e8e4d439cae38087f201ecb2a1f94b9fed19370e7b91a0111843a516e');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('d7f063e42ac54b6f289bf4e8ce2c2f58576016bcedd21ac1c05474be4ea6ecc5');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('9a3f468b4b77e594c563d26d91167abefc2fa07ec23dcd9b02eb15c76600f49b');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add `osc eval import <run-or-plan> --adapter 2000m-v1 --scorer <json>` for importing structured external scorer output into `open-scaffold.evaluation.v1` envelopes.
- Map 2000m v1 per-AC status/provenance, determinism, composite score, correction routes, and analysis metadata without making Open Scaffold the scorer.
- Require scorer AC id/count/text coverage to match non-empty source plan/run criteria, normalize explicit `AC-1`/`AC_1` ids consistently, include determinism in import idempotency, redact generic local absolute paths including separator forms, and block skipped/probe-only criteria even if a scorer also marks them pass.
- Keep plan 135 closed in the same PR and record evidence for the slice; also clarify there is no automatic release-sync PR after plan 134.

## Verification
- `npm test -- --run tests/evaluation.test.ts tests/cli-eval.test.ts` — PASS (2 files / 32 tests)
- `npm test` — PASS (54 files / 558 tests)
- `npm run build` — PASS
- `git diff --check` — PASS
- `./verify.sh --strict` — PASS (10 pass / 0 fail / 0 warn)
- Built CLI smoke: `node dist/cli.js eval import ... --adapter 2000m-v1 ...` then `node dist/cli.js eval check ...` — PASS
- Added-line public-safety scan — PASS

## Review follow-up
- Fixed pre-commit review blockers around skipped/probe-only approval and private-path leakage.
- Fixed Codex findings around stale/wrong scorer coverage, missing source criteria, fallback-id text mismatch, explicit AC id normalization, determinism-sensitive idempotency, generic absolute-path redaction, and `key=/path` / `path:/path` separator-form redaction.

## Boundaries
- No runtime spawning, external API calls, benchmark reruns, benchmark-v2 work, npm publish, or GitHub Release changes.
- No claim that Open Scaffold improved raw 2000m v1 score.
