### PR TITLE
feat: add compact evidence summaries

### DIFF
--- a/.osc/plans/done/136-compact-evidence-mode.md
+++ b/.osc/plans/done/136-compact-evidence-mode.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+done
 
 ## Context
 

--- a/.osc/releases/2026-06-01-136-compact-evidence-mode.md
+++ b/.osc/releases/2026-06-01-136-compact-evidence-mode.md
@@ -15,9 +15,9 @@ Adds `osc evidence compact` as a repo-hygiene surface for run packets and evolut
 
 - `git diff --check` — PASS.
 - `node dist/cli.js plan validate .osc/plans/done/136-compact-evidence-mode.md --strict` — PASS, `0 issues found`.
-- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 14 tests.
+- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 16 tests.
 - `node dist/cli.js evidence compact --help` — PASS; prints the compact-evidence usage surface.
-- `npm test` — PASS, 55 files / 562 tests.
+- `npm test` — PASS, 55 files / 564 tests.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - Public-safety scan over changed files — PASS; no owner identity, local absolute path, secret-token, raw-score-win, or unsupported proof-claim hits.

--- a/.osc/releases/2026-06-01-136-compact-evidence-mode.md
+++ b/.osc/releases/2026-06-01-136-compact-evidence-mode.md
@@ -15,9 +15,9 @@ Adds `osc evidence compact` as a repo-hygiene surface for run packets and evolut
 
 - `git diff --check` — PASS.
 - `node dist/cli.js plan validate .osc/plans/done/136-compact-evidence-mode.md --strict` — PASS, `0 issues found`.
-- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 20 tests.
+- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 21 tests.
 - `node dist/cli.js evidence compact --help` — PASS; prints the compact-evidence usage surface.
-- `npm test` — PASS, 55 files / 568 tests.
+- `npm test` — PASS, 55 files / 569 tests.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - Public-safety scan over changed files — PASS; no owner identity, local absolute path, secret-token, raw-score-win, or unsupported proof-claim hits.

--- a/.osc/releases/2026-06-01-136-compact-evidence-mode.md
+++ b/.osc/releases/2026-06-01-136-compact-evidence-mode.md
@@ -9,7 +9,7 @@ Adds `osc evidence compact` as a repo-hygiene surface for run packets and evolut
 - Roadmap / issue / task: Post-2000m evolve-v2 evidence-volume follow-up from `docs/decisions/2026-05-31-osc-evolve-v2-after-2000m.md`; no GitHub issue selected for this bounded slice.
 - Plan: `.osc/plans/done/136-compact-evidence-mode.md`
 - Run ID / run packet: `N/A` — this slice changed the CLI/docs/tests directly and did not spawn a runtime.
-- Branch / PR: `feat/compact-evidence-mode`; PR pending owner review.
+- Branch / PR: `feat/compact-evidence-mode`; https://github.com/graphanov/open-scaffold/pull/163
 
 ## Verification
 

--- a/.osc/releases/2026-06-01-136-compact-evidence-mode.md
+++ b/.osc/releases/2026-06-01-136-compact-evidence-mode.md
@@ -15,9 +15,9 @@ Adds `osc evidence compact` as a repo-hygiene surface for run packets and evolut
 
 - `git diff --check` — PASS.
 - `node dist/cli.js plan validate .osc/plans/done/136-compact-evidence-mode.md --strict` — PASS, `0 issues found`.
-- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 19 tests.
+- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 20 tests.
 - `node dist/cli.js evidence compact --help` — PASS; prints the compact-evidence usage surface.
-- `npm test` — PASS, 55 files / 567 tests.
+- `npm test` — PASS, 55 files / 568 tests.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - Public-safety scan over changed files — PASS; no owner identity, local absolute path, secret-token, raw-score-win, or unsupported proof-claim hits.

--- a/.osc/releases/2026-06-01-136-compact-evidence-mode.md
+++ b/.osc/releases/2026-06-01-136-compact-evidence-mode.md
@@ -15,9 +15,9 @@ Adds `osc evidence compact` as a repo-hygiene surface for run packets and evolut
 
 - `git diff --check` — PASS.
 - `node dist/cli.js plan validate .osc/plans/done/136-compact-evidence-mode.md --strict` — PASS, `0 issues found`.
-- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 18 tests.
+- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 19 tests.
 - `node dist/cli.js evidence compact --help` — PASS; prints the compact-evidence usage surface.
-- `npm test` — PASS, 55 files / 566 tests.
+- `npm test` — PASS, 55 files / 567 tests.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - Public-safety scan over changed files — PASS; no owner identity, local absolute path, secret-token, raw-score-win, or unsupported proof-claim hits.

--- a/.osc/releases/2026-06-01-136-compact-evidence-mode.md
+++ b/.osc/releases/2026-06-01-136-compact-evidence-mode.md
@@ -15,9 +15,9 @@ Adds `osc evidence compact` as a repo-hygiene surface for run packets and evolut
 
 - `git diff --check` — PASS.
 - `node dist/cli.js plan validate .osc/plans/done/136-compact-evidence-mode.md --strict` — PASS, `0 issues found`.
-- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 13 tests.
+- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 14 tests.
 - `node dist/cli.js evidence compact --help` — PASS; prints the compact-evidence usage surface.
-- `npm test` — PASS, 55 files / 561 tests.
+- `npm test` — PASS, 55 files / 562 tests.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - Public-safety scan over changed files — PASS; no owner identity, local absolute path, secret-token, raw-score-win, or unsupported proof-claim hits.

--- a/.osc/releases/2026-06-01-136-compact-evidence-mode.md
+++ b/.osc/releases/2026-06-01-136-compact-evidence-mode.md
@@ -15,9 +15,9 @@ Adds `osc evidence compact` as a repo-hygiene surface for run packets and evolut
 
 - `git diff --check` — PASS.
 - `node dist/cli.js plan validate .osc/plans/done/136-compact-evidence-mode.md --strict` — PASS, `0 issues found`.
-- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 16 tests.
+- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 18 tests.
 - `node dist/cli.js evidence compact --help` — PASS; prints the compact-evidence usage surface.
-- `npm test` — PASS, 55 files / 564 tests.
+- `npm test` — PASS, 55 files / 566 tests.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
 - Public-safety scan over changed files — PASS; no owner identity, local absolute path, secret-token, raw-score-win, or unsupported proof-claim hits.

--- a/.osc/releases/2026-06-01-136-compact-evidence-mode.md
+++ b/.osc/releases/2026-06-01-136-compact-evidence-mode.md
@@ -1,0 +1,34 @@
+# Release / Evidence Note: 136-compact-evidence-mode
+
+## Summary
+
+Adds `osc evidence compact` as a repo-hygiene surface for run packets and evolution-loop directories. The command emits a compact Markdown summary plus a machine-readable `open-scaffold.compact-evidence.v1` manifest that keeps failed criteria, evaluation status, verification commands, decisions, and digest-backed raw/local evidence refs visible without embedding raw logs or private paths.
+
+## Traceability
+
+- Roadmap / issue / task: Post-2000m evolve-v2 evidence-volume follow-up from `docs/decisions/2026-05-31-osc-evolve-v2-after-2000m.md`; no GitHub issue selected for this bounded slice.
+- Plan: `.osc/plans/done/136-compact-evidence-mode.md`
+- Run ID / run packet: `N/A` — this slice changed the CLI/docs/tests directly and did not spawn a runtime.
+- Branch / PR: `feat/compact-evidence-mode`; PR pending owner review.
+
+## Verification
+
+- `git diff --check` — PASS.
+- `node dist/cli.js plan validate .osc/plans/done/136-compact-evidence-mode.md --strict` — PASS, `0 issues found`.
+- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts` — PASS, 2 files / 13 tests.
+- `node dist/cli.js evidence compact --help` — PASS; prints the compact-evidence usage surface.
+- `npm test` — PASS, 55 files / 561 tests.
+- `npm run build` — PASS, core and runtime-omx TypeScript builds.
+- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
+- Public-safety scan over changed files — PASS; no owner identity, local absolute path, secret-token, raw-score-win, or unsupported proof-claim hits.
+
+## Outcome
+
+Candidate implementation is prepared on a feature branch. The shipped behavior is analysis/summary only: it writes compact evidence only when explicitly requested, does not spawn runtimes, does not delete raw evidence, does not mutate evolution attempt/frontier state, and does not claim benchmark-score or usage-proof wins.
+
+No npm publish, GitHub Release, benchmark rerun, merge, or package-release sync is included in this slice.
+
+## Follow-up
+
+- Owner gate remains for PR review and merge.
+- Package/public release reconciliation remains out of scope unless the owner explicitly authorizes a release train.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-01: closed 136-compact-evidence-mode — Add compact evidence mode for run and evolution-loop summaries
 - 2026-06-01: closed 135-osc-eval-external-scorer-adapter — Close 135 after eval external scorer import
 - 2026-06-01: closed 134-osc-evolve-analyze-plateau-and-impossible-ac — shipped osc evolve analyze via PR #160
 - 2026-05-31: closed 133-2000m-postmortem-evolve-reset — Create 2000m benchmark postmortem and evolve reset package

--- a/docs/EVOLUTION_LOOP.md
+++ b/docs/EVOLUTION_LOOP.md
@@ -93,6 +93,18 @@ osc eval import .osc/runs/demo-run/run.json \
 
 The first adapter maps 2000m v1 conformance JSON (`passCount`, `totalAcs`, `acs[].id`, `name`, `pass`, `skipped`, `quality`, `detail`, `breakdown`, determinism, and composite score) into `open-scaffold.evaluation.v1`. It records scorer provenance and routes non-pass or skipped/probe-only criteria to retry/block instead of approval. Composite score and determinism are verification metadata, not acceptance approval, and the import path does not run the scorer, call an API, rerun a benchmark, or embed raw/private logs.
 
+Write compact evidence when a repeated loop has useful raw local forensics but the repo should promote only a concise public-safe summary and digest-backed manifest:
+
+```bash
+osc evidence compact .osc/evolution/demo-loop --out docs/evidence/demo-compact
+osc evidence compact .osc/runs/demo-run/run.json \
+  --evaluation docs/evidence/demo-evaluation.json \
+  --candidate-note docs/evidence/model-note.md \
+  --out docs/evidence/demo-run-compact
+```
+
+`osc evidence compact` writes `compact-evidence.md` and `compact-evidence.json` when `--out` is supplied. The summary keeps objective, run/attempt ids, evaluation status counts, failed criteria, verification commands, decision, and next recommendation visible. Raw logs, JSONL transcripts, private runtime state, and local absolute paths are not embedded; local files are represented as safe repo-relative labels plus SHA-256 digests when available. `--candidate-note` refs are marked `canonical=false` and do not rewrite `attempts.jsonl` or `frontier.json`.
+
 `osc evolve` does not create a run, launch a runtime, call an LLM, publish benchmark rankings, certify compliance, approve a merge, or decide product taste. It only records and analyzes curated loop state.
 
 ## See it in one screen

--- a/docs/TASK_RUN_MODEL.md
+++ b/docs/TASK_RUN_MODEL.md
@@ -57,6 +57,12 @@ One integrity-oriented envelope for reconstructing the slice/run evidence bundle
 
 The audit envelope is not raw runtime state. It points to promoted artifacts and safe evidence, preserving privacy and source-of-truth boundaries.
 
+### `compact_evidence_id`
+
+One repo-hygiene summary for a run or evolution loop. It keeps the objective, run/attempt ids, evaluation status counts, failed criteria, verification commands, decision, next recommendation, and digest-backed evidence refs in a small public-safe bundle.
+
+Compact evidence is not a replacement for raw local forensics and is not tamper-proof external anchoring. Raw logs, JSONL transcripts, private runtime state, and model-authored candidate notes stay local or are represented as safe labels plus digests; candidate notes must remain `canonical=false` and cannot overwrite `attempts.jsonl` or `frontier.json`.
+
 ### `question_id`
 
 One blocking clarification, approval request, or human decision inside a run. Human replies should route by structured correlation:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { runDashboard, type DashboardRunOptions } from './dashboard.js';
 import { DispatchUsageError, formatDispatchSummary, runDispatch } from './dispatch.js';
 import { doctorExitCode, formatDoctorReport, parseDoctorCheckName, runDoctor, type DoctorOptions, type DoctorSeverity } from './doctor.js';
 import { openDashboardUrl, serveDashboard, writeWebDashboard } from './dashboard-web.js';
+import { buildCompactEvidence, renderCompactEvidenceMarkdown, writeCompactEvidence } from './compact-evidence.js';
 import { collectEvidence } from './evidence.js';
 import { evidenceChainExitCode, formatEvidenceChainReport, verifyEvidenceChain } from './evidence-chain.js';
 import { EXTERNAL_SCORER_ADAPTERS, loadEvaluationSource, renderEvaluationEnvelope, renderImportedEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope, writeImportedEvaluationEnvelope, type ExternalScorerAdapter } from './evaluation.js';
@@ -56,6 +57,7 @@ Stable core protocol:
   osc amend <plan-slug> [--message <text>]
   osc evidence new <slug>
   osc evidence collect <slug> [--ci] [--dry-run] [--verbose]
+  osc evidence compact <run-or-loop> [--evaluation <evaluation-json>] [--candidate-note <path>]... [--out <dir>] [--json]
   osc close <plan-slug> [--message <text>]
   osc trace <plan-slug> [--json] [--include-unverified]
   osc verify [--evidence-chain [--plan <slug>] [--json] [--strict]]
@@ -989,7 +991,7 @@ function compareCommand(args: string[]): void {
 }
 
 function printEvidenceUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
-  printUsage('Usage: osc evidence new <slug> | osc evidence collect <slug> [--ci] [--dry-run] [--verbose]', stream);
+  printUsage('Usage: osc evidence new <slug> | osc evidence collect <slug> [--ci] [--dry-run] [--verbose] | osc evidence compact <run-or-loop> [--evaluation <evaluation-json>] [--candidate-note <path>]... [--out <dir>] [--json]', stream);
 }
 
 function printEvidenceNewUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
@@ -998,6 +1000,10 @@ function printEvidenceNewUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
 
 function printEvidenceCollectUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
   printUsage('Usage: osc evidence collect <slug> [--ci] [--dry-run] [--verbose]', stream);
+}
+
+function printEvidenceCompactUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
+  printUsage('Usage: osc evidence compact <run-or-loop> [--evaluation <evaluation-json>] [--candidate-note <path>]... [--out <dir>] [--json]', stream);
 }
 
 function printTraceUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
@@ -1273,6 +1279,69 @@ function evidenceCommand(args: string[]): void {
       return;
     } catch (error) {
       exitForScaffoldHelperError(error);
+    }
+  }
+
+  if (subcommand === 'compact') {
+    if (isHelpArg(rest[0])) {
+      printEvidenceCompactUsage('stdout');
+      return;
+    }
+    const source = requireArg(rest, 'run-or-loop');
+    let evaluationPath: string | undefined;
+    let outDir: string | undefined;
+    let json = false;
+    const candidateNotes: string[] = [];
+    for (let i = 1; i < rest.length; i += 1) {
+      const flag = rest[i];
+      const take = () => {
+        const value = rest[i + 1];
+        if (!value || value.startsWith('--')) {
+          console.error(`Missing value for ${flag}`);
+          printEvidenceCompactUsage();
+          process.exit(2);
+        }
+        i += 1;
+        return value;
+      };
+      switch (flag) {
+        case '--evaluation':
+          evaluationPath = take();
+          break;
+        case '--candidate-note':
+          candidateNotes.push(take());
+          break;
+        case '--out':
+        case '--output':
+          outDir = take();
+          break;
+        case '--json':
+          json = true;
+          break;
+        default:
+          console.error(`Unknown option for evidence compact: ${flag}`);
+          printEvidenceCompactUsage();
+          process.exit(2);
+      }
+    }
+    try {
+      const options = { evaluationPath, candidateNotes };
+      if (outDir) {
+        const result = writeCompactEvidence(source, outDir, process.cwd(), options);
+        console.log(`Wrote compact evidence summary: ${result.summaryPath}`);
+        console.log(`Wrote compact evidence manifest: ${result.manifestPath}`);
+      } else {
+        const manifest = buildCompactEvidence(source, process.cwd(), options);
+        if (json) {
+          console.log(JSON.stringify(manifest, null, 2));
+        } else {
+          process.stdout.write(renderCompactEvidenceMarkdown(manifest));
+        }
+      }
+      return;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
     }
   }
 

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -122,7 +122,7 @@ function sanitizeText(value: string | null | undefined, fallback: string | null 
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
-    .replace(/(^|[\s("'`=:])(?:\.[\\/])?(?:\.git|\.osc[\\/](?:state|research)|\.osc-dev|\.hermes|node_modules)(?:[\\/][^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
+    .replace(/(^|[\s("'`=:\[{])(?:\.[\\/])?(?:\.git|\.osc[\\/](?:state|research)|\.osc-dev|\.hermes|node_modules)(?:[\\/][^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
     .replace(/[\r\n]+/g, ' ')
     .trim()
     .slice(0, 1000);

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -147,7 +147,11 @@ function safeRef(root: string, ref: string): string {
   if (isForeignWindowsAbsolutePath(ref)) return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
   const realRoot = existsSync(root) ? resolve(root) : root;
   const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(realRoot, ref);
-  if (isInside(realRoot, absolute)) return toPosix(relative(realRoot, absolute)) || '.';
+  if (isInside(realRoot, absolute)) {
+    const relativeRef = toPosix(relative(realRoot, absolute)) || '.';
+    if (isPrivateRef(relativeRef)) return '[private-ref omitted]';
+    return relativeRef;
+  }
   return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
 }
 
@@ -160,6 +164,7 @@ function refAbsolute(root: string, ref: string): string | null {
 }
 
 function digestRef(root: string, ref: string): { digest: string | null; size: number | null } {
+  if (isOmittedRef(safeRef(root, ref))) return { digest: null, size: null };
   const absolute = refAbsolute(root, ref);
   if (!absolute || !existsSync(absolute) || !statSync(absolute).isFile()) return { digest: null, size: null };
   const bytes = readFileSync(absolute);
@@ -171,10 +176,14 @@ function isPrivateRef(ref: string): boolean {
   return PRIVATE_PREFIXES.some((prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix));
 }
 
+function isOmittedRef(ref: string): boolean {
+  return ref.includes('[local-path omitted]') || ref.includes('[private-ref omitted]');
+}
+
 function isRawLocalRef(root: string, ref: string, role: string): boolean {
   if (CANONICAL_EVIDENCE_ROLES.has(role)) return false;
   const safe = safeRef(root, ref);
-  if (safe.includes('[local-path omitted]')) return true;
+  if (isOmittedRef(safe)) return true;
   const normalized = toPosix(ref).replace(/^\.\//, '');
   const lower = normalized.toLowerCase();
   const ext = extname(lower);

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -138,8 +138,13 @@ function isInside(parent: string, child: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
+function isForeignWindowsAbsolutePath(ref: string): boolean {
+  return win32.isAbsolute(ref) && !isAbsolute(ref);
+}
+
 function safeRef(root: string, ref: string): string {
   if (/^[a-z]+:\/\//i.test(ref)) return ref;
+  if (isForeignWindowsAbsolutePath(ref)) return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
   const realRoot = existsSync(root) ? resolve(root) : root;
   const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(realRoot, ref);
   if (isInside(realRoot, absolute)) return toPosix(relative(realRoot, absolute)) || '.';
@@ -148,6 +153,7 @@ function safeRef(root: string, ref: string): string {
 
 function refAbsolute(root: string, ref: string): string | null {
   if (/^[a-z]+:\/\//i.test(ref)) return null;
+  if (isForeignWindowsAbsolutePath(ref)) return null;
   const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(root, ref);
   if (!isInside(resolve(root), absolute)) return null;
   return absolute;
@@ -170,6 +176,7 @@ function isRawLocalRef(ref: string, role: string): boolean {
   const normalized = toPosix(ref).replace(/^\.\//, '');
   const lower = normalized.toLowerCase();
   const ext = extname(lower);
+  if (normalized === '[local-path omitted]') return true;
   if (RAW_EXTENSIONS.has(ext)) return true;
   if (lower.includes('/raw/') || lower.includes('/logs/') || lower.includes('transcript') || lower.includes('codex-events')) return true;
   if (lower.startsWith('.osc/runs/') && !lower.endsWith('/run.json') && !lower.endsWith('evaluation.json') && !lower.endsWith('dispatch-receipt.json')) return true;
@@ -260,7 +267,7 @@ function summarizeEvaluation(root: string, evaluationRef: string | null | undefi
     status_counts: statusCounts(criteria),
     failed_criteria: failedCriteria,
     evaluator_refs: evaluatorRefs,
-    evidence_refs: [...new Set(evidenceRefs)],
+    evidence_refs: [...new Set(evidenceRefs.map((ref) => safeRef(root, ref)))],
   };
 }
 

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -119,7 +119,7 @@ function toPosix(value: string): string {
 
 function sanitizeText(value: string | null | undefined, fallback: string | null = ''): string {
   return (value ?? fallback ?? '')
-    .replace(/\b[A-Za-z]:\\[^\s,;)\]]+/g, '[local-path omitted]')
+    .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/[\r\n]+/g, ' ')
@@ -171,8 +171,10 @@ function isPrivateRef(ref: string): boolean {
   return PRIVATE_PREFIXES.some((prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix));
 }
 
-function isRawLocalRef(ref: string, role: string): boolean {
+function isRawLocalRef(root: string, ref: string, role: string): boolean {
   if (CANONICAL_EVIDENCE_ROLES.has(role)) return false;
+  const safe = safeRef(root, ref);
+  if (safe.includes('[local-path omitted]')) return true;
   const normalized = toPosix(ref).replace(/^\.\//, '');
   const lower = normalized.toLowerCase();
   const ext = extname(lower);
@@ -199,7 +201,7 @@ function compactRef(root: string, ref: string, role: string, note?: string): Com
 
 function addEvidenceRef(root: string, target: { promoted: CompactEvidenceRef[]; raw: CompactEvidenceRef[] }, ref: string, role: string): void {
   if (!ref.trim()) return;
-  const rawLocal = isRawLocalRef(ref, role);
+  const rawLocal = isRawLocalRef(root, ref, role);
   const entry = compactRef(root, ref, role, rawLocal ? 'Payload omitted; digest identifies the local file if present.' : undefined);
   const collection = rawLocal ? target.raw : target.promoted;
   if (!collection.some((existing) => existing.ref === entry.ref && existing.role === entry.role)) collection.push(entry);

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -295,6 +295,11 @@ function latestAttempt(attempts: Record<string, unknown>[]): Record<string, unkn
   return attempts.length ? attempts[attempts.length - 1] : null;
 }
 
+function attemptById(attempts: Record<string, unknown>[], attemptId: string | null): Record<string, unknown> | null {
+  if (!attemptId) return null;
+  return attempts.find((attempt) => asString(attempt.attempt_id) === attemptId) ?? null;
+}
+
 function readAttempts(path: string): Record<string, unknown>[] {
   if (!existsSync(path)) return [];
   return readFileSync(path, 'utf8')
@@ -366,8 +371,8 @@ function buildLoopCompact(inputPath: string, root: string, options: CompactEvide
   const frontier = readJson(frontierPath);
   if (!isRecord(frontier) || frontier.schema !== EVOLUTION_FRONTIER_SCHEMA) throw new Error(`Evolution frontier must declare schema: ${EVOLUTION_FRONTIER_SCHEMA}`);
   const attempts = readAttempts(attemptsPath);
-  const current = latestAttempt(attempts);
   const frontierAttemptId = frontierCurrentAttemptId(frontier);
+  const current = attemptById(attempts, frontierAttemptId) ?? latestAttempt(attempts);
   const evaluationRef = options.evaluationPath ?? asString(current?.evaluation) ?? null;
   const evaluation = summarizeEvaluation(root, evaluationRef);
   const evidence = { promoted: [] as CompactEvidenceRef[], raw: [] as CompactEvidenceRef[] };

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -157,7 +157,7 @@ function safeRef(root: string, ref: string): string {
     if (isPrivateRef(relativeRef)) return '[private-ref omitted]';
     return relativeRef;
   }
-  return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
+  return '[local-path omitted]';
 }
 
 function refAbsolute(root: string, ref: string): string | null {

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -190,7 +190,8 @@ function containedExistingPath(root: string, path: string, label: string): strin
 
 function isCanonicalRunPacketRef(root: string, ref: string): boolean {
   const safe = safeRef(root, ref);
-  return !isOmittedRef(safe) && safe.startsWith('.osc/runs/') && basename(safe) === 'run.json';
+  const parts = safe.split('/');
+  return !isOmittedRef(safe) && parts.length === 4 && parts[0] === '.osc' && parts[1] === 'runs' && Boolean(parts[2]) && parts[3] === 'run.json';
 }
 
 function digestRef(root: string, ref: string): { digest: string | null; size: number | null } {
@@ -258,6 +259,21 @@ function statusCounts(criteria: Record<string, unknown>[]): Record<string, numbe
 
 function summarizeEvaluation(root: string, evaluationRef: string | null | undefined): EvaluationSummary {
   if (!evaluationRef) {
+    return {
+      present: false,
+      path: null,
+      evaluation_id: null,
+      decision: null,
+      decision_rationale: null,
+      improvement_route: null,
+      next_recommendation: 'inspect_evaluation',
+      status_counts: {},
+      failed_criteria: [],
+      evaluator_refs: [],
+      evidence_refs: [],
+    };
+  }
+  if (isOmittedRef(safeRef(root, evaluationRef))) {
     return {
       present: false,
       path: null,

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -119,10 +119,11 @@ function toPosix(value: string): string {
 
 function sanitizeText(value: string | null | undefined, fallback: string | null = ''): string {
   return (value ?? fallback ?? '')
+    .replace(/file:\/\/\/??[^\s,;)\]}'"]+/gi, '[local-path omitted]')
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:\[{,;])\/(?!\/)[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
-    .replace(/(^|[\s("'`=:\[{])(?:\.[\\/])?(?:\.git|\.osc[\\/](?:state|research)|\.osc-dev|\.hermes|node_modules)(?:[\\/][^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
+    .replace(/(^|[\s("'`=:\[{,;])(?:\.[\\/])?(?:\.git|\.osc[\\/](?:state|research)|\.osc-dev|\.hermes|node_modules)(?:[\\/][^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
     .replace(/[\r\n]+/g, ' ')
     .trim()
     .slice(0, 1000);

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -165,6 +165,10 @@ function safeRef(root: string, ref: string): string {
   if (!isInside(lexicalRoot, absolute)) return '[local-path omitted]';
   const realAbsolute = realPathIfExists(absolute);
   if (realAbsolute && !isInside(realRoot, realAbsolute)) return '[local-path omitted]';
+  if (realAbsolute) {
+    const realRelativeRef = toPosix(relative(realRoot, realAbsolute)) || '.';
+    if (isPrivateRef(realRelativeRef)) return '[private-ref omitted]';
+  }
   const relativeRef = toPosix(relative(lexicalRoot, absolute)) || '.';
   if (isPrivateRef(relativeRef)) return '[private-ref omitted]';
   return relativeRef;

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -380,10 +380,10 @@ function buildLoopCompact(inputPath: string, root: string, options: CompactEvide
   addEvidenceRef(root, evidence, safeRef(root, attemptsPath), 'attempt_journal');
   addEvidenceRef(root, evidence, safeRef(root, frontierPath), 'frontier_state');
   if (evaluationRef) addEvidenceRef(root, evidence, evaluationRef, 'evaluation_envelope');
-  for (const attempt of attempts) {
-    asStringArray(attempt.evidence_refs).forEach((ref) => addEvidenceRef(root, evidence, ref, 'attempt_evidence_ref'));
-    asStringArray(attempt.adapter_receipts).forEach((ref) => addEvidenceRef(root, evidence, ref, 'adapter_receipt'));
-    const runPacket = asString(attempt.run_packet);
+  if (current) {
+    asStringArray(current.evidence_refs).forEach((ref) => addEvidenceRef(root, evidence, ref, 'attempt_evidence_ref'));
+    asStringArray(current.adapter_receipts).forEach((ref) => addEvidenceRef(root, evidence, ref, 'adapter_receipt'));
+    const runPacket = asString(current.run_packet);
     if (runPacket) addEvidenceRef(root, evidence, runPacket, 'run_packet');
   }
   evaluation.evidence_refs.forEach((ref) => addEvidenceRef(root, evidence, ref, 'evaluation_evidence_ref'));

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -122,7 +122,7 @@ function sanitizeText(value: string | null | undefined, fallback: string | null 
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
-    .replace(/(^|[\s("'`=:])(?:\.\/)?(?:\.git|\.osc\/state|\.osc\/research|\.osc-dev|\.hermes|node_modules)\/[^\s,;)\]}'"]+/g, '$1[private-ref omitted]')
+    .replace(/(^|[\s("'`=:])(?:\.\/)?(?:\.git|\.osc\/state|\.osc\/research|\.osc-dev|\.hermes|node_modules)(?:\/[^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
     .replace(/[\r\n]+/g, ' ')
     .trim()
     .slice(0, 1000);

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -1,0 +1,553 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, win32 } from 'node:path';
+import { findScaffoldRoot } from './scaffold.js';
+
+export const COMPACT_EVIDENCE_SCHEMA = 'open-scaffold.compact-evidence.v1';
+const RUN_SCHEMA = 'open-scaffold.run.v1';
+const EVALUATION_SCHEMA = 'open-scaffold.evaluation.v1';
+const EVOLUTION_LOOP_SCHEMA = 'open-scaffold.evolution-loop.v1';
+const EVOLUTION_FRONTIER_SCHEMA = 'open-scaffold.evolution-frontier.v1';
+
+const RAW_EXTENSIONS = new Set(['.log', '.jsonl', '.ndjson', '.stdout', '.stderr', '.trace', '.transcript', '.har']);
+const PRIVATE_PREFIXES = ['.git/', '.osc/state/', '.osc/research/', '.osc-dev/', '.hermes/', 'node_modules/'];
+const CANONICAL_EVIDENCE_ROLES = new Set(['attempt_journal', 'loop_state', 'frontier_state', 'run_packet', 'evaluation_envelope']);
+
+export interface CompactEvidenceOptions {
+  evaluationPath?: string;
+  candidateNotes?: string[];
+  now?: Date;
+}
+
+export interface CompactEvidenceFiles {
+  manifestPath: string;
+  summaryPath: string;
+  manifest: CompactEvidenceManifest;
+  markdown: string;
+}
+
+export interface CompactEvidenceRef {
+  label: string;
+  ref: string;
+  role: string;
+  digest_sha256: string | null;
+  size_bytes: number | null;
+  copied_payload: false;
+  note?: string;
+}
+
+interface CriterionFailure {
+  id: string;
+  text: string;
+  status: string;
+  rationale: string | null;
+}
+
+interface EvaluationSummary {
+  present: boolean;
+  path: string | null;
+  evaluation_id: string | null;
+  decision: string | null;
+  decision_rationale: string | null;
+  improvement_route: string | null;
+  next_recommendation: string;
+  status_counts: Record<string, number>;
+  failed_criteria: CriterionFailure[];
+  evaluator_refs: string[];
+  evidence_refs: string[];
+}
+
+export interface CompactEvidenceManifest {
+  schema: typeof COMPACT_EVIDENCE_SCHEMA;
+  generated_at: string;
+  subject: {
+    kind: 'run' | 'evolution_loop';
+    source: string;
+    plan_slug: string | null;
+    objective: string | null;
+    run_id: string | null;
+    loop_id: string | null;
+    task_id: string | null;
+  };
+  summary: {
+    attempt_count: number | null;
+    attempt_ids: string[];
+    current_attempt_id: string | null;
+    frontier_attempt_id: string | null;
+    score: number | null;
+    decision: string | null;
+    next_recommendation: string;
+  };
+  verification_commands: string[];
+  evaluation: EvaluationSummary;
+  promoted_evidence: CompactEvidenceRef[];
+  raw_local_evidence: CompactEvidenceRef[];
+  candidate_notes: Array<CompactEvidenceRef & { canonical: false }>;
+  warnings: string[];
+  boundary: {
+    raw_payloads_embedded: false;
+    raw_payloads_deleted: false;
+    external_anchoring: false;
+    canonical_attempt_state_mutated: false;
+    candidate_notes_are_canonical: false;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown;
+}
+
+function toPosix(value: string): string {
+  return value.split('\\').join('/');
+}
+
+function sanitizeText(value: string | null | undefined, fallback: string | null = ''): string {
+  return (value ?? fallback ?? '')
+    .replace(/\b[A-Za-z]:\\[^\s,;)\]]+/g, '[local-path omitted]')
+    .replace(/(^|[\s("'`=:])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
+    .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
+    .replace(/[\r\n]+/g, ' ')
+    .trim()
+    .slice(0, 1000);
+}
+
+function scaffoldRootFor(inputPath: string, root: string): string {
+  const absolute = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
+  const start = existsSync(absolute) && statSync(absolute).isFile() ? dirname(absolute) : absolute;
+  return findScaffoldRoot(start) ?? findScaffoldRoot(root) ?? root;
+}
+
+function isInside(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function safeRef(root: string, ref: string): string {
+  if (/^[a-z]+:\/\//i.test(ref)) return ref;
+  const realRoot = existsSync(root) ? resolve(root) : root;
+  const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(realRoot, ref);
+  if (isInside(realRoot, absolute)) return toPosix(relative(realRoot, absolute)) || '.';
+  return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
+}
+
+function refAbsolute(root: string, ref: string): string | null {
+  if (/^[a-z]+:\/\//i.test(ref)) return null;
+  const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(root, ref);
+  if (!isInside(resolve(root), absolute)) return null;
+  return absolute;
+}
+
+function digestRef(root: string, ref: string): { digest: string | null; size: number | null } {
+  const absolute = refAbsolute(root, ref);
+  if (!absolute || !existsSync(absolute) || !statSync(absolute).isFile()) return { digest: null, size: null };
+  const bytes = readFileSync(absolute);
+  return { digest: createHash('sha256').update(bytes).digest('hex'), size: bytes.length };
+}
+
+function isPrivateRef(ref: string): boolean {
+  const normalized = toPosix(ref).replace(/^\.\//, '');
+  return PRIVATE_PREFIXES.some((prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix));
+}
+
+function isRawLocalRef(ref: string, role: string): boolean {
+  if (CANONICAL_EVIDENCE_ROLES.has(role)) return false;
+  const normalized = toPosix(ref).replace(/^\.\//, '');
+  const lower = normalized.toLowerCase();
+  const ext = extname(lower);
+  if (RAW_EXTENSIONS.has(ext)) return true;
+  if (lower.includes('/raw/') || lower.includes('/logs/') || lower.includes('transcript') || lower.includes('codex-events')) return true;
+  if (lower.startsWith('.osc/runs/') && !lower.endsWith('/run.json') && !lower.endsWith('evaluation.json') && !lower.endsWith('dispatch-receipt.json')) return true;
+  return isPrivateRef(normalized);
+}
+
+function compactRef(root: string, ref: string, role: string, note?: string): CompactEvidenceRef {
+  const safe = safeRef(root, ref);
+  const { digest, size } = digestRef(root, ref);
+  return {
+    label: basename(safe) || safe,
+    ref: safe,
+    role,
+    digest_sha256: digest,
+    size_bytes: size,
+    copied_payload: false,
+    ...(note ? { note } : {}),
+  };
+}
+
+function addEvidenceRef(root: string, target: { promoted: CompactEvidenceRef[]; raw: CompactEvidenceRef[] }, ref: string, role: string): void {
+  if (!ref.trim()) return;
+  const rawLocal = isRawLocalRef(ref, role);
+  const entry = compactRef(root, ref, role, rawLocal ? 'Payload omitted; digest identifies the local file if present.' : undefined);
+  const collection = rawLocal ? target.raw : target.promoted;
+  if (!collection.some((existing) => existing.ref === entry.ref && existing.role === entry.role)) collection.push(entry);
+}
+
+function statusCounts(criteria: Record<string, unknown>[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const criterion of criteria) {
+    const status = asString(criterion.status) ?? 'unknown';
+    counts[status] = (counts[status] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function summarizeEvaluation(root: string, evaluationRef: string | null | undefined): EvaluationSummary {
+  if (!evaluationRef) {
+    return {
+      present: false,
+      path: null,
+      evaluation_id: null,
+      decision: null,
+      decision_rationale: null,
+      improvement_route: null,
+      next_recommendation: 'inspect_evaluation',
+      status_counts: {},
+      failed_criteria: [],
+      evaluator_refs: [],
+      evidence_refs: [],
+    };
+  }
+  const evaluationPath = refAbsolute(root, evaluationRef) ?? resolve(root, evaluationRef);
+  const parsed = readJson(evaluationPath);
+  if (!isRecord(parsed) || parsed.schema !== EVALUATION_SCHEMA) throw new Error(`Evaluation must declare schema: ${EVALUATION_SCHEMA}`);
+  const criteria = Array.isArray(parsed.acceptance_criteria) ? parsed.acceptance_criteria.filter(isRecord) : [];
+  const failedCriteria = criteria
+    .filter((criterion) => (asString(criterion.status) ?? 'unknown') !== 'pass')
+    .map((criterion, index) => ({
+      id: sanitizeText(asString(criterion.id), `AC${index + 1}`),
+      text: sanitizeText(asString(criterion.text), sanitizeText(asString(criterion.id), `AC${index + 1}`)),
+      status: sanitizeText(asString(criterion.status), 'unknown'),
+      rationale: asString(criterion.rationale) ? sanitizeText(asString(criterion.rationale)) : null,
+    }));
+  const evaluatorRefs = [...new Set(criteria.map((criterion) => {
+    const evaluator = isRecord(criterion.evaluator) ? criterion.evaluator : {};
+    const kind = sanitizeText(asString(evaluator.kind), 'unknown');
+    const name = sanitizeText(asString(evaluator.name), 'unknown');
+    return `${kind}:${name}`;
+  }))];
+  const evidenceRefs = criteria.flatMap((criterion) => {
+    const evidence = Array.isArray(criterion.evidence) ? criterion.evidence.filter(isRecord) : [];
+    return evidence.map((item) => asString(item.ref)).filter((item): item is string => Boolean(item));
+  });
+  const decision = isRecord(parsed.decision) ? parsed.decision : {};
+  const improvement = isRecord(parsed.improvement) ? parsed.improvement : {};
+  const route = asString(improvement.route);
+  const decisionStatus = asString(decision.status);
+  return {
+    present: true,
+    path: safeRef(root, evaluationRef),
+    evaluation_id: sanitizeText(asString(parsed.evaluation_id), null) || null,
+    decision: sanitizeText(decisionStatus, null) || null,
+    decision_rationale: asString(decision.rationale) ? sanitizeText(asString(decision.rationale)) : null,
+    improvement_route: sanitizeText(route, null) || null,
+    next_recommendation: sanitizeText(route ?? decisionStatus ?? 'inspect_evaluation'),
+    status_counts: statusCounts(criteria),
+    failed_criteria: failedCriteria,
+    evaluator_refs: evaluatorRefs,
+    evidence_refs: [...new Set(evidenceRefs)],
+  };
+}
+
+function runPacketVerificationSteps(packet: Record<string, unknown>): string[] {
+  const plan = isRecord(packet.plan) ? packet.plan : {};
+  return asStringArray(plan.verificationSteps).map((step) => sanitizeText(step)).filter(Boolean);
+}
+
+function runPacketInfo(root: string, runPath: string): { packet: Record<string, unknown>; refs: string[]; verification: string[] } {
+  const parsed = readJson(runPath);
+  if (!isRecord(parsed) || parsed.schemaVersion !== RUN_SCHEMA) throw new Error(`Run packet must declare schemaVersion: ${RUN_SCHEMA}`);
+  const artifacts = isRecord(parsed.artifacts) ? parsed.artifacts : {};
+  const refs = ['manifest', 'prompts', 'logs', 'outputs', 'evidence']
+    .flatMap((key) => {
+      const value = artifacts[key];
+      return Array.isArray(value) ? value : (typeof value === 'string' ? [value] : []);
+    })
+    .filter((item): item is string => typeof item === 'string');
+  return { packet: parsed, refs, verification: runPacketVerificationSteps(parsed) };
+}
+
+function latestAttempt(attempts: Record<string, unknown>[]): Record<string, unknown> | null {
+  return attempts.length ? attempts[attempts.length - 1] : null;
+}
+
+function readAttempts(path: string): Record<string, unknown>[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as unknown)
+    .filter(isRecord);
+}
+
+function frontierCurrentAttemptId(frontier: Record<string, unknown>): string | null {
+  return isRecord(frontier.current) ? asString(frontier.current.attempt_id) : null;
+}
+
+function recommendationFor(evaluation: EvaluationSummary, decision: string | null): string {
+  if (evaluation.next_recommendation && evaluation.next_recommendation !== 'inspect_evaluation') return evaluation.next_recommendation;
+  if (decision) return decision;
+  if (evaluation.failed_criteria.length > 0) return 'retry_or_redesign';
+  if (evaluation.present) return 'close_or_continue';
+  return 'inspect_evaluation';
+}
+
+function buildRunCompact(inputPath: string, root: string, options: CompactEvidenceOptions): CompactEvidenceManifest {
+  const absoluteInput = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
+  const { packet, refs, verification } = runPacketInfo(root, absoluteInput);
+  const plan = isRecord(packet.plan) ? packet.plan : {};
+  const runId = asString(packet.runId);
+  const evaluation = summarizeEvaluation(root, options.evaluationPath ?? null);
+  const evidence = { promoted: [] as CompactEvidenceRef[], raw: [] as CompactEvidenceRef[] };
+  addEvidenceRef(root, evidence, safeRef(root, absoluteInput), 'run_packet');
+  if (options.evaluationPath) addEvidenceRef(root, evidence, options.evaluationPath, 'evaluation_envelope');
+  refs.forEach((ref) => addEvidenceRef(root, evidence, ref, 'run_artifact_ref'));
+  evaluation.evidence_refs.forEach((ref) => addEvidenceRef(root, evidence, ref, 'evaluation_evidence_ref'));
+  const candidateNotes = candidateNoteRefs(root, options.candidateNotes ?? []);
+  return baseManifest(root, options, {
+    subject: {
+      kind: 'run',
+      source: safeRef(root, absoluteInput),
+      plan_slug: sanitizeText(asString(plan.slug), null) || null,
+      objective: sanitizeText(asString(plan.goal), null) || null,
+      run_id: sanitizeText(runId, null) || null,
+      loop_id: null,
+      task_id: sanitizeText(asString(packet.taskId), null) || null,
+    },
+    summary: {
+      attempt_count: null,
+      attempt_ids: [],
+      current_attempt_id: null,
+      frontier_attempt_id: null,
+      score: null,
+      decision: evaluation.decision,
+      next_recommendation: recommendationFor(evaluation, evaluation.decision),
+    },
+    verification,
+    evaluation,
+    promoted: evidence.promoted,
+    raw: evidence.raw,
+    candidateNotes,
+  });
+}
+
+function buildLoopCompact(inputPath: string, root: string, options: CompactEvidenceOptions): CompactEvidenceManifest {
+  const absoluteLoopDir = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
+  const loopPath = join(absoluteLoopDir, 'loop.json');
+  const attemptsPath = join(absoluteLoopDir, 'attempts.jsonl');
+  const frontierPath = join(absoluteLoopDir, 'frontier.json');
+  const loop = readJson(loopPath);
+  if (!isRecord(loop) || loop.schema !== EVOLUTION_LOOP_SCHEMA) throw new Error(`Evolution loop must declare schema: ${EVOLUTION_LOOP_SCHEMA}`);
+  const frontier = readJson(frontierPath);
+  if (!isRecord(frontier) || frontier.schema !== EVOLUTION_FRONTIER_SCHEMA) throw new Error(`Evolution frontier must declare schema: ${EVOLUTION_FRONTIER_SCHEMA}`);
+  const attempts = readAttempts(attemptsPath);
+  const current = latestAttempt(attempts);
+  const frontierAttemptId = frontierCurrentAttemptId(frontier);
+  const evaluationRef = options.evaluationPath ?? asString(current?.evaluation) ?? null;
+  const evaluation = summarizeEvaluation(root, evaluationRef);
+  const evidence = { promoted: [] as CompactEvidenceRef[], raw: [] as CompactEvidenceRef[] };
+  addEvidenceRef(root, evidence, safeRef(root, loopPath), 'loop_state');
+  addEvidenceRef(root, evidence, safeRef(root, attemptsPath), 'attempt_journal');
+  addEvidenceRef(root, evidence, safeRef(root, frontierPath), 'frontier_state');
+  if (evaluationRef) addEvidenceRef(root, evidence, evaluationRef, 'evaluation_envelope');
+  for (const attempt of attempts) {
+    asStringArray(attempt.evidence_refs).forEach((ref) => addEvidenceRef(root, evidence, ref, 'attempt_evidence_ref'));
+    asStringArray(attempt.adapter_receipts).forEach((ref) => addEvidenceRef(root, evidence, ref, 'adapter_receipt'));
+    const runPacket = asString(attempt.run_packet);
+    if (runPacket) addEvidenceRef(root, evidence, runPacket, 'run_packet');
+  }
+  evaluation.evidence_refs.forEach((ref) => addEvidenceRef(root, evidence, ref, 'evaluation_evidence_ref'));
+  const currentRunPacket = asString(current?.run_packet);
+  let verification: string[] = [];
+  if (currentRunPacket) {
+    try {
+      verification = runPacketInfo(root, resolve(root, currentRunPacket)).verification;
+    } catch {
+      verification = [];
+    }
+  }
+  const candidateNotes = candidateNoteRefs(root, options.candidateNotes ?? []);
+  return baseManifest(root, options, {
+    subject: {
+      kind: 'evolution_loop',
+      source: safeRef(root, absoluteLoopDir),
+      plan_slug: sanitizeText(asString(isRecord(loop.subject) ? loop.subject.plan_slug : undefined), null) || null,
+      objective: sanitizeText(asString(loop.objective), null) || null,
+      run_id: sanitizeText(asString(current?.run_id), null) || null,
+      loop_id: sanitizeText(asString(loop.loop_id), null) || null,
+      task_id: sanitizeText(asString(isRecord(loop.subject) ? loop.subject.task_id : undefined), null) || null,
+    },
+    summary: {
+      attempt_count: attempts.length,
+      attempt_ids: attempts.map((attempt, index) => sanitizeText(asString(attempt.attempt_id), `attempt-${index + 1}`)),
+      current_attempt_id: sanitizeText(asString(current?.attempt_id), null) || null,
+      frontier_attempt_id: sanitizeText(frontierAttemptId, null) || null,
+      score: asNumber(current?.score),
+      decision: sanitizeText(asString(current?.decision), null) || evaluation.decision,
+      next_recommendation: recommendationFor(evaluation, asString(current?.decision)),
+    },
+    verification,
+    evaluation,
+    promoted: evidence.promoted,
+    raw: evidence.raw,
+    candidateNotes,
+  });
+}
+
+function candidateNoteRefs(root: string, refs: string[]): Array<CompactEvidenceRef & { canonical: false }> {
+  return refs.map((ref) => ({ ...compactRef(root, ref, 'candidate_note', 'Candidate note payload omitted; not canonical attempt/frontier state.'), canonical: false as const }));
+}
+
+function baseManifest(root: string, options: CompactEvidenceOptions, parts: {
+  subject: CompactEvidenceManifest['subject'];
+  summary: CompactEvidenceManifest['summary'];
+  verification: string[];
+  evaluation: EvaluationSummary;
+  promoted: CompactEvidenceRef[];
+  raw: CompactEvidenceRef[];
+  candidateNotes: Array<CompactEvidenceRef & { canonical: false }>;
+}): CompactEvidenceManifest {
+  const warnings: string[] = [];
+  if (!parts.evaluation.present) warnings.push('No evaluation envelope was supplied or found; inspect acceptance status before closing work.');
+  if (parts.evaluation.failed_criteria.length > 0) warnings.push('Failed or non-passing criteria remain visible in compact evidence.');
+  if (parts.raw.length > 0) warnings.push('Raw/local evidence payloads are omitted; use digests and local refs for forensic lookup.');
+  return {
+    schema: COMPACT_EVIDENCE_SCHEMA,
+    generated_at: (options.now ?? new Date()).toISOString(),
+    subject: parts.subject,
+    summary: parts.summary,
+    verification_commands: parts.verification,
+    evaluation: parts.evaluation,
+    promoted_evidence: parts.promoted,
+    raw_local_evidence: parts.raw,
+    candidate_notes: parts.candidateNotes,
+    warnings,
+    boundary: {
+      raw_payloads_embedded: false,
+      raw_payloads_deleted: false,
+      external_anchoring: false,
+      canonical_attempt_state_mutated: false,
+      candidate_notes_are_canonical: false,
+    },
+  };
+}
+
+export function buildCompactEvidence(inputPath: string, root = process.cwd(), options: CompactEvidenceOptions = {}): CompactEvidenceManifest {
+  const scaffoldRoot = scaffoldRootFor(inputPath, root);
+  const absolute = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
+  if (!existsSync(absolute)) throw new Error(`Compact evidence source not found: ${inputPath}`);
+  if (statSync(absolute).isDirectory()) return buildLoopCompact(absolute, scaffoldRoot, options);
+  if (extname(absolute).toLowerCase() === '.json') return buildRunCompact(absolute, scaffoldRoot, options);
+  throw new Error('Compact evidence source must be a run packet JSON or an evolution loop directory.');
+}
+
+function countsLine(counts: Record<string, number>): string {
+  const entries = Object.entries(counts).sort(([a], [b]) => a.localeCompare(b));
+  return entries.length ? entries.map(([status, count]) => `${status}: ${count}`).join(', ') : 'not supplied';
+}
+
+function evidenceLine(ref: CompactEvidenceRef): string {
+  const digest = ref.digest_sha256 ? ` sha256=${ref.digest_sha256.slice(0, 12)}…` : '';
+  const size = ref.size_bytes !== null ? ` size=${ref.size_bytes}` : '';
+  return `- ${ref.role}: \`${ref.ref}\`${digest}${size}`;
+}
+
+export function renderCompactEvidenceMarkdown(manifest: CompactEvidenceManifest): string {
+  const lines = [
+    `# Compact evidence: ${manifest.subject.plan_slug ?? manifest.subject.run_id ?? manifest.subject.loop_id ?? manifest.subject.source}`,
+    '',
+    '> Compact evidence is a repo-hygiene summary. It omits raw payloads by default, preserves failed criteria, and is not external tamper-proof anchoring.',
+    '',
+    '## Subject',
+    '',
+    `- Kind: ${manifest.subject.kind}`,
+    `- Source: \`${manifest.subject.source}\``,
+    `- Objective: ${manifest.subject.objective ?? 'not supplied'}`,
+    `- Run ID: ${manifest.subject.run_id ?? 'n/a'}`,
+    `- Loop ID: ${manifest.subject.loop_id ?? 'n/a'}`,
+    `- Task ID: ${manifest.subject.task_id ?? 'n/a'}`,
+    '',
+    '## Attempts / decision',
+    '',
+    `- Attempt count: ${manifest.summary.attempt_count ?? 'n/a'}`,
+    `- Attempt IDs: ${manifest.summary.attempt_ids.length ? manifest.summary.attempt_ids.join(', ') : 'n/a'}`,
+    `- Current attempt: ${manifest.summary.current_attempt_id ?? 'n/a'}`,
+    `- Frontier attempt: ${manifest.summary.frontier_attempt_id ?? 'n/a'}`,
+    `- Score: ${manifest.summary.score ?? 'n/a'}`,
+    `- Decision: ${manifest.summary.decision ?? 'inspect'}`,
+    `- Next recommendation: ${manifest.summary.next_recommendation}`,
+    '',
+    '## Evaluation',
+    '',
+    `- Evaluation: ${manifest.evaluation.present ? `\`${manifest.evaluation.path}\`` : 'not supplied'}`,
+    `- Evaluation ID: ${manifest.evaluation.evaluation_id ?? 'n/a'}`,
+    `- Status counts: ${countsLine(manifest.evaluation.status_counts)}`,
+    `- Evaluators/scorers: ${manifest.evaluation.evaluator_refs.length ? manifest.evaluation.evaluator_refs.join(', ') : 'not supplied'}`,
+    `- Decision rationale: ${manifest.evaluation.decision_rationale ?? 'not supplied'}`,
+    `- Improvement route: ${manifest.evaluation.improvement_route ?? 'not supplied'}`,
+    '',
+    '### Failed / non-passing criteria',
+    '',
+    ...(manifest.evaluation.failed_criteria.length ? manifest.evaluation.failed_criteria.map((criterion) => `- \`${criterion.id}\` ${criterion.status}: ${criterion.text}${criterion.rationale ? ` — ${criterion.rationale}` : ''}`) : ['- None recorded.']),
+    '',
+    '## Verification commands',
+    '',
+    ...(manifest.verification_commands.length ? manifest.verification_commands.map((command, index) => `${index + 1}. ${command}`) : ['1. No verification commands supplied in the source run packet.']),
+    '',
+    '## Evidence manifest',
+    '',
+    '### Promoted evidence',
+    '',
+    ...(manifest.promoted_evidence.length ? manifest.promoted_evidence.map(evidenceLine) : ['- None.']),
+    '',
+    '### Raw/local evidence omitted from public payload',
+    '',
+    ...(manifest.raw_local_evidence.length ? manifest.raw_local_evidence.map(evidenceLine) : ['- None.']),
+    '',
+    '### Candidate notes',
+    '',
+    ...(manifest.candidate_notes.length ? manifest.candidate_notes.map((note) => `${evidenceLine(note)} canonical=false`) : ['- None.']),
+    '',
+    '## Boundary',
+    '',
+    `- Raw payloads embedded: ${manifest.boundary.raw_payloads_embedded}`,
+    `- Raw payloads deleted: ${manifest.boundary.raw_payloads_deleted}`,
+    `- External anchoring: ${manifest.boundary.external_anchoring}`,
+    `- Canonical attempt state mutated: ${manifest.boundary.canonical_attempt_state_mutated}`,
+    `- Candidate notes are canonical: ${manifest.boundary.candidate_notes_are_canonical}`,
+    '',
+    '## Warnings',
+    '',
+    ...(manifest.warnings.length ? manifest.warnings.map((warning) => `- ${warning}`) : ['- None.']),
+    '',
+  ];
+  return lines.join('\n');
+}
+
+export function writeCompactEvidence(inputPath: string, outDir: string, root = process.cwd(), options: CompactEvidenceOptions = {}): CompactEvidenceFiles {
+  const manifest = buildCompactEvidence(inputPath, root, options);
+  const markdown = renderCompactEvidenceMarkdown(manifest);
+  const absoluteOutDir = isAbsolute(outDir) ? outDir : resolve(root, outDir);
+  mkdirSync(absoluteOutDir, { recursive: true });
+  const manifestPath = join(absoluteOutDir, 'compact-evidence.json');
+  const summaryPath = join(absoluteOutDir, 'compact-evidence.md');
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  writeFileSync(summaryPath, markdown, 'utf8');
+  return { manifestPath, summaryPath, manifest, markdown };
+}

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -188,6 +188,11 @@ function containedExistingPath(root: string, path: string, label: string): strin
   return absolute;
 }
 
+function isCanonicalRunPacketRef(root: string, ref: string): boolean {
+  const safe = safeRef(root, ref);
+  return !isOmittedRef(safe) && safe.startsWith('.osc/runs/') && basename(safe) === 'run.json';
+}
+
 function digestRef(root: string, ref: string): { digest: string | null; size: number | null } {
   if (isOmittedRef(safeRef(root, ref))) return { digest: null, size: null };
   const absolute = refAbsolute(root, ref);
@@ -208,6 +213,7 @@ function isOmittedRef(ref: string): boolean {
 function isRawLocalRef(root: string, ref: string, role: string): boolean {
   const safe = safeRef(root, ref);
   if (isOmittedRef(safe)) return true;
+  if (role === 'run_packet' && !isCanonicalRunPacketRef(root, ref)) return true;
   if (CANONICAL_EVIDENCE_ROLES.has(role)) return false;
   const normalized = toPosix(ref).replace(/^\.\//, '');
   const lower = normalized.toLowerCase();
@@ -375,7 +381,7 @@ function buildRunCompact(inputPath: string, root: string, options: CompactEviden
   const runPathRef = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
   const runPath = containedExistingPath(root, runPathRef, 'run packet');
   const runRef = safeRef(root, runPathRef);
-  if (isOmittedRef(runRef) || !runRef.startsWith('.osc/runs/') || basename(runRef) !== 'run.json') {
+  if (!isCanonicalRunPacketRef(root, runPathRef)) {
     throw new Error('Run packet must remain under .osc/runs/<run-id>/run.json.');
   }
   const { packet, refs, verification } = runPacketInfo(root, runPath);
@@ -447,7 +453,7 @@ function buildLoopCompact(inputPath: string, root: string, options: CompactEvide
   const currentRunPacket = asString(current?.run_packet);
   let verification: string[] = [];
   if (currentRunPacket) {
-    const currentRunPacketPath = refAbsolute(root, currentRunPacket);
+    const currentRunPacketPath = isCanonicalRunPacketRef(root, currentRunPacket) ? refAbsolute(root, currentRunPacket) : null;
     try {
       verification = currentRunPacketPath ? runPacketInfo(root, currentRunPacketPath).verification : [];
     } catch {

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -120,7 +120,7 @@ function toPosix(value: string): string {
 function sanitizeText(value: string | null | undefined, fallback: string | null = ''): string {
   return (value ?? fallback ?? '')
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
-    .replace(/(^|[\s("'`=:])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
+    .replace(/(^|[\s("'`=:\[{])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:\[{])(?:\.[\\/])?(?:\.git|\.osc[\\/](?:state|research)|\.osc-dev|\.hermes|node_modules)(?:[\\/][^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
     .replace(/[\r\n]+/g, ' ')

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -122,7 +122,7 @@ function sanitizeText(value: string | null | undefined, fallback: string | null 
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
-    .replace(/(^|[\s("'`=:])(?:\.\/)?(?:\.git|\.osc\/state|\.osc\/research|\.osc-dev|\.hermes|node_modules)(?:\/[^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
+    .replace(/(^|[\s("'`=:])(?:\.[\\/])?(?:\.git|\.osc[\\/](?:state|research)|\.osc-dev|\.hermes|node_modules)(?:[\\/][^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
     .replace(/[\r\n]+/g, ' ')
     .trim()
     .slice(0, 1000);

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -182,6 +182,12 @@ function refAbsolute(root: string, ref: string): string | null {
   return realAbsolute ?? absolute;
 }
 
+function containedExistingPath(root: string, path: string, label: string): string {
+  const absolute = refAbsolute(root, path);
+  if (!absolute || !existsSync(absolute)) throw new Error(`${label} must remain inside the scaffold root.`);
+  return absolute;
+}
+
 function digestRef(root: string, ref: string): { digest: string | null; size: number | null } {
   if (isOmittedRef(safeRef(root, ref))) return { digest: null, size: null };
   const absolute = refAbsolute(root, ref);
@@ -238,7 +244,7 @@ function addEvidenceRef(root: string, target: { promoted: CompactEvidenceRef[]; 
 function statusCounts(criteria: Record<string, unknown>[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const criterion of criteria) {
-    const status = asString(criterion.status) ?? 'unknown';
+    const status = sanitizeText(asString(criterion.status), 'unknown') || 'unknown';
     counts[status] = (counts[status] ?? 0) + 1;
   }
   return counts;
@@ -406,9 +412,12 @@ function buildRunCompact(inputPath: string, root: string, options: CompactEviden
 
 function buildLoopCompact(inputPath: string, root: string, options: CompactEvidenceOptions): CompactEvidenceManifest {
   const absoluteLoopDir = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
-  const loopPath = join(absoluteLoopDir, 'loop.json');
-  const attemptsPath = join(absoluteLoopDir, 'attempts.jsonl');
-  const frontierPath = join(absoluteLoopDir, 'frontier.json');
+  const loopPathRef = join(absoluteLoopDir, 'loop.json');
+  const attemptsPathRef = join(absoluteLoopDir, 'attempts.jsonl');
+  const frontierPathRef = join(absoluteLoopDir, 'frontier.json');
+  const loopPath = containedExistingPath(root, loopPathRef, 'loop.json');
+  const attemptsPath = containedExistingPath(root, attemptsPathRef, 'attempts.jsonl');
+  const frontierPath = containedExistingPath(root, frontierPathRef, 'frontier.json');
   const loop = readJson(loopPath);
   if (!isRecord(loop) || loop.schema !== EVOLUTION_LOOP_SCHEMA) throw new Error(`Evolution loop must declare schema: ${EVOLUTION_LOOP_SCHEMA}`);
   const frontier = readJson(frontierPath);
@@ -419,9 +428,9 @@ function buildLoopCompact(inputPath: string, root: string, options: CompactEvide
   const evaluationRef = options.evaluationPath ?? asString(current?.evaluation) ?? null;
   const evaluation = summarizeEvaluation(root, evaluationRef);
   const evidence = { promoted: [] as CompactEvidenceRef[], raw: [] as CompactEvidenceRef[] };
-  addEvidenceRef(root, evidence, safeRef(root, loopPath), 'loop_state');
-  addEvidenceRef(root, evidence, safeRef(root, attemptsPath), 'attempt_journal');
-  addEvidenceRef(root, evidence, safeRef(root, frontierPath), 'frontier_state');
+  addEvidenceRef(root, evidence, loopPathRef, 'loop_state');
+  addEvidenceRef(root, evidence, attemptsPathRef, 'attempt_journal');
+  addEvidenceRef(root, evidence, frontierPathRef, 'frontier_state');
   if (evaluationRef) addEvidenceRef(root, evidence, evaluationRef, 'evaluation_envelope');
   if (current) {
     asStringArray(current.evidence_refs).forEach((ref) => addEvidenceRef(root, evidence, ref, 'attempt_evidence_ref'));

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -372,13 +372,18 @@ function recommendationFor(evaluation: EvaluationSummary, decision: string | nul
 }
 
 function buildRunCompact(inputPath: string, root: string, options: CompactEvidenceOptions): CompactEvidenceManifest {
-  const absoluteInput = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
-  const { packet, refs, verification } = runPacketInfo(root, absoluteInput);
+  const runPathRef = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
+  const runPath = containedExistingPath(root, runPathRef, 'run packet');
+  const runRef = safeRef(root, runPathRef);
+  if (isOmittedRef(runRef) || !runRef.startsWith('.osc/runs/') || basename(runRef) !== 'run.json') {
+    throw new Error('Run packet must remain under .osc/runs/<run-id>/run.json.');
+  }
+  const { packet, refs, verification } = runPacketInfo(root, runPath);
   const plan = isRecord(packet.plan) ? packet.plan : {};
   const runId = asString(packet.runId);
   const evaluation = summarizeEvaluation(root, options.evaluationPath ?? null);
   const evidence = { promoted: [] as CompactEvidenceRef[], raw: [] as CompactEvidenceRef[] };
-  addEvidenceRef(root, evidence, safeRef(root, absoluteInput), 'run_packet');
+  addEvidenceRef(root, evidence, runPathRef, 'run_packet');
   if (options.evaluationPath) addEvidenceRef(root, evidence, options.evaluationPath, 'evaluation_envelope');
   refs.forEach((ref) => addEvidenceRef(root, evidence, ref, 'run_artifact_ref'));
   evaluation.evidence_refs.forEach((ref) => addEvidenceRef(root, evidence, ref, 'evaluation_evidence_ref'));
@@ -386,7 +391,7 @@ function buildRunCompact(inputPath: string, root: string, options: CompactEviden
   return baseManifest(root, options, {
     subject: {
       kind: 'run',
-      source: safeRef(root, absoluteInput),
+      source: runRef,
       plan_slug: sanitizeText(asString(plan.slug), null) || null,
       objective: sanitizeText(asString(plan.goal), null) || null,
       run_id: sanitizeText(runId, null) || null,
@@ -519,7 +524,9 @@ export function buildCompactEvidence(inputPath: string, root = process.cwd(), op
   const scaffoldRoot = scaffoldRootFor(inputPath, root);
   const absolute = isAbsolute(inputPath) ? inputPath : resolve(root, inputPath);
   if (!existsSync(absolute)) throw new Error(`Compact evidence source not found: ${inputPath}`);
-  if (statSync(absolute).isDirectory()) return buildLoopCompact(absolute, scaffoldRoot, options);
+  const contained = refAbsolute(scaffoldRoot, absolute);
+  if (!contained || !existsSync(contained)) throw new Error('Compact evidence source must remain inside the scaffold root.');
+  if (statSync(contained).isDirectory()) return buildLoopCompact(absolute, scaffoldRoot, options);
   if (extname(absolute).toLowerCase() === '.json') return buildRunCompact(absolute, scaffoldRoot, options);
   throw new Error('Compact evidence source must be a run packet JSON or an evolution loop directory.');
 }

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -120,7 +120,7 @@ function toPosix(value: string): string {
 function sanitizeText(value: string | null | undefined, fallback: string | null = ''): string {
   return (value ?? fallback ?? '')
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
-    .replace(/(^|[\s("'`=:\[{])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
+    .replace(/(^|[\s("'`=:\[{])\/(?!\/)[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:\[{])(?:\.[\\/])?(?:\.git|\.osc[\\/](?:state|research)|\.osc-dev|\.hermes|node_modules)(?:[\\/][^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
     .replace(/[\r\n]+/g, ' ')

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -122,6 +122,7 @@ function sanitizeText(value: string | null | undefined, fallback: string | null 
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:])\/(?!\/)(?:[A-Za-z0-9._-]+\/)+[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
+    .replace(/(^|[\s("'`=:])(?:\.\/)?(?:\.git|\.osc\/state|\.osc\/research|\.osc-dev|\.hermes|node_modules)\/[^\s,;)\]}'"]+/g, '$1[private-ref omitted]')
     .replace(/[\r\n]+/g, ' ')
     .trim()
     .slice(0, 1000);

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -186,9 +186,9 @@ function isOmittedRef(ref: string): boolean {
 }
 
 function isRawLocalRef(root: string, ref: string, role: string): boolean {
-  if (CANONICAL_EVIDENCE_ROLES.has(role)) return false;
   const safe = safeRef(root, ref);
   if (isOmittedRef(safe)) return true;
+  if (CANONICAL_EVIDENCE_ROLES.has(role)) return false;
   const normalized = toPosix(ref).replace(/^\.\//, '');
   const lower = normalized.toLowerCase();
   const ext = extname(lower);
@@ -246,7 +246,22 @@ function summarizeEvaluation(root: string, evaluationRef: string | null | undefi
       evidence_refs: [],
     };
   }
-  const evaluationPath = refAbsolute(root, evaluationRef) ?? resolve(root, evaluationRef);
+  const evaluationPath = refAbsolute(root, evaluationRef);
+  if (!evaluationPath) {
+    return {
+      present: false,
+      path: null,
+      evaluation_id: null,
+      decision: null,
+      decision_rationale: null,
+      improvement_route: null,
+      next_recommendation: 'inspect_evaluation',
+      status_counts: {},
+      failed_criteria: [],
+      evaluator_refs: [],
+      evidence_refs: [],
+    };
+  }
   const parsed = readJson(evaluationPath);
   if (!isRecord(parsed) || parsed.schema !== EVALUATION_SCHEMA) throw new Error(`Evaluation must declare schema: ${EVALUATION_SCHEMA}`);
   const criteria = Array.isArray(parsed.acceptance_criteria) ? parsed.acceptance_criteria.filter(isRecord) : [];

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, win32 } from 'node:path';
 import { findScaffoldRoot } from './scaffold.js';
 
@@ -144,28 +144,42 @@ function isForeignWindowsAbsolutePath(ref: string): boolean {
   return win32.isAbsolute(ref) && !isAbsolute(ref);
 }
 
+function realPathIfExists(path: string): string | null {
+  if (!existsSync(path)) return null;
+  try {
+    return realpathSync(path);
+  } catch {
+    return null;
+  }
+}
+
 function safeRef(root: string, ref: string): string {
   if (/^file:\/\//i.test(ref)) return '[local-path omitted]';
   if (/^[a-z]+:\/\//i.test(ref)) return ref;
   if (isForeignWindowsAbsolutePath(ref)) return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
   const normalizedInput = toPosix(ref).replace(/^\.\//, '');
   if (normalizedInput === '..' || normalizedInput.startsWith('../')) return '[local-path omitted]';
-  const realRoot = existsSync(root) ? resolve(root) : root;
-  const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(realRoot, ref);
-  if (isInside(realRoot, absolute)) {
-    const relativeRef = toPosix(relative(realRoot, absolute)) || '.';
-    if (isPrivateRef(relativeRef)) return '[private-ref omitted]';
-    return relativeRef;
-  }
-  return '[local-path omitted]';
+  const lexicalRoot = resolve(root);
+  const realRoot = realPathIfExists(lexicalRoot) ?? lexicalRoot;
+  const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(lexicalRoot, ref);
+  if (!isInside(lexicalRoot, absolute)) return '[local-path omitted]';
+  const realAbsolute = realPathIfExists(absolute);
+  if (realAbsolute && !isInside(realRoot, realAbsolute)) return '[local-path omitted]';
+  const relativeRef = toPosix(relative(lexicalRoot, absolute)) || '.';
+  if (isPrivateRef(relativeRef)) return '[private-ref omitted]';
+  return relativeRef;
 }
 
 function refAbsolute(root: string, ref: string): string | null {
   if (/^[a-z]+:\/\//i.test(ref)) return null;
   if (isForeignWindowsAbsolutePath(ref)) return null;
-  const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(root, ref);
-  if (!isInside(resolve(root), absolute)) return null;
-  return absolute;
+  const lexicalRoot = resolve(root);
+  const realRoot = realPathIfExists(lexicalRoot) ?? lexicalRoot;
+  const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(lexicalRoot, ref);
+  if (!isInside(lexicalRoot, absolute)) return null;
+  const realAbsolute = realPathIfExists(absolute);
+  if (realAbsolute && !isInside(realRoot, realAbsolute)) return null;
+  return realAbsolute ?? absolute;
 }
 
 function digestRef(root: string, ref: string): { digest: string | null; size: number | null } {
@@ -419,8 +433,9 @@ function buildLoopCompact(inputPath: string, root: string, options: CompactEvide
   const currentRunPacket = asString(current?.run_packet);
   let verification: string[] = [];
   if (currentRunPacket) {
+    const currentRunPacketPath = refAbsolute(root, currentRunPacket);
     try {
-      verification = runPacketInfo(root, resolve(root, currentRunPacket)).verification;
+      verification = currentRunPacketPath ? runPacketInfo(root, currentRunPacketPath).verification : [];
     } catch {
       verification = [];
     }

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -120,6 +120,7 @@ function toPosix(value: string): string {
 function sanitizeText(value: string | null | undefined, fallback: string | null = ''): string {
   return (value ?? fallback ?? '')
     .replace(/file:\/\/\/??[^\s,;)\]}'"]+/gi, '[local-path omitted]')
+    .replace(/(^|[\s("'`=:\[{,;])~[^\s,;)\]}'"]*/g, '$1[local-path omitted]')
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:\[{,;])\/(?!\/)[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
@@ -157,6 +158,7 @@ function safeRef(root: string, ref: string): string {
   if (/^file:\/\//i.test(ref)) return '[local-path omitted]';
   if (/^[a-z]+:\/\//i.test(ref)) return ref;
   if (isForeignWindowsAbsolutePath(ref)) return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
+  if (ref.startsWith('~')) return '[local-path omitted]';
   const normalizedInput = toPosix(ref).replace(/^\.\//, '');
   if (normalizedInput === '..' || normalizedInput.startsWith('../')) return '[local-path omitted]';
   const lexicalRoot = resolve(root);

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -120,7 +120,7 @@ function toPosix(value: string): string {
 function sanitizeText(value: string | null | undefined, fallback: string | null = ''): string {
   return (value ?? fallback ?? '')
     .replace(/\b[A-Za-z]:[\\/][^\s,;)\]]+/g, '[local-path omitted]')
-    .replace(/(^|[\s("'`=:\[{])\/(?!\/)[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
+    .replace(/(^|[\s("'`=:\[{,;])\/(?!\/)[^\s,;)\]}'"]+/g, '$1[local-path omitted]')
     .replace(/\/(?:Users|home|tmp|private|var|Volumes)\/[^\s,;)\]]+/g, '[local-path omitted]')
     .replace(/(^|[\s("'`=:\[{])(?:\.[\\/])?(?:\.git|\.osc[\\/](?:state|research)|\.osc-dev|\.hermes|node_modules)(?:[\\/][^\s,;)\]}'"]+)?(?=$|[\s,.;:)\]}'"])/g, '$1[private-ref omitted]')
     .replace(/[\r\n]+/g, ' ')
@@ -144,6 +144,7 @@ function isForeignWindowsAbsolutePath(ref: string): boolean {
 }
 
 function safeRef(root: string, ref: string): string {
+  if (/^file:\/\//i.test(ref)) return '[local-path omitted]';
   if (/^[a-z]+:\/\//i.test(ref)) return ref;
   if (isForeignWindowsAbsolutePath(ref)) return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
   const realRoot = existsSync(root) ? resolve(root) : root;

--- a/src/compact-evidence.ts
+++ b/src/compact-evidence.ts
@@ -148,6 +148,8 @@ function safeRef(root: string, ref: string): string {
   if (/^file:\/\//i.test(ref)) return '[local-path omitted]';
   if (/^[a-z]+:\/\//i.test(ref)) return ref;
   if (isForeignWindowsAbsolutePath(ref)) return sanitizeText(ref, '[local-path omitted]') || '[local-path omitted]';
+  const normalizedInput = toPosix(ref).replace(/^\.\//, '');
+  if (normalizedInput === '..' || normalizedInput.startsWith('../')) return '[local-path omitted]';
   const realRoot = existsSync(root) ? resolve(root) : root;
   const absolute = isAbsolute(ref) || win32.isAbsolute(ref) ? resolve(ref) : resolve(realRoot, ref);
   if (isInside(realRoot, absolute)) {

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -32,7 +32,7 @@ function tempRepo() {
       path: '.osc/plans/active/136-demo.md',
       goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',
@@ -66,7 +66,7 @@ function tempRepo() {
           { kind: 'path', ref: 'C:\\Users\\alice\\secret.log', summary: 'Synthetic Windows local path; must be omitted from compact output.' },
           { kind: 'path', ref: 'C:/Users/alice/secret-output.md', summary: 'Synthetic forward-slash Windows local path; must remain raw/local.' },
         ],
-        rationale: 'Failure was reproduced at /home/example/private/raw.log and .osc-dev/research/client-log.jsonl.',
+        rationale: 'Failure was reproduced at /home/example/private/raw.log, .osc-dev/research/client-log.jsonl, and .osc/state.',
       },
     ],
     decision: { status: 'rejected', approver: 'human', rationale: 'AC2 remains failed.' },

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -32,7 +32,7 @@ function tempRepo() {
       path: '.osc/plans/active/136-demo.md',
       goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',
@@ -163,6 +163,7 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('RAW_OUTPUT_SECRET');
     expect(`${markdown}\n${manifestText}`).not.toContain('MODEL_CANDIDATE_SECRET');
     expect(`${markdown}\n${manifestText}`).not.toContain('/home/example');
+    expect(`${markdown}\n${manifestText}`).not.toContain('/workspace');
     expect(`${markdown}\n${manifestText}`).not.toContain('C:/Users');
     expect(`${markdown}\n${manifestText}`).not.toContain('C:\\Users');
     expect(`${markdown}\n${manifestText}`).not.toContain('Users\\\\alice');

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 
@@ -231,6 +231,27 @@ describe('osc evidence compact', () => {
     expect(manifestText).not.toContain('/workspace/symlink-private');
   });
 
+  it('sanitizes evaluation status labels before counting', () => {
+    const { root, runPath } = tempRepo();
+    const evalPath = join(root, 'docs/evidence/weird-status-evaluation.json');
+    writeFileSync(evalPath, JSON.stringify({
+      schema: 'open-scaffold.evaluation.v1',
+      evaluation_id: 'eval-weird-status',
+      acceptance_criteria: [{ id: 'AC_STATUS', text: 'Status should be redacted before counting.', status: 'fail /workspace/status-secret .osc-dev/private-status', evaluator: {}, evidence: [], rationale: 'Status label regression.' }],
+      decision: { status: 'rejected', rationale: 'Status label is malformed.' },
+      improvement: { route: 'inspect_evaluation' },
+    }, null, 2));
+
+    const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', runPath, '--evaluation', evalPath, '--json'], { cwd: root, encoding: 'utf8' });
+    const manifest = JSON.parse(manifestText);
+    const statusKeys = Object.keys(manifest.evaluation.status_counts).join(' ');
+
+    expect(statusKeys).not.toContain('/workspace/status-secret');
+    expect(statusKeys).not.toContain('.osc-dev');
+    expect(manifestText).not.toContain('/workspace/status-secret');
+    expect(manifestText).not.toContain('.osc-dev/private-status');
+  });
+
   it('does not dereference loop run packets outside the scaffold root', () => {
     const { root, runPath, evalPath } = tempRepo();
     const loopDir = writeLoop(root, runPath, evalPath);
@@ -268,6 +289,33 @@ describe('osc evidence compact', () => {
     expect(manifestText).not.toContain('OUTSIDE_RUN_PACKET_SECRET');
     expect(manifestText).not.toContain(traversalRef);
     expect(manifestText).not.toContain('/workspace/outside-run');
+  });
+
+  it('rejects symlinked loop state files outside the scaffold root', () => {
+    const { root, runPath, evalPath } = tempRepo();
+    const loopDir = writeLoop(root, runPath, evalPath);
+    const outsideDir = mkdtempSync(join(tmpdir(), 'osc-outside-loop-state-'));
+    const outsideLoop = join(outsideDir, 'loop.json');
+    writeFileSync(outsideLoop, JSON.stringify({
+      schema: 'open-scaffold.evolution-loop.v1',
+      loop_id: 'SYMLINK_LOOP_SECRET',
+      objective: 'SYMLINK_LOOP_SECRET /workspace/loop-state',
+      subject: { plan_slug: 'secret-plan', task_id: 'secret-task' },
+      strategy: { name: 'manual', executes_in_core: false },
+    }, null, 2));
+    unlinkSync(join(loopDir, 'loop.json'));
+    symlinkSync(outsideLoop, join(loopDir, 'loop.json'));
+
+    let errorText = '';
+    try {
+      execFileSync(tsx, [cli, 'evidence', 'compact', loopDir, '--json'], { cwd: root, encoding: 'utf8', stdio: 'pipe' });
+    } catch (error: any) {
+      errorText = `${error.stdout ?? ''}\n${error.stderr ?? ''}\n${error.message ?? ''}`;
+    }
+
+    expect(errorText).toContain('loop.json must remain inside the scaffold root');
+    expect(errorText).not.toContain('SYMLINK_LOOP_SECRET');
+    expect(errorText).not.toContain('/workspace/loop-state');
   });
 
   it('prints compact loop JSON without mutating loop state', () => {

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -38,7 +38,7 @@ function tempRepo() {
       manifest: '.osc/runs/demo-run/run.json',
       logs: ['.osc/runs/demo-run/codex-events.jsonl'],
       outputs: ['.osc/runs/demo-run/runtime-output.log'],
-      evidence: ['docs/evidence/proof.md'],
+      evidence: ['docs/evidence/proof.md', '.osc/state/session.log', '.osc-dev/research/client-log.jsonl'],
     },
   }, null, 2));
   writeFileSync(join(root, '.osc/runs/demo-run/runtime-output.log'), 'RAW_OUTPUT_SECRET should stay local.');
@@ -149,7 +149,10 @@ describe('osc evidence compact', () => {
     expect(manifest.summary.next_recommendation).toBe('retry_run');
     expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/runs/demo-run/codex-events.jsonl' && ref.digest_sha256)).toBe(true);
     expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[local-path omitted]' && ref.role === 'evaluation_evidence_ref')).toBe(true);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[private-ref omitted]' && ref.role === 'run_artifact_ref')).toBe(true);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[private-ref omitted]' && ref.digest_sha256 === null && ref.size_bytes === null)).toBe(true);
     expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[local-path omitted]')).toBe(false);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[private-ref omitted]')).toBe(false);
     expect(manifest.promoted_evidence.some((ref: any) => ref.ref === 'docs/evidence/demo-run-evaluation.json' && ref.role === 'evaluation_envelope')).toBe(true);
     expect(manifest.candidate_notes[0]).toMatchObject({ ref: 'docs/evidence/model-candidate-note.md', canonical: false });
 
@@ -165,6 +168,9 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('Users\\\\alice');
     expect(`${markdown}\n${manifestText}`).not.toContain('secret.log');
     expect(`${markdown}\n${manifestText}`).not.toContain('secret-output.md');
+    expect(`${markdown}\n${manifestText}`).not.toContain('.osc/state');
+    expect(`${markdown}\n${manifestText}`).not.toContain('.osc-dev');
+    expect(`${markdown}\n${manifestText}`).not.toContain('client-log');
     expect(readFileSync(rawLog, 'utf8')).toContain('RAW_TRANSCRIPT_SECRET');
   });
 

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -181,6 +181,34 @@ describe('osc evidence compact', () => {
     expect(readFileSync(rawLog, 'utf8')).toContain('RAW_TRANSCRIPT_SECRET');
   });
 
+  it('does not dereference symlinked or outside run-packet sources', () => {
+    const { root } = tempRepo();
+    const outsideDir = mkdtempSync(join(tmpdir(), 'osc-outside-run-source-'));
+    const outsideRun = join(outsideDir, 'run.json');
+    writeFileSync(outsideRun, JSON.stringify({
+      schemaVersion: 'open-scaffold.run.v1',
+      runId: 'OUTSIDE_RUN_SOURCE_SECRET',
+      plan: { slug: 'secret-plan', goal: 'OUTSIDE_RUN_SOURCE_SECRET /workspace/source', verificationSteps: ['OUTSIDE_RUN_SOURCE_SECRET'] },
+      artifacts: {},
+    }, null, 2));
+    const symlinkDir = join(root, '.osc/runs/symlink-run');
+    mkdirSync(symlinkDir, { recursive: true });
+    const symlinkRun = join(symlinkDir, 'run.json');
+    symlinkSync(outsideRun, symlinkRun);
+
+    for (const source of [symlinkRun, outsideRun]) {
+      let errorText = '';
+      try {
+        execFileSync(tsx, [cli, 'evidence', 'compact', source, '--json'], { cwd: root, encoding: 'utf8', stdio: 'pipe' });
+      } catch (error: any) {
+        errorText = `${error.stdout ?? ''}\n${error.stderr ?? ''}\n${error.message ?? ''}`;
+      }
+      expect(errorText).toMatch(/Compact evidence source must remain inside the scaffold root|Run packet must remain under \.osc\/runs\/\<run-id\>\/run\.json/);
+      expect(errorText).not.toContain('OUTSIDE_RUN_SOURCE_SECRET');
+      expect(errorText).not.toContain('/workspace/source');
+    }
+  });
+
   it('does not dereference evaluation refs outside the scaffold root', () => {
     const { root, runPath } = tempRepo();
     const outsideDir = mkdtempSync(join(tmpdir(), 'osc-outside-eval-'));

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -32,7 +32,7 @@ function tempRepo() {
       path: '.osc/plans/active/136-demo.md',
       goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]', 'inspect [/workspace] and /repo'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]', 'inspect [/workspace] and /repo', 'inspect,/repo and failed;/workspace/log'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',
@@ -65,6 +65,7 @@ function tempRepo() {
           { kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Curated proof.' },
           { kind: 'path', ref: 'C:\\Users\\alice\\secret.log', summary: 'Synthetic Windows local path; must be omitted from compact output.' },
           { kind: 'path', ref: 'C:/Users/alice/secret-output.md', summary: 'Synthetic forward-slash Windows local path; must remain raw/local.' },
+          { kind: 'path', ref: 'file:///workspace/run.log', summary: 'Synthetic local file URL; must remain raw/local.' },
         ],
         rationale: 'Failure was reproduced at /home/example/private/raw.log, .osc-dev/research/client-log.jsonl, .osc/state, and .osc-dev\\research\\client-log.jsonl.',
       },
@@ -165,6 +166,7 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('/home/example');
     expect(`${markdown}\n${manifestText}`).not.toContain('/workspace');
     expect(`${markdown}\n${manifestText}`).not.toContain('/repo');
+    expect(`${markdown}\n${manifestText}`).not.toContain('file:///');
     expect(`${markdown}\n${manifestText}`).not.toContain('C:/Users');
     expect(`${markdown}\n${manifestText}`).not.toContain('C:\\Users');
     expect(`${markdown}\n${manifestText}`).not.toContain('Users\\\\alice');

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const tsx = join(repoRoot, 'node_modules/.bin/tsx');
@@ -179,6 +179,31 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc-dev');
     expect(`${markdown}\n${manifestText}`).not.toContain('client-log');
     expect(readFileSync(rawLog, 'utf8')).toContain('RAW_TRANSCRIPT_SECRET');
+  });
+
+  it('does not dereference evaluation refs outside the scaffold root', () => {
+    const { root, runPath } = tempRepo();
+    const outsideDir = mkdtempSync(join(tmpdir(), 'osc-outside-eval-'));
+    const outsideEval = join(outsideDir, 'eval.json');
+    writeFileSync(outsideEval, JSON.stringify({
+      schema: 'open-scaffold.evaluation.v1',
+      evaluation_id: 'OUTSIDE_EVAL_SECRET',
+      acceptance_criteria: [{ id: 'AC_OUTSIDE', text: 'Outside criterion should never be copied.', status: 'fail', evaluator: {}, evidence: [], rationale: 'OUTSIDE_EVAL_SECRET /workspace/private' }],
+      decision: { status: 'rejected', rationale: 'OUTSIDE_EVAL_SECRET' },
+      improvement: { route: 'redesign' },
+    }, null, 2));
+    const traversalRef = relative(root, outsideEval);
+    expect(traversalRef.startsWith('..')).toBe(true);
+
+    const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', runPath, '--evaluation', traversalRef, '--json'], { cwd: root, encoding: 'utf8' });
+    const manifest = JSON.parse(manifestText);
+
+    expect(manifest.evaluation.present).toBe(false);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[local-path omitted]' && ref.role === 'evaluation_envelope')).toBe(true);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[local-path omitted]')).toBe(false);
+    expect(manifestText).not.toContain('OUTSIDE_EVAL_SECRET');
+    expect(manifestText).not.toContain(traversalRef);
+    expect(manifestText).not.toContain('/workspace/private');
   });
 
   it('prints compact loop JSON without mutating loop state', () => {

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -32,7 +32,7 @@ function tempRepo() {
       path: '.osc/plans/active/136-demo.md',
       goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]', 'inspect [/workspace] and /repo'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',
@@ -164,6 +164,7 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('MODEL_CANDIDATE_SECRET');
     expect(`${markdown}\n${manifestText}`).not.toContain('/home/example');
     expect(`${markdown}\n${manifestText}`).not.toContain('/workspace');
+    expect(`${markdown}\n${manifestText}`).not.toContain('/repo');
     expect(`${markdown}\n${manifestText}`).not.toContain('C:/Users');
     expect(`${markdown}\n${manifestText}`).not.toContain('C:\\Users');
     expect(`${markdown}\n${manifestText}`).not.toContain('Users\\\\alice');

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -38,7 +38,7 @@ function tempRepo() {
       manifest: '.osc/runs/demo-run/run.json',
       logs: ['.osc/runs/demo-run/codex-events.jsonl'],
       outputs: ['.osc/runs/demo-run/runtime-output.log'],
-      evidence: ['docs/evidence/proof.md', '.osc/state/session.log', '.osc-dev/research/client-log.jsonl'],
+      evidence: ['docs/evidence/proof.md', '.osc/state/session.log', '.osc-dev/research/client-log.jsonl', '../client/secret.md'],
     },
   }, null, 2));
   writeFileSync(join(root, '.osc/runs/demo-run/runtime-output.log'), 'RAW_OUTPUT_SECRET should stay local.');
@@ -172,6 +172,7 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('Users\\\\alice');
     expect(`${markdown}\n${manifestText}`).not.toContain('secret.log');
     expect(`${markdown}\n${manifestText}`).not.toContain('secret-output.md');
+    expect(`${markdown}\n${manifestText}`).not.toContain('../client');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc/state');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc\\\\state');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc-dev');

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -319,6 +319,41 @@ describe('osc evidence compact', () => {
     expect(manifestText).not.toContain('/workspace/outside-run');
   });
 
+  it('does not dereference noncanonical loop run packet JSON refs', () => {
+    const { root, runPath, evalPath } = tempRepo();
+    const loopDir = writeLoop(root, runPath, evalPath);
+    const noncanonicalRef = 'docs/evidence/not-a-run-packet.json';
+    writeFileSync(join(root, noncanonicalRef), JSON.stringify({
+      schemaVersion: 'open-scaffold.run.v1',
+      runId: 'NONCANONICAL_RUN_SECRET',
+      plan: { verificationSteps: ['NONCANONICAL_RUN_SECRET /workspace/noncanonical'] },
+      artifacts: {},
+    }, null, 2));
+    writeFileSync(join(loopDir, 'attempts.jsonl'), `${JSON.stringify({
+      schema: 'open-scaffold.evolution-attempt.v1',
+      attempt_id: 'demo-run',
+      run_id: 'demo-run',
+      task_id: 'task-123',
+      run_packet: noncanonicalRef,
+      evaluation: 'docs/evidence/demo-run-evaluation.json',
+      evaluation_decision: 'rejected',
+      evidence_refs: ['docs/evidence/proof.md'],
+      adapter_receipts: [],
+      decision: 'retry',
+      score: 0.5,
+      rationale: 'AC2 remains failed.',
+    })}\n`);
+
+    const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', loopDir, '--json'], { cwd: root, encoding: 'utf8' });
+    const manifest = JSON.parse(manifestText);
+
+    expect(manifest.verification_commands).toEqual([]);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === noncanonicalRef && ref.role === 'run_packet')).toBe(true);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === noncanonicalRef)).toBe(false);
+    expect(manifestText).not.toContain('NONCANONICAL_RUN_SECRET');
+    expect(manifestText).not.toContain('/workspace/noncanonical');
+  });
+
   it('rejects symlinked loop state files outside the scaffold root', () => {
     const { root, runPath, evalPath } = tempRepo();
     const loopDir = writeLoop(root, runPath, evalPath);

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -84,6 +84,13 @@ function writeLoop(root: string, runPath: string, evalPath: string) {
     subject: { plan_slug: '136-demo', task_id: 'task-123' },
     strategy: { name: 'manual', executes_in_core: false },
   }, null, 2));
+  writeFileSync(join(root, 'docs/evidence/unpromoted-evaluation.json'), JSON.stringify({
+    schema: 'open-scaffold.evaluation.v1',
+    evaluation_id: 'eval-unpromoted',
+    acceptance_criteria: [{ id: 'AC_UNPROMOTED', text: 'Unpromoted retry should not drive compact summary.', status: 'fail', evaluator: {}, evidence: [], rationale: 'This later attempt was not promoted.' }],
+    decision: { status: 'rejected', rationale: 'Unpromoted attempt remains worse.' },
+    improvement: { route: 'redesign' },
+  }, null, 2));
   writeFileSync(join(loopDir, 'attempts.jsonl'), `${JSON.stringify({
     schema: 'open-scaffold.evolution-attempt.v1',
     attempt_id: 'demo-run',
@@ -97,6 +104,19 @@ function writeLoop(root: string, runPath: string, evalPath: string) {
     decision: 'retry',
     score: 0.5,
     rationale: 'AC2 remains failed.',
+  })}\n${JSON.stringify({
+    schema: 'open-scaffold.evolution-attempt.v1',
+    attempt_id: 'unpromoted-run',
+    run_id: 'unpromoted-run',
+    task_id: 'task-123',
+    run_packet: '.osc/runs/unpromoted-run/run.json',
+    evaluation: 'docs/evidence/unpromoted-evaluation.json',
+    evaluation_decision: 'rejected',
+    evidence_refs: ['docs/evidence/unpromoted-evidence.md'],
+    adapter_receipts: [],
+    decision: 'stop',
+    score: 0.1,
+    rationale: 'Later attempt was not promoted to frontier.',
   })}\n`);
   writeFileSync(join(loopDir, 'frontier.json'), JSON.stringify({
     schema: 'open-scaffold.evolution-frontier.v1',
@@ -160,8 +180,11 @@ describe('osc evidence compact', () => {
     const manifest = JSON.parse(execFileSync(tsx, [cli, 'evidence', 'compact', loopDir, '--json'], { cwd: root, encoding: 'utf8' }));
 
     expect(manifest.subject).toMatchObject({ kind: 'evolution_loop', loop_id: 'demo-loop', plan_slug: '136-demo' });
-    expect(manifest.summary).toMatchObject({ attempt_count: 1, current_attempt_id: 'demo-run', frontier_attempt_id: 'demo-run', decision: 'retry' });
+    expect(manifest.summary).toMatchObject({ attempt_count: 2, current_attempt_id: 'demo-run', frontier_attempt_id: 'demo-run', decision: 'retry', score: 0.5 });
+    expect(manifest.evaluation).toMatchObject({ evaluation_id: 'eval-demo-run' });
     expect(manifest.evaluation.failed_criteria[0]).toMatchObject({ id: 'AC2', status: 'fail' });
+    expect(JSON.stringify(manifest)).not.toContain('eval-unpromoted');
+    expect(JSON.stringify(manifest)).not.toContain('AC_UNPROMOTED');
     expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/runs/demo-run/codex-events.jsonl')).toBe(true);
     expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '.osc/evolution/demo-loop/attempts.jsonl' && ref.role === 'attempt_journal')).toBe(true);
     expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/evolution/demo-loop/attempts.jsonl')).toBe(false);

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -185,6 +185,8 @@ describe('osc evidence compact', () => {
     expect(manifest.evaluation.failed_criteria[0]).toMatchObject({ id: 'AC2', status: 'fail' });
     expect(JSON.stringify(manifest)).not.toContain('eval-unpromoted');
     expect(JSON.stringify(manifest)).not.toContain('AC_UNPROMOTED');
+    expect(JSON.stringify(manifest)).not.toContain('unpromoted-evidence.md');
+    expect(JSON.stringify(manifest)).not.toContain('.osc/runs/unpromoted-run/run.json');
     expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/runs/demo-run/codex-events.jsonl')).toBe(true);
     expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '.osc/evolution/demo-loop/attempts.jsonl' && ref.role === 'attempt_journal')).toBe(true);
     expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/evolution/demo-loop/attempts.jsonl')).toBe(false);

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -38,7 +38,7 @@ function tempRepo() {
       manifest: '.osc/runs/demo-run/run.json',
       logs: ['.osc/runs/demo-run/codex-events.jsonl'],
       outputs: ['.osc/runs/demo-run/runtime-output.log'],
-      evidence: ['docs/evidence/proof.md', '.osc/state/session.log', '.osc-dev/research/client-log.jsonl', '../client/secret.md'],
+      evidence: ['docs/evidence/proof.md', '.osc/state/session.log', '.osc-dev/research/client-log.jsonl', '../client/secret.md', 'docs/../../client/secret.md'],
     },
   }, null, 2));
   writeFileSync(join(root, '.osc/runs/demo-run/runtime-output.log'), 'RAW_OUTPUT_SECRET should stay local.');
@@ -173,6 +173,7 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('secret.log');
     expect(`${markdown}\n${manifestText}`).not.toContain('secret-output.md');
     expect(`${markdown}\n${manifestText}`).not.toContain('../client');
+    expect(`${markdown}\n${manifestText}`).not.toContain('docs/../../client');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc/state');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc\\\\state');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc-dev');

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -32,7 +32,7 @@ function tempRepo() {
       path: '.osc/plans/active/136-demo.md',
       goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]', 'inspect [/workspace] and /repo', 'inspect,/repo and failed;/workspace/log'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]', 'inspect [/workspace] and /repo', 'inspect,/repo and failed;/workspace/log', 'inspect file:///workspace/run.log and inspect,.osc-dev/research/client-log.jsonl'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -32,13 +32,13 @@ function tempRepo() {
       path: '.osc/plans/active/136-demo.md',
       goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]', 'inspect [/workspace] and /repo', 'inspect,/repo and failed;/workspace/log', 'inspect file:///workspace/run.log and inspect,.osc-dev/research/client-log.jsonl'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]', 'inspect [/workspace/open-scaffold/.osc/state/session.log]', 'inspect [/workspace] and /repo', 'inspect,/repo and failed;/workspace/log', 'inspect file:///workspace/run.log and inspect,.osc-dev/research/client-log.jsonl', 'inspect ~/.osc-dev/research/client-log.jsonl and ~/private/run.log'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',
       logs: ['.osc/runs/demo-run/codex-events.jsonl'],
       outputs: ['.osc/runs/demo-run/runtime-output.log'],
-      evidence: ['docs/evidence/proof.md', '.osc/state/session.log', '.osc-dev/research/client-log.jsonl', '../client/secret.md', 'docs/../../client/secret.md'],
+      evidence: ['docs/evidence/proof.md', '.osc/state/session.log', '.osc-dev/research/client-log.jsonl', '../client/secret.md', 'docs/../../client/secret.md', '~/.osc-dev/research/client-log.jsonl', '~/private/run.log'],
     },
   }, null, 2));
   writeFileSync(join(root, '.osc/runs/demo-run/runtime-output.log'), 'RAW_OUTPUT_SECRET should stay local.');
@@ -174,6 +174,8 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('secret-output.md');
     expect(`${markdown}\n${manifestText}`).not.toContain('../client');
     expect(`${markdown}\n${manifestText}`).not.toContain('docs/../../client');
+    expect(`${markdown}\n${manifestText}`).not.toContain('~/');
+    expect(`${markdown}\n${manifestText}`).not.toContain('~/.osc-dev');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc/state');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc\\\\state');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc-dev');

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -30,9 +30,9 @@ function tempRepo() {
     plan: {
       slug: '136-demo',
       path: '.osc/plans/active/136-demo.md',
-      goal: 'Compact repeated-run evidence without leaking raw logs.',
+      goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',
@@ -66,7 +66,7 @@ function tempRepo() {
           { kind: 'path', ref: 'C:\\Users\\alice\\secret.log', summary: 'Synthetic Windows local path; must be omitted from compact output.' },
           { kind: 'path', ref: 'C:/Users/alice/secret-output.md', summary: 'Synthetic forward-slash Windows local path; must remain raw/local.' },
         ],
-        rationale: 'Failure was reproduced at /home/example/private/raw.log.',
+        rationale: 'Failure was reproduced at /home/example/private/raw.log and .osc-dev/research/client-log.jsonl.',
       },
     ],
     decision: { status: 'rejected', approver: 'human', rationale: 'AC2 remains failed.' },

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 
@@ -204,6 +204,70 @@ describe('osc evidence compact', () => {
     expect(manifestText).not.toContain('OUTSIDE_EVAL_SECRET');
     expect(manifestText).not.toContain(traversalRef);
     expect(manifestText).not.toContain('/workspace/private');
+  });
+
+  it('does not dereference symlinked evaluation refs outside the scaffold root', () => {
+    const { root, runPath } = tempRepo();
+    const outsideDir = mkdtempSync(join(tmpdir(), 'osc-outside-symlink-eval-'));
+    const outsideEval = join(outsideDir, 'eval.json');
+    writeFileSync(outsideEval, JSON.stringify({
+      schema: 'open-scaffold.evaluation.v1',
+      evaluation_id: 'SYMLINK_EVAL_SECRET',
+      acceptance_criteria: [{ id: 'AC_SYMLINK', text: 'Symlinked outside criterion should never be copied.', status: 'fail', evaluator: {}, evidence: [], rationale: 'SYMLINK_EVAL_SECRET /workspace/symlink-private' }],
+      decision: { status: 'rejected', rationale: 'SYMLINK_EVAL_SECRET' },
+      improvement: { route: 'redesign' },
+    }, null, 2));
+    const symlinkRef = 'docs/evidence/symlink-eval.json';
+    symlinkSync(outsideEval, join(root, symlinkRef));
+
+    const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', runPath, '--evaluation', symlinkRef, '--json'], { cwd: root, encoding: 'utf8' });
+    const manifest = JSON.parse(manifestText);
+
+    expect(manifest.evaluation.present).toBe(false);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[local-path omitted]' && ref.role === 'evaluation_envelope')).toBe(true);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[local-path omitted]')).toBe(false);
+    expect(manifestText).not.toContain('SYMLINK_EVAL_SECRET');
+    expect(manifestText).not.toContain(symlinkRef);
+    expect(manifestText).not.toContain('/workspace/symlink-private');
+  });
+
+  it('does not dereference loop run packets outside the scaffold root', () => {
+    const { root, runPath, evalPath } = tempRepo();
+    const loopDir = writeLoop(root, runPath, evalPath);
+    const outsideDir = mkdtempSync(join(tmpdir(), 'osc-outside-run-packet-'));
+    const outsideRun = join(outsideDir, 'run.json');
+    writeFileSync(outsideRun, JSON.stringify({
+      schemaVersion: 'open-scaffold.run.v1',
+      runId: 'outside-run',
+      plan: { verificationSteps: ['OUTSIDE_RUN_PACKET_SECRET /workspace/outside-run'] },
+      artifacts: {},
+    }, null, 2));
+    const traversalRef = relative(root, outsideRun);
+    expect(traversalRef.startsWith('..')).toBe(true);
+    writeFileSync(join(loopDir, 'attempts.jsonl'), `${JSON.stringify({
+      schema: 'open-scaffold.evolution-attempt.v1',
+      attempt_id: 'demo-run',
+      run_id: 'demo-run',
+      task_id: 'task-123',
+      run_packet: traversalRef,
+      evaluation: 'docs/evidence/demo-run-evaluation.json',
+      evaluation_decision: 'rejected',
+      evidence_refs: ['docs/evidence/proof.md'],
+      adapter_receipts: [],
+      decision: 'retry',
+      score: 0.5,
+      rationale: 'AC2 remains failed.',
+    })}\n`);
+
+    const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', loopDir, '--json'], { cwd: root, encoding: 'utf8' });
+    const manifest = JSON.parse(manifestText);
+
+    expect(manifest.verification_commands).toEqual([]);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[local-path omitted]' && ref.role === 'run_packet')).toBe(true);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[local-path omitted]')).toBe(false);
+    expect(manifestText).not.toContain('OUTSIDE_RUN_PACKET_SECRET');
+    expect(manifestText).not.toContain(traversalRef);
+    expect(manifestText).not.toContain('/workspace/outside-run');
   });
 
   it('prints compact loop JSON without mutating loop state', () => {

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -32,7 +32,7 @@ function tempRepo() {
       path: '.osc/plans/active/136-demo.md',
       goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log', 'inspect [.osc\\state\\session.log]'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const tsx = join(repoRoot, 'node_modules/.bin/tsx');
+const cli = join(repoRoot, 'src/cli.ts');
+
+function tempRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'osc-evidence-compact-'));
+  mkdirSync(join(root, '.osc/plans/active'), { recursive: true });
+  mkdirSync(join(root, '.osc/releases'), { recursive: true });
+  mkdirSync(join(root, '.osc/runs/demo-run'), { recursive: true });
+  mkdirSync(join(root, '.osc/evolution/demo-loop'), { recursive: true });
+  mkdirSync(join(root, 'docs/evidence'), { recursive: true });
+  writeFileSync(join(root, 'MISSION.md'), '# Mission\n\nBuild the thing.\n');
+  const rawLog = join(root, '.osc/runs/demo-run/codex-events.jsonl');
+  writeFileSync(rawLog, 'RAW_TRANSCRIPT_SECRET /home/example/private/path\n{"event":"token"}\n');
+  const candidateNote = join(root, 'docs/evidence/model-candidate-note.md');
+  writeFileSync(candidateNote, 'MODEL_CANDIDATE_SECRET: model-authored draft notes should not be embedded.');
+  const proof = join(root, 'docs/evidence/proof.md');
+  writeFileSync(proof, 'Curated proof: verification failed on AC2.');
+  const runPath = join(root, '.osc/runs/demo-run/run.json');
+  writeFileSync(runPath, JSON.stringify({
+    schemaVersion: 'open-scaffold.run.v1',
+    runId: 'demo-run',
+    taskId: 'task-123',
+    plan: {
+      slug: '136-demo',
+      path: '.osc/plans/active/136-demo.md',
+      goal: 'Compact repeated-run evidence without leaking raw logs.',
+      acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build'],
+    },
+    artifacts: {
+      manifest: '.osc/runs/demo-run/run.json',
+      logs: ['.osc/runs/demo-run/codex-events.jsonl'],
+      outputs: ['.osc/runs/demo-run/runtime-output.log'],
+      evidence: ['docs/evidence/proof.md'],
+    },
+  }, null, 2));
+  writeFileSync(join(root, '.osc/runs/demo-run/runtime-output.log'), 'RAW_OUTPUT_SECRET should stay local.');
+  const evalPath = join(root, 'docs/evidence/demo-run-evaluation.json');
+  writeFileSync(evalPath, JSON.stringify({
+    schema: 'open-scaffold.evaluation.v1',
+    evaluation_id: 'eval-demo-run',
+    subject: { source: 'run', plan: '.osc/plans/active/136-demo.md', plan_slug: '136-demo', task_id: 'task-123', run_id: 'demo-run', run_packet: '.osc/runs/demo-run/run.json' },
+    acceptance_criteria: [
+      {
+        id: 'AC1',
+        text: 'Summary exists.',
+        status: 'pass',
+        evaluator: { kind: 'automated-check', name: 'compact-fixture', ref: 'docs/evidence/proof.md' },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Curated proof.' }],
+        rationale: 'Summary was generated.',
+      },
+      {
+        id: 'AC2',
+        text: 'Failures remain visible.',
+        status: 'fail',
+        evaluator: { kind: 'automated-check', name: 'compact-fixture', ref: 'docs/evidence/proof.md' },
+        evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Curated proof.' }],
+        rationale: 'Failure was reproduced at /home/example/private/raw.log.',
+      },
+    ],
+    decision: { status: 'rejected', approver: 'human', rationale: 'AC2 remains failed.' },
+    improvement: { route: 'retry_run', target: null, carried_forward: ['AC2 must stay visible.'], do_not_assume: ['Compact evidence is not proof of correctness.'] },
+  }, null, 2));
+  return { root, runPath, evalPath, rawLog, candidateNote };
+}
+
+function writeLoop(root: string, runPath: string, evalPath: string) {
+  const loopDir = join(root, '.osc/evolution/demo-loop');
+  writeFileSync(join(loopDir, 'loop.json'), JSON.stringify({
+    schema: 'open-scaffold.evolution-loop.v1',
+    loop_id: 'demo-loop',
+    objective: 'Compact a repeated-attempt loop.',
+    subject: { plan_slug: '136-demo', task_id: 'task-123' },
+    strategy: { name: 'manual', executes_in_core: false },
+  }, null, 2));
+  writeFileSync(join(loopDir, 'attempts.jsonl'), `${JSON.stringify({
+    schema: 'open-scaffold.evolution-attempt.v1',
+    attempt_id: 'demo-run',
+    run_id: 'demo-run',
+    task_id: 'task-123',
+    run_packet: '.osc/runs/demo-run/run.json',
+    evaluation: 'docs/evidence/demo-run-evaluation.json',
+    evaluation_decision: 'rejected',
+    evidence_refs: ['docs/evidence/proof.md', '.osc/runs/demo-run/codex-events.jsonl'],
+    adapter_receipts: [],
+    decision: 'retry',
+    score: 0.5,
+    rationale: 'AC2 remains failed.',
+  })}\n`);
+  writeFileSync(join(loopDir, 'frontier.json'), JSON.stringify({
+    schema: 'open-scaffold.evolution-frontier.v1',
+    loop_id: 'demo-loop',
+    current: { attempt_id: 'demo-run', run_id: 'demo-run', score: 0.5, rationale: 'Best but still failed.' },
+    history: [],
+  }, null, 2));
+  expect(existsSync(runPath)).toBe(true);
+  expect(existsSync(evalPath)).toBe(true);
+  return loopDir;
+}
+
+describe('osc evidence compact', () => {
+  it('writes compact run summary and manifest without embedding raw logs or local paths', () => {
+    const { root, runPath, evalPath, rawLog, candidateNote } = tempRepo();
+    const outDir = join(root, 'docs/evidence/compact-demo-run');
+
+    const output = execFileSync(tsx, [cli, 'evidence', 'compact', runPath, '--evaluation', evalPath, '--candidate-note', candidateNote, '--out', outDir], { cwd: root, encoding: 'utf8' });
+
+    expect(output).toContain('Wrote compact evidence summary:');
+    expect(output).toContain('Wrote compact evidence manifest:');
+    const markdown = readFileSync(join(outDir, 'compact-evidence.md'), 'utf8');
+    const manifestText = readFileSync(join(outDir, 'compact-evidence.json'), 'utf8');
+    const manifest = JSON.parse(manifestText);
+
+    expect(manifest.schema).toBe('open-scaffold.compact-evidence.v1');
+    expect(manifest.subject).toMatchObject({ kind: 'run', run_id: 'demo-run', plan_slug: '136-demo' });
+    expect(manifest.evaluation.status_counts).toMatchObject({ pass: 1, fail: 1 });
+    expect(manifest.evaluation.failed_criteria[0]).toMatchObject({ id: 'AC2', status: 'fail' });
+    expect(manifest.summary.next_recommendation).toBe('retry_run');
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/runs/demo-run/codex-events.jsonl' && ref.digest_sha256)).toBe(true);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === 'docs/evidence/demo-run-evaluation.json' && ref.role === 'evaluation_envelope')).toBe(true);
+    expect(manifest.candidate_notes[0]).toMatchObject({ ref: 'docs/evidence/model-candidate-note.md', canonical: false });
+
+    expect(markdown).toContain('AC2');
+    expect(markdown).toContain('retry_run');
+    expect(markdown).toContain('Raw/local evidence omitted from public payload');
+    expect(`${markdown}\n${manifestText}`).not.toContain('RAW_TRANSCRIPT_SECRET');
+    expect(`${markdown}\n${manifestText}`).not.toContain('RAW_OUTPUT_SECRET');
+    expect(`${markdown}\n${manifestText}`).not.toContain('MODEL_CANDIDATE_SECRET');
+    expect(`${markdown}\n${manifestText}`).not.toContain('/home/example');
+    expect(readFileSync(rawLog, 'utf8')).toContain('RAW_TRANSCRIPT_SECRET');
+  });
+
+  it('prints compact loop JSON without mutating loop state', () => {
+    const { root, runPath, evalPath } = tempRepo();
+    const loopDir = writeLoop(root, runPath, evalPath);
+    const before = {
+      loop: readFileSync(join(loopDir, 'loop.json'), 'utf8'),
+      attempts: readFileSync(join(loopDir, 'attempts.jsonl'), 'utf8'),
+      frontier: readFileSync(join(loopDir, 'frontier.json'), 'utf8'),
+    };
+
+    const manifest = JSON.parse(execFileSync(tsx, [cli, 'evidence', 'compact', loopDir, '--json'], { cwd: root, encoding: 'utf8' }));
+
+    expect(manifest.subject).toMatchObject({ kind: 'evolution_loop', loop_id: 'demo-loop', plan_slug: '136-demo' });
+    expect(manifest.summary).toMatchObject({ attempt_count: 1, current_attempt_id: 'demo-run', frontier_attempt_id: 'demo-run', decision: 'retry' });
+    expect(manifest.evaluation.failed_criteria[0]).toMatchObject({ id: 'AC2', status: 'fail' });
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/runs/demo-run/codex-events.jsonl')).toBe(true);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '.osc/evolution/demo-loop/attempts.jsonl' && ref.role === 'attempt_journal')).toBe(true);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/evolution/demo-loop/attempts.jsonl')).toBe(false);
+    expect(JSON.stringify(manifest)).not.toContain('RAW_TRANSCRIPT_SECRET');
+
+    expect(readFileSync(join(loopDir, 'loop.json'), 'utf8')).toBe(before.loop);
+    expect(readFileSync(join(loopDir, 'attempts.jsonl'), 'utf8')).toBe(before.attempts);
+    expect(readFileSync(join(loopDir, 'frontier.json'), 'utf8')).toBe(before.frontier);
+  });
+});

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, relative, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const tsx = join(repoRoot, 'node_modules/.bin/tsx');
@@ -280,6 +280,28 @@ describe('osc evidence compact', () => {
     expect(manifestText).not.toContain('.osc-dev/private-status');
   });
 
+  it('does not dereference private evaluation envelopes', () => {
+    const { root, runPath } = tempRepo();
+    mkdirSync(join(root, '.osc-dev'), { recursive: true });
+    const privateEval = '.osc-dev/private-evaluation.json';
+    writeFileSync(join(root, privateEval), JSON.stringify({
+      schema: 'open-scaffold.evaluation.v1',
+      evaluation_id: 'PRIVATE_EVAL_SECRET',
+      acceptance_criteria: [{ id: 'AC_PRIVATE', text: 'Private criterion should not be copied.', status: 'fail', evaluator: {}, evidence: [], rationale: 'PRIVATE_EVAL_SECRET /workspace/private-eval' }],
+      decision: { status: 'rejected', rationale: 'PRIVATE_EVAL_SECRET' },
+      improvement: { route: 'redesign' },
+    }, null, 2));
+
+    const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', runPath, '--evaluation', privateEval, '--json'], { cwd: root, encoding: 'utf8' });
+    const manifest = JSON.parse(manifestText);
+
+    expect(manifest.evaluation.present).toBe(false);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[private-ref omitted]' && ref.role === 'evaluation_envelope')).toBe(true);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[private-ref omitted]')).toBe(false);
+    expect(manifestText).not.toContain('PRIVATE_EVAL_SECRET');
+    expect(manifestText).not.toContain('/workspace/private-eval');
+  });
+
   it('does not dereference loop run packets outside the scaffold root', () => {
     const { root, runPath, evalPath } = tempRepo();
     const loopDir = writeLoop(root, runPath, evalPath);
@@ -322,36 +344,40 @@ describe('osc evidence compact', () => {
   it('does not dereference noncanonical loop run packet JSON refs', () => {
     const { root, runPath, evalPath } = tempRepo();
     const loopDir = writeLoop(root, runPath, evalPath);
-    const noncanonicalRef = 'docs/evidence/not-a-run-packet.json';
-    writeFileSync(join(root, noncanonicalRef), JSON.stringify({
-      schemaVersion: 'open-scaffold.run.v1',
-      runId: 'NONCANONICAL_RUN_SECRET',
-      plan: { verificationSteps: ['NONCANONICAL_RUN_SECRET /workspace/noncanonical'] },
-      artifacts: {},
-    }, null, 2));
-    writeFileSync(join(loopDir, 'attempts.jsonl'), `${JSON.stringify({
-      schema: 'open-scaffold.evolution-attempt.v1',
-      attempt_id: 'demo-run',
-      run_id: 'demo-run',
-      task_id: 'task-123',
-      run_packet: noncanonicalRef,
-      evaluation: 'docs/evidence/demo-run-evaluation.json',
-      evaluation_decision: 'rejected',
-      evidence_refs: ['docs/evidence/proof.md'],
-      adapter_receipts: [],
-      decision: 'retry',
-      score: 0.5,
-      rationale: 'AC2 remains failed.',
-    })}\n`);
+    const noncanonicalRefs = ['docs/evidence/not-a-run-packet.json', '.osc/runs/demo-run/raw/run.json'];
 
-    const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', loopDir, '--json'], { cwd: root, encoding: 'utf8' });
-    const manifest = JSON.parse(manifestText);
+    for (const noncanonicalRef of noncanonicalRefs) {
+      mkdirSync(dirname(join(root, noncanonicalRef)), { recursive: true });
+      writeFileSync(join(root, noncanonicalRef), JSON.stringify({
+        schemaVersion: 'open-scaffold.run.v1',
+        runId: 'NONCANONICAL_RUN_SECRET',
+        plan: { verificationSteps: ['NONCANONICAL_RUN_SECRET /workspace/noncanonical'] },
+        artifacts: {},
+      }, null, 2));
+      writeFileSync(join(loopDir, 'attempts.jsonl'), `${JSON.stringify({
+        schema: 'open-scaffold.evolution-attempt.v1',
+        attempt_id: 'demo-run',
+        run_id: 'demo-run',
+        task_id: 'task-123',
+        run_packet: noncanonicalRef,
+        evaluation: 'docs/evidence/demo-run-evaluation.json',
+        evaluation_decision: 'rejected',
+        evidence_refs: ['docs/evidence/proof.md'],
+        adapter_receipts: [],
+        decision: 'retry',
+        score: 0.5,
+        rationale: 'AC2 remains failed.',
+      })}\n`);
 
-    expect(manifest.verification_commands).toEqual([]);
-    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === noncanonicalRef && ref.role === 'run_packet')).toBe(true);
-    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === noncanonicalRef)).toBe(false);
-    expect(manifestText).not.toContain('NONCANONICAL_RUN_SECRET');
-    expect(manifestText).not.toContain('/workspace/noncanonical');
+      const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', loopDir, '--json'], { cwd: root, encoding: 'utf8' });
+      const manifest = JSON.parse(manifestText);
+
+      expect(manifest.verification_commands).toEqual([]);
+      expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === noncanonicalRef && ref.role === 'run_packet')).toBe(true);
+      expect(manifest.promoted_evidence.some((ref: any) => ref.ref === noncanonicalRef)).toBe(false);
+      expect(manifestText).not.toContain('NONCANONICAL_RUN_SECRET');
+      expect(manifestText).not.toContain('/workspace/noncanonical');
+    }
   });
 
   it('rejects symlinked loop state files outside the scaffold root', () => {

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -61,7 +61,10 @@ function tempRepo() {
         text: 'Failures remain visible.',
         status: 'fail',
         evaluator: { kind: 'automated-check', name: 'compact-fixture', ref: 'docs/evidence/proof.md' },
-        evidence: [{ kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Curated proof.' }],
+        evidence: [
+          { kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Curated proof.' },
+          { kind: 'path', ref: 'C:\\Users\\alice\\secret.log', summary: 'Synthetic Windows local path; must be omitted from compact output.' },
+        ],
         rationale: 'Failure was reproduced at /home/example/private/raw.log.',
       },
     ],
@@ -134,6 +137,10 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('RAW_OUTPUT_SECRET');
     expect(`${markdown}\n${manifestText}`).not.toContain('MODEL_CANDIDATE_SECRET');
     expect(`${markdown}\n${manifestText}`).not.toContain('/home/example');
+    expect(`${markdown}\n${manifestText}`).not.toContain('C:/Users');
+    expect(`${markdown}\n${manifestText}`).not.toContain('C:\\Users');
+    expect(`${markdown}\n${manifestText}`).not.toContain('Users\\\\alice');
+    expect(`${markdown}\n${manifestText}`).not.toContain('secret.log');
     expect(readFileSync(rawLog, 'utf8')).toContain('RAW_TRANSCRIPT_SECRET');
   });
 

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -284,22 +284,28 @@ describe('osc evidence compact', () => {
     const { root, runPath } = tempRepo();
     mkdirSync(join(root, '.osc-dev'), { recursive: true });
     const privateEval = '.osc-dev/private-evaluation.json';
-    writeFileSync(join(root, privateEval), JSON.stringify({
+    const privateEvalPath = join(root, privateEval);
+    writeFileSync(privateEvalPath, JSON.stringify({
       schema: 'open-scaffold.evaluation.v1',
       evaluation_id: 'PRIVATE_EVAL_SECRET',
       acceptance_criteria: [{ id: 'AC_PRIVATE', text: 'Private criterion should not be copied.', status: 'fail', evaluator: {}, evidence: [], rationale: 'PRIVATE_EVAL_SECRET /workspace/private-eval' }],
       decision: { status: 'rejected', rationale: 'PRIVATE_EVAL_SECRET' },
       improvement: { route: 'redesign' },
     }, null, 2));
+    const publicSymlink = 'docs/evidence/private-evaluation-symlink.json';
+    symlinkSync(privateEvalPath, join(root, publicSymlink));
 
-    const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', runPath, '--evaluation', privateEval, '--json'], { cwd: root, encoding: 'utf8' });
-    const manifest = JSON.parse(manifestText);
+    for (const evaluationRef of [privateEval, publicSymlink]) {
+      const manifestText = execFileSync(tsx, [cli, 'evidence', 'compact', runPath, '--evaluation', evaluationRef, '--json'], { cwd: root, encoding: 'utf8' });
+      const manifest = JSON.parse(manifestText);
 
-    expect(manifest.evaluation.present).toBe(false);
-    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[private-ref omitted]' && ref.role === 'evaluation_envelope')).toBe(true);
-    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[private-ref omitted]')).toBe(false);
-    expect(manifestText).not.toContain('PRIVATE_EVAL_SECRET');
-    expect(manifestText).not.toContain('/workspace/private-eval');
+      expect(manifest.evaluation.present).toBe(false);
+      expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[private-ref omitted]' && ref.role === 'evaluation_envelope')).toBe(true);
+      expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[private-ref omitted]')).toBe(false);
+      expect(manifestText).not.toContain('PRIVATE_EVAL_SECRET');
+      expect(manifestText).not.toContain('/workspace/private-eval');
+      expect(manifestText).not.toContain(publicSymlink);
+    }
   });
 
   it('does not dereference loop run packets outside the scaffold root', () => {

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -64,6 +64,7 @@ function tempRepo() {
         evidence: [
           { kind: 'path', ref: 'docs/evidence/proof.md', summary: 'Curated proof.' },
           { kind: 'path', ref: 'C:\\Users\\alice\\secret.log', summary: 'Synthetic Windows local path; must be omitted from compact output.' },
+          { kind: 'path', ref: 'C:/Users/alice/secret-output.md', summary: 'Synthetic forward-slash Windows local path; must remain raw/local.' },
         ],
         rationale: 'Failure was reproduced at /home/example/private/raw.log.',
       },
@@ -127,6 +128,8 @@ describe('osc evidence compact', () => {
     expect(manifest.evaluation.failed_criteria[0]).toMatchObject({ id: 'AC2', status: 'fail' });
     expect(manifest.summary.next_recommendation).toBe('retry_run');
     expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '.osc/runs/demo-run/codex-events.jsonl' && ref.digest_sha256)).toBe(true);
+    expect(manifest.raw_local_evidence.some((ref: any) => ref.ref === '[local-path omitted]' && ref.role === 'evaluation_evidence_ref')).toBe(true);
+    expect(manifest.promoted_evidence.some((ref: any) => ref.ref === '[local-path omitted]')).toBe(false);
     expect(manifest.promoted_evidence.some((ref: any) => ref.ref === 'docs/evidence/demo-run-evaluation.json' && ref.role === 'evaluation_envelope')).toBe(true);
     expect(manifest.candidate_notes[0]).toMatchObject({ ref: 'docs/evidence/model-candidate-note.md', canonical: false });
 
@@ -141,6 +144,7 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('C:\\Users');
     expect(`${markdown}\n${manifestText}`).not.toContain('Users\\\\alice');
     expect(`${markdown}\n${manifestText}`).not.toContain('secret.log');
+    expect(`${markdown}\n${manifestText}`).not.toContain('secret-output.md');
     expect(readFileSync(rawLog, 'utf8')).toContain('RAW_TRANSCRIPT_SECRET');
   });
 

--- a/tests/cli-evidence-compact.test.ts
+++ b/tests/cli-evidence-compact.test.ts
@@ -32,7 +32,7 @@ function tempRepo() {
       path: '.osc/plans/active/136-demo.md',
       goal: 'Compact repeated-run evidence without leaking raw logs or .osc/state/session.log.',
       acceptanceCriteria: ['AC1: Summary exists.', 'AC2: Failures remain visible.'],
-      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev'],
+      verificationSteps: ['npm test -- --run tests/cli-evidence-compact.test.ts', 'npm run build', 'inspect .osc-dev/research/client-log.jsonl', 'inspect .osc-dev', 'inspect .osc\\state\\session.log'],
     },
     artifacts: {
       manifest: '.osc/runs/demo-run/run.json',
@@ -66,7 +66,7 @@ function tempRepo() {
           { kind: 'path', ref: 'C:\\Users\\alice\\secret.log', summary: 'Synthetic Windows local path; must be omitted from compact output.' },
           { kind: 'path', ref: 'C:/Users/alice/secret-output.md', summary: 'Synthetic forward-slash Windows local path; must remain raw/local.' },
         ],
-        rationale: 'Failure was reproduced at /home/example/private/raw.log, .osc-dev/research/client-log.jsonl, and .osc/state.',
+        rationale: 'Failure was reproduced at /home/example/private/raw.log, .osc-dev/research/client-log.jsonl, .osc/state, and .osc-dev\\research\\client-log.jsonl.',
       },
     ],
     decision: { status: 'rejected', approver: 'human', rationale: 'AC2 remains failed.' },
@@ -169,6 +169,7 @@ describe('osc evidence compact', () => {
     expect(`${markdown}\n${manifestText}`).not.toContain('secret.log');
     expect(`${markdown}\n${manifestText}`).not.toContain('secret-output.md');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc/state');
+    expect(`${markdown}\n${manifestText}`).not.toContain('.osc\\\\state');
     expect(`${markdown}\n${manifestText}`).not.toContain('.osc-dev');
     expect(`${markdown}\n${manifestText}`).not.toContain('client-log');
     expect(readFileSync(rawLog, 'utf8')).toContain('RAW_TRANSCRIPT_SECRET');

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -38,6 +38,7 @@ const topLevelHelpCommands = [
   'osc amend <plan-slug> [--message <text>]',
   'osc evidence new <slug>',
   'osc evidence collect <slug> [--ci] [--dry-run] [--verbose]',
+  'osc evidence compact <run-or-loop> [--evaluation <evaluation-json>] [--candidate-note <path>]... [--out <dir>] [--json]',
   'osc close <plan-slug> [--message <text>]',
   'osc trace <plan-slug> [--json] [--include-unverified]',
   'osc verify [--evidence-chain [--plan <slug>] [--json] [--strict]]',
@@ -132,6 +133,12 @@ const cases: HelpCase[] = [
     name: 'trace',
     args: ['trace', '--help'],
     expected: 'Usage: osc trace <plan-slug> [--json] [--include-unverified]',
+    forbidden: 'Missing required argument',
+  },
+  {
+    name: 'evidence compact',
+    args: ['evidence', 'compact', '--help'],
+    expected: 'Usage: osc evidence compact <run-or-loop> [--evaluation <evaluation-json>] [--candidate-note <path>]... [--out <dir>] [--json]',
     forbidden: 'Missing required argument',
   },
 ];

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('916c935e8e4d439cae38087f201ecb2a1f94b9fed19370e7b91a0111843a516e');
+    expect(hash(planIssueSnapshot)).toBe('c93a7419924f9a2de4523be994b1fa06ff707c03c5930a237fe921b05e6690f0');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('9a3f468b4b77e594c563d26d91167abefc2fa07ec23dcd9b02eb15c76600f49b');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('1907c701fe3e7a1716ce012ce6b4e1c34a2ea10401c025db7dd7f253dae67b86');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `osc evidence compact <run-or-loop>` for explicit compact evidence summaries.
- Emits `open-scaffold.compact-evidence.v1` JSON plus Markdown when `--out` is supplied, while JSON/Markdown can also be printed directly.
- Preserves failed criteria, evaluation counts, verification commands, decisions, and digest-backed raw/local refs without embedding raw logs, private paths, or mutating evolution state.
- Closes `.osc/plans/done/136-compact-evidence-mode.md` with repo-local evidence note `.osc/releases/2026-06-01-136-compact-evidence-mode.md`.

## Verification
- `git diff --check`
- `node dist/cli.js plan validate .osc/plans/done/136-compact-evidence-mode.md --strict`
- `npm test -- --run tests/cli-evidence-compact.test.ts tests/cli-lifecycle-help.test.ts`
- `node dist/cli.js evidence compact --help`
- `npm test`
- `npm run build`
- `./verify.sh --strict`
- public-safety scan over changed files

## Risk / gates
- Analysis/summary only: no runtime spawning, benchmark rerun, raw evidence deletion, attempt/frontier mutation, npm publish, or GitHub Release.
- Merge remains owner-gated.
