### PR TITLE
Add benchmark v2 workflow fixture

### DIFF
--- a/.osc/plans/active/137-benchmark-v2-workflow-value-fixture.md
+++ b/.osc/plans/active/137-benchmark-v2-workflow-value-fixture.md
@@ -1,0 +1,87 @@
+# Plan: 137-benchmark-v2-workflow-value-fixture
+
+## Status
+
+active
+
+## Context
+
+Plans 134, 135, and 136 shipped the Open Scaffold-side prep exposed by the 2000m v1 negative result: plateau/impossible-AC analysis, external scorer import, and compact evidence. The next benchmark-v2 phase needs a public-safe handoff contract before the benchmark repo grows scorer or harness code, so the next slice is a two-repo protocol fixture rather than another raw 2000m score run.
+
+## Goal
+
+Create a machine-readable benchmark-v2 scenario fixture and public handoff notes that define how the benchmark repo should test workflow value instead of raw model intelligence.
+
+## Constraints / Out of scope
+
+- Do not claim Open Scaffold improved the raw 2000m v1 score.
+- Do not claim adoption proof, model-ranking proof, or a benchmark win.
+- Do not npm publish, create a GitHub Release, merge, or mutate prior stopped 2000m v1 evidence.
+- Do not implement the full 2000m v2 scorer, controller, hidden-seed harness, or runtime execution in this repo.
+- Keep benchmark implementation ownership in `graphanov/2000m`; this repo may provide the public protocol fixture and claim boundaries.
+
+## Files to touch
+
+- `docs/benchmarks/2000m-v2-workflow-benchmark-proposal.md` — promote the first v2 slice decision and link the machine-readable fixture.
+- `docs/benchmarks/README.md` — index the new fixture and honesty boundary.
+- `docs/examples/benchmark-v2-workflow/README.md` — explain the scenario packet and how the benchmark repo should consume it.
+- `docs/examples/benchmark-v2-workflow/scenario.schema.json` — define the workflow-value scenario shape.
+- `docs/examples/benchmark-v2-workflow/workflow-value-scenario.json` — provide the first concrete v2 scenario packet.
+- `tests/benchmark-workflow-fixture.test.ts` — prove the fixture tests workflow pain rather than score-only deltas.
+- `.osc/releases/2026-06-01-137-benchmark-v2-workflow-value-fixture.md` — record public-safe evidence for this slice.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+| --- | --- | --- | --- |
+| T1 | Define the v2 scenario schema and concrete scenario packet. | None | A |
+| T2 | Update benchmark proposal and fixture README with ownership boundaries. | T1 | B |
+| T3 | Add tests that reject score-only/model-ranking benchmark shapes. | T1 | B |
+| T4 | Add evidence note and run full verification gates. | T2, T3 | C |
+
+### Parallel groups
+
+- **Group A:** the schema/fixture sets the contract.
+- **Group B:** docs and tests can proceed after the fixture exists.
+- **Group C:** evidence and verification wait until docs and tests are coherent.
+
+### Dependencies
+
+T2 and T3 depend on T1 so the prose and tests point at the same machine-readable contract. T4 depends on both because the evidence note must describe the final changed surface.
+
+### Delegation notes
+
+A reviewer can independently inspect the fixture for public-safety and claim boundaries. Benchmark-repo implementation is a follow-up slice, not delegated here.
+
+## Implementation Architecture Coverage
+
+- Strengthens: benchmark design, recovery/handoff evidence, stop-condition checks, and public claim boundaries.
+- Audit envelope: this plan, the v2 proposal, the scenario schema, the scenario fixture, the fixture tests, and the evidence note.
+- Evaluation envelope: tests verify that the fixture contains workflow/recovery tracks, impossible/stale requirement handling, scorer-feedback integration, and score-only/model-ranking non-claims.
+- Feedback routing: benchmark scorer/harness work moves to `graphanov/2000m`; Open Scaffold controller/runtime work remains behind explicit safety and adapter gates.
+- Boundary: no runtime execution, no scorer implementation, no raw benchmark rerun, no publish/release, no merge authority, no adoption proof.
+
+## Acceptance criteria
+
+- [ ] The slice records the decision that benchmark-v2 starts as a two-repo protocol plus benchmark fixture, not as an Open Scaffold-only design note or full benchmark implementation.
+- [ ] A machine-readable scenario fixture defines phases for staged requirements, reviewer injection, regression trap, context wipe/handoff, and impossible/stale requirement handling.
+- [ ] The scenario separates mechanical, artifact-quality, process-control, and handoff/recovery tracks instead of collapsing the result into a flattering raw score.
+- [ ] The fixture references current Open Scaffold prep surfaces: `osc evolve analyze`, `osc eval import`, and `osc evidence compact`.
+- [ ] Tests fail if the fixture omits workflow-value dimensions or permits model-ranking/adoption-proof claims.
+- [ ] Docs explain that the benchmark repo owns the scorer/harness implementation and that Open Scaffold owns only the work-record/control evidence surfaces.
+- [ ] Public-safety scan finds no private names, local paths, Discord/thread IDs, raw-score win claims, or adoption-proof claims in changed public files.
+
+## Verification steps
+
+1. Run `npm test -- benchmark-workflow-fixture.test.ts` and expect the fixture tests to pass.
+2. Run `git diff --check` and expect no whitespace errors.
+3. Run `npm test` and expect the full suite to pass.
+4. Run `npm run build` and expect TypeScript/package build success.
+5. Run `./verify.sh --strict` and expect repository compliance to pass.
+6. Run a public-safety scan over changed files for private names, local paths, Discord/thread IDs, unsupported score-win claims, model-ranking claims, and adoption-proof claims.
+
+## Open questions
+
+- Should the next slice port this fixture into `graphanov/2000m` as `v2/` scorer/harness scaffolding, or should it first open a benchmark-repo design PR with no scorer code? This slice assumes the fixture should be reviewed here before benchmark-repo mutation.

--- a/.osc/releases/2026-06-01-137-benchmark-v2-workflow-value-fixture.md
+++ b/.osc/releases/2026-06-01-137-benchmark-v2-workflow-value-fixture.md
@@ -1,0 +1,34 @@
+# Release / Evidence Note: 137-benchmark-v2-workflow-value-fixture
+
+## Summary
+
+Adds a public-safe, machine-readable benchmark-v2 workflow-value scenario fixture after the 2000m v1 raw-score tie. The fixture defines a two-repo protocol handoff: Open Scaffold records the work-record/control evidence contract, while `graphanov/2000m` remains the owner of future v2 scorer and harness implementation.
+
+## Traceability
+
+- Roadmap / issue / task: Post-2000m benchmark-v2 follow-up from `docs/benchmarks/2000m-v1-two-lane-postmortem.md` and `docs/decisions/2026-05-31-osc-evolve-v2-after-2000m.md`; no GitHub issue selected for this bounded slice.
+- Plan: `.osc/plans/active/137-benchmark-v2-workflow-value-fixture.md`
+- Run ID / run packet: `N/A` — this slice changed docs, fixture JSON, and tests directly and did not spawn a runtime.
+- Branch / PR: `feat/benchmark-v2-workflow-fixture`; PR pending owner review.
+
+## Verification
+
+- `npm test -- benchmark-workflow-fixture.test.ts` — PASS, 1 file / 5 tests.
+- `npm run osc -- plan validate 137-benchmark-v2-workflow-value-fixture --strict` — PASS, `0 issues found`.
+- `git diff --check` — PASS.
+- `npm test` — PASS, 56 files / 574 tests.
+- `npm run build` — PASS, core and runtime-omx TypeScript builds.
+- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
+- Public-safety scan over changed files — PASS; no private identity, local absolute path, Discord/thread ID, secret-token, unsupported raw-score-win, adoption-proof, or model-ranking claim hits.
+
+## Outcome
+
+Candidate fixture is prepared on a feature branch. It separates mechanical conformance, artifact quality, process-control quality, and handoff/recovery quality; includes staged requirement, reviewer-injection, regression-trap, context-wipe, and impossible/stale-requirement phases; and references `osc evolve analyze`, `osc eval import`, and `osc evidence compact` as evidence surfaces without making Open Scaffold the benchmark scorer or runtime.
+
+No npm publish, GitHub Release, benchmark rerun, 2000m v1 evidence mutation, merge, or model-ranking claim is included in this slice.
+
+## Follow-up
+
+- Owner gate remains for PR review and merge.
+- Next likely slice: port or adapt this fixture into `graphanov/2000m` as a v2 scorer/harness design or implementation PR.
+- Package/public release reconciliation remains out of scope unless the owner explicitly authorizes a release train.

--- a/docs/benchmarks/2000m-v2-workflow-benchmark-proposal.md
+++ b/docs/benchmarks/2000m-v2-workflow-benchmark-proposal.md
@@ -10,6 +10,18 @@ A useful v2 should not be just “more SkiFree acceptance criteria.” It should
 
 Separate the scores. Do not collapse everything into one flattering number.
 
+## First implementation slice
+
+The first benchmark-v2 slice should be a **two-repo protocol plus benchmark fixture**:
+
+- Open Scaffold provides the public-safe scenario contract, scenario fixture, and claim boundaries.
+- The `graphanov/2000m` benchmark repo later ports that fixture into a real v2 scorer and harness.
+- Results records stay separate and source-label every mechanical, artifact, process, and recovery metric.
+
+This is narrower than a full benchmark implementation but stronger than a design-only note. It gives the benchmark repo a concrete packet to implement while keeping Open Scaffold honest about what it owns: `osc evolve analyze`, `osc eval import`, compact evidence, plans, run packets, evaluation envelopes, and public non-claims.
+
+The initial machine-readable handoff lives at [`../examples/benchmark-v2-workflow/`](../examples/benchmark-v2-workflow/).
+
 | Track | What it measures | Where it belongs |
 | --- | --- | --- |
 | Mechanical conformance | Does the produced driver satisfy deterministic protocol checks? | Benchmark scorer. |
@@ -109,6 +121,8 @@ The benchmark repo should own:
 - regression-trap tests;
 - replay/viewer metrics;
 - result schema for separate mechanical, artifact, process, and handoff tracks.
+
+The handoff fixture in this repository should be treated as input to that work, not as the benchmark implementation itself. A later `graphanov/2000m` slice should decide whether the scenario becomes `v2/scenarios/workflow-value.json`, a scorer fixture, or both.
 
 Open Scaffold should own:
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -8,6 +8,7 @@ Current notes:
 
 - [`2000m-v1-two-lane-postmortem.md`](2000m-v1-two-lane-postmortem.md) — a local two-lane 2000m v1 run showed no raw-score advantage for Open Scaffold over a naked Codex/GPT-5.5 lane.
 - [`2000m-v2-workflow-benchmark-proposal.md`](2000m-v2-workflow-benchmark-proposal.md) — a handoff proposal for a benchmark v2 that tests recovery, handoff, stop conditions, and artifact quality.
+- [`../examples/benchmark-v2-workflow/`](../examples/benchmark-v2-workflow/) — a machine-readable scenario fixture for the first v2 workflow-value slice.
 
 Honesty rules:
 
@@ -15,3 +16,4 @@ Honesty rules:
 - Evidence/recovery value is not smuggled into a raw-score claim.
 - Owner-run local experiments are not adoption proof.
 - Headless protocol drivers are not called playable games unless a real player/viewer exists.
+- Scenario fixtures are not benchmark results; the benchmark repo still owns scorer and harness implementation.

--- a/docs/examples/benchmark-v2-workflow/README.md
+++ b/docs/examples/benchmark-v2-workflow/README.md
@@ -1,0 +1,52 @@
+# Benchmark v2 workflow-value scenario fixture
+
+This folder is a public-safe handoff packet for the next 2000m benchmark phase.
+It is not a benchmark run, a leaderboard, or evidence that Open Scaffold improved a
+model's raw score.
+
+The fixture exists because 2000m v1 showed no raw-score advantage for the Open
+Scaffold lane. A useful v2 must test the product claim Open Scaffold can actually
+make: long-lived AI work should be easier to recover, hand off, inspect, stop,
+and redirect.
+
+## Files
+
+- `scenario.schema.json` — machine-readable shape for workflow-value benchmark
+  scenarios.
+- `workflow-value-scenario.json` — first concrete 2000m v2 scenario proposal.
+
+## Ownership split
+
+```text
+Open Scaffold repo
+  owns: work-record/control surfaces, public claim boundaries, this handoff
+        fixture, and tests that keep the fixture from becoming score-only.
+
+2000m benchmark repo
+  owns: v2 scorer, context-wipe harness, hidden seeds, reviewer fixtures,
+        replay/viewer metrics, and benchmark result schema.
+
+Results records
+  own: repeated run outcomes, source-labeled metrics, produced-artifact links,
+        and human-feel notes when a formal review track exists.
+```
+
+## What the fixture should make hard
+
+A v2 scenario should fail if it only ranks final mechanical score. It should ask:
+
+- can a fresh worker recover after context wipe from repo artifacts only;
+- does a handoff package preserve current goal, passed/failed criteria, blockers,
+  evidence, and next action;
+- does reviewer feedback become an explicit fix route instead of chat drift;
+- do regression traps catch overfitting to public examples;
+- does the lane stop or redesign when a requirement is impossible, stale, or
+  contradictory;
+- do `osc evolve analyze`, `osc eval import`, and `osc evidence compact` improve
+  the decision record without pretending to be a scorer or runtime.
+
+## Non-claims
+
+This fixture does not claim adoption, benchmark victory, model intelligence gains,
+compliance, or production readiness. It is a design contract for the next benchmark
+implementation slice.

--- a/docs/examples/benchmark-v2-workflow/scenario.schema.json
+++ b/docs/examples/benchmark-v2-workflow/scenario.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graphanov/open-scaffold/docs/examples/benchmark-v2-workflow/scenario.schema.json",
+  "title": "Open Scaffold workflow benchmark scenario v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "scenario_id",
+    "purpose",
+    "benchmark_owner",
+    "non_claims",
+    "conditions",
+    "tracks",
+    "phases",
+    "open_scaffold_surfaces",
+    "success_gate"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "open-scaffold.workflow-benchmark-scenario.v1"
+    },
+    "scenario_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "purpose": {
+      "type": "string",
+      "minLength": 40
+    },
+    "benchmark_owner": {
+      "type": "object",
+      "required": ["repo", "owns"],
+      "additionalProperties": false,
+      "properties": {
+        "repo": { "type": "string" },
+        "owns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 3
+        }
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 4,
+      "uniqueItems": true
+    },
+    "conditions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "description", "allowed_inputs"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "description": { "type": "string" },
+          "allowed_inputs": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          }
+        }
+      },
+      "minItems": 3
+    },
+    "tracks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "weight", "measures", "must_not_measure"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "weight": { "type": "number", "minimum": 0, "maximum": 1 },
+          "measures": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 2
+          },
+          "must_not_measure": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          }
+        }
+      },
+      "minItems": 4
+    },
+    "phases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "generation", "stimulus", "workflow_value_under_test", "evidence_required", "expected_decision"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "generation": { "type": "integer", "minimum": 1 },
+          "stimulus": { "type": "string" },
+          "workflow_value_under_test": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          },
+          "evidence_required": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          },
+          "expected_decision": {
+            "type": "string",
+            "enum": ["continue", "fix", "handoff", "stop", "redesign", "inspect_scorer"]
+          }
+        }
+      },
+      "minItems": 5
+    },
+    "open_scaffold_surfaces": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 3,
+      "uniqueItems": true
+    },
+    "success_gate": {
+      "type": "object",
+      "required": ["requires", "rejects"],
+      "additionalProperties": false,
+      "properties": {
+        "requires": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 4
+        },
+        "rejects": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 3
+        }
+      }
+    }
+  }
+}

--- a/docs/examples/benchmark-v2-workflow/workflow-value-scenario.json
+++ b/docs/examples/benchmark-v2-workflow/workflow-value-scenario.json
@@ -1,0 +1,160 @@
+{
+  "schema": "open-scaffold.workflow-benchmark-scenario.v1",
+  "scenario_id": "2000m-v2-workflow-value",
+  "purpose": "Test whether repo-native work records improve recovery, handoff, stop-condition correctness, scorer-feedback integration, and artifact reviewability after the 2000m v1 raw-score tie.",
+  "benchmark_owner": {
+    "repo": "graphanov/2000m",
+    "owns": [
+      "v2 scorer and harness implementation",
+      "context-wipe execution mechanics",
+      "hidden and randomized seed policy",
+      "reviewer-injection fixtures",
+      "replay/viewer metrics",
+      "result schema for source-labeled benchmark outputs"
+    ]
+  },
+  "non_claims": [
+    "does_not_claim_open_scaffold_improved_2000m_v1_raw_score",
+    "does_not_claim_model_intelligence_gain",
+    "does_not_claim_adoption_or_market_proof",
+    "does_not_claim_benchmark_win_from_evidence_quality",
+    "does_not_rank_models_without_repeated_controlled_runs"
+  ],
+  "conditions": [
+    {
+      "id": "naked-runtime",
+      "description": "A capable model/runtime receives benchmark docs, neutral scorer feedback, and a plain trajectory log without Open Scaffold records.",
+      "allowed_inputs": ["benchmark spec", "scorer output", "plain trajectory"]
+    },
+    {
+      "id": "open-scaffold-ledger",
+      "description": "The same model/runtime receives plan, run, eval, evolve, and compact evidence records, but no autonomous controller authority.",
+      "allowed_inputs": ["active plan", "run packet", "evaluation envelope", "evolution loop", "compact evidence"]
+    },
+    {
+      "id": "open-scaffold-controller-candidate",
+      "description": "A future reviewed controller candidate uses the same records plus explicit hypotheses, deltas, and stop/redesign recommendations.",
+      "allowed_inputs": ["active plan", "run packet", "evaluation envelope", "evolution analysis", "compact evidence", "explicit controller decision log"]
+    }
+  ],
+  "tracks": [
+    {
+      "id": "mechanical_conformance",
+      "weight": 0.25,
+      "measures": [
+        "deterministic protocol checks",
+        "fixed-seed hidden regression checks",
+        "source-labeled scorer output"
+      ],
+      "must_not_measure": ["model ranking by itself", "workflow value by itself"]
+    },
+    {
+      "id": "artifact_quality",
+      "weight": 0.20,
+      "measures": [
+        "state-trace replay richness",
+        "obstacle spread and density balance",
+        "event richness and recovery cadence",
+        "viewer or renderer replayability"
+      ],
+      "must_not_measure": ["native game UI unless one exists", "taste as mechanical pass"]
+    },
+    {
+      "id": "process_control",
+      "weight": 0.30,
+      "measures": [
+        "plateau detection",
+        "impossible or stale requirement detection",
+        "scorer-feedback integration",
+        "continue stop redesign or inspect-scorer recommendation quality"
+      ],
+      "must_not_measure": ["more attempts as automatically better", "score-frontier promotion as approval"]
+    },
+    {
+      "id": "handoff_recovery",
+      "weight": 0.25,
+      "measures": [
+        "fresh-agent recovery after context wipe",
+        "current best attempt reconstruction",
+        "passed and failed criterion reconstruction",
+        "evidence and blocker traceability",
+        "next-action clarity"
+      ],
+      "must_not_measure": ["chat-memory recall", "private transcript access"]
+    }
+  ],
+  "phases": [
+    {
+      "id": "baseline-driver",
+      "generation": 1,
+      "stimulus": "Implement or repair a deterministic baseline headless driver under the published benchmark contract.",
+      "workflow_value_under_test": ["baseline evidence capture", "clear current objective"],
+      "evidence_required": ["scorer output", "run or trajectory record", "failed criterion list"],
+      "expected_decision": "continue"
+    },
+    {
+      "id": "staged-requirement-change",
+      "generation": 2,
+      "stimulus": "Introduce a new requirement after generation 1, such as a scoring variant or slalom-gate behavior.",
+      "workflow_value_under_test": ["plan or requirement update", "avoidance of stale goal drift"],
+      "evidence_required": ["updated acceptance criteria", "delta from prior attempt", "regression check output"],
+      "expected_decision": "continue"
+    },
+    {
+      "id": "reviewer-injection",
+      "generation": 3,
+      "stimulus": "Inject a valid reviewer finding that maps to a criterion or correction route.",
+      "workflow_value_under_test": ["review-feedback capture", "fix routing", "evidence of correction"],
+      "evidence_required": ["review finding", "mapped criterion or amendment", "post-fix scorer output"],
+      "expected_decision": "fix"
+    },
+    {
+      "id": "regression-trap",
+      "generation": 4,
+      "stimulus": "Reveal hidden or delayed seed checks that catch a patch overfit to public examples.",
+      "workflow_value_under_test": ["regression resistance", "source-labeled scorer feedback"],
+      "evidence_required": ["hidden-seed summary", "previous invariant status", "new failure route"],
+      "expected_decision": "continue"
+    },
+    {
+      "id": "context-wipe-handoff",
+      "generation": 5,
+      "stimulus": "Wipe chat context and give a fresh worker only the repo artifacts and allowed benchmark outputs.",
+      "workflow_value_under_test": ["fresh-agent recovery", "handoff quality", "next-action reconstruction"],
+      "evidence_required": ["fresh-worker recovery report", "current best attempt", "remaining blockers", "next recommended action"],
+      "expected_decision": "handoff"
+    },
+    {
+      "id": "impossible-or-stale-requirement",
+      "generation": 6,
+      "stimulus": "Introduce a requirement that is impossible under the current artifact type, stale after a spec change, or contradictory with another criterion.",
+      "workflow_value_under_test": ["impossible requirement handling", "stop-condition correctness", "scorer inspection"],
+      "evidence_required": ["criterion sensitivity analysis", "scorer metadata or reviewer rationale", "stop or redesign recommendation"],
+      "expected_decision": "redesign"
+    }
+  ],
+  "open_scaffold_surfaces": [
+    "osc evolve analyze",
+    "osc eval import --adapter 2000m-v1",
+    "osc evidence compact",
+    "plan/run/evaluation/evolution records",
+    "public-safe evidence note"
+  ],
+  "success_gate": {
+    "requires": [
+      "all tracks are reported separately",
+      "mechanical conformance is source-labeled and not treated as the whole verdict",
+      "context-wipe recovery is scored without chat history",
+      "review feedback changes the work record or a correction route",
+      "impossible or stale requirements produce stop, redesign, or inspect_scorer instead of blind retry",
+      "compact evidence preserves failed criteria and verification status"
+    ],
+    "rejects": [
+      "single aggregate score presented as benchmark win",
+      "adoption proof from an owner-run local experiment",
+      "Open Scaffold raw-score-improvement claim from the v1 tie",
+      "private transcript or local path access as a recovery input",
+      "model leaderboard claim without repeated controlled runs"
+    ]
+  }
+}

--- a/tests/benchmark-workflow-fixture.test.ts
+++ b/tests/benchmark-workflow-fixture.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const fixtureRoot = join(repoRoot, 'docs/examples/benchmark-v2-workflow');
+
+interface ScenarioTrack {
+  id: string;
+  weight: number;
+  measures: string[];
+  must_not_measure: string[];
+}
+
+interface ScenarioPhase {
+  id: string;
+  generation: number;
+  workflow_value_under_test: string[];
+  evidence_required: string[];
+  expected_decision: string;
+}
+
+interface WorkflowScenario {
+  schema: string;
+  scenario_id: string;
+  benchmark_owner: { repo: string; owns: string[] };
+  non_claims: string[];
+  conditions: Array<{ id: string; allowed_inputs: string[] }>;
+  tracks: ScenarioTrack[];
+  phases: ScenarioPhase[];
+  open_scaffold_surfaces: string[];
+  success_gate: { requires: string[]; rejects: string[] };
+}
+
+function loadScenario(): WorkflowScenario {
+  return JSON.parse(readFileSync(join(fixtureRoot, 'workflow-value-scenario.json'), 'utf8')) as WorkflowScenario;
+}
+
+function loadSchema(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(fixtureRoot, 'scenario.schema.json'), 'utf8')) as Record<string, unknown>;
+}
+
+function allText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(allText).join(' ');
+  if (value && typeof value === 'object') return Object.values(value).map(allText).join(' ');
+  return typeof value === 'string' ? value : '';
+}
+
+describe('benchmark v2 workflow-value fixture', () => {
+  it('declares a machine-readable scenario schema and concrete fixture', () => {
+    const schema = loadSchema();
+    const scenario = loadScenario();
+
+    expect(schema.$id).toContain('scenario.schema.json');
+    expect(scenario.schema).toBe('open-scaffold.workflow-benchmark-scenario.v1');
+    expect(scenario.scenario_id).toBe('2000m-v2-workflow-value');
+    expect(scenario.benchmark_owner.repo).toBe('graphanov/2000m');
+    expect(scenario.benchmark_owner.owns.join(' ')).toMatch(/scorer|harness|seed|reviewer|viewer/i);
+  });
+
+  it('starts as a two-repo protocol fixture, not an Open Scaffold-owned benchmark implementation', () => {
+    const scenario = loadScenario();
+
+    expect(scenario.benchmark_owner.owns).toEqual(expect.arrayContaining([
+      'v2 scorer and harness implementation',
+      'context-wipe execution mechanics',
+      'reviewer-injection fixtures',
+    ]));
+    expect(scenario.open_scaffold_surfaces).toEqual(expect.arrayContaining([
+      'osc evolve analyze',
+      'osc eval import --adapter 2000m-v1',
+      'osc evidence compact',
+    ]));
+  });
+
+  it('requires the workflow pain points that v1 failed to test', () => {
+    const scenario = loadScenario();
+    const phaseIds = scenario.phases.map((phase) => phase.id);
+    const phaseText = allText(scenario.phases);
+
+    expect(phaseIds).toEqual(expect.arrayContaining([
+      'staged-requirement-change',
+      'reviewer-injection',
+      'regression-trap',
+      'context-wipe-handoff',
+      'impossible-or-stale-requirement',
+    ]));
+    expect(phaseText).toMatch(/fresh-agent recovery/i);
+    expect(phaseText).toMatch(/stop-condition correctness/i);
+    expect(phaseText).toMatch(/scorer inspection/i);
+  });
+
+  it('separates workflow, handoff, artifact, and mechanical tracks instead of score-only ranking', () => {
+    const scenario = loadScenario();
+    const tracks = new Map(scenario.tracks.map((track) => [track.id, track]));
+
+    expect([...tracks.keys()]).toEqual(expect.arrayContaining([
+      'mechanical_conformance',
+      'artifact_quality',
+      'process_control',
+      'handoff_recovery',
+    ]));
+    expect(tracks.get('mechanical_conformance')?.weight).toBeLessThanOrEqual(0.35);
+    expect(tracks.get('process_control')?.measures.join(' ')).toMatch(/plateau|stop|redesign|scorer/i);
+    expect(tracks.get('handoff_recovery')?.measures.join(' ')).toMatch(/fresh-agent|criterion|blocker|next-action/i);
+  });
+
+  it('keeps public claim boundaries explicit', () => {
+    const scenario = loadScenario();
+    const text = allText(scenario);
+
+    expect(scenario.non_claims).toEqual(expect.arrayContaining([
+      'does_not_claim_open_scaffold_improved_2000m_v1_raw_score',
+      'does_not_claim_model_intelligence_gain',
+      'does_not_claim_adoption_or_market_proof',
+      'does_not_claim_benchmark_win_from_evidence_quality',
+    ]));
+    expect(text).toMatch(/single aggregate score presented as benchmark win/i);
+    expect(text).toMatch(/private transcript or local path access/i);
+  });
+});

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('c93a7419924f9a2de4523be994b1fa06ff707c03c5930a237fe921b05e6690f0');
+    expect(hash(planIssueSnapshot)).toBe('cf21827f1100c6332775701808b5baade4d6eae83db3986ac4f7b051b9bfb8f9');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('1907c701fe3e7a1716ce012ce6b4e1c34a2ea10401c025db7dd7f253dae67b86');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('fb282cee402115ed157b8c8090068c3c1e2e8056ca1d4c31e40536afa045622a');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a benchmark-v2 workflow-value scenario fixture after the 2000m v1 raw-score tie.
- Documents the first v2 slice as a two-repo protocol plus benchmark fixture: Open Scaffold owns work-record/control evidence surfaces, while `graphanov/2000m` owns future scorer and harness implementation.
- Adds tests that keep the fixture focused on recovery, handoff, process control, scorer feedback, and non-claim boundaries rather than score-only ranking.

## Verification

- `npm test -- benchmark-workflow-fixture.test.ts`
- `npm run osc -- plan validate 137-benchmark-v2-workflow-value-fixture --strict`
- `git diff --check`
- `npm test`
- `npm run build`
- `./verify.sh --strict`
- Public-safety scan over changed files for private identity/path leaks and unsupported benchmark/adoption/model-ranking claims

## Risk / gates

- No npm publish.
- No GitHub Release update.
- No benchmark rerun or 2000m v1 evidence mutation.
- No merge without owner approval.
