### PR TITLE
chore: close decoupling repair plan

### DIFF
--- a/.osc/plans/done/137-decouple-2000m-benchmark-boundary.md
+++ b/.osc/plans/done/137-decouple-2000m-benchmark-boundary.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 

--- a/.osc/releases/2026-06-01-137-decouple-2000m-benchmark-boundary.md
+++ b/.osc/releases/2026-06-01-137-decouple-2000m-benchmark-boundary.md
@@ -9,9 +9,9 @@ This slice removes the Open Scaffold-owned benchmark-v2 proposal, generalizes `o
 ## Traceability
 
 - Roadmap / issue / task: owner-directed repair after PR #164 was closed as the wrong benchmark-v2 coupling shape.
-- Plan: `.osc/plans/active/137-decouple-2000m-benchmark-boundary.md`.
+- Plan: `.osc/plans/done/137-decouple-2000m-benchmark-boundary.md`.
 - Run ID / run packet: N/A — direct docs/code/test repair slice; no runtime, benchmark rerun, npm publish, or GitHub Release.
-- Branch / PR: branch `fix/decouple-2000m-boundary`; PR pending.
+- Branch / PR: branch `fix/decouple-2000m-boundary`; PR #165 merged.
 
 ## Verification
 
@@ -25,10 +25,10 @@ This slice removes the Open Scaffold-owned benchmark-v2 proposal, generalizes `o
 
 ## Outcome
 
-Implemented and locally verified on the repair branch. Open Scaffold keeps generic evaluator/import/analyze/evidence mechanics while 2000m remains the independent home for benchmark design/scorer/harness work.
+Merged and locally verified in PR #165. The plan has been closed to `done/`. Open Scaffold keeps generic evaluator/import/analyze/evidence mechanics while 2000m remains the independent home for benchmark design/scorer/harness work.
 
 ## Follow-up
 
-- Do not merge without owner approval.
+- Closeout PR remains owner-gated.
 - No npm publish or GitHub Release work is included in this slice.
 - If a future 2000m-specific converter is needed, put it in `graphanov/2000m` or an optional integration rather than Open Scaffold core.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-01: closed 137-decouple-2000m-benchmark-boundary — Close decoupling repair plan after PR #165 merge
 - 2026-06-01: closed 136-compact-evidence-mode — Add compact evidence mode for run and evolution-loop summaries
 - 2026-06-01: closed 135-osc-eval-external-scorer-adapter — Close 135 after eval external scorer import
 - 2026-06-01: closed 134-osc-evolve-analyze-plateau-and-impossible-ac — shipped osc evolve analyze via PR #160

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('b19a7bf914d57c0ffddc562af0a7423ba29cd9f68081fb5f04205c9ba822ca03');
+    expect(hash(planIssueSnapshot)).toBe('0887c3f1488669b2658a006892f73bf8eecacc3bb67c3f750ee1e60a0327e51f');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('8e1f67ad613fffb5cbf46248b37ba405c9cd9b30ee3597768da9d9a7ab084b4c');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary
- Closes plan 137 after PR #165 merged the 2000m/Open Scaffold boundary repair.
- Moves the plan from `active/` to `done/` and aligns the evidence note with the merged PR.
- Updates the live-corpus validation hash after the plan-stage move.

## Verification
- `npm test -- tests/section-parser.test.ts --run`
- `node dist/cli.js plan validate .osc/plans/done/137-decouple-2000m-benchmark-boundary.md --strict`
- stale active-path scan for plan 137
- `git diff --check`
- `npm test -- --run`
- `npm run build`
- `./verify.sh --strict`
- changed-line public-safety scan

## Risk / gates
- Hygiene-only closeout; no runtime, benchmark, npm publish, or GitHub Release work.
- Merge remains owner-gated.
