### PR TITLE
fix(dispatch): restrict adapter env and bound logs

### DIFF
--- a/.osc/plans/active/138-blueprint-security-adoption-program.md
+++ b/.osc/plans/active/138-blueprint-security-adoption-program.md
@@ -1,0 +1,86 @@
+# Plan: 138-blueprint-security-adoption-program
+
+## Status
+
+active
+
+## Context
+
+A 2026-06-02 external review/blueprint package was provided as source input for Open Scaffold's next hardening wave. The package prioritizes security/trust hardening, first-run adoption, reviewer value, runtime-lane stabilization, adoption proof, schema/help cleanup, and trust-boundary clarity while explicitly dropping Korean adoption/localization.
+
+## Goal
+
+Turn the accepted blueprint package into staged, reviewable Open Scaffold slices with P0/P1 work prioritized and P2 work captured as concrete follow-up plans.
+
+## Constraints / Out of scope
+
+- Do not commit the full blueprint package as product documentation; it remains ignored research input unless a specific public-safe excerpt is promoted.
+- Do not add Korean docs, examples, localization, or translation-maintenance work.
+- Do not publish npm, create/mark GitHub Releases, merge, push protected branches, deploy, expose secrets, or claim compliance/correctness certification.
+- Do not weaken the no-spawn core boundary or make runtime execution default-on.
+- Do not turn this into one giant unreviewable PR; keep implementation slices small enough to inspect.
+
+## Files to touch
+
+- `.osc/plans/active/139-dispatch-env-timeout-log-bounds.md` — first executable P0 security slice.
+- `.osc/plans/backlog/` — future P0/P1/P2 slices when not implemented in the current branch.
+- `.osc/releases/` — slice evidence notes after concrete implementation work.
+- Product/code/docs files named by each child slice plan.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Ingest blueprint package and compare against current repo truth | None | A |
+| T2 | Create staged plan map and first executable dispatch hardening plan | T1 | B |
+| T3 | Implement dispatch env restriction + timeout/log bounds | T2 | C |
+| T4 | Create remaining backlog plans for adapter trust, redaction/docs, README/help, first-run, PR checks, runtime beta, adoption proof, and P2 cleanup | T1 | D |
+| T5 | Verify each implemented slice and record evidence | T3 or later implementation slices | E |
+
+### Parallel groups
+
+- **Group A**: research/source-truth reading only.
+- **Group B/C**: first P0 implementation sequence; T3 depends on T2.
+- **Group D**: backlog planning can proceed after T1 but should not block the first P0 security patch.
+- **Group E**: verification/evidence after each implementation slice.
+
+### Dependencies
+
+- Child implementation plans must exist before non-trivial code/doc changes.
+- P0 dispatch hardening should land before runtime beta or broader adapter trust work.
+- Runtime beta claims depend on env allowlist, timeout, bounded logs, redaction, trust workflow, and worktree/protected-branch enforcement.
+
+### Delegation notes
+
+- Future docs/adoption/help slices can be delegated to bounded workers after their plans exist.
+- Security/runtime slices should use strict TDD and avoid runtime spawning unless a child plan explicitly gates it.
+
+## Implementation Architecture Coverage
+
+- Strengthens: authority, runtime boundary, audit trails, recovery/ownership, and adoption trust.
+- Audit envelope: blueprint source path `.osc/research/2026-06-02-review-blueprint-ingest/`, child plan slugs, evidence notes, verification commands, and PR/branch identifiers.
+- Evaluation envelope: each child slice must define mechanical acceptance criteria and local verification commands.
+- Feedback routing: scope changes become child plan amendments; deferred recommendations become backlog plans, not chat-only promises.
+- Boundary: this program is structural and local by default; it is not a runtime launch, correctness certification, compliance claim, npm release, or localization program.
+
+## Acceptance criteria
+
+- [ ] Blueprint package is unpacked only in ignored research/temp storage and treated as input, not product docs.
+- [ ] P0/P1/P2 recommendations are mapped to implemented slices or concrete backlog plans.
+- [ ] The first P0 dispatch hardening slice has its own plan, tests, implementation, evidence note, and verification results.
+- [ ] Public-facing changes avoid Korean localization and avoid overclaiming semantic correctness, compliance, runtime support, or release status.
+- [ ] Remaining owner-gated actions are explicit at final handoff.
+
+## Verification steps
+
+1. Run `git status --short --branch --ignored` and verify the blueprint package remains under ignored `.osc/research/` unless explicitly promoted.
+2. Run `npm run osc -- plan validate .osc/plans/active/138-blueprint-security-adoption-program.md --strict`.
+3. Run child-plan validation for every new/touched plan.
+4. For implemented code slices, run `git diff --check`, focused tests, `npm test`, `npm run build`, `./verify.sh --strict`, and relevant `npm run osc -- verify` / evidence-chain checks.
+
+## Open questions
+
+- Whether the owner wants the later implementation slices opened as individual PRs immediately after local verification or staged locally first.
+- Whether adapter trust (`OSB-005`) should be the next PR after this branch or bundled only if the first P0 dispatch patch stays small.

--- a/.osc/plans/done/139-dispatch-env-timeout-log-bounds.md
+++ b/.osc/plans/done/139-dispatch-env-timeout-log-bounds.md
@@ -1,0 +1,93 @@
+# Plan: 139-dispatch-env-timeout-log-bounds
+
+## Status
+
+done
+
+## Context
+
+The 2026-06-02 blueprint package identifies `OSB-003` / `SEC-01` and `OSB-004` / `SEC-02` as immediate P0 dispatch safety work. Current source inspection confirms `src/dispatch.ts` passes `process.env` directly to adapter subprocesses and does not enforce adapter timeouts or bounded log capture.
+
+## Goal
+
+Harden `osc dispatch` so project-local adapters receive a restricted allowlisted environment by default and cannot hang indefinitely or write unbounded stdout/stderr logs.
+
+## Constraints / Out of scope
+
+- Do not implement the adapter trust workflow in this slice; create/keep it as the next security slice.
+- Do not implement full secret-redaction or doctor scanning here; leave that for the redaction/trust-boundary slice unless a small helper is required for log metadata safety.
+- Do not spawn real OMC/OMX/Codex/Claude/OpenCode sessions.
+- Do not add network, credential, commit, push, PR, merge, publish, release, deploy, or production side effects.
+- Do not expose environment values in summaries, logs, docs, tests, or evidence.
+- Keep backwards compatibility for existing adapter configs except where the old full-env behavior is now restricted by default.
+
+## Files to touch
+
+- `src/dispatch.ts` — parse adapter env/timeout/log config, build safe env, enforce timeout/log bounds, and summarize metadata without values.
+- `src/cli.ts` — dispatch CLI flags/help for any explicit unsafe local override.
+- `tests/cli-dispatch.test.ts` — failing-first coverage for secret env exclusion, allowlisted/env config values, timeout, truncation, and summary output.
+- `docs/RUNTIME_ADOPTION_WORKFLOW.md` and/or runtime docs — document the restricted environment and bounded logs if CLI behavior changes user-facing semantics.
+- `.osc/releases/2026-06-02-dispatch-env-timeout-log-bounds.md` — evidence note for this slice.
+
+## Execution strategy
+
+### Task decomposition
+
+| ID | Task | Dependencies | Parallel group |
+|----|------|--------------|----------------|
+| T1 | Add failing dispatch tests for default env restriction and adapter allowlisted/env config behavior | None | A |
+| T2 | Add failing dispatch tests for timeout and stdout/stderr truncation | None | A |
+| T3 | Implement adapter config parsing and safe env builder | T1 | B |
+| T4 | Implement timeout/log bounds and summary fields | T2 | B |
+| T5 | Update docs/evidence and run full verification gates | T3, T4 | C |
+
+### Parallel groups
+
+- **Group A**: tests can be written independently but should run and fail before code changes.
+- **Group B**: implementation touches the same dispatch module; keep it in one worktree/session to avoid merge conflicts.
+- **Group C**: docs/evidence and final verification after code is green.
+
+### Dependencies
+
+- T3/T4 depend on red tests proving the current unsafe behavior.
+- Receipt/evidence discovery should continue to use safe paths and should not infer stale files.
+
+### Delegation notes
+
+- This slice is small enough for Hermes direct TDD implementation.
+- If delegated later, the worker must touch only files listed above unless it stops and proposes an amendment.
+
+## Implementation Architecture Coverage
+
+- Strengthens: runtime boundary, adapter authority, evidence/log containment, and security posture before any runtime beta lane.
+- Audit envelope: dispatch summary should record adapter ID, run ID, env mode/key names, timeout/log limits, timeout signal/status, log paths, receipt/evidence paths, and verification results without secret values.
+- Evaluation envelope: tests prove default secret exclusion, allowlisted and explicit adapter env values, controlled timeout failure, bounded log files, and truncation markers.
+- Feedback routing: adapter trust, secret redaction, worktree isolation, receipt schema validation, and docs-wide trust boundaries become follow-up plans if not included here.
+- Boundary: dispatch remains local adapter glue; bounded structural hardening is not semantic correctness, runtime production support, or compliance certification.
+
+## Acceptance criteria
+
+- [x] Secret-like parent env vars such as `SECRET_TOKEN` are not passed to adapters by default. Evidence: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`.
+- [x] Adapter config allowlists pass only named parent env keys, and adapter-provided env values are passed explicitly. Evidence: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`.
+- [x] Dispatch summary reports a restricted environment and env key names only, never env values. Evidence: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`.
+- [x] An explicit unsafe local full-env override exists only if clearly named, warns in output, and remains blocked or clearly unsafe in CI-sensitive contexts. Evidence: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`.
+- [x] Dispatch enforces adapter timeout and reports timeout as controlled adapter failure. Evidence: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`.
+- [x] Stdout/stderr log files are bounded by configured/default byte limits and include clear truncation markers when shortened. Evidence: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`.
+- [x] Receipt/evidence path discovery remains safe and works when reported paths appear within retained output. Evidence: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`.
+- [x] Focused dispatch tests, `npm test`, `npm run build`, `./verify.sh --strict`, plan validation, and `git diff --check` pass or blockers are reported honestly. Evidence: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`.
+
+## Verification steps
+
+1. Run focused failing tests before implementation: `npm test -- tests/cli-dispatch.test.ts --run` and confirm new cases fail for the expected missing behavior.
+2. After implementation, run `npm test -- tests/cli-dispatch.test.ts --run` and confirm the dispatch suite passes.
+3. Run `git diff --check`.
+4. Run `npm test`.
+5. Run `npm run build`.
+6. Run `./verify.sh --strict`.
+7. Run `npm run osc -- plan validate .osc/plans/active/139-dispatch-env-timeout-log-bounds.md --strict`.
+8. Run `npm run osc -- verify --evidence-chain --plan 139-dispatch-env-timeout-log-bounds --strict` if the plan/evidence note chain is ready; otherwise record why it is not applicable before PR.
+
+## Open questions
+
+- Should the unsafe full-env override be implemented in this first slice or deferred entirely until the adapter trust workflow lands? Current recommendation: implement it only if needed for compatibility, name it `--allow-full-env`, mark it unsafe, and keep default restricted.
+- What default timeout/log limits should be used before a stable adapter registry exists? Current recommendation: conservative defaults that keep tests fast and logs bounded, with adapter config overrides validated as positive integers.

--- a/.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md
+++ b/.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md
@@ -19,20 +19,20 @@ Implemented the first P0 dispatch hardening slice from the 2026-06-02 blueprint 
 - Meta-plan validation for `138-blueprint-security-adoption-program` — PASS, `0 issues found`.
 - `npm run osc -- plan validate .osc/plans/active/139-dispatch-env-timeout-log-bounds.md --strict` — PASS before close, `0 issues found`.
 - RED: `npm test -- tests/cli-dispatch.test.ts --run` — FAIL as expected before implementation: 5 new dispatch hardening tests failed for missing env summary/restriction, unsafe override support, timeout handling, log truncation, and wildcard env refusal.
-- GREEN focused: `npm test -- tests/cli-dispatch.test.ts --run` — PASS, 18 dispatch tests including SIGTERM-ignoring timeout, CI full-env refusal, env config validation/no-value-leakage, and resource-ceiling regressions.
+- GREEN focused: `npm test -- tests/cli-dispatch.test.ts --run` — PASS, 19 dispatch tests including SIGTERM-ignoring timeout, CI full-env refusal, env config validation/no-value-leakage, resource-ceiling regressions, and successful noisy adapters above retained-log limits but below the process hard cap.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `git diff --check` — PASS.
 - `npm run osc -- close 139-dispatch-env-timeout-log-bounds --message "hardened dispatch env timeout and log bounds"` — PASS, moved plan to `done/` and stamped `MISSION.md` changelog.
 - `npm run osc -- plan validate .osc/plans/done/139-dispatch-env-timeout-log-bounds.md --strict` — PASS, `0 issues found`.
 - `./verify.sh --strict` — PASS, `10 pass, 0 fail, 0 warn`.
 - `npm run osc -- verify --evidence-chain --plan 139-dispatch-env-timeout-log-bounds --strict` — PASS, `21 intact, 0 broken, 0 missing, 0 unverifiable`.
-- `npm test` — PASS, 55 files / 578 tests.
+- `npm test` — PASS, 55 files / 579 tests.
 - Independent pre-commit re-review — PASS; no blocking security concerns or logic errors after adding `SIGKILL`, env validation, CI full-env refusal, and policy maxima. Non-blocking follow-up noted: process-tree cleanup and marker-inclusive byte caps can be considered in later hardening.
 - `npm run osc -- verify` — PASS with 7 pre-existing repository warnings unrelated to this slice; no warnings for plan 139 or this evidence note.
 
 ## Outcome
 
-`osc dispatch` now uses a restricted environment by default, reports environment key names without values, supports `--allow-full-env` only as an explicit unsafe local override with a warning and CI guard, validates adapter env names and control characters before spawn, refuses wildcard env allowlists without the unsafe override, enforces adapter timeout with `SIGKILL`, caps adapter-configured timeout/log limits, times out sleeping or SIGTERM-ignoring adapters, and writes bounded stdout/stderr logs with clear truncation markers. Receipt/evidence discovery remains path-contained and uses retained stdout only.
+`osc dispatch` now uses a restricted environment by default, reports environment key names without values, supports `--allow-full-env` only as an explicit unsafe local override with a warning and CI guard, validates adapter env names and control characters before spawn, refuses wildcard env allowlists without the unsafe override, enforces adapter timeout with `SIGKILL`, caps adapter-configured timeout/log limits, lets successful adapters exceed retained-log limits below the process hard cap, times out sleeping or SIGTERM-ignoring adapters, and writes bounded stdout/stderr logs with clear truncation markers. Receipt/evidence discovery remains path-contained and uses retained stdout only.
 
 ## Follow-up
 

--- a/.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md
+++ b/.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md
@@ -1,0 +1,48 @@
+# Release / Evidence Note: 139-dispatch-env-timeout-log-bounds
+
+## Summary
+
+Implemented the first P0 dispatch hardening slice from the 2026-06-02 blueprint package: `osc dispatch` no longer passes the full parent environment by default, adapter configs can provide an explicit env allowlist and literal adapter env values, dispatch summaries list env keys only, adapter env config is validated before spawn, adapters run with hard timeout/kill behavior, and stdout/stderr logs are bounded with truncation markers and policy maxima.
+
+## Traceability
+
+- Blueprint input: ignored research package at `.osc/research/2026-06-02-review-blueprint-ingest/open-scaffold-review-blueprints/`.
+- Blueprint IDs: `OSB-003` / `SEC-01` and `OSB-004` / `SEC-02`.
+- Program plan slug: `138-blueprint-security-adoption-program`.
+- Slice plan: `.osc/plans/done/139-dispatch-env-timeout-log-bounds.md`.
+- Branch: `security/dispatch-env-timeout-logs`.
+- PR: not opened in this local slice yet.
+
+## Verification
+
+- `./verify.sh --quick --quiet` — PASS before source changes.
+- Meta-plan validation for `138-blueprint-security-adoption-program` — PASS, `0 issues found`.
+- `npm run osc -- plan validate .osc/plans/active/139-dispatch-env-timeout-log-bounds.md --strict` — PASS before close, `0 issues found`.
+- RED: `npm test -- tests/cli-dispatch.test.ts --run` — FAIL as expected before implementation: 5 new dispatch hardening tests failed for missing env summary/restriction, unsafe override support, timeout handling, log truncation, and wildcard env refusal.
+- GREEN focused: `npm test -- tests/cli-dispatch.test.ts --run` — PASS, 18 dispatch tests including SIGTERM-ignoring timeout, CI full-env refusal, env config validation/no-value-leakage, and resource-ceiling regressions.
+- `npm run build` — PASS, core and runtime-omx TypeScript builds.
+- `git diff --check` — PASS.
+- `npm run osc -- close 139-dispatch-env-timeout-log-bounds --message "hardened dispatch env timeout and log bounds"` — PASS, moved plan to `done/` and stamped `MISSION.md` changelog.
+- `npm run osc -- plan validate .osc/plans/done/139-dispatch-env-timeout-log-bounds.md --strict` — PASS, `0 issues found`.
+- `./verify.sh --strict` — PASS, `10 pass, 0 fail, 0 warn`.
+- `npm run osc -- verify --evidence-chain --plan 139-dispatch-env-timeout-log-bounds --strict` — PASS, `21 intact, 0 broken, 0 missing, 0 unverifiable`.
+- `npm test` — PASS, 55 files / 578 tests.
+- Independent pre-commit re-review — PASS; no blocking security concerns or logic errors after adding `SIGKILL`, env validation, CI full-env refusal, and policy maxima. Non-blocking follow-up noted: process-tree cleanup and marker-inclusive byte caps can be considered in later hardening.
+- `npm run osc -- verify` — PASS with 7 pre-existing repository warnings unrelated to this slice; no warnings for plan 139 or this evidence note.
+
+## Outcome
+
+`osc dispatch` now uses a restricted environment by default, reports environment key names without values, supports `--allow-full-env` only as an explicit unsafe local override with a warning and CI guard, validates adapter env names and control characters before spawn, refuses wildcard env allowlists without the unsafe override, enforces adapter timeout with `SIGKILL`, caps adapter-configured timeout/log limits, times out sleeping or SIGTERM-ignoring adapters, and writes bounded stdout/stderr logs with clear truncation markers. Receipt/evidence discovery remains path-contained and uses retained stdout only.
+
+## Follow-up
+
+- Next security slice: `OSB-005` / `SEC-03` adapter trust workflow (`osc adapter check/trust/list`, gitignored trust state, config digest invalidation).
+- Later security/docs slice: `OSB-006` / `SEC-04` redaction and doctor checks plus `OSB-014` trust boundaries documentation.
+- Runtime beta (`OSB-009`) remains blocked until adapter trust, redaction, worktree/protected-branch enforcement, and schema validation hardening land.
+
+## Boundary statement
+
+This is local structural hardening for dispatch adapter invocation. It does not spawn a real runtime by default, does not grant network/credential/commit/push/PR/merge/publish/release/deploy authority, does not certify adapter correctness, and does not claim compliance or semantic task correctness.
+
+approval.status: weak_approved
+approval.rationale: Local structural acceptance criteria for plan 139 passed in focused tests, plan validation, build, `git diff --check`, and strict scaffold verification. Owner approval is still required for push, PR publication if desired, merge, npm publish, GitHub Release, runtime beta claims, or any external side effect.

--- a/.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md
+++ b/.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md
@@ -19,20 +19,20 @@ Implemented the first P0 dispatch hardening slice from the 2026-06-02 blueprint 
 - Meta-plan validation for `138-blueprint-security-adoption-program` — PASS, `0 issues found`.
 - `npm run osc -- plan validate .osc/plans/active/139-dispatch-env-timeout-log-bounds.md --strict` — PASS before close, `0 issues found`.
 - RED: `npm test -- tests/cli-dispatch.test.ts --run` — FAIL as expected before implementation: 5 new dispatch hardening tests failed for missing env summary/restriction, unsafe override support, timeout handling, log truncation, and wildcard env refusal.
-- GREEN focused: `npm test -- tests/cli-dispatch.test.ts --run` — PASS, 20 dispatch tests including SIGTERM-ignoring timeout, CI full-env refusal, env config validation/no-value-leakage, resource-ceiling regressions, successful noisy adapters above retained-log limits but below the process hard cap, and ignored clipped receipt paths.
+- GREEN focused: `npm test -- tests/cli-dispatch.test.ts --run` — PASS, 21 dispatch tests including SIGTERM-ignoring timeout, CI full-env refusal, env config validation/no-value-leakage, resource-ceiling regressions, successful noisy adapters above retained-log limits but below the process hard cap, dual-stream stdout/stderr output within the bounded process cap, and ignored clipped receipt paths.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `git diff --check` — PASS.
 - `npm run osc -- close 139-dispatch-env-timeout-log-bounds --message "hardened dispatch env timeout and log bounds"` — PASS, moved plan to `done/` and stamped `MISSION.md` changelog.
 - `npm run osc -- plan validate .osc/plans/done/139-dispatch-env-timeout-log-bounds.md --strict` — PASS, `0 issues found`.
 - `./verify.sh --strict` — PASS, `10 pass, 0 fail, 0 warn`.
 - `npm run osc -- verify --evidence-chain --plan 139-dispatch-env-timeout-log-bounds --strict` — PASS, `21 intact, 0 broken, 0 missing, 0 unverifiable`.
-- `npm test` — PASS, 55 files / 580 tests.
+- `npm test` — PASS, 55 files / 581 tests.
 - Independent pre-commit re-review — PASS; no blocking security concerns or logic errors after adding `SIGKILL`, env validation, CI full-env refusal, and policy maxima. Non-blocking follow-up noted: process-tree cleanup and marker-inclusive byte caps can be considered in later hardening.
 - `npm run osc -- verify` — PASS with 7 pre-existing repository warnings unrelated to this slice; no warnings for plan 139 or this evidence note.
 
 ## Outcome
 
-`osc dispatch` now uses a restricted environment by default, reports environment key names without values, supports `--allow-full-env` only as an explicit unsafe local override with a warning and CI guard, validates adapter env names and control characters before spawn, refuses wildcard env allowlists without the unsafe override, enforces adapter timeout with `SIGKILL`, caps adapter-configured timeout/log limits, lets successful adapters exceed retained-log limits below the process hard cap, times out sleeping or SIGTERM-ignoring adapters, and writes bounded stdout/stderr logs with clear truncation markers. Receipt/evidence discovery remains path-contained and only uses complete retained stdout lines so clipped paths do not become broken output references.
+`osc dispatch` now uses a restricted environment by default, reports environment key names without values, supports `--allow-full-env` only as an explicit unsafe local override with a warning and CI guard, validates adapter env names and control characters before spawn, refuses wildcard env allowlists without the unsafe override, enforces adapter timeout with `SIGKILL`, caps adapter-configured timeout/log limits, lets successful adapters exceed retained-log limits below the bounded combined-stream process cap, times out sleeping or SIGTERM-ignoring adapters, and writes bounded stdout/stderr logs with clear truncation markers. Receipt/evidence discovery remains path-contained and only uses complete retained stdout lines so clipped paths do not become broken output references.
 
 ## Follow-up
 

--- a/.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md
+++ b/.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md
@@ -19,20 +19,20 @@ Implemented the first P0 dispatch hardening slice from the 2026-06-02 blueprint 
 - Meta-plan validation for `138-blueprint-security-adoption-program` — PASS, `0 issues found`.
 - `npm run osc -- plan validate .osc/plans/active/139-dispatch-env-timeout-log-bounds.md --strict` — PASS before close, `0 issues found`.
 - RED: `npm test -- tests/cli-dispatch.test.ts --run` — FAIL as expected before implementation: 5 new dispatch hardening tests failed for missing env summary/restriction, unsafe override support, timeout handling, log truncation, and wildcard env refusal.
-- GREEN focused: `npm test -- tests/cli-dispatch.test.ts --run` — PASS, 19 dispatch tests including SIGTERM-ignoring timeout, CI full-env refusal, env config validation/no-value-leakage, resource-ceiling regressions, and successful noisy adapters above retained-log limits but below the process hard cap.
+- GREEN focused: `npm test -- tests/cli-dispatch.test.ts --run` — PASS, 20 dispatch tests including SIGTERM-ignoring timeout, CI full-env refusal, env config validation/no-value-leakage, resource-ceiling regressions, successful noisy adapters above retained-log limits but below the process hard cap, and ignored clipped receipt paths.
 - `npm run build` — PASS, core and runtime-omx TypeScript builds.
 - `git diff --check` — PASS.
 - `npm run osc -- close 139-dispatch-env-timeout-log-bounds --message "hardened dispatch env timeout and log bounds"` — PASS, moved plan to `done/` and stamped `MISSION.md` changelog.
 - `npm run osc -- plan validate .osc/plans/done/139-dispatch-env-timeout-log-bounds.md --strict` — PASS, `0 issues found`.
 - `./verify.sh --strict` — PASS, `10 pass, 0 fail, 0 warn`.
 - `npm run osc -- verify --evidence-chain --plan 139-dispatch-env-timeout-log-bounds --strict` — PASS, `21 intact, 0 broken, 0 missing, 0 unverifiable`.
-- `npm test` — PASS, 55 files / 579 tests.
+- `npm test` — PASS, 55 files / 580 tests.
 - Independent pre-commit re-review — PASS; no blocking security concerns or logic errors after adding `SIGKILL`, env validation, CI full-env refusal, and policy maxima. Non-blocking follow-up noted: process-tree cleanup and marker-inclusive byte caps can be considered in later hardening.
 - `npm run osc -- verify` — PASS with 7 pre-existing repository warnings unrelated to this slice; no warnings for plan 139 or this evidence note.
 
 ## Outcome
 
-`osc dispatch` now uses a restricted environment by default, reports environment key names without values, supports `--allow-full-env` only as an explicit unsafe local override with a warning and CI guard, validates adapter env names and control characters before spawn, refuses wildcard env allowlists without the unsafe override, enforces adapter timeout with `SIGKILL`, caps adapter-configured timeout/log limits, lets successful adapters exceed retained-log limits below the process hard cap, times out sleeping or SIGTERM-ignoring adapters, and writes bounded stdout/stderr logs with clear truncation markers. Receipt/evidence discovery remains path-contained and uses retained stdout only.
+`osc dispatch` now uses a restricted environment by default, reports environment key names without values, supports `--allow-full-env` only as an explicit unsafe local override with a warning and CI guard, validates adapter env names and control characters before spawn, refuses wildcard env allowlists without the unsafe override, enforces adapter timeout with `SIGKILL`, caps adapter-configured timeout/log limits, lets successful adapters exceed retained-log limits below the process hard cap, times out sleeping or SIGTERM-ignoring adapters, and writes bounded stdout/stderr logs with clear truncation markers. Receipt/evidence discovery remains path-contained and only uses complete retained stdout lines so clipped paths do not become broken output references.
 
 ## Follow-up
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-02: closed 139-dispatch-env-timeout-log-bounds — hardened dispatch env timeout and log bounds
 - 2026-06-01: closed 137-decouple-2000m-benchmark-boundary — Close decoupling repair plan after PR #165 merge
 - 2026-06-01: closed 136-compact-evidence-mode — Add compact evidence mode for run and evolution-loop summaries
 - 2026-06-01: closed 135-osc-eval-external-scorer-adapter — Close 135 after eval external scorer import

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,7 @@ For root `osc dispatch` adapter glue:
 - `--allow-full-env` is an unsafe local override and warns before handing the full parent environment to an adapter;
 - CI refuses `--allow-full-env` unless `OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI=1` is set;
 - adapter runs have timeout and bounded stdout/stderr log capture, with a hard kill at timeout and truncation markers written under `.osc/runs/<run_id>/dispatch/`;
+- process buffering remains bounded by a combined policy cap while staying independent from smaller retained-log limits;
 - adapter-configured timeouts and log limits are capped by policy so project-local configs cannot make them unbounded;
 - receipt/evidence discovery remains path-contained, only uses complete retained output lines, and should be treated as structural handoff proof, not task correctness or compliance proof.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,7 +55,7 @@ For root `osc dispatch` adapter glue:
 - CI refuses `--allow-full-env` unless `OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI=1` is set;
 - adapter runs have timeout and bounded stdout/stderr log capture, with a hard kill at timeout and truncation markers written under `.osc/runs/<run_id>/dispatch/`;
 - adapter-configured timeouts and log limits are capped by policy so project-local configs cannot make them unbounded;
-- receipt/evidence discovery remains path-contained and should be treated as structural handoff proof, not task correctness or compliance proof.
+- receipt/evidence discovery remains path-contained, only uses complete retained output lines, and should be treated as structural handoff proof, not task correctness or compliance proof.
 
 For `@open-scaffold/runtime-omx`:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,17 @@ When the optional dependency is unavailable, Open Scaffold should fail only the 
 
 Open Scaffold core does not spawn agents by default. Runtime packages and adapters must keep launch authority explicit and auditable.
 
+For root `osc dispatch` adapter glue:
+
+- adapter subprocesses receive a restricted environment by default, built from adapter `envAllowlist` plus explicit adapter `env` values;
+- adapter env names are validated and adapter-provided env values with unsupported control characters are rejected before subprocess spawn;
+- dispatch summaries report environment key names only, never values;
+- `--allow-full-env` is an unsafe local override and warns before handing the full parent environment to an adapter;
+- CI refuses `--allow-full-env` unless `OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI=1` is set;
+- adapter runs have timeout and bounded stdout/stderr log capture, with a hard kill at timeout and truncation markers written under `.osc/runs/<run_id>/dispatch/`;
+- adapter-configured timeouts and log limits are capped by policy so project-local configs cannot make them unbounded;
+- receipt/evidence discovery remains path-contained and should be treated as structural handoff proof, not task correctness or compliance proof.
+
 For `@open-scaffold/runtime-omx`:
 
 - default behavior validates a run packet and writes receipt/evidence artifacts;

--- a/docs/RUNTIME_ADOPTION_WORKFLOW.md
+++ b/docs/RUNTIME_ADOPTION_WORKFLOW.md
@@ -202,7 +202,14 @@ osc dispatch .osc/runs/RUN_ID/run.json --adapter omx
 {
   "schemaVersion": "open-scaffold.adapter.v1",
   "id": "omx",
-  "command": ["open-scaffold-runtime-omx"]
+  "command": ["open-scaffold-runtime-omx"],
+  "envAllowlist": ["PATH"],
+  "env": {
+    "OPEN_SCAFFOLD_ADAPTER": "omx"
+  },
+  "timeoutMs": 600000,
+  "maxStdoutBytes": 2000000,
+  "maxStderrBytes": 2000000
 }
 ```
 
@@ -210,12 +217,17 @@ The command:
 
 - requires an existing `open-scaffold.run.v1` packet under `.osc/runs/`;
 - invokes only the explicitly selected local adapter command;
-- refuses missing, unknown, unsafe, URL-based, shell-wrapper, platform-shim, network-fetching, or auto-installing adapter commands by default;
-- captures adapter stdout/stderr logs under `.osc/runs/RUN_ID/dispatch/`;
-- reads adapter-reported receipt/evidence paths only when they remain under the run directory;
-- prints the next verification and human-approval step.
+- refuses missing, unknown, unsafe, URL-based, shell-wrapper, platform-shim, network-fetching, auto-installing, or wildcard-env adapter commands by default;
+- passes a restricted adapter environment by default from adapter `envAllowlist` plus explicit adapter `env` values;
+- validates adapter env key names and rejects adapter-provided env values with unsupported control characters before spawning;
+- supports `--allow-full-env` only as an unsafe local override and reports a warning without printing environment values;
+- refuses `--allow-full-env` in CI unless `OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI=1` is set;
+- enforces adapter timeout with a hard kill plus bounded stdout/stderr logs under `.osc/runs/RUN_ID/dispatch/` with truncation markers;
+- caps adapter-configured timeouts at 30 minutes and stdout/stderr byte limits at 10 MB each;
+- reads adapter-reported receipt/evidence paths only when they remain under the run directory and appear in retained output;
+- prints environment key names, timeout/log-bound facts, and the next verification and human-approval step.
 
-`osc dispatch` is adapter invocation glue, not a hidden provider runtime. Core does not import provider SDKs, auto-install adapters, own credentials, supervise tmux/processes, or grant commit/push/PR/merge/publish authority. Adapter packages own their launch policy and must return receipts/evidence that the operator can inspect.
+`osc dispatch` is adapter invocation glue, not a hidden provider runtime. Core does not import provider SDKs, auto-install adapters, own credentials, supervise tmux/processes, or grant commit/push/PR/merge/publish authority. Adapter packages own their launch policy and must return receipts/evidence that the operator can inspect. Dispatch hardening is structural safety posture; it does not prove runtime correctness or compliance.
 
 ### Stage 4 — `osc work --dry-run`
 

--- a/docs/RUNTIME_ADOPTION_WORKFLOW.md
+++ b/docs/RUNTIME_ADOPTION_WORKFLOW.md
@@ -223,6 +223,7 @@ The command:
 - supports `--allow-full-env` only as an unsafe local override and reports a warning without printing environment values;
 - refuses `--allow-full-env` in CI unless `OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI=1` is set;
 - enforces adapter timeout with a hard kill plus bounded stdout/stderr logs under `.osc/runs/RUN_ID/dispatch/` with truncation markers;
+- keeps adapter process buffering bounded by the combined policy cap while decoupling it from the smaller retained-log limits;
 - caps adapter-configured timeouts at 30 minutes and stdout/stderr byte limits at 10 MB each;
 - reads adapter-reported receipt/evidence paths only when they remain under the run directory and appear on complete retained output lines;
 - prints environment key names, timeout/log-bound facts, and the next verification and human-approval step.

--- a/docs/RUNTIME_ADOPTION_WORKFLOW.md
+++ b/docs/RUNTIME_ADOPTION_WORKFLOW.md
@@ -224,7 +224,7 @@ The command:
 - refuses `--allow-full-env` in CI unless `OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI=1` is set;
 - enforces adapter timeout with a hard kill plus bounded stdout/stderr logs under `.osc/runs/RUN_ID/dispatch/` with truncation markers;
 - caps adapter-configured timeouts at 30 minutes and stdout/stderr byte limits at 10 MB each;
-- reads adapter-reported receipt/evidence paths only when they remain under the run directory and appear in retained output;
+- reads adapter-reported receipt/evidence paths only when they remain under the run directory and appear on complete retained output lines;
 - prints environment key names, timeout/log-bound facts, and the next verification and human-approval step.
 
 `osc dispatch` is adapter invocation glue, not a hidden provider runtime. Core does not import provider SDKs, auto-install adapters, own credentials, supervise tmux/processes, or grant commit/push/PR/merge/publish authority. Adapter packages own their launch policy and must return receipts/evidence that the operator can inspect. Dispatch hardening is structural safety posture; it does not prove runtime correctness or compliance.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1472,9 +1472,13 @@ function startCommand(args: string[]): void {
 }
 
 function printDispatchUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
-  printUsage(`Usage: osc dispatch <run-json> --adapter <adapter-id>
+  printUsage(`Usage: osc dispatch <run-json> --adapter <adapter-id> [--allow-full-env]
 
-Invokes an explicit trusted adapter for an existing run packet, captures adapter stdout/stderr logs, and prints receipt/evidence paths. Open Scaffold core does not auto-install adapters or grant commit/push/merge/publish authority.`, stream);
+Invokes an explicit trusted adapter for an existing run packet, captures bounded adapter stdout/stderr logs, and prints receipt/evidence paths. Open Scaffold core restricts adapter environment variables by default, does not auto-install adapters, and does not grant commit/push/merge/publish authority.
+
+Options:
+  --adapter <adapter-id>  Project-local adapter config to invoke
+  --allow-full-env       UNSAFE local override: pass the full parent environment to the adapter`, stream);
 }
 
 function takeDispatchValue(args: string[], index: number, flag: string): string {
@@ -1494,6 +1498,7 @@ function dispatchCommand(args: string[]): void {
   }
   const runJson = requireArg(args, 'run-json');
   let adapterId: string | undefined;
+  let allowFullEnv = false;
   const rest = args.slice(1);
   for (let i = 0; i < rest.length; i += 1) {
     const flag = rest[i];
@@ -1501,6 +1506,9 @@ function dispatchCommand(args: string[]): void {
       case '--adapter':
         adapterId = takeDispatchValue(rest, i, flag);
         i += 1;
+        break;
+      case '--allow-full-env':
+        allowFullEnv = true;
         break;
       default:
         console.error(`Unknown option for dispatch: ${flag}`);
@@ -1514,7 +1522,7 @@ function dispatchCommand(args: string[]): void {
     process.exit(2);
   }
   try {
-    const result = runDispatch(runJson, { adapterId }, process.cwd());
+    const result = runDispatch(runJson, { adapterId, allowFullEnv }, process.cwd());
     const root = findScaffoldRoot(dirname(result.runPacketPath)) ?? process.cwd();
     process.stdout.write(formatDispatchSummary(result, root));
     if (result.exitStatus !== 0) process.exit(1);

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -358,7 +358,7 @@ export function runDispatch(runPacketArg: string, options: DispatchOptions, star
     env: adapterEnv.env,
     timeout: adapter.timeoutMs,
     killSignal: 'SIGKILL',
-    maxBuffer: Math.max(adapter.maxStdoutBytes, adapter.maxStderrBytes) + maxAdapterLogSlackBytes,
+    maxBuffer: maxAdapterLogBytes + maxAdapterLogSlackBytes,
   });
   const rawStdout = String(result.stdout ?? '');
   const stderrParts = [String(result.stderr ?? ''), processErrorDetails(result.error)].filter((part): part is string => Boolean(part));

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -9,10 +9,16 @@ interface AdapterConfigFile {
   schemaVersion?: unknown;
   id?: unknown;
   command?: unknown;
+  envAllowlist?: unknown;
+  env?: unknown;
+  timeoutMs?: unknown;
+  maxStdoutBytes?: unknown;
+  maxStderrBytes?: unknown;
 }
 
 export interface DispatchOptions {
   adapterId: string;
+  allowFullEnv?: boolean;
 }
 
 export interface DispatchResult {
@@ -25,12 +31,47 @@ export interface DispatchResult {
   stderrLogPath: string;
   exitStatus: number | null;
   signal: string | null;
+  envMode: 'restricted' | 'full-unsafe';
+  envKeys: string[];
+  unsafeEnvWarning: string | null;
+  timeoutMs: number;
+  timedOut: boolean;
+  maxStdoutBytes: number;
+  maxStderrBytes: number;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
 }
 
 interface AdapterDefinition {
   id: string;
   command: string[];
+  envAllowlist: string[];
+  env: Record<string, string>;
+  timeoutMs: number;
+  maxStdoutBytes: number;
+  maxStderrBytes: number;
 }
+
+interface AdapterEnvBuildResult {
+  env: NodeJS.ProcessEnv;
+  mode: 'restricted' | 'full-unsafe';
+  keys: string[];
+  warning: string | null;
+}
+
+interface TruncatedLog {
+  content: string;
+  truncated: boolean;
+}
+
+const defaultAdapterEnvAllowlist = ['PATH'];
+const defaultAdapterTimeoutMs = 10 * 60 * 1000;
+const defaultAdapterMaxLogBytes = 2_000_000;
+const maxAdapterTimeoutMs = 30 * 60 * 1000;
+const maxAdapterLogBytes = 10_000_000;
+const maxAdapterLogSlackBytes = 64 * 1024;
+const safeEnvNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const envControlCharPattern = /[\u0000-\u001F\u007F]/;
 
 const forbiddenAdapterExecutables = new Set([
   'npx',
@@ -101,6 +142,53 @@ function adapterConfigPath(root: string, adapterId: string): string {
   return join(root, '.osc', 'adapters', `${adapterId}.json`);
 }
 
+function readOptionalStringArray(value: unknown, field: string, adapterId: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string' || !entry.trim())) {
+    throw new DispatchUsageError(`Adapter ${adapterId} ${field} must be an array of non-empty strings.`);
+  }
+  const entries = value.map((entry) => entry.trim());
+  for (const entry of entries) {
+    if (field === 'envAllowlist' && entry === '*') continue;
+    if (field === 'envAllowlist' && !safeEnvNamePattern.test(entry)) {
+      throw new DispatchUsageError(`Adapter ${adapterId} ${field} contains an invalid environment variable name.`);
+    }
+  }
+  return entries;
+}
+
+function readOptionalStringRecord(value: unknown, field: string, adapterId: string): Record<string, string> {
+  if (value === undefined) return {};
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new DispatchUsageError(`Adapter ${adapterId} ${field} must be an object with string values.`);
+  }
+  const result: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (!key.trim() || typeof entry !== 'string') {
+      throw new DispatchUsageError(`Adapter ${adapterId} ${field} must be an object with string values.`);
+    }
+    if (field === 'env' && !safeEnvNamePattern.test(key)) {
+      throw new DispatchUsageError(`Adapter ${adapterId} ${field} contains an invalid environment variable name.`);
+    }
+    if (field === 'env' && envControlCharPattern.test(entry)) {
+      throw new DispatchUsageError(`Adapter ${adapterId} ${field} contains a value with unsupported control characters.`);
+    }
+    result[key] = entry;
+  }
+  return result;
+}
+
+function readOptionalPositiveInteger(value: unknown, field: string, adapterId: string, fallback: number, maximum: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || typeof value !== 'number' || value <= 0) {
+    throw new DispatchUsageError(`Adapter ${adapterId} ${field} must be a positive integer.`);
+  }
+  if (value > maximum) {
+    throw new DispatchUsageError(`Adapter ${adapterId} ${field} must be at most ${maximum}.`);
+  }
+  return value;
+}
+
 function loadProjectAdapter(root: string, adapterId: string): AdapterDefinition | null {
   const path = adapterConfigPath(root, adapterId);
   if (!existsSync(path)) return null;
@@ -112,7 +200,15 @@ function loadProjectAdapter(root: string, adapterId: string): AdapterDefinition 
   if (!Array.isArray(parsed.command) || parsed.command.length === 0 || parsed.command.some((part) => typeof part !== 'string' || !part.trim())) {
     throw new DispatchUsageError(`Adapter ${adapterId} command must be a non-empty string array.`);
   }
-  return { id: adapterId, command: parsed.command };
+  return {
+    id: adapterId,
+    command: parsed.command,
+    envAllowlist: readOptionalStringArray(parsed.envAllowlist, 'envAllowlist', adapterId),
+    env: readOptionalStringRecord(parsed.env, 'env', adapterId),
+    timeoutMs: readOptionalPositiveInteger(parsed.timeoutMs, 'timeoutMs', adapterId, defaultAdapterTimeoutMs, maxAdapterTimeoutMs),
+    maxStdoutBytes: readOptionalPositiveInteger(parsed.maxStdoutBytes, 'maxStdoutBytes', adapterId, defaultAdapterMaxLogBytes, maxAdapterLogBytes),
+    maxStderrBytes: readOptionalPositiveInteger(parsed.maxStderrBytes, 'maxStderrBytes', adapterId, defaultAdapterMaxLogBytes, maxAdapterLogBytes),
+  };
 }
 
 function resolveAdapter(root: string, adapterId: string): AdapterDefinition {
@@ -199,26 +295,82 @@ function writeLogFile(dispatchDir: string, adapterId: string, kind: 'stdout' | '
   return path;
 }
 
+function buildAdapterEnv(adapter: AdapterDefinition, parentEnv: NodeJS.ProcessEnv, allowFullEnv = false): AdapterEnvBuildResult {
+  if (allowFullEnv) {
+    if (parentEnv.CI && parentEnv.OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI !== '1') {
+      throw new DispatchUsageError('Refusing --allow-full-env in CI unless OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI=1 is set.');
+    }
+    const env = { ...parentEnv, ...adapter.env };
+    return {
+      env,
+      mode: 'full-unsafe',
+      keys: Object.keys(env).sort(),
+      warning: 'Warning: --allow-full-env passed the full parent environment to the adapter.',
+    };
+  }
+
+  if (adapter.envAllowlist.includes('*')) {
+    throw new DispatchUsageError(`Adapter ${adapter.id} uses wildcard envAllowlist; use --allow-full-env for unsafe local override.`);
+  }
+
+  const env: NodeJS.ProcessEnv = {};
+  const allowlist = new Set([...defaultAdapterEnvAllowlist, ...adapter.envAllowlist]);
+  for (const key of allowlist) {
+    const value = parentEnv[key];
+    if (value !== undefined) env[key] = value;
+  }
+  for (const [key, value] of Object.entries(adapter.env)) {
+    env[key] = value;
+  }
+  return { env, mode: 'restricted', keys: Object.keys(env).sort(), warning: null };
+}
+
+function truncateLog(content: string, maxBytes: number): TruncatedLog {
+  const data = Buffer.from(content, 'utf8');
+  if (data.length <= maxBytes) return { content, truncated: false };
+  const marker = `\n[open-scaffold: log truncated to ${maxBytes} bytes from ${data.length} bytes]\n`;
+  return { content: `${data.subarray(0, maxBytes).toString('utf8')}${marker}`, truncated: true };
+}
+
+function processErrorDetails(error: Error | undefined): string | null {
+  if (!error) return null;
+  const coded = error as Error & { code?: unknown };
+  const code = typeof coded.code === 'string' ? `${coded.code}: ` : '';
+  return `[open-scaffold: adapter process error] ${code}${error.message}`;
+}
+
+function isTimeoutError(error: Error | undefined): boolean {
+  const coded = error as (Error & { code?: unknown }) | undefined;
+  return coded?.code === 'ETIMEDOUT';
+}
+
 export function runDispatch(runPacketArg: string, options: DispatchOptions, start = process.cwd()): DispatchResult {
   if (!runPacketArg) throw new DispatchUsageError('Missing required argument: run-json');
   const run = resolveRunPacket(start, runPacketArg);
   assertNoSymlinksUnder(run.runDir, 'Run directory must not contain symlinks before adapter dispatch.');
   const adapter = resolveAdapter(run.root, options.adapterId);
+  const adapterEnv = buildAdapterEnv(adapter, process.env, options.allowFullEnv);
   prepareDispatchDir(run.runDir);
 
   const result = spawnSync(adapter.command[0]!, [...adapter.command.slice(1), run.runPacketPath], {
     cwd: run.root,
     encoding: 'utf8',
-    env: process.env,
+    env: adapterEnv.env,
+    timeout: adapter.timeoutMs,
+    killSignal: 'SIGKILL',
+    maxBuffer: Math.max(adapter.maxStdoutBytes, adapter.maxStderrBytes) + maxAdapterLogSlackBytes,
   });
-  const stdout = String(result.stdout ?? '');
-  const stderr = result.error ? String(result.error.message) : String(result.stderr ?? '');
+  const rawStdout = String(result.stdout ?? '');
+  const stderrParts = [String(result.stderr ?? ''), processErrorDetails(result.error)].filter((part): part is string => Boolean(part));
+  const rawStderr = stderrParts.join(stderrParts.length > 1 ? '\n' : '');
+  const stdout = truncateLog(rawStdout, adapter.maxStdoutBytes);
+  const stderr = truncateLog(rawStderr, adapter.maxStderrBytes);
   const finalDispatchDir = prepareDispatchDir(run.runDir);
-  const stdoutLogPath = writeLogFile(finalDispatchDir, adapter.id, 'stdout', stdout);
-  const stderrLogPath = writeLogFile(finalDispatchDir, adapter.id, 'stderr', stderr);
+  const stdoutLogPath = writeLogFile(finalDispatchDir, adapter.id, 'stdout', stdout.content);
+  const stderrLogPath = writeLogFile(finalDispatchDir, adapter.id, 'stderr', stderr.content);
 
-  const receiptPath = discoverReceipt(run.root, run.runDir, stdout);
-  const evidencePaths = discoverEvidence(run.root, run.runDir, stdout);
+  const receiptPath = discoverReceipt(run.root, run.runDir, stdout.content);
+  const evidencePaths = discoverEvidence(run.root, run.runDir, stdout.content);
 
   return {
     adapterId: adapter.id,
@@ -230,16 +382,35 @@ export function runDispatch(runPacketArg: string, options: DispatchOptions, star
     stderrLogPath,
     exitStatus: result.status,
     signal: result.signal,
+    envMode: adapterEnv.mode,
+    envKeys: adapterEnv.keys,
+    unsafeEnvWarning: adapterEnv.warning,
+    timeoutMs: adapter.timeoutMs,
+    timedOut: isTimeoutError(result.error),
+    maxStdoutBytes: adapter.maxStdoutBytes,
+    maxStderrBytes: adapter.maxStderrBytes,
+    stdoutTruncated: stdout.truncated,
+    stderrTruncated: stderr.truncated,
   };
 }
 
 export function formatDispatchSummary(result: DispatchResult, root: string): string {
   const evidence = result.evidencePaths.length ? result.evidencePaths.map((path) => `Evidence: ${toRelative(root, path)}`).join('\n') : 'Evidence: (none reported)';
+  const envLabel = result.envMode === 'full-unsafe' ? 'full (unsafe override)' : 'restricted';
   return [
     'Open Scaffold dispatch complete',
     `Adapter: ${result.adapterId}`,
     `Run ID: ${result.runId}`,
     `Run packet: ${toRelative(root, result.runPacketPath)}`,
+    `Environment: ${envLabel}`,
+    `Environment keys: ${result.envKeys.length ? result.envKeys.join(', ') : '(none)'}`,
+    result.unsafeEnvWarning,
+    `Timeout: ${result.timeoutMs} ms`,
+    `Timed out: ${result.timedOut ? 'yes' : 'no'}`,
+    `Stdout limit: ${result.maxStdoutBytes} bytes`,
+    `Stderr limit: ${result.maxStderrBytes} bytes`,
+    `Stdout truncated: ${result.stdoutTruncated ? 'yes' : 'no'}`,
+    `Stderr truncated: ${result.stderrTruncated ? 'yes' : 'no'}`,
     `Dispatch receipt: ${toRelative(root, result.receiptPath) ?? '(none reported)'}`,
     evidence,
     `Stdout log: ${toRelative(root, result.stdoutLogPath)}`,

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -329,7 +329,10 @@ function truncateLog(content: string, maxBytes: number): TruncatedLog {
   const data = Buffer.from(content, 'utf8');
   if (data.length <= maxBytes) return { content, truncated: false };
   const marker = `\n[open-scaffold: log truncated to ${maxBytes} bytes from ${data.length} bytes]\n`;
-  return { content: `${data.subarray(0, maxBytes).toString('utf8')}${marker}`, truncated: true };
+  const retained = data.subarray(0, maxBytes).toString('utf8');
+  const lastNewline = retained.lastIndexOf('\n');
+  const completeLinePrefix = lastNewline >= 0 ? retained.slice(0, lastNewline + 1) : '';
+  return { content: `${completeLinePrefix}${marker}`, truncated: true };
 }
 
 function processErrorDetails(error: Error | undefined): string | null {

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -70,6 +70,7 @@ const defaultAdapterMaxLogBytes = 2_000_000;
 const maxAdapterTimeoutMs = 30 * 60 * 1000;
 const maxAdapterLogBytes = 10_000_000;
 const maxAdapterLogSlackBytes = 64 * 1024;
+const maxAdapterProcessBufferBytes = maxAdapterLogBytes * 2 + maxAdapterLogSlackBytes;
 const safeEnvNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const envControlCharPattern = /[\u0000-\u001F\u007F]/;
 
@@ -361,7 +362,7 @@ export function runDispatch(runPacketArg: string, options: DispatchOptions, star
     env: adapterEnv.env,
     timeout: adapter.timeoutMs,
     killSignal: 'SIGKILL',
-    maxBuffer: maxAdapterLogBytes + maxAdapterLogSlackBytes,
+    maxBuffer: maxAdapterProcessBufferBytes,
   });
   const rawStdout = String(result.stdout ?? '');
   const stderrParts = [String(result.stderr ?? ''), processErrorDetails(result.error)].filter((part): part is string => Boolean(part));

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -104,10 +104,10 @@ console.log('fake adapter evidence written: ' + evidencePath);
   }, null, 2) + '\n');
 }
 
-function writeAdapterConfig(root: string, id: string, command: string[]): void {
+function writeAdapterConfig(root: string, id: string, command: string[], extra: Record<string, unknown> = {}): void {
   const adapterDir = join(root, '.osc/adapters');
   mkdirSync(adapterDir, { recursive: true });
-  writeFileSync(join(adapterDir, `${id}.json`), JSON.stringify({ schemaVersion: 'open-scaffold.adapter.v1', id, command }, null, 2) + '\n');
+  writeFileSync(join(adapterDir, `${id}.json`), JSON.stringify({ schemaVersion: 'open-scaffold.adapter.v1', id, command, ...extra }, null, 2) + '\n');
 }
 
 function fileSnapshot(root: string): string[] {
@@ -276,6 +276,253 @@ console.log('multi adapter evidence written: ' + second);
       expect(result.stdout).toContain('Evidence: .osc/runs/');
       expect(result.stdout).toContain('first-evidence.md');
       expect(result.stdout).toContain('second-evidence.md');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('passes a restricted adapter environment by default and reports env key names only', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'env-check.mjs'), `import { dirname, join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+const runDir = dirname(process.argv[2]);
+const evidencePath = join(runDir, 'env-evidence.json');
+writeFileSync(evidencePath, JSON.stringify({
+  secret: process.env.SECRET_TOKEN ?? null,
+  allowed: process.env.ALLOWED_FROM_PARENT ?? null,
+  explicit: process.env.OPEN_SCAFFOLD_ADAPTER ?? null,
+  pathPresent: Boolean(process.env.PATH)
+}, null, 2) + '\\n');
+console.log('env adapter evidence written: ' + evidencePath);
+`);
+      writeAdapterConfig(root, 'env-check', ['node', '.osc/adapters/env-check.mjs'], {
+        envAllowlist: ['ALLOWED_FROM_PARENT'],
+        env: { OPEN_SCAFFOLD_ADAPTER: 'env-check' }
+      });
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'env-check'], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, SECRET_TOKEN: 'test-secret-token', ALLOWED_FROM_PARENT: 'allowed-value' }
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('Environment: restricted');
+      expect(result.stdout).toContain('Environment keys: ALLOWED_FROM_PARENT, OPEN_SCAFFOLD_ADAPTER, PATH');
+      expect(result.stdout).not.toContain('test-secret-token');
+      expect(result.stdout).not.toContain('allowed-value');
+      const evidence = JSON.parse(readFileSync(join(dirname(runJson), 'env-evidence.json'), 'utf8'));
+      expect(evidence).toMatchObject({ secret: null, allowed: 'allowed-value', explicit: 'env-check', pathPresent: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('allows explicit unsafe full environment only with a warning', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'full-env.mjs'), `import { dirname, join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+const evidencePath = join(dirname(process.argv[2]), 'full-env-evidence.json');
+writeFileSync(evidencePath, JSON.stringify({ secret: process.env.SECRET_TOKEN ?? null }) + '\\n');
+console.log('full env adapter evidence written: ' + evidencePath);
+`);
+      writeAdapterConfig(root, 'full-env', ['node', '.osc/adapters/full-env.mjs']);
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'full-env', '--allow-full-env'], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, SECRET_TOKEN: 'test-secret-token', CI: '' }
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Environment: full (unsafe override)');
+      expect(result.stdout).toContain('Warning: --allow-full-env passed the full parent environment to the adapter.');
+      expect(result.stdout).not.toContain('test-secret-token');
+      const evidence = JSON.parse(readFileSync(join(dirname(runJson), 'full-env-evidence.json'), 'utf8'));
+      expect(evidence).toMatchObject({ secret: 'test-secret-token' });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('times out a sleeping adapter and writes bounded failure logs', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'sleepy.mjs'), "setTimeout(() => {}, 300);\n");
+      writeAdapterConfig(root, 'sleepy', ['node', '.osc/adapters/sleepy.mjs'], { timeoutMs: 50 });
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'sleepy'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('Timeout: 50 ms');
+      expect(result.stdout).toContain('Timed out: yes');
+      expect(result.stdout).toContain('Exit status: (none)');
+      const stderrLog = readFileSync(join(dirname(runJson), 'dispatch', 'sleepy-stderr.log'), 'utf8');
+      expect(stderrLog).toContain('ETIMEDOUT');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('kills SIGTERM-ignoring adapters when the timeout expires', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'ignore-term.mjs'), "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);\n");
+      writeAdapterConfig(root, 'ignore-term', ['node', '.osc/adapters/ignore-term.mjs'], { timeoutMs: 50 });
+
+      const started = Date.now();
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'ignore-term'], {
+        cwd: root,
+        encoding: 'utf8',
+        timeout: 2000
+      });
+
+      expect(Date.now() - started).toBeLessThan(1500);
+      expect(result.status).toBe(1);
+      expect(result.error).toBeUndefined();
+      expect(result.stdout).toContain('Timed out: yes');
+      expect(result.stdout).toContain('Signal: SIGKILL');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses unsafe full-env override in CI unless separately acknowledged', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'ci-env.mjs'), "console.log('should not run');\n");
+      writeAdapterConfig(root, 'ci-env', ['node', '.osc/adapters/ci-env.mjs']);
+      const before = fileSnapshot(root);
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'ci-env', '--allow-full-env'], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, CI: '1' }
+      });
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('Refusing --allow-full-env in CI unless OPEN_SCAFFOLD_ALLOW_FULL_ENV_IN_CI=1 is set.');
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unsafe adapter env config without leaking configured values', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'env-invalid.mjs'), "console.log('should not run');\n");
+      writeAdapterConfig(root, 'bad-env-name', ['node', '.osc/adapters/env-invalid.mjs'], { env: { 'BAD-KEY': 'do-not-leak-name' } });
+      writeAdapterConfig(root, 'bad-env-value', ['node', '.osc/adapters/env-invalid.mjs'], { env: { BAD_VALUE: 'do-not-leak-value\u0000secret' } });
+      writeAdapterConfig(root, 'bad-env-allowlist', ['node', '.osc/adapters/env-invalid.mjs'], { envAllowlist: ['BAD-KEY'] });
+      const before = fileSnapshot(root);
+
+      const badName = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'bad-env-name'], { cwd: root, encoding: 'utf8' });
+      const badValue = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'bad-env-value'], { cwd: root, encoding: 'utf8' });
+      const badAllowlist = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'bad-env-allowlist'], { cwd: root, encoding: 'utf8' });
+
+      expect(badName.status).toBe(2);
+      expect(badName.stderr).toContain('Adapter bad-env-name env contains an invalid environment variable name.');
+      expect(badName.stderr).not.toContain('do-not-leak-name');
+      expect(badValue.status).toBe(2);
+      expect(badValue.stderr).toContain('Adapter bad-env-value env contains a value with unsupported control characters.');
+      expect(badValue.stderr).not.toContain('do-not-leak-value');
+      expect(badAllowlist.status).toBe(2);
+      expect(badAllowlist.stderr).toContain('Adapter bad-env-allowlist envAllowlist contains an invalid environment variable name.');
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses adapter timeout and log limits above policy maxima', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'limits.mjs'), "console.log('should not run');\n");
+      writeAdapterConfig(root, 'huge-timeout', ['node', '.osc/adapters/limits.mjs'], { timeoutMs: 1_800_001 });
+      writeAdapterConfig(root, 'huge-stdout', ['node', '.osc/adapters/limits.mjs'], { maxStdoutBytes: 10_000_001 });
+      writeAdapterConfig(root, 'huge-stderr', ['node', '.osc/adapters/limits.mjs'], { maxStderrBytes: 10_000_001 });
+      const before = fileSnapshot(root);
+
+      const hugeTimeout = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'huge-timeout'], { cwd: root, encoding: 'utf8' });
+      const hugeStdout = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'huge-stdout'], { cwd: root, encoding: 'utf8' });
+      const hugeStderr = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'huge-stderr'], { cwd: root, encoding: 'utf8' });
+
+      expect(hugeTimeout.status).toBe(2);
+      expect(hugeTimeout.stderr).toContain('Adapter huge-timeout timeoutMs must be at most 1800000.');
+      expect(hugeStdout.status).toBe(2);
+      expect(hugeStdout.stderr).toContain('Adapter huge-stdout maxStdoutBytes must be at most 10000000.');
+      expect(hugeStderr.status).toBe(2);
+      expect(hugeStderr.stderr).toContain('Adapter huge-stderr maxStderrBytes must be at most 10000000.');
+      expect(fileSnapshot(root)).toEqual(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('bounds noisy adapter stdout and stderr with truncation markers', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'noisy.mjs'), `console.log('x'.repeat(400));
+console.error('y'.repeat(400));
+`);
+      writeAdapterConfig(root, 'noisy', ['node', '.osc/adapters/noisy.mjs'], { maxStdoutBytes: 64, maxStderrBytes: 64 });
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'noisy'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Stdout truncated: yes');
+      expect(result.stdout).toContain('Stderr truncated: yes');
+      const stdoutLog = readFileSync(join(dirname(runJson), 'dispatch', 'noisy-stdout.log'), 'utf8');
+      const stderrLog = readFileSync(join(dirname(runJson), 'dispatch', 'noisy-stderr.log'), 'utf8');
+      expect(stdoutLog.length).toBeLessThan(220);
+      expect(stderrLog.length).toBeLessThan(220);
+      expect(stdoutLog).toContain('[open-scaffold: log truncated');
+      expect(stderrLog).toContain('[open-scaffold: log truncated');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses wildcard env allowlists without the unsafe full-env override', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      writeAdapterConfig(root, 'wildcard-env', ['node', '-e', 'console.log("should not run")'], { envAllowlist: ['*'] });
+      const before = fileSnapshot(root);
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'wildcard-env'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('Adapter wildcard-env uses wildcard envAllowlist; use --allow-full-env for unsafe local override.');
+      expect(fileSnapshot(root)).toEqual(before);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -540,6 +540,34 @@ console.log('z'.repeat(70_000));
     }
   });
 
+  it('ignores receipt paths clipped by stdout truncation instead of failing dispatch', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'clipped-receipt.mjs'), `import { dirname, join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+const runDir = dirname(process.argv[2]);
+const receiptPath = join(runDir, 'clipped-receipt.json');
+writeFileSync(receiptPath, JSON.stringify({ status: 'ok' }) + '\\n');
+process.stdout.write('clipped adapter receipt written: ' + receiptPath + '-this-line-is-intentionally-too-long');
+`);
+      writeAdapterConfig(root, 'clipped-receipt', ['node', '.osc/adapters/clipped-receipt.mjs'], { maxStdoutBytes: 40, maxStderrBytes: 256 });
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'clipped-receipt'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Dispatch receipt: (none reported)');
+      expect(result.stdout).toContain('Stdout truncated: yes');
+      const stdoutLog = readFileSync(join(dirname(runJson), 'dispatch', 'clipped-receipt-stdout.log'), 'utf8');
+      expect(stdoutLog).not.toContain('receipt written:');
+      expect(stdoutLog).toContain('[open-scaffold: log truncated');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('refuses wildcard env allowlists without the unsafe full-env override', () => {
     const root = tempRepo();
     try {

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -540,6 +540,34 @@ console.log('z'.repeat(70_000));
     }
   });
 
+  it('allows successful adapters to use both stdout and stderr up to the bounded process cap', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'dual-stream-retained.mjs'), `import { dirname, join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+const runDir = dirname(process.argv[2]);
+const receiptPath = join(runDir, 'dual-stream-retained-receipt.json');
+writeFileSync(receiptPath, JSON.stringify({ status: 'ok' }) + '\\n');
+console.log('dual stream adapter receipt written: ' + receiptPath);
+process.stdout.write('o'.repeat(5_400_000));
+process.stderr.write('e'.repeat(5_400_000));
+`);
+      writeAdapterConfig(root, 'dual-stream-retained', ['node', '.osc/adapters/dual-stream-retained.mjs'], { maxStdoutBytes: 6_000_000, maxStderrBytes: 6_000_000 });
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'dual-stream-retained'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Dispatch receipt: .osc/runs/');
+      expect(result.stdout).toContain('Stdout truncated: no');
+      expect(result.stdout).toContain('Stderr truncated: no');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('ignores receipt paths clipped by stdout truncation instead of failing dispatch', () => {
     const root = tempRepo();
     try {

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -511,6 +511,35 @@ console.error('y'.repeat(400));
     }
   });
 
+  it('does not fail successful adapters that exceed retained-log limits below the process hard cap', () => {
+    const root = tempRepo();
+    try {
+      const runJson = createRunPacket(root);
+      const adapterDir = join(root, '.osc/adapters');
+      mkdirSync(adapterDir, { recursive: true });
+      writeFileSync(join(adapterDir, 'large-retained.mjs'), `import { dirname, join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+const runDir = dirname(process.argv[2]);
+const receiptPath = join(runDir, 'large-retained-receipt.json');
+writeFileSync(receiptPath, JSON.stringify({ status: 'ok' }) + '\\n');
+console.log('large retained adapter receipt written: ' + receiptPath);
+console.log('z'.repeat(70_000));
+`);
+      writeAdapterConfig(root, 'large-retained', ['node', '.osc/adapters/large-retained.mjs'], { maxStdoutBytes: 256, maxStderrBytes: 256 });
+
+      const result = spawnSync(tsx, [cli, 'dispatch', runJson, '--adapter', 'large-retained'], { cwd: root, encoding: 'utf8' });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Dispatch receipt: .osc/runs/');
+      expect(result.stdout).toContain('Stdout truncated: yes');
+      const stdoutLog = readFileSync(join(dirname(runJson), 'dispatch', 'large-retained-stdout.log'), 'utf8');
+      expect(stdoutLog).toContain('[open-scaffold: log truncated');
+      expect(stdoutLog.length).toBeLessThan(520);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('refuses wildcard env allowlists without the unsafe full-env override', () => {
     const root = tempRepo();
     try {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('0887c3f1488669b2658a006892f73bf8eecacc3bb67c3f750ee1e60a0327e51f');
+    expect(hash(planIssueSnapshot)).toBe('94c5fe5e4e6c35b40529318cc655204be3e4001ba6d6e378b67531d0904e765d');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('8e1f67ad613fffb5cbf46248b37ba405c9cd9b30ee3597768da9d9a7ab084b4c');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('b318d16ff52d8d6bec5be78d8bbd4456396420471a92a26b341972b9e1248119');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds restricted-by-default adapter environments for `osc dispatch`, with adapter `envAllowlist` and explicit adapter `env` values.
- Adds the explicit unsafe `--allow-full-env` override with warnings and a CI refusal unless separately acknowledged.
- Adds adapter timeout hard-kill behavior, stdout/stderr byte limits, truncation markers, env config validation, and policy maxima.
- Updates dispatch docs/security posture, plan/evidence records, and regression coverage for the new trust boundary.

## Task / Run Trace

- Task ID / issue: OSB-003 / SEC-01 and OSB-004 / SEC-02 from the blueprint backlog
- Run ID: N/A — local structural implementation slice, no runtime spawn
- Plan/spec: `.osc/plans/done/139-dispatch-env-timeout-log-bounds.md`
- Source refs: `.osc/plans/active/138-blueprint-security-adoption-program.md`, `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`

## Execution

- Executor lane: local implementation
- Harness skill: none
- Branch/worktree: `security/dispatch-env-timeout-logs`
- Operator surface: approval-gated local CLI workflow

## Verification

- [x] `npm run osc -- verify`
- [x] `./verify.sh --strict`
- [x] `npm test`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `npm run osc -- plan validate .osc/plans/active/138-blueprint-security-adoption-program.md --strict`
- [x] `npm run osc -- plan validate .osc/plans/done/139-dispatch-env-timeout-log-bounds.md --strict`
- [x] `npm run osc -- verify --evidence-chain --plan 139-dispatch-env-timeout-log-bounds --strict`
- [x] Independent pre-commit review passed after blocker fixes
- [x] Diff scan for obvious secrets/private local paths passed

## Evidence

- Run packet: N/A — no runtime/spawn lane used
- Logs/artifacts: N/A — test/build/verification output recorded in the evidence note
- Screenshots/demo: N/A
- Release/evidence note: `.osc/releases/2026-06-02-139-dispatch-env-timeout-log-bounds.md`

## Review Gates

- [x] Codex review requested or triggered
- [x] CI green, or failures classified as external/infrastructure
- [ ] Human approval captured where required
- [x] No commit/push/merge policy violations

## Notes for reviewers

This is structural dispatch hardening only. It does not claim adapter correctness, semantic task correctness, compliance certification, production runtime support, or authority to merge, publish, release, deploy, or run spawn-capable lanes.

Follow-up security slices remain open in the program plan: adapter trust workflow, redaction/secret scanning, trust-boundary docs, runtime worktree/protected-branch hardening, and schema/receipt validation.
