### PR TITLE
chore: prepare 0.30.0 package release sync

### DIFF
--- a/.osc/plans/active/141-0300-npx-release-sync.md
+++ b/.osc/plans/active/141-0300-npx-release-sync.md
@@ -1,0 +1,58 @@
+# Plan: 141-0300-npx-release-sync
+
+## Status
+
+active
+
+## Context
+
+`main` contains the blueprint security/adoption work from PR #168 plus the follow-up Dependabot maintenance merges from PRs #169 and #170. The package-visible CLI/help/docs surface is still public only through the repository because npm `open-scaffold@latest` and the GitHub Latest Release remain at `0.20.4`.
+
+## Goal
+
+Publish `open-scaffold@0.30.0` on the npm `latest` dist-tag, create GitHub Release `v0.30.0` as Latest, prove the fresh `npx` public surface from an isolated external directory, and then close this release-sync plan with final evidence.
+
+## Constraints / Out of scope
+
+- Do not add Korean adoption/localization work.
+- Do not weaken the no-spawn core boundary or run real runtime/spawn-capable lanes.
+- Do not implement `119-osc-work-execute-controller` or add new product features.
+- Do not claim semantic correctness, compliance certification, production readiness, or runtime correctness.
+- Do not publish if package, local verification, CI, Codex/latest-head review, trusted-publishing, npm, fresh `npx`, or GitHub Release gates fail.
+- Do not use unquoted shell heredocs for release notes or any Markdown containing backtick command snippets.
+- Do not deploy, use webhooks, or perform unrelated external side effects; this plan is limited to GitHub/npm release flow explicitly authorized by the owner.
+
+## Files to touch
+
+- `package.json` — bump the package candidate version to `0.30.0`.
+- `package-lock.json` — keep the lockfile root package version aligned with `package.json`.
+- `docs/CHANGELOG.md` — add release-facing `v0.30.0` candidate/published notes.
+- `docs/VERSION_TRUTH.md` — reconcile repository, npm, and GitHub Release truth for the `0.30.0` release flow.
+- `README.md` and `docs/STABILITY.md` — align package-line language when the release target moves from `v0.20.x` to `v0.30.x`.
+- `.osc/releases/2026-06-03-141-0300-npx-release-sync.md` — record candidate gates, public publish proof, GitHub Release proof, and final closeout evidence.
+- `.osc/plans/active/141-0300-npx-release-sync.md` / `.osc/plans/done/141-0300-npx-release-sync.md` — keep this plan active until public npm/GitHub Release/fresh `npx` proof exists, then close it through the normal closeout protocol.
+
+## Acceptance criteria
+
+- [ ] `package.json`, `package-lock.json`, changelog/version-truth docs, and release evidence prepare target version `0.30.0` without claiming npm/GitHub publication before it happens.
+- [ ] `npm pack --dry-run --json` and an extracted-tarball smoke prove the package payload includes the built CLI, README/help/docs, and package-visible surfaces from the OSB security/adoption work.
+- [ ] Pre-publish gates pass from the candidate branch: `npm ci`, `git diff --check`, focused package/help tests, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `./verify.sh --strict`, `npm run osc -- verify`, `npm pack --dry-run --json`, and extracted-package smoke from a temp directory outside the repository.
+- [ ] Release candidate PR is merged only after CI is green, latest-head Codex review is clean if triggered, and unresolved current-head review threads are zero.
+- [ ] Trusted publishing publishes `open-scaffold@0.30.0` with dist-tag `latest`, and `npm view open-scaffold version dist-tags --json --prefer-online` confirms `0.30.0` / `latest`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest` proof from outside the repository verifies top-level help plus the package-visible command/help surfaces: `first-run`, `pr check`, adapter trust commands, schemas, and `--online-github` verification language.
+- [ ] GitHub Release `v0.30.0 — Blueprint security and adoption release` exists, targets the merged `main` commit, is marked Latest, and uses concise public-safe boundary language.
+- [ ] Final evidence records npm URL, trusted-publishing run, GitHub Release URL, fresh `npx` commands/results, PR/merge commits, and remaining risks; this plan is moved to `done/` only after those public surfaces are verified.
+
+## Verification steps
+
+1. Sync and inspect live truth: `git status --short --branch`, `git fetch --prune origin`, `node -p "require('./package.json').version"`, `npm view open-scaffold version dist-tags --json --prefer-online`, `gh release list --repo graphanov/open-scaffold --limit 5`, and `gh pr list --repo graphanov/open-scaffold --state open`.
+2. Candidate pre-publish gates: `npm ci`; `git diff --check`; focused package/help tests; `npm test -- --run`; `npm run build`; `npm run osc -- doctor --check secret-scan`; `./verify.sh --strict`; `npm run osc -- verify`; `npm pack --dry-run --json`; extracted-tarball smoke from an external temp directory.
+3. PR gate: create a release candidate PR, monitor CI, trigger/poll Codex if normal for the repo, and require unresolved current-head review threads = 0 before merge.
+4. Publish gate: dispatch the trusted-publishing workflow for expected version `0.30.0` and npm tag `latest`, wait for success, and verify registry truth with `npm view`.
+5. Public package smoke: run fresh isolated-cache `npx --yes open-scaffold@latest --help`, `first-run --help`, command/help greps for `pr check`, `adapter check`, `adapter trust`, `schemas`, and `--online-github` from a temp directory outside the repository.
+6. Release gate: create or update GitHub Release `v0.30.0`, mark it Latest, and verify release list/view output.
+7. Closeout gate: patch final evidence, close this plan to `done/`, run `git diff --check`, `./verify.sh --strict`, `npm run osc -- verify`, and `npm run osc -- plan validate .osc/plans/done/141-0300-npx-release-sync.md --strict` before any closeout PR/merge.
+
+## Open questions
+
+- None. Owner authorization for the end-to-end `0.30.0` release flow is explicit in the release coordination prompt; any failed gate blocks publication and must be reported instead of forced.

--- a/.osc/releases/2026-06-03-141-0300-npx-release-sync.md
+++ b/.osc/releases/2026-06-03-141-0300-npx-release-sync.md
@@ -10,7 +10,7 @@ Candidate boundary: `0.30.0` is not published until trusted publishing succeeds 
 
 - Release-sync plan: `.osc/plans/active/141-0300-npx-release-sync.md` while public follow-through is in progress; final closeout should move it to `.osc/plans/done/141-0300-npx-release-sync.md`.
 - Release-sync branch: `release/0.30.0-npx-sync`.
-- Release-sync PR: pending.
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/171.
 - Source blueprint/security/adoption PR: https://github.com/graphanov/open-scaffold/pull/168.
 - Follow-up maintenance PRs included on `main`: https://github.com/graphanov/open-scaffold/pull/169 and https://github.com/graphanov/open-scaffold/pull/170.
 - Main baseline before this release-sync branch: `bb9b6146f831a0834b27b28e4d0c71554a8fe592`.

--- a/.osc/releases/2026-06-03-141-0300-npx-release-sync.md
+++ b/.osc/releases/2026-06-03-141-0300-npx-release-sync.md
@@ -1,0 +1,70 @@
+# Release / Evidence Note: 141 0.30.0 npx release sync
+
+## Summary
+
+This note tracks the owner-approved release-sync candidate for `open-scaffold@0.30.0`. The release is intended to make the OSB blueprint security/adoption work visible through fresh `npx open-scaffold@latest`: restricted/bounded dispatch posture, adapter trust commands, redaction/secret-scan support, trust-boundary docs, first-run onboarding, PR-native structural checks, command/schema registries, optional GitHub-online verification labels, and clearer structural-only boundaries.
+
+Candidate boundary: `0.30.0` is not published until trusted publishing succeeds and npm registry truth confirms it. Open Scaffold remains repo-native and no-spawn by default; these checks support reviewability and traceability, not semantic correctness, compliance certification, production readiness, or runtime correctness.
+
+## Traceability
+
+- Release-sync plan: `.osc/plans/active/141-0300-npx-release-sync.md` while public follow-through is in progress; final closeout should move it to `.osc/plans/done/141-0300-npx-release-sync.md`.
+- Release-sync branch: `release/0.30.0-npx-sync`.
+- Release-sync PR: pending.
+- Source blueprint/security/adoption PR: https://github.com/graphanov/open-scaffold/pull/168.
+- Follow-up maintenance PRs included on `main`: https://github.com/graphanov/open-scaffold/pull/169 and https://github.com/graphanov/open-scaffold/pull/170.
+- Main baseline before this release-sync branch: `bb9b6146f831a0834b27b28e4d0c71554a8fe592`.
+- Target npm package: `open-scaffold@0.30.0` with dist-tag `latest` after trusted publishing succeeds.
+- Target GitHub Release: `v0.30.0 — Blueprint security and adoption release` after npm publication succeeds.
+- Trusted publishing workflow: pending.
+- Run ID / run packet: N/A for this scoped package/release sync.
+
+## Verification
+
+Baseline live-truth inspection before release-sync edits:
+
+- `git status --short --branch` — PASS: clean `main...origin/main`.
+- `git fetch --prune origin` — PASS.
+- `git rev-parse main` / `git rev-parse origin/main` — PASS: both `bb9b6146f831a0834b27b28e4d0c71554a8fe592`.
+- `node -p "require('./package.json').version"` — PASS: `0.20.4` before candidate bump.
+- `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before publish: `0.20.4`, `latest: 0.20.4`.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS before publish: `v0.20.4 — Fresh npx compare demo repair` is Latest.
+- `gh pr list --repo graphanov/open-scaffold --state open` — PASS: no open PRs.
+- Active plans — PASS: none before creating this release-sync plan.
+
+Candidate gates before PR-ready:
+
+- [x] `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `0.30.0 / 0.30.0 / 0.30.0`.
+- [x] `npm ci` — PASS: installed 88 packages; npm audit found 0 vulnerabilities.
+- [x] `git diff --check` — PASS.
+- [x] Focused package/help tests: `npm test -- tests/blueprint-mega.test.ts tests/cli-lifecycle-help.test.ts tests/first-run-docs.test.ts tests/resume-docs.test.ts tests/package-payload.test.ts tests/section-parser.test.ts --run` — PASS: 6 files / 62 tests.
+- [x] `npm test -- --run` — PASS: 56 files / 624 tests.
+- [x] `npm run build` — PASS: core TypeScript build and runtime-omx build.
+- [x] `npm run osc -- doctor --check secret-scan` — PASS: `Doctor: no issues found.`
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
+- [x] `npm run osc -- verify` — PASS with 9 warnings: 7 historical warnings plus 2 expected active-plan/release-note warnings while this release-sync plan remains active pending public proof.
+- [x] `npm run osc -- plan validate .osc/plans/active/141-0300-npx-release-sync.md --strict` — PASS: 0 issues.
+- [x] `npm pack --dry-run --json` payload inspection — PASS for `open-scaffold@0.30.0`; entry count 231; includes `dist/cli.js`, README/docs, examples, `.osc` template files, and shell helpers.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.30.0` with tag `latest`.
+- [x] Extracted-tarball smoke from a temp directory outside the repository — PASS: top-level help, `first-run --help`, `pr check --help`, adapter help surfaces, `schemas list --json`, and `schemas show open-scaffold.run.v1` all worked; required public help strings `osc first-run`, `osc pr check`, `osc adapter check`, `osc adapter trust`, `osc schemas list`, and `--online-github` were present.
+- [ ] Release candidate PR CI and latest-head Codex/thread gate — pending.
+
+Post-merge/publication gates after owner-approved follow-through:
+
+- [ ] Sync clean `main` after release PR merge — pending.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.30.0` with dist-tag `latest` — pending.
+- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.30.0` and `latest: 0.30.0` — pending.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory — pending.
+- [ ] Fresh isolated-cache command/help smokes for `first-run`, `pr check`, adapter trust commands, schemas, and `--online-github` — pending.
+- [ ] GitHub Release `v0.30.0` exists, targets the merged `main` commit, and is marked Latest — pending.
+- [ ] This plan is closed to `done/` with final public proof — pending.
+
+## Outcome
+
+Candidate in progress. Do not treat `open-scaffold@0.30.0` as published until the trusted-publishing workflow, npm registry checks, fresh isolated-cache `npx` smokes, and GitHub Release Latest verification are all recorded here.
+
+## Follow-up
+
+- Open the release candidate PR after local candidate gates pass.
+- After PR merge, dispatch trusted publishing with `expected-version=0.30.0` and `npm-tag=latest`.
+- Patch this note with final npm/GitHub Release URLs and verification output before moving plan `141-0300-npx-release-sync` to `done/`.

--- a/README.md
+++ b/README.md
@@ -303,11 +303,11 @@ For the one-screen version, see [`docs/examples/evolution-loop-compare.md`](docs
 
 ## Current pre-1.0 hardening line
 
-Open Scaffold is usable, but it is still in active credibility and adoption hardening. The forward-moving package line is `v0.20.x`: stable enough to try on real repos, honest enough not to pretend every workflow, runtime boundary, and public surface is final.
+Open Scaffold is usable, but it is still in active credibility and adoption hardening. The forward-moving package line is `v0.30.x` after the blueprint security/adoption package sync: stable enough to try on real repos, honest enough not to pretend every workflow, runtime boundary, and public surface is final.
 
 Stable enough to rely on today:
 
-- CLI: `osc init`, `osc status`, `osc plan new`, `osc plan validate`, `osc plan move`, `osc amend`, `osc close`, `osc evidence new`, `osc evidence collect`, `osc verify`, `osc trace`, and read-only `osc compare`.
+- CLI: `osc init`, `osc first-run`, `osc status`, `osc plan new`, `osc plan validate`, `osc plan move`, `osc amend`, `osc close`, `osc evidence new`, `osc evidence collect`, `osc verify`, `osc trace`, `osc pr check`, adapter trust inspection, schema registry inspection, and read-only `osc compare`.
 - Protocol: `MISSION.md`, `ROADMAP.md`, `.osc/plans/`, the Status + seven content-heading plan schema, folder-as-status workflow, amendments, evidence notes, and run-packet records.
 - Verification floor: `verify.sh` plus package tests/builds for this repository.
 
@@ -328,7 +328,7 @@ Use cases the current contract supports today:
 - teams that want PRs to carry intent, evidence, and approval state;
 - consulting or audit-sensitive delivery where later readers need to reconstruct what happened.
 
-Publication truth lives outside git, and the two public surfaces move separately. Check `npm view open-scaffold version dist-tags --json` to see which package `npx open-scaffold@latest` installs. Check the GitHub Release marked **Latest** to see which release note GitHub highlights. The historical `v1.0.5` / `v1.0.x` tags remain published history; the current forward-moving line is `v0.20.x` until the protocol and product surface earn a real 1.0 again. See [`docs/VERSION_TRUTH.md`](docs/VERSION_TRUTH.md), [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
+Publication truth lives outside git, and the two public surfaces move separately. Check `npm view open-scaffold version dist-tags --json` to see which package `npx open-scaffold@latest` installs. Check the GitHub Release marked **Latest** to see which release note GitHub highlights. The historical `v1.0.5` / `v1.0.x` tags remain published history; the current forward-moving line is `v0.30.x` after the blueprint security/adoption package sync and remains pre-1.0 until the protocol and product surface earn a real 1.0 again. See [`docs/VERSION_TRUTH.md`](docs/VERSION_TRUTH.md), [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.30.0 — Blueprint security and adoption release
+
+Status: release-sync candidate in this branch. It is not published to npm and not GitHub Latest until the release PR merges, trusted publishing succeeds, fresh `npx` proof passes, and GitHub Release `v0.30.0` is created/marked Latest.
+
+Highlights:
+
+- Publishes the OSB blueprint security/adoption work from PR #168 to the public `npx open-scaffold@latest` package surface.
+- Makes guided first-run onboarding, PR-native structural checks, adapter trust commands, command/schema registries, redaction/secret-scan support, and optional GitHub-online verification labels available in the package.
+- Documents the trust boundary more explicitly: Open Scaffold remains repo-native and no-spawn by default; it supports reviewability and traceability, not semantic correctness, compliance certification, production readiness, or runtime correctness.
+- Includes the maintenance tail from PRs #169 and #170 before the release-sync cut.
+
+Evidence:
+
+- Release-sync plan: `.osc/plans/active/141-0300-npx-release-sync.md` until final public proof exists; expected closeout path is `.osc/plans/done/141-0300-npx-release-sync.md`.
+- Source PR: https://github.com/graphanov/open-scaffold/pull/168
+- Release-sync evidence note: `.osc/releases/2026-06-03-141-0300-npx-release-sync.md`
+
 ## v0.20.4 — Fresh npx compare demo repair
 
 Status: published to npm as `open-scaffold@0.20.4`; GitHub Release `v0.20.4` is Latest after owner-approved trusted publishing and release follow-through.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -2,13 +2,13 @@
 
 This page defines Open Scaffold's current package contract and maturity boundary.
 
-The short version: Open Scaffold is back on a pre-1.0 hardening line (`v0.20.x`) because the protocol is useful but the public product surface, runtime boundary, and adoption story are still moving quickly. The stable-enough core is the repo-native work-record loop — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus read-only work-record commands such as `osc compare` and `osc trace` that help humans inspect recorded work without launching runtimes. Runtime launch, provider-specific automation, evaluation helpers, dashboards, and external cockpit transports remain opt-in lab/experimental surfaces unless a later release explicitly promotes them.
+The short version: Open Scaffold is on a pre-1.0 hardening line (`v0.30.x` after the blueprint security/adoption package sync) because the protocol is useful but the public product surface, runtime boundary, and adoption story are still moving quickly. The stable-enough core is the repo-native work-record loop — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus adoption/review/trust helpers such as `osc first-run`, `osc pr check`, adapter trust inspection, schema registry inspection, and read-only work-record commands such as `osc compare` and `osc trace` that help humans inspect recorded work without launching runtimes. Runtime launch, provider-specific automation, evaluation helpers, dashboards, and external cockpit transports remain opt-in lab/experimental surfaces unless a later release explicitly promotes them.
 
 The historical `v1.0.x` packages and GitHub Releases remain available for provenance. They are not erased, but they should not set the current expectation that Open Scaffold has fully earned a mature 1.0 contract.
 
 ## Release status
 
-- Current cadence: pre-1.0 hardening on the `v0.20.x` line.
+- Current cadence: pre-1.0 hardening on the `v0.30.x` line.
 - Historical note: `v1.0.x` exists as a previously published launch line (most recent tag: `v1.0.5`) and remains immutable package/release history.
 - Current repository package version: check `package.json`.
 - Live npm package truth: check `npm view open-scaffold version dist-tags --json`.
@@ -44,6 +44,10 @@ The stable day-two CLI surface is:
 - `osc evidence new`
 - `osc evidence collect`
 - `osc verify`
+- `osc first-run` as guided repo initialization for the minimum work record
+- `osc pr check` as a PR-native structural check surface
+- `osc adapter check`, `osc adapter trust`, and trusted adapter listing for adapter trust inspection
+- `osc schemas list` and `osc schemas show` for package-visible schema discovery
 - `osc compare` as a read-only first-read demo for comparing two recorded attempts
 - `osc trace` as a read-only replay of one plan's local work-record chain
 
@@ -98,7 +102,7 @@ Future work can explore those areas only through explicit plans, evidence, safet
 
 ## Versioning policy
 
-Open Scaffold uses npm package versions as public distribution coordinates. The current `v0.20.x` line is intentionally pre-1.0: it communicates that the core work-record pattern is usable, but the product is still earning its long-term stable contract.
+Open Scaffold uses npm package versions as public distribution coordinates. The current `v0.30.x` line is intentionally pre-1.0: it communicates that the core work-record pattern is usable and the security/adoption package surface has hardened, but the product is still earning its long-term stable contract.
 
 The previously published `v1.0.x` packages remain immutable historical artifacts. They should be treated as an over-eager launch line, not as a reason to force every future change through mature-1.0 pressure. A future real 1.0 should be cut only after the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives feel durable enough to sustain that promise.
 

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -2,11 +2,11 @@
 
 This page is the canonical reconciliation between the current package version and the historical git tag line. Check it when the numbers look contradictory.
 
-## Current line: `v0.20.x` (pre-1.0 hardening)
+## Current line: `v0.30.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.20.4`
-- **npm latest:** `0.20.4` with dist-tag `latest` after trusted publishing run `26689646203`; run `npm view open-scaffold version dist-tags --json` for live confirmation.
-- **GitHub Release latest:** `v0.20.4` is marked **Latest** after the fresh npx compare-demo repair release.
+- **Current `package.json` version:** `0.30.0` release-sync candidate.
+- **npm latest:** still `0.20.4` with dist-tag `latest` until trusted publishing for `0.30.0` succeeds; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** still `v0.20.4` until `v0.30.0` is created and marked Latest after npm publication succeeds.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.
@@ -15,18 +15,18 @@ Do not treat the repository version alone as proof of npm publication or GitHub 
 
 - **Most recent historical tag:** `v1.0.5` — published as `open-scaffold@1.0.5` on the historical `v1.0.x` launch line.
 - **Status:** immutable historical artifacts. The `v1.0.x` packages remain available on npm for provenance; they are not erased.
-- **Why it is not the current line:** the `v1.0.x` launch was premature. The project reset to a pre-1.0 `v0.20.x` hardening cadence at `v0.20.0` to earn the long-term stable contract honestly. A future real 1.0 requires the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives to feel durable enough to sustain that promise.
+- **Why it is not the current line:** the `v1.0.x` launch was premature. The project reset to a pre-1.0 hardening cadence at `v0.20.0` to earn the long-term stable contract honestly; `v0.30.x` continues that pre-1.0 hardening line after the OSB security/adoption package sync. A future real 1.0 requires the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives to feel durable enough to sustain that promise.
 
 ## Stable vs experimental in the current line
 
-The `v0.20.x` line defines a stable-enough core (the repo-native work-record loop, the Status + seven content-heading plan schema, lifecycle helpers, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). See [`docs/STABILITY.md`](STABILITY.md) for the full listing.
+The `v0.30.x` line defines a stable-enough core (the repo-native work-record loop, the Status + seven content-heading plan schema, lifecycle helpers, first-run onboarding, PR-native structural checks, adapter trust inspection, command/schema registries, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). See [`docs/STABILITY.md`](STABILITY.md) for the full listing.
 
 ## Summary
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.20.4` |
-| Current package line | `v0.20.x` (pre-1.0) |
+| `package.json` version | `0.30.0` release-sync candidate |
+| Current package line | `v0.30.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |
 | npm live truth | `npm view open-scaffold version` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.20.4",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.20.4",
+      "version": "0.30.0",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.20.4",
+  "version": "0.30.0",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/tests/resume-docs.test.ts
+++ b/tests/resume-docs.test.ts
@@ -117,21 +117,21 @@ describe('resume docs self-checks (AC-6 through AC-10)', () => {
       expect(exists('docs/VERSION_TRUTH.md')).toBe(true);
     });
 
-    it('README contains both v0.20.x current and v1.0.5 historical version tokens', () => {
+    it('README contains both v0.30.x current and v1.0.5 historical version tokens', () => {
       const readme = read('README.md');
-      expect(readme).toMatch(/v0\.20\.x|v0\.20\.\d/);
+      expect(readme).toMatch(/v0\.30\.x|v0\.30\.\d/);
       expect(readme).toMatch(/v1\.0\.5/);
     });
 
-    it('STABILITY.md contains v0.20.x current line and v1.0.x historical reference', () => {
+    it('STABILITY.md contains v0.30.x current line and v1.0.x historical reference', () => {
       const stability = read('docs/STABILITY.md');
-      expect(stability).toMatch(/v0\.20\.x/);
+      expect(stability).toMatch(/v0\.30\.x/);
       expect(stability).toMatch(/v1\.0\.[x5]/);
     });
 
-    it('CHANGELOG.md contains v0.20.x entries and v1.0.5 historical entry', () => {
+    it('CHANGELOG.md contains v0.30.x entries and v1.0.5 historical entry', () => {
       const changelog = read('docs/CHANGELOG.md');
-      expect(changelog).toMatch(/v0\.20\.\d/);
+      expect(changelog).toMatch(/v0\.30\.\d/);
       expect(changelog).toMatch(/v1\.0\.5/);
     });
   });

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('6dc77549ab27b550f580e52e7e0f4d1ac8141eb2021387beb7353e0e5c1752a7');
+    expect(hash(planIssueSnapshot)).toBe('7e61f811088307e67927177d0c4fa7128e793f60177da9674625b0a4610b5046');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('7d15509195396067e33ebecd596e75c5f182b7f018900eae0b1cbe9b68560496');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('967d7321c554b640d7b1bee28308bab0289cb6eb6b3236ba8c4d0db128639276');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Prepare `open-scaffold@0.30.0` as the owner-approved package/release sync for the OSB blueprint security/adoption work from PR #168 plus PRs #169/#170.
- Update package version, lockfile, changelog, version-truth/stability/README language, and release-sync evidence.
- Keep plan `141-0300-npx-release-sync` active until npm `latest`, fresh isolated-cache `npx`, and GitHub Release `v0.30.0` Latest are verified after merge.

## Verification

- [x] Simple added-line public-safety scan for private paths, personal names, emails, and Discord IDs — PASS.
- [x] `npm ci` — PASS, 0 vulnerabilities.
- [x] version check — PASS: `0.30.0 / 0.30.0 / 0.30.0`.
- [x] `git diff --check` — PASS.
- [x] focused tests — PASS: 6 files / 62 tests.
- [x] `npm test -- --run` — PASS: 56 files / 624 tests.
- [x] `npm run build` — PASS.
- [x] `npm run osc -- doctor --check secret-scan` — PASS.
- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
- [x] `npm run osc -- verify` — PASS with 9 warnings: 7 historical warnings plus 2 expected active release-plan warnings while plan 141 remains active pending public proof.
- [x] `npm run osc -- plan validate .osc/plans/active/141-0300-npx-release-sync.md --strict` — PASS: 0 issues.
- [x] `npm pack --dry-run --json` — PASS for `open-scaffold@0.30.0`, 231 files.
- [x] `npm publish --dry-run --tag latest` — PASS.
- [x] extracted-tarball smoke from outside the repo — PASS: top-level help, `first-run --help`, `pr check --help`, adapter trust/help surfaces, `schemas list --json`, `schemas show open-scaffold.run.v1`, and required strings `osc first-run`, `osc pr check`, `osc adapter check`, `osc adapter trust`, `osc schemas list`, `--online-github`.

## Risk / gates

- Package publish, GitHub Release creation, and plan closeout remain gated on PR merge, trusted-publishing success, npm registry proof, fresh isolated-cache `npx` proof, and GitHub Release Latest verification.
- Open Scaffold remains repo-native and no-spawn by default; this release supports reviewability and traceability, not semantic correctness, compliance certification, production readiness, or runtime correctness.
