### PR TITLE
docs: close 0.30.0 release sync

### DIFF
--- a/.osc/plans/done/141-0300-npx-release-sync.md
+++ b/.osc/plans/done/141-0300-npx-release-sync.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
-`main` contains the blueprint security/adoption work from PR #168 plus the follow-up Dependabot maintenance merges from PRs #169 and #170. The package-visible CLI/help/docs surface is still public only through the repository because npm `open-scaffold@latest` and the GitHub Latest Release remain at `0.20.4`.
+At plan creation, `main` contained the blueprint security/adoption work from PR #168 plus the follow-up Dependabot maintenance merges from PRs #169 and #170, while npm `open-scaffold@latest` and the GitHub Latest Release still pointed at `0.20.4`. This closeout published the package-visible CLI/help/docs surface as `open-scaffold@0.30.0` and marked GitHub Release `v0.30.0` Latest.
 
 ## Goal
 
@@ -24,24 +24,24 @@ Publish `open-scaffold@0.30.0` on the npm `latest` dist-tag, create GitHub Relea
 
 ## Files to touch
 
-- `package.json` — bump the package candidate version to `0.30.0`.
+- `package.json` — bump the package version to `0.30.0`.
 - `package-lock.json` — keep the lockfile root package version aligned with `package.json`.
-- `docs/CHANGELOG.md` — add release-facing `v0.30.0` candidate/published notes.
+- `docs/CHANGELOG.md` — add release-facing `v0.30.0` published notes.
 - `docs/VERSION_TRUTH.md` — reconcile repository, npm, and GitHub Release truth for the `0.30.0` release flow.
 - `README.md` and `docs/STABILITY.md` — align package-line language when the release target moves from `v0.20.x` to `v0.30.x`.
 - `.osc/releases/2026-06-03-141-0300-npx-release-sync.md` — record candidate gates, public publish proof, GitHub Release proof, and final closeout evidence.
-- `.osc/plans/active/141-0300-npx-release-sync.md` / `.osc/plans/done/141-0300-npx-release-sync.md` — keep this plan active until public npm/GitHub Release/fresh `npx` proof exists, then close it through the normal closeout protocol.
+- `.osc/plans/done/141-0300-npx-release-sync.md` — final closed plan path after public npm/GitHub Release/fresh `npx` proof exists.
 
 ## Acceptance criteria
 
-- [ ] `package.json`, `package-lock.json`, changelog/version-truth docs, and release evidence prepare target version `0.30.0` without claiming npm/GitHub publication before it happens.
-- [ ] `npm pack --dry-run --json` and an extracted-tarball smoke prove the package payload includes the built CLI, README/help/docs, and package-visible surfaces from the OSB security/adoption work.
-- [ ] Pre-publish gates pass from the candidate branch: `npm ci`, `git diff --check`, focused package/help tests, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `./verify.sh --strict`, `npm run osc -- verify`, `npm pack --dry-run --json`, and extracted-package smoke from a temp directory outside the repository.
-- [ ] Release candidate PR is merged only after CI is green, latest-head Codex review is clean if triggered, and unresolved current-head review threads are zero.
-- [ ] Trusted publishing publishes `open-scaffold@0.30.0` with dist-tag `latest`, and `npm view open-scaffold version dist-tags --json --prefer-online` confirms `0.30.0` / `latest`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest` proof from outside the repository verifies top-level help plus the package-visible command/help surfaces: `first-run`, `pr check`, adapter trust commands, schemas, and `--online-github` verification language.
-- [ ] GitHub Release `v0.30.0 — Blueprint security and adoption release` exists, targets the merged `main` commit, is marked Latest, and uses concise public-safe boundary language.
-- [ ] Final evidence records npm URL, trusted-publishing run, GitHub Release URL, fresh `npx` commands/results, PR/merge commits, and remaining risks; this plan is moved to `done/` only after those public surfaces are verified.
+- [x] `package.json`, `package-lock.json`, changelog/version-truth docs, and release evidence prepare target version `0.30.0` without claiming npm/GitHub publication before it happens.
+- [x] `npm pack --dry-run --json` and an extracted-tarball smoke prove the package payload includes the built CLI, README/help/docs, and package-visible surfaces from the OSB security/adoption work.
+- [x] Pre-publish gates pass from the candidate branch: `npm ci`, `git diff --check`, focused package/help tests, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `./verify.sh --strict`, `npm run osc -- verify`, `npm pack --dry-run --json`, and extracted-package smoke from a temp directory outside the repository.
+- [x] Release candidate PR is merged only after CI is green, latest-head Codex review is clean if triggered, and unresolved current-head review threads are zero.
+- [x] Trusted publishing publishes `open-scaffold@0.30.0` with dist-tag `latest`, and `npm view open-scaffold version dist-tags --json --prefer-online` confirms `0.30.0` / `latest`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest` proof from outside the repository verifies top-level help plus the package-visible command/help surfaces: `first-run`, `pr check`, adapter trust commands, schemas, and `--online-github` verification language.
+- [x] GitHub Release `v0.30.0 — Blueprint security and adoption release` exists, targets the merged `main` commit, is marked Latest, and uses concise public-safe boundary language.
+- [x] Final evidence records npm URL, trusted-publishing run, GitHub Release URL, fresh `npx` commands/results, PR/merge commits, and remaining risks; this plan is moved to `done/` only after those public surfaces are verified.
 
 ## Verification steps
 

--- a/.osc/releases/2026-05-30-129-npx-compare-demo-repair.md
+++ b/.osc/releases/2026-05-30-129-npx-compare-demo-repair.md
@@ -15,7 +15,7 @@ This release keeps `osc compare` local and read-only. It does not add runtime sp
 - Repair merge commit: `2c8c81f973c500f43a7796645a92d7f790c7194e`.
 - Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/26689646203.
 - npm package: `open-scaffold@0.20.4` with dist-tag `latest`.
-- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.20.4.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.20.4; this release was Latest until superseded by `v0.30.0`.
 - Run ID / run packet: N/A for this scoped package repair.
 
 ## Verification
@@ -49,12 +49,12 @@ Post-merge/publication gates after owner-approved follow-through:
 - [x] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.20.4` and `latest: 0.20.4`.
 - [x] Fresh isolated-cache `npx --yes open-scaffold@latest --version` reports `0.20.4`.
 - [x] Fresh isolated-cache `npx --yes open-scaffold@latest compare examples/attempt-compare/attempt-a examples/attempt-compare/attempt-b` succeeds from a fresh external directory.
-- [x] GitHub Release `v0.20.4` exists and is marked Latest.
+- [x] GitHub Release `v0.20.4` exists and was marked Latest at publication time; it is now superseded by `v0.30.0`.
 - [x] Source plan 129 is closed to `done/` with final public proof in this closeout branch.
 
 ## Outcome
 
-Completed. PR #155 merged the package-path repair, trusted publishing succeeded, npm `open-scaffold@latest` resolves to `0.20.4`, fresh isolated-cache `npx` proves the zero-context compare demo from an external directory, GitHub Release `v0.20.4` is Latest, and plan 129 is closed to `done/` by the closeout branch.
+Completed. PR #155 merged the package-path repair, trusted publishing succeeded, npm `open-scaffold@latest` resolved to `0.20.4` at publication time, fresh isolated-cache `npx` proved the zero-context compare demo from an external directory, GitHub Release `v0.20.4` was Latest until superseded by `v0.30.0`, and plan 129 is closed to `done/`.
 
 ## Follow-up
 

--- a/.osc/releases/2026-06-03-141-0300-npx-release-sync.md
+++ b/.osc/releases/2026-06-03-141-0300-npx-release-sync.md
@@ -2,21 +2,22 @@
 
 ## Summary
 
-This note tracks the owner-approved release-sync candidate for `open-scaffold@0.30.0`. The release is intended to make the OSB blueprint security/adoption work visible through fresh `npx open-scaffold@latest`: restricted/bounded dispatch posture, adapter trust commands, redaction/secret-scan support, trust-boundary docs, first-run onboarding, PR-native structural checks, command/schema registries, optional GitHub-online verification labels, and clearer structural-only boundaries.
+Published `open-scaffold@0.30.0` as the owner-approved release-sync for the OSB blueprint security/adoption work. The release makes the blueprint surfaces visible through fresh `npx open-scaffold@latest`: restricted/bounded dispatch posture, adapter trust commands, redaction/secret-scan support, trust-boundary docs, first-run onboarding, PR-native structural checks, command/schema registries, optional GitHub-online verification labels, and clearer structural-only boundaries.
 
-Candidate boundary: `0.30.0` is not published until trusted publishing succeeds and npm registry truth confirms it. Open Scaffold remains repo-native and no-spawn by default; these checks support reviewability and traceability, not semantic correctness, compliance certification, production readiness, or runtime correctness.
+Open Scaffold remains repo-native and no-spawn by default. These checks support reviewability and traceability; they do not claim semantic correctness, compliance certification, production readiness, or runtime correctness.
 
 ## Traceability
 
-- Release-sync plan: `.osc/plans/active/141-0300-npx-release-sync.md` while public follow-through is in progress; final closeout should move it to `.osc/plans/done/141-0300-npx-release-sync.md`.
+- Release-sync plan: `.osc/plans/done/141-0300-npx-release-sync.md`.
 - Release-sync branch: `release/0.30.0-npx-sync`.
 - Release-sync PR: https://github.com/graphanov/open-scaffold/pull/171.
+- Release-sync merge commit: `007d2a34431f4f6c02faba72edde29247ca4213f`.
 - Source blueprint/security/adoption PR: https://github.com/graphanov/open-scaffold/pull/168.
 - Follow-up maintenance PRs included on `main`: https://github.com/graphanov/open-scaffold/pull/169 and https://github.com/graphanov/open-scaffold/pull/170.
 - Main baseline before this release-sync branch: `bb9b6146f831a0834b27b28e4d0c71554a8fe592`.
-- Target npm package: `open-scaffold@0.30.0` with dist-tag `latest` after trusted publishing succeeds.
-- Target GitHub Release: `v0.30.0 — Blueprint security and adoption release` after npm publication succeeds.
-- Trusted publishing workflow: pending.
+- Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/26871381097.
+- npm package: https://www.npmjs.com/package/open-scaffold/v/0.30.0 with dist-tag `latest`.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.30.0.
 - Run ID / run packet: N/A for this scoped package/release sync.
 
 ## Verification
@@ -28,12 +29,13 @@ Baseline live-truth inspection before release-sync edits:
 - `git rev-parse main` / `git rev-parse origin/main` — PASS: both `bb9b6146f831a0834b27b28e4d0c71554a8fe592`.
 - `node -p "require('./package.json').version"` — PASS: `0.20.4` before candidate bump.
 - `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before publish: `0.20.4`, `latest: 0.20.4`.
-- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS before publish: `v0.20.4 — Fresh npx compare demo repair` is Latest.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS before publish: `v0.20.4 — Fresh npx compare demo repair` was Latest.
 - `gh pr list --repo graphanov/open-scaffold --state open` — PASS: no open PRs.
 - Active plans — PASS: none before creating this release-sync plan.
 
 Candidate gates before PR-ready:
 
+- [x] Simple added-line public-safety scan for private paths, personal names, emails, and Discord IDs — PASS.
 - [x] `node -p "require('./package.json').version + ' / ' + require('./package-lock.json').version + ' / ' + require('./package-lock.json').packages[''].version"` — PASS: `0.30.0 / 0.30.0 / 0.30.0`.
 - [x] `npm ci` — PASS: installed 88 packages; npm audit found 0 vulnerabilities.
 - [x] `git diff --check` — PASS.
@@ -42,29 +44,31 @@ Candidate gates before PR-ready:
 - [x] `npm run build` — PASS: core TypeScript build and runtime-omx build.
 - [x] `npm run osc -- doctor --check secret-scan` — PASS: `Doctor: no issues found.`
 - [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
-- [x] `npm run osc -- verify` — PASS with 9 warnings: 7 historical warnings plus 2 expected active-plan/release-note warnings while this release-sync plan remains active pending public proof.
-- [x] `npm run osc -- plan validate .osc/plans/active/141-0300-npx-release-sync.md --strict` — PASS: 0 issues.
+- [x] `npm run osc -- verify` — PASS with 9 warnings: 7 historical warnings plus 2 expected active-plan/release-note warnings while this release-sync plan remained active before public proof.
+- [x] Candidate plan validation before PR-ready — PASS: 0 issues.
 - [x] `npm pack --dry-run --json` payload inspection — PASS for `open-scaffold@0.30.0`; entry count 231; includes `dist/cli.js`, README/docs, examples, `.osc` template files, and shell helpers.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.30.0` with tag `latest`.
 - [x] Extracted-tarball smoke from a temp directory outside the repository — PASS: top-level help, `first-run --help`, `pr check --help`, adapter help surfaces, `schemas list --json`, and `schemas show open-scaffold.run.v1` all worked; required public help strings `osc first-run`, `osc pr check`, `osc adapter check`, `osc adapter trust`, `osc schemas list`, and `--online-github` were present.
-- [ ] Release candidate PR CI and latest-head Codex/thread gate — pending.
+- [x] Release candidate PR CI and latest-head Codex/thread gate — PASS: PR #171 CI green, Codex latest-head clean comment at 2026-06-03T07:46:36Z, no formal/inline findings after trigger, and review threads total/unresolved = 0.
 
 Post-merge/publication gates after owner-approved follow-through:
 
-- [ ] Sync clean `main` after release PR merge — pending.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.30.0` with dist-tag `latest` — pending.
-- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.30.0` and `latest: 0.30.0` — pending.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory — pending.
-- [ ] Fresh isolated-cache command/help smokes for `first-run`, `pr check`, adapter trust commands, schemas, and `--online-github` — pending.
-- [ ] GitHub Release `v0.30.0` exists, targets the merged `main` commit, and is marked Latest — pending.
-- [ ] This plan is closed to `done/` with final public proof — pending.
+- [x] Sync clean `main` after release PR merge — PASS: `main` fast-forwarded to `007d2a34431f4f6c02faba72edde29247ca4213f`.
+- [x] Post-merge main CI — PASS: `ci` completed successfully for `007d2a34431f4f6c02faba72edde29247ca4213f`.
+- [x] Post-merge local gates — PASS: `git diff --check`, `npm test -- tests/section-parser.test.ts --run`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `./verify.sh --strict`, `npm run osc -- verify`, corrected `npm pack --dry-run --json` payload assertion, and `npm publish --dry-run --tag latest`.
+- [x] Trusted publishing workflow published `open-scaffold@0.30.0` with dist-tag `latest` — PASS: run `26871381097` succeeded.
+- [x] `npm view open-scaffold version dist-tags --json --prefer-online` — PASS: `0.30.0`, `latest: 0.30.0`.
+- [x] `npm view open-scaffold@0.30.0 version --prefer-online` — PASS: `0.30.0`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory — PASS.
+- [x] Fresh isolated-cache command/help smokes for `first-run`, `pr check`, adapter trust commands, schemas, and `--online-github` — PASS: required help strings and schema ids were present.
+- [x] GitHub Release `v0.30.0` exists, targets `007d2a34431f4f6c02faba72edde29247ca4213f`, and is marked Latest — PASS.
+- [x] This plan is closed to `done/` with final public proof — PASS in this closeout branch.
 
 ## Outcome
 
-Candidate in progress. Do not treat `open-scaffold@0.30.0` as published until the trusted-publishing workflow, npm registry checks, fresh isolated-cache `npx` smokes, and GitHub Release Latest verification are all recorded here.
+Completed. PR #171 merged the release-sync update, trusted publishing succeeded, npm `open-scaffold@latest` resolves to `0.30.0`, fresh isolated-cache `npx` proves the package-visible OSB/security/adoption surfaces from outside the repository, GitHub Release `v0.30.0` is Latest, and plan `141-0300-npx-release-sync` is closed to `done/` by the closeout branch.
 
 ## Follow-up
 
-- Open the release candidate PR after local candidate gates pass.
-- After PR merge, dispatch trusted publishing with `expected-version=0.30.0` and `npm-tag=latest`.
-- Patch this note with final npm/GitHub Release URLs and verification output before moving plan `141-0300-npx-release-sync` to `done/`.
+- After the closeout branch merges, the release-sync plan should no longer appear in `.osc/plans/active/`.
+- Next product work can proceed from the remaining backlog only after this closeout lands and trunk verification remains clean.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-03: closed 141-0300-npx-release-sync — published open-scaffold@0.30.0, verified npm latest/fresh npx, and created GitHub Release v0.30.0
 - 2026-06-02: closed 138-blueprint-security-adoption-program — Closed blueprint program through child plans 139 and 140; remaining owner gates are PR review, merge, publish/release decisions, and real runtime side effects.
 - 2026-06-02: closed 140-blueprint-mega-security-adoption — Completed remaining blueprint security, adoption, runtime-boundary, proof, help, and schema surfaces in the mega Ralph-loop branch.
 - 2026-06-02: Owner requested one Ralph-loop mega PR for the remaining blueprint items; child plan 140 supersedes the original small-PR sequencing while preserving no-publish/no-release/no-spawn gates. — see .osc/plans/active/138-blueprint-security-adoption-program-amendment-1.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -393,7 +393,7 @@ Acceptance criteria:
 
 ### Milestone 18 — historical v1.0.0 stability launch
 
-Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel is intentionally corrected back to pre-1.0 hardening (`v0.20.x`) until the public product surface earns a mature 1.0 contract.
+Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel was intentionally corrected back to pre-1.0 hardening; after the blueprint security/adoption package sync, that current hardening line is `v0.30.x` until the public product surface earns a mature 1.0 contract.
 
 Goal: make the adoption contract explicit before the first major-release experiment.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.30.0 — Blueprint security and adoption release
 
-Status: release-sync candidate in this branch. It is not published to npm and not GitHub Latest until the release PR merges, trusted publishing succeeds, fresh `npx` proof passes, and GitHub Release `v0.30.0` is created/marked Latest.
+Status: published to npm as `open-scaffold@0.30.0`; GitHub Release `v0.30.0` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
@@ -17,13 +17,14 @@ Highlights:
 
 Evidence:
 
-- Release-sync plan: `.osc/plans/active/141-0300-npx-release-sync.md` until final public proof exists; expected closeout path is `.osc/plans/done/141-0300-npx-release-sync.md`.
+- Release-sync plan: `.osc/plans/done/141-0300-npx-release-sync.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/168
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/171
 - Release-sync evidence note: `.osc/releases/2026-06-03-141-0300-npx-release-sync.md`
 
 ## v0.20.4 — Fresh npx compare demo repair
 
-Status: published to npm as `open-scaffold@0.20.4`; GitHub Release `v0.20.4` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.20.4`; GitHub Release `v0.20.4` was Latest after owner-approved trusted publishing and release follow-through, then was superseded by `v0.30.0`.
 
 Highlights:
 

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -4,9 +4,9 @@ This page is the canonical reconciliation between the current package version an
 
 ## Current line: `v0.30.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.30.0` release-sync candidate.
-- **npm latest:** still `0.20.4` with dist-tag `latest` until trusted publishing for `0.30.0` succeeds; run `npm view open-scaffold version dist-tags --json` for live confirmation.
-- **GitHub Release latest:** still `v0.20.4` until `v0.30.0` is created and marked Latest after npm publication succeeds.
+- **Current `package.json` version:** `0.30.0`.
+- **npm latest:** `0.30.0` with dist-tag `latest` after trusted publishing run `26871381097`; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** `v0.30.0` is marked **Latest** after the blueprint security/adoption release.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.
@@ -25,7 +25,7 @@ The `v0.30.x` line defines a stable-enough core (the repo-native work-record loo
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.30.0` release-sync candidate |
+| `package.json` version | `0.30.0` |
 | Current package line | `v0.30.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('7e61f811088307e67927177d0c4fa7128e793f60177da9674625b0a4610b5046');
+    expect(hash(planIssueSnapshot)).toBe('1da65247ee6f7511bf694c856c5321c15163966d71d10c6a286c42e1aa88f4c2');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('967d7321c554b640d7b1bee28308bab0289cb6eb6b3236ba8c4d0db128639276');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary

- Close release-sync plan `141-0300-npx-release-sync` now that `open-scaffold@0.30.0` is published and GitHub Release `v0.30.0` is Latest.
- Patch final release evidence with PR, merge commit, trusted-publishing run, npm package, fresh `npx`, and GitHub Release proof.
- Reconcile changelog/version-truth/roadmap and the superseded `v0.20.4` evidence note so current public surfaces no longer describe `0.30.0` as pending/candidate or `v0.20.4` as current Latest.

## Verification

- [x] Simple added-line public-safety scan for private paths, personal names, emails, and Discord IDs — PASS.
- [x] `git diff --check` — PASS.
- [x] `npm run osc -- plan validate .osc/plans/done/141-0300-npx-release-sync.md --strict` — PASS: 0 issues.
- [x] `npm test -- tests/section-parser.test.ts --run` — PASS: 7 tests.
- [x] `npm test -- --run` — PASS: 56 files / 624 tests.
- [x] `npm run build` — PASS.
- [x] `npm run osc -- doctor --check secret-scan` — PASS.
- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
- [x] `npm run osc -- verify` — PASS with 7 historical warnings.
- [x] `npm view open-scaffold version dist-tags --json --prefer-online` — PASS: `0.30.0`, `latest: 0.30.0`.
- [x] `gh release list --repo graphanov/open-scaffold --limit 3` — PASS: `v0.30.0` marked Latest.

## Risk / gates

- Closeout-only branch: no runtime/spawn/deploy/webhook changes.
- After merge, trunk should have no active release-sync plan for `141-0300-npx-release-sync`.
