### PR TITLE
Close merged evolve-control plan

### DIFF
--- a/.osc/plans/done/142-private-pilot-usage-and-evolve-control.md
+++ b/.osc/plans/done/142-private-pilot-usage-and-evolve-control.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-03: closed 142-private-pilot-usage-and-evolve-control — landed evolve repair hypotheses and usage telemetry
 - 2026-06-03: closed 141-0300-npx-release-sync — published open-scaffold@0.30.0, verified npm latest/fresh npx, and created GitHub Release v0.30.0
 - 2026-06-02: closed 138-blueprint-security-adoption-program — Closed blueprint program through child plans 139 and 140; remaining owner gates are PR review, merge, publish/release decisions, and real runtime side effects.
 - 2026-06-02: closed 140-blueprint-mega-security-adoption — Completed remaining blueprint security, adoption, runtime-boundary, proof, help, and schema surfaces in the mega Ralph-loop branch.

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('71f38cbde5a4b8cdfb5f1ba6fc481edd0f358c49a86cab0c3f5c2b3f2b864d68');
+    expect(hash(planIssueSnapshot)).toBe('886ece880780f8d26c3dfed36d3ef494a9f95d964d547301c0321203bb807234');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('967d7321c554b640d7b1bee28308bab0289cb6eb6b3236ba8c4d0db128639276');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
Summary:
- move plan 142 from active to done after the merged evolve-control work
- stamp the mission changelog through the lifecycle helper
- update the live plan corpus hash pin after the planned state transition

Verification:
- ./verify.sh --quick --quiet
- git diff --check
- npm run build
- npm test
- ./verify.sh --strict

Not included:
- no release
- no publish
- no new benchmark-specific Open Scaffold feature