### PR TITLE
Add evolve next-action packets

### DIFF
--- a/.osc/plans/active/143-framework-value-next-action-packet.md
+++ b/.osc/plans/active/143-framework-value-next-action-packet.md
@@ -1,0 +1,59 @@
+# Plan: 143-framework-value-next-action-packet
+
+## Status
+
+active
+
+## Context
+
+The private framework-value reset found that prior slices already added repair hypotheses, usage receipts, plateau/impossible-criteria analysis, external scorer import, and compact evidence. The remaining generic control gap is handoff/recovery: `osc evolve analyze` recommends an action, but it does not emit a compact next-action packet that a fresh human, agent, or coordinator can use after context loss.
+
+## Goal
+
+Add a compact, benchmark-neutral next-action packet to `osc evolve analyze` so repeated-attempt loops produce controller-grade handoff guidance without runtime spawning or public proof claims.
+
+## Constraints / Out of scope
+
+- Do not add benchmark-specific contracts, fields, scorer rules, or 2000m assumptions.
+- Do not claim Open Scaffold makes models smarter, improves benchmark scores, or has benchmark support.
+- Do not spawn runtimes, select models, approve work, publish, release, push, open a PR, merge, or tag.
+- Do not add dependencies.
+- Keep the diff reviewable and focused on evolution analysis/handoff output.
+
+## Files to touch
+
+- `src/evolution.ts` — add next-action packet data model, synthesis, and terminal/markdown/JSON rendering.
+- `tests/evolution.test.ts` — cover packet content for redesign and stop/handoff cases.
+- `tests/cli-evolution.test.ts` — cover CLI JSON/markdown packet output.
+- `docs/EVOLUTION_LOOP.md` — document the packet as decision support, not execution/control proof.
+- `.osc-dev/framework-value-reset-2026-06-03.md` — private investigation report and evidence log for this reset.
+- `.omx/interviews/` and `.omx/state/` — Ralph PRD/interview/progress artifacts for this session.
+
+## Implementation Architecture Coverage
+
+- Strengthens: workflow control, handoff/recovery, stop/redesign decisions, token-efficiency pressure, and audit trails.
+- Audit envelope: this plan, `.omx/plans/prd-framework-value-reset.md`, `.osc-dev/framework-value-reset-2026-06-03.md`, changed code/tests/docs, and final verification command output.
+- Evaluation envelope: unit/CLI tests must prove the packet carries action, reasons, resume point, remaining criteria, required next fields, evidence refs, and boundary notes.
+- Feedback routing: packet actions route to stop, inspect_scorer, redesign, or continue; it must say what evidence or fields are missing before another retry.
+- Boundary: no runtime enforcement, benchmark certification, score approval, model ranking, or production release authority.
+
+## Acceptance criteria
+
+- [ ] `analyzeEvolutionLoop` JSON includes a compact `nextActionPacket` derived from current analysis evidence.
+- [ ] The packet includes recommended action, reasons, resume/current/frontier attempt ids, plateau state, acceptance counts, remaining failing criteria, safe evidence refs, required next fields, and boundary notes.
+- [ ] Terminal and markdown `osc evolve analyze` output render the packet in a concise handoff section.
+- [ ] Tests show redesign packets block blind retry and stop packets route to human closeout without treating frontier score as approval.
+- [ ] Docs describe the packet as handoff/decision support, not a runtime spawner, benchmark claim, approval authority, or model-improvement proof.
+- [ ] Full verification passes: `git diff --check`, `npm run build`, `npm test`, and `./verify.sh --strict`.
+
+## Verification steps
+
+1. `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts` — focused packet and regression coverage passes.
+2. `git diff --check` — no whitespace errors.
+3. `npm run build` — TypeScript builds for core and runtime package.
+4. `npm test` — full Vitest suite passes.
+5. `./verify.sh --strict` — repository compliance passes.
+
+## Open questions
+
+- None for this slice. Broader native controller behavior remains out of scope until independent evidence shows a need and boundary decision.

--- a/docs/EVOLUTION_LOOP.md
+++ b/docs/EVOLUTION_LOOP.md
@@ -88,6 +88,8 @@ osc evolve analyze .osc/evolution/demo-loop --format markdown --out docs/evidenc
 
 `osc evolve analyze` reads `loop.json`, `attempts.jsonl`, `frontier.json`, and linked evaluation envelopes. It reports plateau/stagnation, current-vs-previous and current-vs-frontier acceptance-criteria deltas, observed score sensitivity, criteria flagged as probe-only / hardcoded non-pass / skipped / stale / impossible, the current attempt's repair hypothesis and usage, and a next-action recommendation: `continue`, `stop`, `redesign`, or `inspect_scorer`. Criterion-level hints can come from evaluation/scorer metadata such as `analysis.score_sensitivity`, `analysis.impossible`, `analysis.reason`, and `analysis.source`, or from explicit evidence/rationale wording.
 
+The JSON, terminal, and markdown analysis outputs also include a compact next-action packet. It is a context-wipe handoff summary: recommended action, reasons, current/frontier resume point, plateau state, current pass/fail counts, remaining failing criteria, required next fields, safe evidence refs, and boundary notes. Use it to hand a loop to a fresh human, agent, or coordinator without copying bulky logs into prompt context. The packet is not an executor, benchmark result, approval, model ranking, or proof that Open Scaffold improved output quality.
+
 The analysis command is a decision aid. It does not mutate loop files unless `--out` is supplied for a rendered report, and even then it writes only the requested report path. It does not spawn runtimes, rerun benchmarks, rank models, certify compliance, promote a frontier, or approve work.
 
 Import structured external scorer output into an evaluation envelope when a domain tool already did the judging:

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -7,6 +7,7 @@ import type { ValidationIssue, ValidationResult } from './validation.js';
 export const EVOLUTION_LOOP_SCHEMA = 'open-scaffold.evolution-loop.v1';
 export const EVOLUTION_ATTEMPT_SCHEMA = 'open-scaffold.evolution-attempt.v1';
 export const EVOLUTION_FRONTIER_SCHEMA = 'open-scaffold.evolution-frontier.v1';
+export const EVOLUTION_NEXT_ACTION_PACKET_SCHEMA = 'open-scaffold.evolution-next-action-packet.v1';
 const RUN_SCHEMA = 'open-scaffold.run.v1';
 const EVALUATION_SCHEMA = 'open-scaffold.evaluation.v1';
 const DISPATCH_RECEIPT_SCHEMA = 'open-scaffold.dispatch-receipt.v1';
@@ -990,6 +991,49 @@ export interface EvolutionAnalysisCriterion {
   evidence: string[];
 }
 
+export interface EvolutionNextActionPacket {
+  schema: typeof EVOLUTION_NEXT_ACTION_PACKET_SCHEMA;
+  loop: { loopDir: string; loopId: string | null; objective: string | null };
+  recommendedAction: EvolutionAnalysisRecommendationAction;
+  summary: string;
+  reasons: string[];
+  resumeFrom: {
+    currentAttemptId: string | null;
+    currentRunId: string | null;
+    currentEvaluation: string | null;
+    frontierAttemptId: string | null;
+    frontierRunId: string | null;
+  };
+  plateau: {
+    status: EvolutionPlateauStatus;
+    noImprovementCount: number;
+    currentScore: number | null;
+    bestScore: number | null;
+  };
+  acceptance: {
+    currentPass: number;
+    currentTotal: number;
+    remainingFailures: Array<{
+      id: string;
+      text: string;
+      status: string | null;
+      sensitivity: EvolutionCriterionSensitivity;
+      impossible: boolean;
+      reasons: string[];
+      evidence: string[];
+    }>;
+  };
+  currentAttemptControl: {
+    repairHypothesis: EvolutionAttemptRepairHypothesis | null;
+    usage: EvolutionAttemptUsageSummary | null;
+    budgetWarning: string | null;
+  };
+  requiredNextFields: string[];
+  handoffChecklist: string[];
+  evidenceRefs: string[];
+  boundaryNotes: string[];
+}
+
 export interface EvolutionAnalysisResult {
   kind: 'analysis';
   loop: { loopDir: string; loopId: string | null; objective: string | null; strategy: string | null; attemptCount: number };
@@ -1002,6 +1046,7 @@ export interface EvolutionAnalysisResult {
   currentVsPrevious: { present: boolean; previousAttemptId: string | null; currentAttemptId: string | null; rows: EvolutionAnalysisDeltaRow[] };
   currentVsFrontier: { present: boolean; frontierAttemptId: string | null; currentAttemptId: string | null; rows: EvolutionAnalysisDeltaRow[] };
   recommendation: { action: EvolutionAnalysisRecommendationAction; summary: string; reasons: string[] };
+  nextActionPacket: EvolutionNextActionPacket;
   notes: string[];
 }
 
@@ -1064,6 +1109,37 @@ function collectEvidenceRefsFromCriterion(criterion: Record<string, unknown>, an
   return uniqueRefs(refs.filter((ref): ref is string => Boolean(ref && ref.trim() && isAnalysisRefSafe(ref))));
 }
 
+function localAnalysisRef(root: string, ref: string): { path: string; ref: string } | null {
+  if (/^[a-z]+:\/\//i.test(ref)) return null;
+  if (ref.startsWith('~')) return null;
+  const realRoot = rootRealpath(root);
+  if (isAbsolute(ref) || win32.isAbsolute(ref)) {
+    const absolute = resolve(ref);
+    const comparablePath = existsSync(absolute) ? realpathSync(absolute) : absolute;
+    if (!isInsideRoot(realRoot, comparablePath)) return null;
+    const rel = toPosix(relative(realRoot, comparablePath));
+    if (isPrivatePath(rel)) return null;
+    return { path: comparablePath, ref: rel };
+  }
+  if (!isAnalysisRefSafe(ref)) return null;
+  const safeRef = toPosix(ref).replace(/^\.\//, '');
+  const absolute = resolve(realRoot, safeRef);
+  const comparablePath = existsSync(absolute) ? realpathSync(absolute) : absolute;
+  if (!isInsideRoot(realRoot, comparablePath)) return null;
+  const rel = existsSync(absolute) ? toPosix(relative(realRoot, comparablePath)) : safeRef;
+  if (isPrivatePath(rel)) return null;
+  return { path: comparablePath, ref: rel };
+}
+
+function analysisEvaluationPath(root: string, evaluationRef: string): string | null {
+  return localAnalysisRef(root, evaluationRef)?.path ?? null;
+}
+
+function safeAnalysisOutputRef(root: string, ref: string): string | null {
+  if (/^https?:\/\//i.test(ref)) return ref;
+  return localAnalysisRef(root, ref)?.ref ?? null;
+}
+
 function metadataForCriterion(criterion: Record<string, unknown>): { impossible: boolean; reasons: string[]; evidence: string[]; sensitivityOverride: EvolutionCriterionSensitivity | null } {
   const analysis = isRecord(criterion.analysis) ? criterion.analysis : {};
   const reasons = new Set<string>();
@@ -1104,7 +1180,8 @@ function metadataForCriterion(criterion: Record<string, unknown>): { impossible:
 
 function readEvaluationCriteriaForAnalysis(root: string, evaluationRef: string | null): EvolutionAnalysisCriterionSnapshot[] {
   if (!evaluationRef) return [];
-  const evaluationPath = isAbsolute(evaluationRef) || win32.isAbsolute(evaluationRef) ? evaluationRef : resolve(root, evaluationRef);
+  const evaluationPath = analysisEvaluationPath(root, evaluationRef);
+  if (!evaluationPath) return [];
   try {
     const parsed = readJson(evaluationPath);
     if (!isRecord(parsed) || parsed.schema !== EVALUATION_SCHEMA) return [];
@@ -1221,13 +1298,13 @@ function inferObservedSensitivity(id: string, attempts: EvolutionCompareAttempt[
   return null;
 }
 
-function attemptSummary(attempt: EvolutionCompareAttempt | null) {
+function attemptSummary(root: string, attempt: EvolutionCompareAttempt | null) {
   return {
     attemptId: attempt?.attemptId ?? null,
     runId: attempt?.runId ?? null,
     decision: attempt?.decision ?? null,
     score: attempt?.score ?? null,
-    evaluation: attempt?.evaluation ?? null,
+    evaluation: attempt?.evaluation ? safeAnalysisOutputRef(root, attempt.evaluation) : null,
     repairHypothesis: attempt?.repairHypothesis ?? null,
     usage: attempt?.usage ?? null,
   };
@@ -1261,6 +1338,153 @@ function recommendAnalysis(plateau: EvolutionAnalysisResult['plateau'], criteria
     return { action: 'inspect_scorer', summary: 'Latest score is below the best recorded score; inspect scorer/evidence before continuing.', reasons: ['score_regressed'] };
   }
   return { action: 'continue', summary: 'Score or acceptance-criteria evidence is still moving; one more bounded attempt may be useful.', reasons: ['still_moving'] };
+}
+
+function requiredNextFieldsForAction(action: EvolutionAnalysisRecommendationAction): string[] {
+  switch (action) {
+    case 'stop':
+      return [
+        'human_approval_or_closeout_decision',
+        'closeout_verification_evidence',
+        'next_slice_or_done_routing',
+      ];
+    case 'redesign':
+      return [
+        'redesigned_criterion_scorer_or_artifact_shape',
+        'measurable_repair_hypothesis_before_retry',
+        'target_metric',
+        'expected_gain',
+        'usage_receipt_or_unavailable_reason',
+      ];
+    case 'inspect_scorer':
+      return [
+        'current_evaluation_or_scorer_inspection',
+        'score_sensitivity_or_impossibility_metadata',
+        'measurable_repair_hypothesis_before_retry',
+        'usage_receipt_or_unavailable_reason',
+      ];
+    case 'continue':
+      return [
+        'measurable_repair_hypothesis',
+        'target_metric',
+        'expected_gain',
+        'next_evaluation_envelope',
+        'usage_receipt_or_unavailable_reason',
+      ];
+  }
+}
+
+function budgetWarningForAttempt(attempt: EvolutionAnalysisResult['currentAttempt'], action: EvolutionAnalysisRecommendationAction): string | null {
+  const tokens = attempt.usage?.totalTokens ?? null;
+  if (tokens === null) return null;
+  const actualDelta = attempt.repairHypothesis?.actualDelta ?? null;
+  if ((action === 'redesign' || action === 'inspect_scorer') && actualDelta === 0) {
+    return `Last recorded attempt spent ${formatInteger(tokens)} token(s) for actual delta 0; do not spend another retry without new measurable control evidence.`;
+  }
+  if (action === 'continue') return `Record whether the next attempt beats the current ${formatInteger(tokens)} token cost for the target metric.`;
+  return null;
+}
+
+function handoffChecklistForAction(action: EvolutionAnalysisRecommendationAction, remainingFailures: EvolutionNextActionPacket['acceptance']['remainingFailures']): string[] {
+  const remaining = remainingFailures.length > 0 ? `Carry forward remaining failing criteria: ${remainingFailures.map((criterion) => criterion.id).join(', ')}.` : 'No current failing criteria are recorded.';
+  switch (action) {
+    case 'stop':
+      return [
+        'Stop retrying this loop unless a human rejects closeout evidence.',
+        'Route to human approval/closeout; frontier score is not acceptance approval.',
+        remaining,
+      ];
+    case 'redesign':
+      return [
+        'Do not record another blind retry against the same criterion/scorer/artifact shape.',
+        'Create or amend the next slice around the redesign before spending another attempt.',
+        remaining,
+      ];
+    case 'inspect_scorer':
+      return [
+        'Inspect scorer/evaluation coverage before recording another attempt.',
+        'Add explicit score-sensitivity, stale, skipped, probe-only, or impossible metadata where evidence supports it.',
+        remaining,
+      ];
+    case 'continue':
+      return [
+        'Run at most one bounded next attempt unless fresh evidence changes the stop condition.',
+        'Record repair hypothesis, target metric, expected gain, actual delta, and usage receipt.',
+        remaining,
+      ];
+  }
+}
+
+function buildNextActionPacket(
+  root: string,
+  loop: EvolutionAnalysisResult['loop'],
+  plateau: EvolutionAnalysisResult['plateau'],
+  currentAttempt: EvolutionAnalysisResult['currentAttempt'],
+  frontierAttempt: EvolutionAnalysisResult['frontierAttempt'],
+  acceptanceSummary: EvolutionAnalysisResult['acceptanceSummary'],
+  criteria: EvolutionAnalysisCriterion[],
+  recommendation: EvolutionAnalysisResult['recommendation'],
+): EvolutionNextActionPacket {
+  const remainingFailures = criteria
+    .filter((criterion) => criterion.currentStatus !== 'pass')
+    .map((criterion) => ({
+      id: criterion.id,
+      text: criterion.text,
+      status: criterion.currentStatus ?? 'missing_current',
+      sensitivity: criterion.sensitivity,
+      impossible: criterion.impossible,
+      reasons: criterion.reasons,
+      evidence: criterion.evidence,
+    }));
+  const evidenceRefs = uniqueRefs([
+    currentAttempt.evaluation,
+    ...remainingFailures.flatMap((criterion) => criterion.evidence),
+  ].flatMap((ref) => {
+    if (!ref || !ref.trim()) return [];
+    const safe = safeAnalysisOutputRef(root, ref);
+    return safe ? [safe] : [];
+  }));
+  return {
+    schema: EVOLUTION_NEXT_ACTION_PACKET_SCHEMA,
+    loop: {
+      loopDir: loop.loopDir,
+      loopId: loop.loopId,
+      objective: loop.objective,
+    },
+    recommendedAction: recommendation.action,
+    summary: recommendation.summary,
+    reasons: recommendation.reasons,
+    resumeFrom: {
+      currentAttemptId: currentAttempt.attemptId,
+      currentRunId: currentAttempt.runId,
+      currentEvaluation: currentAttempt.evaluation,
+      frontierAttemptId: frontierAttempt.attemptId,
+      frontierRunId: frontierAttempt.runId,
+    },
+    plateau: {
+      status: plateau.status,
+      noImprovementCount: plateau.noImprovementCount,
+      currentScore: plateau.currentScore,
+      bestScore: plateau.bestScore,
+    },
+    acceptance: {
+      currentPass: acceptanceSummary.currentPass,
+      currentTotal: acceptanceSummary.currentTotal,
+      remainingFailures,
+    },
+    currentAttemptControl: {
+      repairHypothesis: currentAttempt.repairHypothesis,
+      usage: currentAttempt.usage,
+      budgetWarning: budgetWarningForAttempt(currentAttempt, recommendation.action),
+    },
+    requiredNextFields: requiredNextFieldsForAction(recommendation.action),
+    handoffChecklist: handoffChecklistForAction(recommendation.action, remainingFailures),
+    evidenceRefs,
+    boundaryNotes: [
+      'This packet is handoff/decision support only; it does not spawn runtimes or execute the next attempt.',
+      'It is not benchmark support, model ranking, correctness certification, or acceptance approval.',
+    ],
+  };
 }
 
 export function analyzeEvolutionLoop(loopDir: string, options: EvolutionAnalyzeOptions = {}, root = process.cwd()): EvolutionAnalysisResult {
@@ -1338,13 +1562,17 @@ export function analyzeEvolutionLoop(loopDir: string, options: EvolutionAnalyzeO
     remainingFailures: currentCounts.remainingFailures,
   };
   const recommendation = recommendAnalysis(plateau, criteria, currentCounts.total);
+  const currentAttemptResult = attemptSummary(analysisRoot, currentAttempt);
+  const previousAttemptResult = attemptSummary(analysisRoot, previousAttempt);
+  const frontierAttemptResult = attemptSummary(analysisRoot, frontierAttempt);
+  const nextActionPacket = buildNextActionPacket(analysisRoot, loopInfo, plateau, currentAttemptResult, frontierAttemptResult, acceptanceSummary, criteria, recommendation);
   return {
     kind: 'analysis',
     loop: loopInfo,
     plateau,
-    currentAttempt: attemptSummary(currentAttempt),
-    previousAttempt: attemptSummary(previousAttempt),
-    frontierAttempt: attemptSummary(frontierAttempt),
+    currentAttempt: currentAttemptResult,
+    previousAttempt: previousAttemptResult,
+    frontierAttempt: frontierAttemptResult,
     acceptanceSummary,
     criteria,
     currentVsPrevious: {
@@ -1360,6 +1588,7 @@ export function analyzeEvolutionLoop(loopDir: string, options: EvolutionAnalyzeO
       rows: buildCurrentFrontierRows(ids, textById, frontierMap, currentMap),
     },
     recommendation,
+    nextActionPacket,
     notes: [
       'This analysis is read-only and does not spawn runtimes, rerun benchmarks, mutate loop state, rank models, or approve work.',
       'Score-frontier promotion is not acceptance approval; use human/maintainer review for closeout decisions.',
@@ -1381,6 +1610,7 @@ function impossibleLabel(criterion: EvolutionAnalysisCriterion): string {
 function renderAnalysisTerminal(analysis: EvolutionAnalysisResult): string {
   const currentHypothesis = analysis.currentAttempt.repairHypothesis;
   const currentUsage = analysis.currentAttempt.usage;
+  const packet = analysis.nextActionPacket;
   const lines = [
     `Evolution Analysis: ${analysis.loop.loopDir}`,
     `Objective: ${analysis.loop.objective ?? '—'}`,
@@ -1413,6 +1643,15 @@ function renderAnalysisTerminal(analysis: EvolutionAnalysisResult): string {
     `Recommendation: ${analysis.recommendation.action}`,
     `  ${analysis.recommendation.summary}`,
     '',
+    'Next action packet',
+    `  Action: ${packet.recommendedAction}`,
+    `  Resume: current=${packet.resumeFrom.currentAttemptId ?? '—'} | frontier=${packet.resumeFrom.frontierAttemptId ?? '—'}`,
+    `  Acceptance: ${packet.acceptance.currentPass}/${packet.acceptance.currentTotal} pass | remaining=${packet.acceptance.remainingFailures.map((criterion) => criterion.id).join(', ') || '—'}`,
+    `  Required next fields: ${packet.requiredNextFields.join(', ')}`,
+    ...(packet.currentAttemptControl.budgetWarning ? [`  Budget: ${packet.currentAttemptControl.budgetWarning}`] : []),
+    ...(packet.evidenceRefs.length > 0 ? [`  Evidence refs: ${packet.evidenceRefs.join(', ')}`] : []),
+    `  Boundary: ${packet.boundaryNotes.join(' ')}`,
+    '',
     'Notes',
     ...analysis.notes.map((note) => `  ${note}`),
     '',
@@ -1424,6 +1663,7 @@ function renderAnalysisTerminal(analysis: EvolutionAnalysisResult): string {
 function renderAnalysisMarkdown(analysis: EvolutionAnalysisResult): string {
   const currentHypothesis = analysis.currentAttempt.repairHypothesis;
   const currentUsage = analysis.currentAttempt.usage;
+  const packet = analysis.nextActionPacket;
   const lines = [
     `# Evolution analysis: ${analysis.loop.loopDir}`,
     '',
@@ -1478,6 +1718,27 @@ function renderAnalysisMarkdown(analysis: EvolutionAnalysisResult): string {
     '## Recommendation',
     '',
     `\`${analysis.recommendation.action}\` — ${analysis.recommendation.summary}`,
+    '',
+    '## Next action packet',
+    '',
+    `- Schema: \`${packet.schema}\``,
+    `- Action: \`${packet.recommendedAction}\``,
+    `- Resume: current \`${packet.resumeFrom.currentAttemptId ?? '—'}\`; frontier \`${packet.resumeFrom.frontierAttemptId ?? '—'}\``,
+    `- Acceptance: ${packet.acceptance.currentPass}/${packet.acceptance.currentTotal} pass; remaining ${packet.acceptance.remainingFailures.map((criterion) => `\`${criterion.id}\``).join(', ') || '—'}`,
+    `- Required next fields: ${packet.requiredNextFields.map((field) => `\`${field}\``).join(', ')}`,
+    ...(packet.currentAttemptControl.budgetWarning ? [`- Budget warning: ${packet.currentAttemptControl.budgetWarning}`] : []),
+    '',
+    '### Handoff checklist',
+    '',
+    ...packet.handoffChecklist.map((item) => `- ${item}`),
+    '',
+    '### Packet evidence refs',
+    '',
+    ...(packet.evidenceRefs.length > 0 ? packet.evidenceRefs.map((ref) => `- \`${ref}\``) : ['- —']),
+    '',
+    '### Packet boundaries',
+    '',
+    ...packet.boundaryNotes.map((note) => `- ${note}`),
     '',
     '## Boundaries',
     '',

--- a/tests/cli-evolution.test.ts
+++ b/tests/cli-evolution.test.ts
@@ -187,6 +187,71 @@ function writePlateauCliLoop() {
   return { root, outDir };
 }
 
+function writeInspectCliEvaluation(root: string, runId: string) {
+  const evalPath = join(root, `docs/evidence/${runId}-inspect-evaluation.json`);
+  writeFileSync(evalPath, JSON.stringify({
+    schema: 'open-scaffold.evaluation.v1',
+    evaluation_id: `eval-${runId}`,
+    subject: { source: 'run', plan: '.osc/plans/active/087-demo.md', plan_slug: '087-demo', task_id: 'task-123', run_id: runId, run_packet: `.osc/runs/${runId}/run.json` },
+    acceptance_criteria: [
+      {
+        id: 'AC1',
+        text: 'Loop state is created.',
+        status: 'pass',
+        evaluator: { kind: 'human', name: 'reviewer', ref: null },
+        evidence: [{ kind: 'path', ref: `docs/evidence/${runId}-proof.md`, summary: 'Synthetic CLI evidence.' }],
+        rationale: 'Loop state exists.',
+      },
+      {
+        id: 'AC2',
+        text: 'Frontier promotion is explicit.',
+        status: 'fail',
+        evaluator: { kind: 'human', name: 'reviewer', ref: null },
+        evidence: [{ kind: 'path', ref: `docs/evidence/${runId}-proof.md`, summary: 'Reachable work remains incomplete.' }],
+        rationale: 'Reachable criterion remains failed; scorer sensitivity needs inspection before another retry.',
+        analysis: { reason: 'missing_tests', source: `docs/evidence/${runId}-proof.md` },
+      },
+    ],
+    decision: { status: 'rejected', approver: 'human', rationale: 'Reachable failure remains.' },
+    improvement: { route: 'retry_run', target: null, carried_forward: ['AC2 remains reachable.'], do_not_assume: ['No model benchmark claim.'] },
+  }, null, 2));
+  return evalPath;
+}
+
+function writeInspectCliLoop() {
+  const { root, planPath } = tempRepo();
+  const outDir = join(root, '.osc/evolution/inspect-loop');
+  execFileSync(tsx, [cli, 'evolve', 'init', planPath, '--out', outDir, '--strategy', 'greedy'], { cwd: root, encoding: 'utf8' });
+  const attempts = [
+    { runId: 'attempt-a', decision: 'promote', rationale: 'Initial score frontier.' },
+    { runId: 'attempt-b', decision: 'retry', rationale: 'Retry plateaued with reachable failure.' },
+    { runId: 'attempt-c', decision: 'retry', rationale: 'Another retry plateaued with reachable failure.' },
+  ];
+  for (const attempt of attempts) {
+    const runPath = writeRunPacket(root, attempt.runId);
+    const evalPath = writeInspectCliEvaluation(root, attempt.runId);
+    const args = [cli, 'evolve', 'record', outDir, '--run', runPath, '--evaluation', evalPath, '--decision', attempt.decision, '--score', '0.7', '--rationale', attempt.rationale];
+    if (attempt.decision === 'retry') {
+      args.push(
+        '--repair-hypothesis',
+        `Repair reachable failure for ${attempt.runId}.`,
+        '--target-metric',
+        'accepted_ac_count',
+        '--expected-gain',
+        '1',
+        '--actual-delta',
+        '0',
+        '--tokens-total',
+        '1200',
+        '--usage-source',
+        'test fixture',
+      );
+    }
+    execFileSync(tsx, args, { cwd: root, encoding: 'utf8' });
+  }
+  return { root, outDir };
+}
+
 describe('checked-in evolution ledger demo fixture through the CLI', () => {
   it('checks the committed fixture and renders the expected markdown exactly', () => {
     const check = execFileSync(tsx, [cli, 'evolve', 'check', evolutionDemoLoop], { cwd: repoRoot, encoding: 'utf8' });
@@ -420,6 +485,12 @@ describe('osc evolve CLI', () => {
 
     const json = JSON.parse(execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--format', 'json'], { cwd: root, encoding: 'utf8' }));
     expect(json.recommendation.action).toBe('redesign');
+    expect(json.nextActionPacket).toMatchObject({
+      schema: 'open-scaffold.evolution-next-action-packet.v1',
+      recommendedAction: 'redesign',
+      acceptance: { currentPass: 2, currentTotal: 3 },
+    });
+    expect(json.nextActionPacket.requiredNextFields).toContain('redesigned_criterion_scorer_or_artifact_shape');
     expect(json.criteria.find((criterion: { id: string }) => criterion.id === 'AC3')).toMatchObject({ impossible: true, sensitivity: 'none' });
 
     const output = execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--format', 'markdown', '--out', reportPath], { cwd: root, encoding: 'utf8' });
@@ -428,10 +499,30 @@ describe('osc evolve CLI', () => {
     expect(report).toContain('# Evolution analysis: plateau-loop');
     expect(report).toContain('## Current vs frontier AC delta');
     expect(report).toContain('`redesign`');
+    expect(report).toContain('## Next action packet');
+    expect(report).toContain('Do not record another blind retry');
+    expect(report).toContain('`redesigned_criterion_scorer_or_artifact_shape`');
 
     expect(readFileSync(join(outDir, 'loop.json'), 'utf8')).toBe(before.loop);
     expect(readFileSync(join(outDir, 'attempts.jsonl'), 'utf8')).toBe(before.attempts);
     expect(readFileSync(join(outDir, 'frontier.json'), 'utf8')).toBe(before.frontier);
+  });
+
+  it('renders inspect_scorer next-action packets through the CLI', () => {
+    const { root, outDir } = writeInspectCliLoop();
+
+    const json = JSON.parse(execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--format', 'json'], { cwd: root, encoding: 'utf8' }));
+    expect(json.recommendation.action).toBe('inspect_scorer');
+    expect(json.nextActionPacket).toMatchObject({
+      recommendedAction: 'inspect_scorer',
+      acceptance: { currentPass: 1, currentTotal: 2 },
+    });
+    expect(json.nextActionPacket.requiredNextFields).toContain('current_evaluation_or_scorer_inspection');
+
+    const markdown = execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--format', 'markdown'], { cwd: root, encoding: 'utf8' });
+    expect(markdown).toContain('## Next action packet');
+    expect(markdown).toContain('`inspect_scorer`');
+    expect(markdown).toContain('Inspect scorer/evaluation coverage before recording another attempt.');
   });
 
   it('rejects unknown strategies and prints evolve usage', () => {

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
   EVOLUTION_LOOP_SCHEMA,
+  EVOLUTION_NEXT_ACTION_PACKET_SCHEMA,
   analyzeEvolutionLoop,
   compareEvolutionLoop,
   loadEvolutionSource,
@@ -731,6 +732,30 @@ describe('evolution analysis', () => {
     });
     expect(analysis.recommendation).toMatchObject({ action: 'redesign' });
     expect(analysis.recommendation.summary).toContain('remaining failing criteria');
+    expect(analysis.nextActionPacket).toMatchObject({
+      schema: EVOLUTION_NEXT_ACTION_PACKET_SCHEMA,
+      recommendedAction: 'redesign',
+      resumeFrom: { currentAttemptId: 'attempt-d', frontierAttemptId: 'attempt-b' },
+      acceptance: { currentPass: 2, currentTotal: 3 },
+      currentAttemptControl: {
+        budgetWarning: 'Last recorded attempt spent 1,003 token(s) for actual delta 0; do not spend another retry without new measurable control evidence.',
+      },
+    });
+    expect(analysis.nextActionPacket.acceptance.remainingFailures).toEqual([
+      expect.objectContaining({
+        id: 'AC3',
+        sensitivity: 'none',
+        impossible: true,
+        evidence: expect.arrayContaining(['docs/evidence/scorer.md#AC3']),
+      }),
+    ]);
+    expect(analysis.nextActionPacket.requiredNextFields).toEqual(expect.arrayContaining([
+      'redesigned_criterion_scorer_or_artifact_shape',
+      'measurable_repair_hypothesis_before_retry',
+      'usage_receipt_or_unavailable_reason',
+    ]));
+    expect(analysis.nextActionPacket.handoffChecklist.join('\n')).toContain('Do not record another blind retry');
+    expect(analysis.nextActionPacket.evidenceRefs).toEqual(expect.arrayContaining(['docs/evidence/attempt-d-evaluation.json', 'docs/evidence/scorer.md#AC3']));
     expect(analysis.notes.join('\n')).toContain('Score-frontier promotion is not acceptance approval');
 
     const terminal = renderEvolutionAnalysis(analysis, 'terminal');
@@ -739,6 +764,8 @@ describe('evolution analysis', () => {
     expect(terminal).toContain('Token cost: 1,003');
     expect(terminal).toContain('AC3: fail | sensitivity=none | impossible=probe_only');
     expect(terminal).toContain('Recommendation: redesign');
+    expect(terminal).toContain('Next action packet');
+    expect(terminal).toContain('Required next fields: redesigned_criterion_scorer_or_artifact_shape');
 
     const markdown = renderEvolutionAnalysis(analysis, 'markdown');
     expect(markdown).toContain('# Evolution analysis: plateau-loop');
@@ -748,15 +775,51 @@ describe('evolution analysis', () => {
     expect(markdown).toContain('| AC3 — Third criterion is probe-only for the current artifact shape. | ✗ fail | ✗ fail |');
     expect(markdown).toContain('## Recommendation');
     expect(markdown).toContain('`redesign`');
+    expect(markdown).toContain('## Next action packet');
+    expect(markdown).toContain('Do not record another blind retry');
 
     const json = JSON.parse(renderEvolutionAnalysis(analysis, 'json'));
     expect(json.recommendation.action).toBe('redesign');
+    expect(json.nextActionPacket.recommendedAction).toBe('redesign');
     expect(json.criteria.find((criterion: { id: string }) => criterion.id === 'AC3').impossible).toBe(true);
 
     expect(readFileSync(join(outDir, 'loop.json'), 'utf8')).toBe(before.loop);
     expect(readFileSync(join(outDir, 'attempts.jsonl'), 'utf8')).toBe(before.attempts);
     expect(readFileSync(join(outDir, 'frontier.json'), 'utf8')).toBe(before.frontier);
     expect(readFileSync(join(root, 'docs/evidence/attempt-d-evaluation.json'), 'utf8')).toBe(before.evaluation);
+  });
+
+  it('builds a stop packet that routes all-pass loops to human closeout instead of approval by score', () => {
+    const root = tempRepo();
+    const planPath = writePlan(root);
+    const runPath = writeRunPacket(root, 'attempt-a');
+    const evalPath = writeEvaluation(root, 'attempt-a');
+    const outDir = join(root, '.osc/evolution/stop-loop');
+    writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-06-03T08:00:00.000Z'), strategy: 'greedy' });
+    recordEvolutionAttempt(outDir, {
+      runPath,
+      evaluationPath: evalPath,
+      decision: 'promote',
+      score: 1,
+      rationale: 'All acceptance criteria pass; route to human closeout.',
+      now: new Date('2026-06-03T08:10:00.000Z'),
+    }, root);
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+
+    expect(analysis.recommendation).toMatchObject({ action: 'stop' });
+    expect(analysis.nextActionPacket).toMatchObject({
+      recommendedAction: 'stop',
+      acceptance: { currentPass: 2, currentTotal: 2, remainingFailures: [] },
+      resumeFrom: { currentAttemptId: 'attempt-a', frontierAttemptId: 'attempt-a' },
+    });
+    expect(analysis.nextActionPacket.requiredNextFields).toEqual([
+      'human_approval_or_closeout_decision',
+      'closeout_verification_evidence',
+      'next_slice_or_done_routing',
+    ]);
+    expect(analysis.nextActionPacket.handoffChecklist.join('\n')).toContain('frontier score is not acceptance approval');
+    expect(analysis.nextActionPacket.boundaryNotes.join('\n')).toContain('does not spawn runtimes');
   });
 
   it('uses current-attempt blocker metadata for recommendation instead of stale frontier metadata', () => {
@@ -774,6 +837,40 @@ describe('evolution analysis', () => {
     });
     expect(ac28?.reasons).not.toContain('probe_only');
     expect(analysis.recommendation.action).toBe('inspect_scorer');
+    expect(analysis.nextActionPacket).toMatchObject({
+      recommendedAction: 'inspect_scorer',
+      acceptance: { currentPass: 1, currentTotal: 2 },
+    });
+    expect(analysis.nextActionPacket.requiredNextFields).toEqual(expect.arrayContaining([
+      'current_evaluation_or_scorer_inspection',
+      'score_sensitivity_or_impossibility_metadata',
+      'usage_receipt_or_unavailable_reason',
+    ]));
+    expect(analysis.nextActionPacket.handoffChecklist.join('\n')).toContain('Inspect scorer/evaluation coverage');
+    expect(analysis.nextActionPacket.boundaryNotes.join('\n')).toContain('not benchmark support');
+  });
+
+  it('reads absolute local evaluation refs while rendering safe packet evidence refs', () => {
+    const { outDir, root } = writeOrdinaryFailureLoop();
+    const attemptsPath = join(outDir, 'attempts.jsonl');
+    const attempts = readFileSync(attemptsPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    attempts[attempts.length - 1].evaluation = join(root, 'docs/evidence/attempt-c-ordinary-evaluation.json');
+    writeFileSync(attemptsPath, `${attempts.map((attempt) => JSON.stringify(attempt)).join('\n')}\n`);
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+
+    expect(analysis.acceptanceSummary).toMatchObject({ currentPass: 1, currentTotal: 2 });
+    expect(analysis.criteria.find((criterion) => criterion.id === 'AC2')).toMatchObject({
+      currentStatus: 'fail',
+      sensitivity: 'unknown',
+    });
+    expect(analysis.nextActionPacket.evidenceRefs).toEqual(expect.arrayContaining([
+      'docs/evidence/skipped-rows-report.md',
+    ]));
+    expect(analysis.nextActionPacket.evidenceRefs.join('\n')).not.toContain(root);
   });
 
   it('treats missing current criterion metadata as scorer-inspection instead of stale blocker evidence', () => {
@@ -795,6 +892,22 @@ describe('evolution analysis', () => {
       action: 'inspect_scorer',
       reasons: expect.arrayContaining(['missing_current_acceptance_criteria']),
     });
+    expect(analysis.nextActionPacket).toMatchObject({
+      recommendedAction: 'inspect_scorer',
+      acceptance: {
+        currentPass: 1,
+        currentTotal: 1,
+        remainingFailures: [
+          expect.objectContaining({
+            id: 'AC3',
+            status: 'missing_current',
+            sensitivity: 'unknown',
+            impossible: false,
+          }),
+        ],
+      },
+    });
+    expect(analysis.nextActionPacket.handoffChecklist.join('\n')).toContain('AC3');
   });
 
   it('does not classify ordinary reachable failure reasons as impossible redesign-only blockers', () => {
@@ -834,6 +947,87 @@ describe('evolution analysis', () => {
     expect(markdown).not.toContain('.osc/research/private-scorer.md');
     expect(markdown).not.toContain('../raw-scorer.log');
     expect(markdown).not.toContain('docs/../../.osc-dev/notes.md');
+  });
+
+  it('does not read or render unsafe evaluation refs from hand-written attempt journals', () => {
+    const { outDir, root } = writeOrdinaryFailureLoop();
+    mkdirSync(join(root, '.osc-dev'), { recursive: true });
+    writeFileSync(join(root, '.osc-dev/private-evaluation.json'), JSON.stringify({
+      schema: 'open-scaffold.evaluation.v1',
+      acceptance_criteria: [
+        {
+          id: 'SECRET',
+          text: 'Private criterion must not leak.',
+          status: 'fail',
+          evidence: [{ kind: 'path', ref: '.osc-dev/private-note.md', summary: 'Private details.' }],
+          rationale: 'Private rationale.',
+        },
+      ],
+    }, null, 2));
+    const attemptsPath = join(outDir, 'attempts.jsonl');
+    const attempts = readFileSync(attemptsPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    attempts[attempts.length - 1].evaluation = '.osc-dev/private-evaluation.json';
+    writeFileSync(attemptsPath, `${attempts.map((attempt) => JSON.stringify(attempt)).join('\n')}\n`);
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+    const terminal = renderEvolutionAnalysis(analysis, 'terminal');
+    const markdown = renderEvolutionAnalysis(analysis, 'markdown');
+    const json = renderEvolutionAnalysis(analysis, 'json');
+
+    expect(analysis.currentAttempt.evaluation).toBeNull();
+    expect(analysis.nextActionPacket.evidenceRefs).not.toContain('.osc-dev/private-evaluation.json');
+    for (const output of [terminal, markdown, json]) {
+      expect(output).not.toContain('.osc-dev/private-evaluation.json');
+      expect(output).not.toContain('Private criterion');
+      expect(output).not.toContain('Private rationale');
+      expect(output).not.toContain('.osc-dev/private-note.md');
+    }
+  });
+
+  it('does not follow relative evaluation symlinks into private workspace state', () => {
+    const { outDir, root } = writeOrdinaryFailureLoop();
+    mkdirSync(join(root, '.osc-dev'), { recursive: true });
+    writeFileSync(join(root, '.osc-dev/private-evaluation.json'), JSON.stringify({
+      schema: 'open-scaffold.evaluation.v1',
+      acceptance_criteria: [
+        {
+          id: 'SECRET',
+          text: 'Private symlinked criterion must not leak.',
+          status: 'fail',
+          evidence: [{ kind: 'path', ref: '.osc-dev/private-note.md', summary: 'Private details.' }],
+          rationale: 'Private symlink rationale.',
+        },
+      ],
+    }, null, 2));
+    try {
+      symlinkSync(join(root, '.osc-dev/private-evaluation.json'), join(root, 'docs/evidence/private-evaluation-link.json'));
+    } catch {
+      return;
+    }
+    const attemptsPath = join(outDir, 'attempts.jsonl');
+    const attempts = readFileSync(attemptsPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    attempts[attempts.length - 1].evaluation = 'docs/evidence/private-evaluation-link.json';
+    writeFileSync(attemptsPath, `${attempts.map((attempt) => JSON.stringify(attempt)).join('\n')}\n`);
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+    const terminal = renderEvolutionAnalysis(analysis, 'terminal');
+    const markdown = renderEvolutionAnalysis(analysis, 'markdown');
+    const json = renderEvolutionAnalysis(analysis, 'json');
+
+    expect(analysis.currentAttempt.evaluation).toBeNull();
+    expect(analysis.nextActionPacket.evidenceRefs).not.toContain('docs/evidence/private-evaluation-link.json');
+    for (const output of [terminal, markdown, json]) {
+      expect(output).not.toContain('private-evaluation-link.json');
+      expect(output).not.toContain('Private symlinked criterion');
+      expect(output).not.toContain('Private symlink rationale');
+      expect(output).not.toContain('.osc-dev/private-note.md');
+    }
   });
 });
 

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('886ece880780f8d26c3dfed36d3ef494a9f95d964d547301c0321203bb807234');
+    expect(hash(planIssueSnapshot)).toBe('4aa044b31db19ddda885136a24e2067b39e504afa75c8a2ce4040d24983f6627');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('967d7321c554b640d7b1bee28308bab0289cb6eb6b3236ba8c4d0db128639276');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary
- Add a compact nextActionPacket to osc evolve analyze JSON, terminal, and markdown output.
- Preserve runtime-neutral boundaries: the packet is handoff/decision support, not execution, approval, model ranking, or benchmark proof.
- Include missing-current acceptance criteria in packet remaining failures so inspect_scorer handoffs do not hide omitted criteria.
- Harden evaluation refs so analysis rejects private/internal refs and relative symlinks into private workspace state.

## Verification
- git diff --check
- npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts tests/section-parser.test.ts
- npm run build
- npm test
- ./verify.sh --strict

## Not tested
- Live external coordinator consumption of nextActionPacket.