### PR TITLE
chore: close next-action packet plan

### DIFF
--- a/.osc/plans/done/143-framework-value-next-action-packet.md
+++ b/.osc/plans/done/143-framework-value-next-action-packet.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-03: closed 143-framework-value-next-action-packet — PR #175 merged; next-action packet shipped as workflow-neutral handoff guidance
 - 2026-06-03: closed 142-private-pilot-usage-and-evolve-control — landed evolve repair hypotheses and usage telemetry
 - 2026-06-03: closed 141-0300-npx-release-sync — published open-scaffold@0.30.0, verified npm latest/fresh npx, and created GitHub Release v0.30.0
 - 2026-06-02: closed 138-blueprint-security-adoption-program — Closed blueprint program through child plans 139 and 140; remaining owner gates are PR review, merge, publish/release decisions, and real runtime side effects.

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('4aa044b31db19ddda885136a24e2067b39e504afa75c8a2ce4040d24983f6627');
+    expect(hash(planIssueSnapshot)).toBe('72551f58ca50445175f57b34cbce1dab728dd45d40827f80071dfae5b678d6d1');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('967d7321c554b640d7b1bee28308bab0289cb6eb6b3236ba8c4d0db128639276');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary
- Moves plan `143-framework-value-next-action-packet` from active to done after PR #175 merged.
- Stamps the mission changelog with the closeout entry.
- Re-pins the live plan corpus hash after the plan move.

## Verification
- `git diff --check`
- `node dist/cli.js plan validate .osc/plans/done/143-framework-value-next-action-packet.md`
- `./verify.sh --strict`
- `npm test -- --run`
- `npm run build`

## Risk / boundaries
- Closeout-only follow-up; no product behavior change.
- No publish, release, npm, or tag action.
