### PR TITLE
chore: prepare 0.30.1 release sync

### DIFF
--- a/.osc/plans/active/144-next-action-packet-npx-release-sync.md
+++ b/.osc/plans/active/144-next-action-packet-npx-release-sync.md
@@ -1,0 +1,54 @@
+# Plan: 144-next-action-packet-npx-release-sync
+
+## Status
+
+active
+
+## Context
+
+PR #175 added workflow-neutral next-action packets to `osc evolve analyze`, and PR #176 closed the shipped plan. The repository now exposes the new behavior on `main`, but npm `open-scaffold@latest` and GitHub Latest still point at `0.30.0`. A package/release sync is needed before fresh `npx open-scaffold@latest` users can see the new evolution handoff packet.
+
+## Goal
+
+Publish `open-scaffold@0.30.1` on the npm `latest` dist-tag, create GitHub Release `v0.30.1` as Latest, prove fresh isolated-cache `npx` exposes the next-action packet surface, and then close this release-sync plan with final evidence.
+
+## Constraints / Out of scope
+
+- Do not add product features beyond the package/release sync for already-merged PRs #175 and #176.
+- Do not claim benchmark support, model improvement, score improvement, workflow support, compliance certification, runtime correctness, or production readiness.
+- Do not spawn runtimes, select models, approve work, publish unrelated packages, or change runtime boundaries.
+- Do not publish if package, local verification, CI, trusted publishing, npm, fresh `npx`, or GitHub Release gates fail.
+- Keep the package line on the current pre-1.0 `v0.30.x` track.
+
+## Files to touch
+
+- `package.json` — bump the package version to `0.30.1`.
+- `package-lock.json` — keep the lockfile root package version aligned with `package.json`.
+- `docs/CHANGELOG.md` — add release-facing `v0.30.1` notes.
+- `docs/VERSION_TRUTH.md` — reconcile repository, npm, and GitHub Release truth for the `0.30.1` release flow.
+- `.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md` — record candidate gates, public publish proof, GitHub Release proof, and final closeout evidence.
+- `.osc/plans/done/144-next-action-packet-npx-release-sync.md` — final closed plan path after public npm/GitHub Release/fresh `npx` proof exists.
+
+## Acceptance criteria
+
+- [ ] `package.json`, `package-lock.json`, changelog/version-truth docs, and release evidence prepare target version `0.30.1` without claiming npm/GitHub publication before it happens.
+- [ ] Candidate gates pass: `npm ci`, `git diff --check`, focused evolution/package tests, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `./verify.sh --strict`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [ ] Release candidate PR is merged only after CI is green, latest-head Codex review is clean if triggered, and unresolved current-head review threads are zero.
+- [ ] Trusted publishing publishes `open-scaffold@0.30.1` with dist-tag `latest`, and `npm view open-scaffold version dist-tags --json --prefer-online` confirms `0.30.1` / `latest`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest` proof from outside the repository verifies top-level help and the `osc evolve analyze` next-action packet JSON/markdown surface.
+- [ ] GitHub Release `v0.30.1` exists, targets the merged `main` commit, is marked Latest, and uses concise public-safe boundary language.
+- [ ] Final evidence records npm URL, trusted-publishing run, GitHub Release URL, fresh `npx` commands/results, PR/merge commits, and remaining risks; this plan is moved to `done/` only after those public surfaces are verified.
+
+## Verification steps
+
+1. Sync and inspect live truth: `git status --short --branch`, `git fetch --prune origin`, `node -p "require('./package.json').version"`, `npm view open-scaffold version dist-tags --json --prefer-online`, `gh release list --repo graphanov/open-scaffold --limit 5`, and `gh pr list --repo graphanov/open-scaffold --state open`.
+2. Candidate pre-publish gates: `npm ci`; `git diff --check`; focused evolution/package tests; `npm test -- --run`; `npm run build`; `npm run osc -- doctor --check secret-scan`; `./verify.sh --strict`; `npm pack --dry-run --json`; `npm publish --dry-run --tag latest`.
+3. PR gate: create a release candidate PR, monitor CI, trigger/poll Codex if normal for the repo, and require unresolved current-head review threads = 0 before merge.
+4. Publish gate: dispatch the trusted-publishing workflow for expected version `0.30.1` and npm tag `latest`, wait for success, and verify registry truth with `npm view`.
+5. Public package smoke: run fresh isolated-cache `npx --yes open-scaffold@latest --help`, `npx --yes open-scaffold@latest evolve analyze <loop> --format json`, and markdown output from a temp directory outside the repository.
+6. Release gate: create GitHub Release `v0.30.1`, mark it Latest, and verify release list/view output.
+7. Closeout gate: patch final evidence, close this plan to `done`, run `git diff --check`, `./verify.sh --strict`, and `npm run osc -- plan validate .osc/plans/done/144-next-action-packet-npx-release-sync.md --strict` before any closeout PR/merge.
+
+## Open questions
+
+- None. Owner authorization for the end-to-end `0.30.1` release flow is explicit; any failed gate blocks publication and must be reported instead of forced.

--- a/.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md
+++ b/.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md
@@ -1,0 +1,65 @@
+# Release / Evidence Note: 144 next-action packet npx release sync
+
+## Summary
+
+Prepares `open-scaffold@0.30.1` as the owner-approved package/release sync for the `osc evolve analyze` next-action packet work from PRs #175 and #176.
+
+The package-visible change is workflow-neutral handoff guidance: `osc evolve analyze` can emit a compact next-action packet for a fresh human, agent, or coordinator after context loss. Open Scaffold remains repo-native and no-spawn by default. This release does not claim benchmark support, model improvement, score improvement, workflow support, compliance certification, runtime correctness, or production readiness.
+
+## Traceability
+
+- Release-sync plan: `.osc/plans/active/144-next-action-packet-npx-release-sync.md` while candidate/publication gates are not complete.
+- Source feature PR: https://github.com/graphanov/open-scaffold/pull/175.
+- Source closeout PR: https://github.com/graphanov/open-scaffold/pull/176.
+- Release-sync branch: `release/0.30.1-next-action-packet`.
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/177.
+- Trusted publishing workflow: not run yet for `0.30.1`.
+- npm package: not published yet for `open-scaffold@0.30.1`.
+- GitHub Release: not created yet for `v0.30.1`.
+- Run ID / run packet: N/A for this scoped package/release sync.
+
+## Verification
+
+Baseline live-truth inspection before release-sync edits:
+
+- `git status --short --branch` — PASS: clean `main...origin/main` after PR #176 merge.
+- `git fetch --prune origin` — PASS.
+- `node -p "require('./package.json').version"` — PASS: `0.30.0` before candidate bump.
+- `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before publish: `0.30.0`, `latest: 0.30.0`.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS before publish: `v0.30.0 — Blueprint security and adoption release` was Latest.
+- `gh pr list --repo graphanov/open-scaffold --state open` — PASS before candidate branch: none after PR #176 merged.
+
+Candidate gates before PR-ready:
+
+- [x] Version alignment — PASS: `0.30.1 / 0.30.1 / 0.30.1` for `package.json`, `package-lock.json`, and lockfile root package version.
+- [x] `npm ci` — PASS: installed 88 packages; npm audit found 0 vulnerabilities.
+- [x] `git diff --check` — PASS.
+- [x] Focused evolution/package tests: `npm test -- tests/evolution.test.ts tests/cli-evolution.test.ts tests/package-payload.test.ts tests/section-parser.test.ts --run` — PASS: 4 files / 57 tests.
+- [x] `npm test -- --run` — PASS: 56 files / 633 tests.
+- [x] `npm run build` — PASS: core TypeScript build and runtime-omx build.
+- [x] `npm run osc -- doctor --check secret-scan` — PASS: `Doctor: no issues found.`
+- [x] `./verify.sh --strict` — PASS with expected active-release-plan warning: 9 pass / 0 fail / 1 warn while this release-sync plan remains active before public proof.
+- [x] Candidate plan validation — PASS: `npm run osc -- plan validate .osc/plans/active/144-next-action-packet-npx-release-sync.md --strict` reported 0 issues.
+- [x] `npm pack --dry-run --json` payload inspection — PASS for `open-scaffold@0.30.1`; entry count 231; includes `dist/cli.js`, `dist/evolution.js`, `README.md`, `docs/EVOLUTION_LOOP.md`, and package metadata.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.30.1` with tag `latest`.
+- [x] Release candidate PR created for final gate: https://github.com/graphanov/open-scaffold/pull/177. Final merge readiness is determined from the PR conversation/checks after the last push, not from this committed evidence note.
+
+Post-merge/publication gates after owner-approved follow-through:
+
+- [ ] Sync clean `main` after release PR merge.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.30.1` with dist-tag `latest`.
+- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` confirms `0.30.1`, `latest: 0.30.1`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory passes.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest evolve analyze <loop> --format json` proves `nextActionPacket.schema = open-scaffold.evolution-next-action-packet.v1`.
+- [ ] Fresh isolated-cache markdown output contains `## Next action packet`.
+- [ ] GitHub Release `v0.30.1` exists, targets the merged `main` commit, and is marked Latest.
+- [ ] This plan is closed to `done` with final public proof.
+
+## Outcome
+
+Not complete. This candidate evidence note must not be read as publication proof until the trusted-publishing, fresh `npx`, GitHub Release, and closeout gates above are checked off with real command output.
+
+## Follow-up
+
+- Keep this release-sync plan active until npm/latest, fresh `npx`, GitHub Release Latest, and closeout evidence are real.
+- Do not start a new product slice until this release/public-surface train is either completed or explicitly parked with a blocker.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,24 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.30.1 — Evolution handoff packet release
+
+Status: release candidate prepared for `open-scaffold@0.30.1`; publication proof is tracked in `.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md` and must be verified against npm/GitHub live truth.
+
+Highlights:
+
+- Publishes the `osc evolve analyze` next-action packet work from PR #175 plus plan closeout from PR #176 to the public `npx open-scaffold@latest` package surface.
+- Adds workflow-neutral handoff guidance for repeated-attempt/evolution loops: recommended action, reasons, resume/frontier context, remaining criteria, required next fields, safe evidence refs, and boundary notes.
+- Keeps the packet as decision support only: no runtime spawning, no model selection, no benchmark-support claim, no score-improvement claim, and no approval authority.
+
+Evidence:
+
+- Source plan: `.osc/plans/done/143-framework-value-next-action-packet.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/175
+- Closeout PR: https://github.com/graphanov/open-scaffold/pull/176
+- Release-sync plan: `.osc/plans/active/144-next-action-packet-npx-release-sync.md`
+- Release-sync evidence note: `.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md`
+
 ## v0.30.0 — Blueprint security and adoption release
 
 Status: published to npm as `open-scaffold@0.30.0`; GitHub Release `v0.30.0` is Latest after owner-approved trusted publishing and release follow-through.

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -4,9 +4,9 @@ This page is the canonical reconciliation between the current package version an
 
 ## Current line: `v0.30.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.30.0`.
-- **npm latest:** `0.30.0` with dist-tag `latest` after trusted publishing run `26871381097`; run `npm view open-scaffold version dist-tags --json` for live confirmation.
-- **GitHub Release latest:** `v0.30.0` is marked **Latest** after the blueprint security/adoption release.
+- **Current `package.json` version:** `0.30.1`.
+- **npm latest:** candidate target `0.30.1` with dist-tag `latest` after the next-action packet release-sync; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** candidate target `v0.30.1` after the next-action packet release-sync; GitHub Releases remains the live truth.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.
@@ -25,7 +25,7 @@ The `v0.30.x` line defines a stable-enough core (the repo-native work-record loo
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.30.0` |
+| `package.json` version | `0.30.1` |
 | Current package line | `v0.30.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('72551f58ca50445175f57b34cbce1dab728dd45d40827f80071dfae5b678d6d1');
+    expect(hash(planIssueSnapshot)).toBe('52fb49579673150ab5c512a206d175fdcced08f1495708b86ac2d5c9fb29409a');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('967d7321c554b640d7b1bee28308bab0289cb6eb6b3236ba8c4d0db128639276');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('32a0a8261494920e76e7fcf10b0c3bfa4878428cccbe7d334ad6ce703b3a0073');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Prepares `open-scaffold@0.30.1` for the `osc evolve analyze` next-action packet surface from PR #175 and plan closeout from PR #176.
- Adds the release-sync plan/evidence note, changelog entry, and version-truth update.
- Keeps claims bounded: decision-support handoff packet only; no runtime spawning, benchmark-support claim, model-improvement claim, or approval authority.

## Verification
- `npm ci`
- `git diff --check`
- `npm test -- tests/evolution.test.ts tests/cli-evolution.test.ts tests/package-payload.test.ts tests/section-parser.test.ts --run`
- `npm test -- --run`
- `npm run build`
- `npm run osc -- doctor --check secret-scan`
- `./verify.sh --strict` (9 pass / 0 fail / 1 expected active-release-plan warning)
- `npm run osc -- plan validate .osc/plans/active/144-next-action-packet-npx-release-sync.md --strict`
- `npm pack --dry-run --json`
- `npm publish --dry-run --tag latest`

## Risk / boundaries
- Real npm trusted publishing and GitHub Release creation happen only after this PR lands on `main`.
- This does not publish unrelated packages, spawn runtimes, or claim workflow/benchmark support.
