### PR TITLE
chore: close 0.30.1 release sync

### DIFF
--- a/.osc/plans/done/144-next-action-packet-npx-release-sync.md
+++ b/.osc/plans/done/144-next-action-packet-npx-release-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
@@ -31,13 +31,13 @@ Publish `open-scaffold@0.30.1` on the npm `latest` dist-tag, create GitHub Relea
 
 ## Acceptance criteria
 
-- [ ] `package.json`, `package-lock.json`, changelog/version-truth docs, and release evidence prepare target version `0.30.1` without claiming npm/GitHub publication before it happens.
-- [ ] Candidate gates pass: `npm ci`, `git diff --check`, focused evolution/package tests, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `./verify.sh --strict`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
-- [ ] Release candidate PR is merged only after CI is green, latest-head Codex review is clean if triggered, and unresolved current-head review threads are zero.
-- [ ] Trusted publishing publishes `open-scaffold@0.30.1` with dist-tag `latest`, and `npm view open-scaffold version dist-tags --json --prefer-online` confirms `0.30.1` / `latest`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest` proof from outside the repository verifies top-level help and the `osc evolve analyze` next-action packet JSON/markdown surface.
-- [ ] GitHub Release `v0.30.1` exists, targets the merged `main` commit, is marked Latest, and uses concise public-safe boundary language.
-- [ ] Final evidence records npm URL, trusted-publishing run, GitHub Release URL, fresh `npx` commands/results, PR/merge commits, and remaining risks; this plan is moved to `done/` only after those public surfaces are verified.
+- [x] `package.json`, `package-lock.json`, changelog/version-truth docs, and release evidence prepare target version `0.30.1` without claiming npm/GitHub publication before it happens.
+- [x] Candidate gates pass: `npm ci`, `git diff --check`, focused evolution/package tests, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `./verify.sh --strict`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Release candidate PR is merged only after CI is green, latest-head Codex review is clean if triggered, and unresolved current-head review threads are zero.
+- [x] Trusted publishing publishes `open-scaffold@0.30.1` with dist-tag `latest`, and `npm view open-scaffold version dist-tags --json --prefer-online` confirms `0.30.1` / `latest`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest` proof from outside the repository verifies top-level help and the `osc evolve analyze` next-action packet JSON/markdown surface.
+- [x] GitHub Release `v0.30.1` exists, targets the merged `main` commit, is marked Latest, and uses concise public-safe boundary language.
+- [x] Final evidence records npm URL, trusted-publishing run, GitHub Release URL, fresh `npx` commands/results, PR/merge commits, and remaining risks; this plan is moved to `done/` only after those public surfaces are verified.
 
 ## Verification steps
 

--- a/.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md
+++ b/.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md
@@ -2,20 +2,21 @@
 
 ## Summary
 
-Prepares `open-scaffold@0.30.1` as the owner-approved package/release sync for the `osc evolve analyze` next-action packet work from PRs #175 and #176.
+Published `open-scaffold@0.30.1` as the owner-approved package/release sync for the `osc evolve analyze` next-action packet work from PRs #175 and #176.
 
 The package-visible change is workflow-neutral handoff guidance: `osc evolve analyze` can emit a compact next-action packet for a fresh human, agent, or coordinator after context loss. Open Scaffold remains repo-native and no-spawn by default. This release does not claim benchmark support, model improvement, score improvement, workflow support, compliance certification, runtime correctness, or production readiness.
 
 ## Traceability
 
-- Release-sync plan: `.osc/plans/active/144-next-action-packet-npx-release-sync.md` while candidate/publication gates are not complete.
+- Release-sync plan: `.osc/plans/done/144-next-action-packet-npx-release-sync.md`.
 - Source feature PR: https://github.com/graphanov/open-scaffold/pull/175.
 - Source closeout PR: https://github.com/graphanov/open-scaffold/pull/176.
-- Release-sync branch: `release/0.30.1-next-action-packet`.
-- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/177.
-- Trusted publishing workflow: not run yet for `0.30.1`.
-- npm package: not published yet for `open-scaffold@0.30.1`.
-- GitHub Release: not created yet for `v0.30.1`.
+- Release-sync branch / PR: https://github.com/graphanov/open-scaffold/pull/177.
+- Release-sync merge commit: `55021ca8a88d3d8a5a2aebbaa248a98ca5db9976`.
+- Main CI for release commit: https://github.com/graphanov/open-scaffold/actions/runs/26901024436.
+- Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/26901169778.
+- npm package: https://www.npmjs.com/package/open-scaffold/v/0.30.1 with dist-tag `latest`.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.30.1.
 - Run ID / run packet: N/A for this scoped package/release sync.
 
 ## Verification
@@ -38,28 +39,31 @@ Candidate gates before PR-ready:
 - [x] `npm test -- --run` — PASS: 56 files / 633 tests.
 - [x] `npm run build` — PASS: core TypeScript build and runtime-omx build.
 - [x] `npm run osc -- doctor --check secret-scan` — PASS: `Doctor: no issues found.`
-- [x] `./verify.sh --strict` — PASS with expected active-release-plan warning: 9 pass / 0 fail / 1 warn while this release-sync plan remains active before public proof.
+- [x] `./verify.sh --strict` — PASS with expected active-release-plan warning: 9 pass / 0 fail / 1 warn while this release-sync plan remained active before public proof.
 - [x] Candidate plan validation — PASS: `npm run osc -- plan validate .osc/plans/active/144-next-action-packet-npx-release-sync.md --strict` reported 0 issues.
 - [x] `npm pack --dry-run --json` payload inspection — PASS for `open-scaffold@0.30.1`; entry count 231; includes `dist/cli.js`, `dist/evolution.js`, `README.md`, `docs/EVOLUTION_LOOP.md`, and package metadata.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.30.1` with tag `latest`.
-- [x] Release candidate PR created for final gate: https://github.com/graphanov/open-scaffold/pull/177. Final merge readiness is determined from the PR conversation/checks after the last push, not from this committed evidence note.
+- [x] Release candidate PR #177 CI and latest-head Codex/thread gate — PASS: CI green, Codex latest-head clean comment after final push, no inline findings, and review threads total/unresolved = 0.
 
 Post-merge/publication gates after owner-approved follow-through:
 
-- [ ] Sync clean `main` after release PR merge.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.30.1` with dist-tag `latest`.
-- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` confirms `0.30.1`, `latest: 0.30.1`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory passes.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest evolve analyze <loop> --format json` proves `nextActionPacket.schema = open-scaffold.evolution-next-action-packet.v1`.
-- [ ] Fresh isolated-cache markdown output contains `## Next action packet`.
-- [ ] GitHub Release `v0.30.1` exists, targets the merged `main` commit, and is marked Latest.
-- [ ] This plan is closed to `done` with final public proof.
+- [x] Sync clean `main` after release PR merge — PASS: `main` fast-forwarded to `55021ca8a88d3d8a5a2aebbaa248a98ca5db9976`.
+- [x] Main CI for release commit — PASS: run `26901024436` succeeded.
+- [x] Post-merge local gates — PASS: `git diff --check`, `npm test -- tests/section-parser.test.ts --run`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `./verify.sh --strict`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Trusted publishing workflow published `open-scaffold@0.30.1` with dist-tag `latest` — PASS: run `26901169778` succeeded.
+- [x] `npm view open-scaffold version dist-tags --json --prefer-online` — PASS: `0.30.1`, `latest: 0.30.1`.
+- [x] `npm view open-scaffold@0.30.1 version dist.tarball dist.integrity --json --prefer-online` — PASS: `0.30.1`, tarball `https://registry.npmjs.org/open-scaffold/-/open-scaffold-0.30.1.tgz`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory — PASS.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest evolve analyze <loop> --format json` — PASS: `nextActionPacket.schema = open-scaffold.evolution-next-action-packet.v1`, `recommendedAction = redesign`.
+- [x] Fresh isolated-cache markdown output — PASS: contained `## Next action packet`.
+- [x] GitHub Release `v0.30.1` exists, targets `55021ca8a88d3d8a5a2aebbaa248a98ca5db9976`, and is marked Latest — PASS.
+- [x] This plan is closed to `done` with final public proof — PASS in this closeout branch.
 
 ## Outcome
 
-Not complete. This candidate evidence note must not be read as publication proof until the trusted-publishing, fresh `npx`, GitHub Release, and closeout gates above are checked off with real command output.
+Completed. PR #177 merged the release-sync update, trusted publishing succeeded, npm `open-scaffold@latest` resolves to `0.30.1`, fresh isolated-cache `npx` proves the package-visible next-action packet surface from outside the repository, GitHub Release `v0.30.1` is Latest, and plan `144-next-action-packet-npx-release-sync` is closed to `done` by the closeout branch.
 
 ## Follow-up
 
-- Keep this release-sync plan active until npm/latest, fresh `npx`, GitHub Release Latest, and closeout evidence are real.
-- Do not start a new product slice until this release/public-surface train is either completed or explicitly parked with a blocker.
+- After the closeout branch merges, the release-sync plan should no longer appear in `.osc/plans/active/`.
+- Next product work can proceed from the remaining backlog only after this closeout lands and trunk verification remains clean.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-03: closed 144-next-action-packet-npx-release-sync — published open-scaffold@0.30.1, verified npm latest/fresh npx, and created GitHub Release v0.30.1
 - 2026-06-03: closed 143-framework-value-next-action-packet — PR #175 merged; next-action packet shipped as workflow-neutral handoff guidance
 - 2026-06-03: closed 142-private-pilot-usage-and-evolve-control — landed evolve repair hypotheses and usage telemetry
 - 2026-06-03: closed 141-0300-npx-release-sync — published open-scaffold@0.30.0, verified npm latest/fresh npx, and created GitHub Release v0.30.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.30.1 — Evolution handoff packet release
 
-Status: release candidate prepared for `open-scaffold@0.30.1`; publication proof is tracked in `.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md` and must be verified against npm/GitHub live truth.
+Status: published to npm as `open-scaffold@0.30.1`; GitHub Release `v0.30.1` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
@@ -19,7 +19,7 @@ Evidence:
 - Source plan: `.osc/plans/done/143-framework-value-next-action-packet.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/175
 - Closeout PR: https://github.com/graphanov/open-scaffold/pull/176
-- Release-sync plan: `.osc/plans/active/144-next-action-packet-npx-release-sync.md`
+- Release-sync plan: `.osc/plans/done/144-next-action-packet-npx-release-sync.md`
 - Release-sync evidence note: `.osc/releases/2026-06-03-144-next-action-packet-npx-release-sync.md`
 
 ## v0.30.0 — Blueprint security and adoption release

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -5,8 +5,8 @@ This page is the canonical reconciliation between the current package version an
 ## Current line: `v0.30.x` (pre-1.0 hardening)
 
 - **Current `package.json` version:** `0.30.1`.
-- **npm latest:** candidate target `0.30.1` with dist-tag `latest` after the next-action packet release-sync; run `npm view open-scaffold version dist-tags --json` for live confirmation.
-- **GitHub Release latest:** candidate target `v0.30.1` after the next-action packet release-sync; GitHub Releases remains the live truth.
+- **npm latest:** `0.30.1` with dist-tag `latest` after trusted publishing run `26901169778`; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** `v0.30.1` is marked **Latest** after the evolution handoff packet release.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('52fb49579673150ab5c512a206d175fdcced08f1495708b86ac2d5c9fb29409a');
+    expect(hash(planIssueSnapshot)).toBe('e04f819d868a98f49cec31e21634fd2ab9ce3e3259efc5ee54dad9a48ca728b6');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('32a0a8261494920e76e7fcf10b0c3bfa4878428cccbe7d334ad6ce703b3a0073');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary
- Closes the `144-next-action-packet-npx-release-sync` plan after `open-scaffold@0.30.1` was published and GitHub Release `v0.30.1` was marked Latest.
- Updates release evidence, changelog, version truth, and the mission changelog with final public proof.
- Re-pins the live plan corpus hash after moving the plan to done.

## Verification
- `git diff --check`
- `npm test -- tests/section-parser.test.ts --run`
- `npm run osc -- plan validate .osc/plans/done/144-next-action-packet-npx-release-sync.md --strict`
- `./verify.sh --strict`
- `npm view open-scaffold version dist-tags --json --prefer-online`
- `gh release list --repo graphanov/open-scaffold --limit 3`

## Risk / boundaries
- Closeout-only follow-up after the already-completed trusted-publishing and GitHub Release gates.
- No new product behavior, runtime spawning, benchmark-support claim, model-improvement claim, or approval authority.
