### PR TITLE
feat(evolve): add compact efficiency diagnostics

### DIFF
--- a/.osc/plans/active/150-open-scaffold-efficiency-reset.md
+++ b/.osc/plans/active/150-open-scaffold-efficiency-reset.md
@@ -1,0 +1,51 @@
+# Plan: 150-open-scaffold-efficiency-reset
+
+## Status
+
+active
+
+## Context
+
+The latest private A/B result did not support a "makes Codex better" claim: Open Scaffold used more tokens while final mechanical outcome tied. The useful remaining thesis is narrower: Open Scaffold may earn its overhead as a workflow-control layer only if it can produce smaller, sharper stop/inspect/redesign/continue signals with measurable cost and handoff discipline.
+
+## Goal
+
+Add public-safe measurement and compact controller output for `osc evolve analyze` so workflow-control efficiency is computed from artifacts rather than claimed in prose.
+
+## Constraints / Out of scope
+
+- Do not add 2000m-specific fields, paths, scorer contracts, or benchmark claims.
+- Do not add runtime spawning, process control, provider APIs, publishing, release, push, PR, or merge behavior.
+- Do not treat evidence volume as score or hide missing current criteria.
+- Do not claim Open Scaffold makes models smarter, improves benchmark outcomes, or proves productivity.
+- Prefer compaction, deletion, and sharper decision packets over new ceremony or dependencies.
+
+## Files to touch
+
+- `src/evolution.ts` — analyze/report controller-signal metrics and compact analysis rendering.
+- `src/cli.ts` — expose any compact/efficiency analysis flags without changing execution boundaries.
+- `tests/evolution.test.ts` / `tests/cli-evolution.test.ts` — prove compactness, preserved control fields, leak safety, and measured ratios.
+- `docs/EVOLUTION_LOOP.md` / `README.md` / related evidence docs — document benchmark-neutral workflow-control efficiency claims.
+- `.osc/plans/active/150-open-scaffold-efficiency-reset.md` — trace this slice.
+
+## Acceptance criteria
+
+- [ ] Efficiency is explicitly defined in code and docs as controller signal per report/evidence overhead, with no benchmark or model-intelligence claim.
+- [ ] A local public-safe harness reports before/after metrics including output bytes per useful decision field, evidence bytes per action recommendation, token/cost telemetry completeness, blind retries prevented, next-action packet compactness, analyze-to-recommendation steps, and required-control-field ratio.
+- [ ] Compact/default analysis output is materially smaller while preserving required control fields, missing-current criteria, boundary notes, and safe evidence refs.
+- [ ] Retry recommendations require a measurable repair hypothesis and no-op/blind retry fixtures are routed away from blind continuation.
+- [ ] Tests prove private/unsafe refs do not leak and stop/redesign/inspect/continue recommendations remain boundary-safe.
+- [ ] Any 1.5x efficiency result is computed by code from before/after artifacts, not asserted manually.
+- [ ] The efficiency harness finds at least 10 additional measured full-to-compact controller targets that preserve required fields and clear the 1.5x byte-reduction threshold, or reports the miss explicitly.
+
+## Verification steps
+
+1. `git diff --check` — no whitespace errors.
+2. `npm run build` — TypeScript builds for core and runtime package.
+3. `npm test` — vitest suite passes.
+4. `./verify.sh --strict` — repo verification gate passes.
+5. Run the efficiency harness command added by this slice — report numeric before/after and whether 1.5x is achieved.
+
+## Open questions
+
+- None for implementation. If metrics do not prove 1.5x, report the miss bluntly instead of stretching the claim.

--- a/.osc/specs/150-efficiency-reset-hermes-review.md
+++ b/.osc/specs/150-efficiency-reset-hermes-review.md
@@ -1,0 +1,319 @@
+# Hermes review handoff: Open Scaffold efficiency reset
+
+## Review target
+
+Worktree: `<isolated-worktree>`
+
+Branch: `research/open-scaffold-efficiency-150`
+
+Source repo left alone: `<source-repo>`
+
+No commit, push, PR, merge, publish, or release was performed.
+
+## Constraints honored
+
+- Work was done in an isolated git worktree.
+- No runtime spawning/control was added to core Open Scaffold.
+- No 2000m-specific fields, paths, scorer contracts, or claims were added.
+- No public proof claims were added.
+- No claim was made that Open Scaffold makes models smarter.
+- No claim was made that Open Scaffold has benchmark support.
+- No dependencies were added.
+- Efficiency is measured as workflow-control output overhead reduction, not model capability or final task quality.
+
+## Executive summary
+
+This patch makes `osc evolve analyze` produce and measure a smaller workflow-control packet.
+
+The useful part: the new compact controller signal keeps required decision fields while cutting the analysis output from `2679` bytes to `916` bytes on the public evolution demo fixture, a measured `2.924672x` reduction.
+
+The honest caveat: this does not prove Open Scaffold improves model intelligence, benchmark performance, productivity, token/cost, or correctness. It proves only that one controller-output surface can preserve required control fields with less report overhead on public-safe fixtures. The efficiency report is now explicitly diagnostic/experimental, with `11/12` strong public-summary targets and one marginal `1.56x` target.
+
+## What changed in plain terms
+
+Before, Open Scaffold analysis tended to behave like a ledger: useful signals existed, but they were surrounded by too much explanatory/report text.
+
+After this patch, the analysis command can emit a compact "what should the controller do next?" packet. It keeps the action, reason, remaining failures, missing criteria, retry/plateau flags, token-cost receipt status, and handoff state in a smaller shape.
+
+The patch also adds a diagnostic/experimental efficiency report so future narrow controller-output claims are computed by code instead of stated in prose.
+
+## Files changed
+
+- `src/evolution.ts`
+  - Added compact controller-signal schema.
+  - Added efficiency-report schema.
+  - Added strict no-op retry routing to `inspect_scorer`.
+
+- `src/evolution-efficiency.ts`
+  - Isolated diagnostic/experimental efficiency-report machinery outside the core evolution loop implementation.
+  - Added `measureEvolutionAnalysisEfficiency()`.
+  - Added `renderEvolutionEfficiencyReport()`.
+  - Added rendered-output required-field checks.
+  - Added a 12-target diagnostic controller-output matrix with marginal-target classification.
+
+- `src/cli.ts`
+  - Added `osc evolve analyze <loop-dir> --compact`.
+  - Added diagnostic/experimental `osc evolve analyze <loop-dir> --efficiency`.
+  - Added JSON support for efficiency output.
+
+- `tests/evolution.test.ts`
+  - Tests compact output is materially smaller.
+  - Tests required control fields are preserved.
+  - Tests no-op retries route away from blind retry.
+  - Tests missing current criteria are not hidden.
+  - Tests private/unsafe refs do not leak.
+  - Tests at least 10 additional 1.5x efficiency targets; current diagnostic count is 12, public-summary strong count is 11, and the `1.56x` row is marginal.
+
+- `tests/cli-evolution.test.ts`
+  - Tests CLI compact output.
+  - Tests CLI efficiency JSON output.
+
+- `tests/public-positioning.test.ts`
+  - Locks benchmark-neutral language.
+  - Requires docs to say Open Scaffold does not make models smarter and is not benchmark proof.
+  - Requires diagnostic/experimental measured before/after artifacts for efficiency claims.
+
+- `tests/section-parser.test.ts`
+  - Updated pinned corpus hash after adding the active plan trace.
+
+- `README.md`
+  - Added benchmark-neutral positioning.
+  - Added compact/efficiency command docs.
+
+- `docs/EVOLUTION_LOOP.md`
+  - Added compact controller signal docs.
+  - Added diagnostic/experimental efficiency metrics and limitations.
+
+- `docs/EVIDENCE_METHODOLOGY.md`
+  - Added workflow-control efficiency measurement rules.
+
+- `docs/FAQ.md`
+  - Replaced unmeasured token/time-savings language with measured-artifact language.
+
+- `.osc/plans/active/150-open-scaffold-efficiency-reset.md`
+  - Active local plan trace for the worktree exercise.
+
+## Efficiency definition used
+
+Primary efficiency:
+
+Same or better workflow-control decision quality with no more than `66.7%` of the prior token/context/evidence overhead.
+
+Secondary efficiency:
+
+At least `1.5x` more useful controller signal per output/evidence byte.
+
+This patch measures output bytes, evidence bytes, required field preservation, recommendation count, receipt completeness, retry prevention, and compact handoff size.
+The efficiency report is diagnostic/experimental. Its rendered compact output must preserve required fields directly, not only in the in-memory signal.
+
+## Metrics added
+
+- Output bytes per useful decision field.
+- Evidence bytes per action recommendation.
+- Token/cost telemetry completeness.
+- Blind retries prevented in fixtures.
+- Next-action packet compactness.
+- Analyze-input-to-actionable-recommendation steps.
+- Required control fields present versus total report size.
+- Additional full-to-compact controller-output targets.
+
+## Main before/after result
+
+Command:
+
+```sh
+npm run osc -- evolve analyze examples/evolution-ledger-demo/.osc/evolution/reviewable-csv-importer --efficiency
+```
+
+Measured public fixture result:
+
+| Metric | Before | After | Result |
+| --- | ---: | ---: | ---: |
+| Full output bytes | `2679` | `916` | `2.924672x` smaller |
+| Bytes per useful decision field | `178.6` | `61.066667` | `2.924672x` better |
+| Required control fields | `15/15` | `15/15` | preserved |
+| Rendered compact required fields | — | `15/15` | preserved |
+| Token/cost telemetry completeness | `0/3` | `0/3` | still missing receipts |
+| Blind retries prevented in demo fixture | `0` | `0` | fixture is all-pass/stop |
+| Additional diagnostic 1.5x targets | `12/12` | `12/12` | met diagnostically |
+| Public-summary strong targets | — | `11/12` | one marginal target excluded from headline |
+
+## Additional diagnostic 1.5x target matrix
+
+All targets below are public-safe controller-output surfaces. They measure output compaction, not benchmark performance. The matrix is diagnostic; public-facing summary should use the strong-target count and label marginal rows.
+
+| Target | Before bytes | After bytes | Ratio | Preserved | Classification | Public-summary counted |
+| --- | ---: | ---: | ---: | --- | --- | --- |
+| `target.markdown.full_to_compact` | `2914` | `1006` | `2.89662x` | yes | strong | yes |
+| `target.json.full_to_controller_signal` | `6305` | `1558` | `4.046855x` | yes | strong | yes |
+| `target.terminal.control_section_to_usage_receipt` | `142` | `59` | `2.40678x` | yes | strong | yes |
+| `target.terminal.sensitivity_to_acceptance` | `545` | `36` | `15.138889x` | yes | strong | yes |
+| `target.terminal.previous_delta_to_plateau` | `367` | `60` | `6.116667x` | yes | strong | yes |
+| `target.terminal.frontier_delta_to_resume` | `359` | `136` | `2.639706x` | yes | strong | yes |
+| `target.terminal.packet_to_action_block` | `507` | `325` | `1.56x` | yes | marginal | no |
+| `target.markdown.control_to_compact_bullets` | `420` | `145` | `2.896552x` | yes | strong | yes |
+| `target.markdown.delta_tables_to_failures` | `798` | `28` | `28.5x` | yes | strong | yes |
+| `target.markdown.packet_sections_to_compact_required` | `824` | `125` | `6.592x` | yes | strong | yes |
+| `target.json.criteria_to_remaining_failures` | `1040` | `2` | `520x` | yes | strong | yes |
+| `target.json_deltas_to_resume` | `1467` | `139` | `10.553957x` | yes | strong | yes |
+
+## What this proves
+
+- Compact controller output can preserve required control fields while using materially fewer bytes on the public demo fixture.
+- The CLI can now generate measured before/after diagnostic efficiency artifacts.
+- Missing token/cost receipts are surfaced instead of faked.
+- No-op retry detection can route to inspection instead of another blind retry in tests.
+- Documentation now avoids benchmark-proof and model-intelligence claims.
+
+## What this does not prove
+
+- It does not prove Open Scaffold makes Codex or any model smarter.
+- It does not prove Open Scaffold wins benchmarks.
+- It does not prove end-to-end productivity improves.
+- It does not prove correctness improves.
+- It does not prove token/cost savings in real runs, because token/cost receipts are still incomplete.
+- It does not prove the 12 target matrix is product-wide; it is a local diagnostic controller-output measurement harness with one marginal row.
+
+## Root-cause assessment
+
+Useful:
+
+- Plateau/no-op retry detection.
+- Explicit next-action recommendation.
+- Missing-current-criteria reporting.
+- Handoff packet shape.
+- Token/cost receipt checks, even though receipts are currently missing.
+- Compact controller signal small enough to paste into a fresh context.
+
+Ceremony:
+
+- Long markdown analysis sections that restate ledger facts.
+- Repeated acceptance/delta/report text around a single controller decision.
+- Evidence volume without clear action impact.
+- Report text that looks authoritative but does not add control signal.
+
+Costs too many tokens:
+
+- Full analysis rendering.
+- Verbose markdown packet sections.
+- Delta tables when the actionable result is just stop/inspect/redesign/continue.
+
+Still unmeasured:
+
+- Real token savings across live runs.
+- Real cost savings across live runs.
+- Whether compact handoffs improve recovery.
+- Whether no-op retry prevention reduces wall-clock time.
+- Whether stop/redesign thresholds improve human decision quality.
+
+What must become true for Open Scaffold to be valuable:
+
+- It must prevent blind retries in real workflows, not only fixtures.
+- It must produce reliable token/cost receipts.
+- It must make stop/inspect/redesign/continue decisions faster and cheaper than ad hoc prompting.
+- It must keep reports compact by default where control, not explanation, is the product.
+- It must keep proof separate from score and never treat evidence volume as success.
+
+## Verification run
+
+All verification was run inside `<isolated-worktree>`.
+
+```sh
+git diff --check
+npm run build
+npm test
+./verify.sh --strict
+```
+
+Result:
+
+- `git diff --check`: pass.
+- `npm run build`: pass.
+- `npm test`: pass, `56` files and `636` tests.
+- `./verify.sh --strict`: pass, `9` pass, `0` fail, `1` warn.
+
+The strict verify warning was:
+
+```text
+Plan immutability check skipped (not a git repository or git not available).
+```
+
+## Current status
+
+Expected worktree status:
+
+```text
+## research/open-scaffold-efficiency-150...origin/main
+ M README.md
+ M docs/EVIDENCE_METHODOLOGY.md
+ M docs/EVOLUTION_LOOP.md
+ M docs/FAQ.md
+ M src/cli.ts
+ M src/evolution.ts
+?? src/evolution-efficiency.ts
+ M tests/cli-evolution.test.ts
+ M tests/evolution.test.ts
+ M tests/public-positioning.test.ts
+ M tests/section-parser.test.ts
+?? .osc/plans/active/150-open-scaffold-efficiency-reset.md
+?? .osc/specs/150-efficiency-reset-hermes-review.md
+```
+
+## Hermes recommendation applied
+
+Hermes recommended `accept with scope reduction` and this worktree now reflects that:
+
+1. `--compact` remains product-facing controller output.
+2. `--efficiency` is explicitly diagnostic/experimental, not a polished public proof surface.
+3. The 12-target matrix is diagnostic; public summary counts `11/12` strong targets and labels `target.terminal.packet_to_action_block` as marginal.
+4. Missing token/cost telemetry blocks token/cost savings claims and remains a prominent warning.
+5. Efficiency-report machinery was isolated into `src/evolution-efficiency.ts` instead of growing `src/evolution.ts` further.
+6. The active plan trace remains in the diff as the scaffold-native work record.
+7. Public docs remain blunt about "not smarter, not benchmark proof" and now call the efficiency report diagnostic/experimental.
+8. No-op retry routing remains `inspect_scorer` as the boundary-safe first action; `redesign` remains reserved for plateau plus non-moving/impossible failures.
+
+## Recommended Hermes checks
+
+Run these from the worktree:
+
+```sh
+cd <isolated-worktree>
+git status --short --branch
+git diff --stat
+git diff -- src/evolution.ts src/evolution-efficiency.ts src/cli.ts tests/evolution.test.ts tests/cli-evolution.test.ts
+npm run osc -- evolve analyze examples/evolution-ledger-demo/.osc/evolution/reviewable-csv-importer --efficiency
+npm run osc -- evolve analyze examples/evolution-ledger-demo/.osc/evolution/reviewable-csv-importer --compact
+git diff --check
+npm run build
+npm test
+./verify.sh --strict
+```
+
+Also verify the source repo was not edited:
+
+```sh
+cd <source-repo>
+git status --short --branch
+```
+
+## Decision options
+
+Accept with scope reduction:
+
+- Current recommended path. Keep the compact signal, keep diagnostic efficiency measurement, but do not headline raw `12/12` target count as product proof.
+
+Request more measurement:
+
+- Appropriate if token/cost receipts must exist before any efficiency language lands.
+
+Reject:
+
+- Appropriate if Hermes decides this is still too much scaffolding and the right move is deletion/compaction without new report machinery.
+
+## Bottom line
+
+The patch achieves a measured `2.924672x` controller-output reduction on the public fixture, finds `12/12` diagnostic local `>=1.5x` targets, and exposes `11/12` as strong public-summary targets after excluding one marginal `1.56x` row.
+
+That is enough to review as an Open Scaffold workflow-control efficiency improvement.
+
+It is not enough to claim benchmark support, model improvement, real cost reduction, or real-world productivity improvement.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Use it when AI-assisted work needs **control**, **clarity**, **reviewability**, 
 
 It does not replace your agent, IDE, task tracker, CI, or compliance process. Those tools do the work or run the program. Open Scaffold records what was asked, what was handed off, what came back, what was checked, and what humans approved. For the boundary between structural evidence and process assurance, see [`docs/AUDITABILITY.md`](docs/AUDITABILITY.md) and [`docs/TRUST_BOUNDARIES.md`](docs/TRUST_BOUNDARIES.md).
 
+Open Scaffold does not make models smarter and is not benchmark proof. The current value claim under test is narrower: workflow control, handoff recovery, governance, and measured controller-output efficiency. Any efficiency claim needs a diagnostic/experimental before/after artifact such as `osc evolve analyze --efficiency`; do not promote token, cost, or quality wins from prose alone.
+
 **First command for an existing repo:**
 
 ```bash
@@ -295,7 +297,7 @@ npx open-scaffold evolve compare .osc/evolution/my-task \
   --out .osc/releases/evolution-compare.md
 ```
 
-`osc evolve` records attempt/frontier state only. It is a record, not an execution, compliance, model-evaluation, or approval system.
+`osc evolve` records attempt/frontier state only. It is a record, not an execution, compliance, model-evaluation, benchmark-proof, or approval system. `osc evolve analyze --compact` prints a pasteable controller signal, and `osc evolve analyze --efficiency` computes before/after output-overhead metrics for that signal.
 
 For the one-screen version, see [`docs/examples/evolution-loop-compare.md`](docs/examples/evolution-loop-compare.md). For a small fixture you can run locally, see [`examples/evolution-ledger-demo/`](examples/evolution-ledger-demo/).
 

--- a/docs/EVIDENCE_METHODOLOGY.md
+++ b/docs/EVIDENCE_METHODOLOGY.md
@@ -30,6 +30,23 @@ These are enforced by `osc study` and by `tests/study.test.ts`, not just stated 
 
 Moving from "scaffolded work *correlates* with X" to "the scaffold *caused* X" is the job of `docs/AB_COMPARISON_PROTOCOL.md`, which is **out of scope for this study and is not run here.**
 
+## Workflow-control efficiency
+
+Open Scaffold does not make models smarter, and `osc study` is not benchmark proof. The narrower efficiency thesis is that the repo record may reduce workflow-control overhead by producing smaller, sharper stop / inspect / redesign / continue signals while preserving decision quality.
+
+For evolution loops, measure that thesis with the diagnostic/experimental `osc evolve analyze <loop-dir> --efficiency` report. A valid efficiency report must include:
+
+- output bytes per useful decision field;
+- evidence reference bytes per action recommendation;
+- token/cost telemetry completeness, with missing receipts reported rather than imputed;
+- blind retries prevented in the fixture;
+- next-action packet compactness;
+- time/steps from analyze input to actionable recommendation;
+- required control fields present versus total report size.
+- a matrix of additional full-to-compact controller surfaces, each counted diagnostically only when required fields are preserved and the byte reduction is at least 1.5x, with marginal targets labeled instead of folded into a public headline.
+
+The primary threshold is compact controller output with the same required control fields and no more than 66.7% of baseline full-analysis bytes. The secondary threshold is at least 1.5x fewer output bytes per useful decision field. These are workflow-control metrics only. They do not prove task quality, productivity, benchmark performance, model intelligence, or token/cost savings unless the before/after artifacts directly measure those things.
+
 ## The scaffolded-vs-unscaffolded control model
 
 The FAQ claims are implicitly comparative — they say scaffolded work goes better *than winging it*. Honest evaluation therefore needs two arms:

--- a/docs/EVOLUTION_LOOP.md
+++ b/docs/EVOLUTION_LOOP.md
@@ -84,11 +84,28 @@ Analyze a stopped or in-flight loop without recording a new attempt:
 osc evolve analyze .osc/evolution/demo-loop
 osc evolve analyze .osc/evolution/demo-loop --format json
 osc evolve analyze .osc/evolution/demo-loop --format markdown --out docs/evidence/evolution-analysis.md
+osc evolve analyze .osc/evolution/demo-loop --compact
+osc evolve analyze .osc/evolution/demo-loop --efficiency
 ```
 
 `osc evolve analyze` reads `loop.json`, `attempts.jsonl`, `frontier.json`, and linked evaluation envelopes. It reports plateau/stagnation, current-vs-previous and current-vs-frontier acceptance-criteria deltas, observed score sensitivity, criteria flagged as probe-only / hardcoded non-pass / skipped / stale / impossible, the current attempt's repair hypothesis and usage, and a next-action recommendation: `continue`, `stop`, `redesign`, or `inspect_scorer`. Criterion-level hints can come from evaluation/scorer metadata such as `analysis.score_sensitivity`, `analysis.impossible`, `analysis.reason`, and `analysis.source`, or from explicit evidence/rationale wording.
 
-The JSON, terminal, and markdown analysis outputs also include a compact next-action packet. It is a context-wipe handoff summary: recommended action, reasons, current/frontier resume point, plateau state, current pass/fail counts, remaining failing criteria, required next fields, safe evidence refs, and boundary notes. Use it to hand a loop to a fresh human, agent, or coordinator without copying bulky logs into prompt context. The packet is not an executor, benchmark result, approval, model ranking, or proof that Open Scaffold improved output quality.
+The JSON, terminal, and markdown analysis outputs also include a next-action packet. `--compact` renders only the controller signal: recommended action, reasons, current/frontier resume point, plateau state, current pass/fail counts, remaining failing criteria, required next fields, usage receipt completeness, safe evidence refs, and boundary notes. Use it to hand a loop to a fresh human, agent, or coordinator without copying bulky logs into prompt context. The packet is not an executor, benchmark result, approval, model ranking, or proof that Open Scaffold improved output quality.
+
+`--efficiency` is the diagnostic/experimental local measurement harness for controller-output overhead. It compares baseline full terminal analysis against compact controller output and reports:
+
+- output bytes per useful decision field;
+- evidence reference bytes per action recommendation;
+- token/cost telemetry completeness;
+- blind retries prevented in the analyzed fixture;
+- next-action packet byte size;
+- analyze-input-to-recommendation step count;
+- required control fields present versus total report size.
+- an additional measured target matrix for section-level full-to-compact controller surfaces.
+
+The primary efficiency definition is: preserve the same required workflow-control decision fields while compact output uses no more than 66.7% of baseline output bytes. The secondary definition is: at least 1.5x fewer output bytes per useful decision field. The report computes those ratios from rendered artifacts. It does not score evidence volume, infer missing token/cost receipts, claim a benchmark win, or claim Open Scaffold made a model smarter.
+
+The additional target matrix is deliberately narrow and diagnostic. It measures report overhead surfaces such as full markdown to compact markdown, full JSON to controller-signal JSON, verbose score-sensitivity tables to compact acceptance lines, AC delta tables to remaining-failure summaries, and full criteria JSON to remaining-failure JSON. A target counts diagnostically when required controller fields are preserved and the compact surface is at least 1.5x smaller. Public-summary language should prefer strong targets and label marginal rows instead of headlining a raw `N/N` count. This is still not a product-wide efficiency proof.
 
 The analysis command is a decision aid. It does not mutate loop files unless `--out` is supplied for a rendered report, and even then it writes only the requested report path. It does not spawn runtimes, rerun benchmarks, rank models, certify compliance, promote a frontier, or approve work.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -18,7 +18,7 @@ Questions that did not fit in the main README but are still worth answering.
 
 ### Does this reduce token usage / cost?
 
-> Often, indirectly — but this is not benchmarked yet. Plans mean less context-stuffing ("remember yesterday when..."). Immutability means fewer loops about what was already decided. `verify.sh` catches methodology drift mechanically instead of relying only on another review round. Treat cost reduction as a workflow hypothesis to measure in your own repo, not as a guaranteed benchmark.
+> Not proven. Plans may reduce context-stuffing and blind retries, but token/cost savings require receipts. Treat cost reduction as a workflow-control hypothesis to measure in your own repo. For repeated-attempt loops, start with the diagnostic/experimental `osc evolve analyze <loop-dir> --efficiency` report; if token/cost telemetry is missing, the report must say missing rather than guessing.
 
 ### Will my agent actually follow the protocol, or will it just ignore the files?
 
@@ -34,7 +34,7 @@ Questions that did not fit in the main README but are still worth answering.
 
 ### How much time does this actually save me vs. just winging it?
 
-> Not benchmarked, honestly. Treat any specific time-savings number as a hypothesis until you've measured it on your own workflow. What *is* observable: fewer "wait, I thought we decided X" moments, and sessions that resume in under a minute instead of fifteen.
+> Not benchmarked, honestly. Treat any specific time-savings number as a hypothesis until you have measured before/after artifacts. Open Scaffold does not make the model smarter and is not a public proof of productivity. What can be measured locally is workflow control: smaller handoff packets, required decision fields preserved, missing criteria surfaced, blind retries prevented, and token/cost receipts recorded when available.
 
 ### What if I'm bad at writing plans? Does this fall apart?
 
@@ -42,7 +42,7 @@ Questions that did not fit in the main README but are still worth answering.
 
 ### Is this just going to slow me down? I'm used to vibing.
 
-> A little on day one. That is the tax. After that, it should speed you up because session two does not start with "OK so where were we..." You trade a short setup step for lower re-explanation cost on future sessions. For anything you will work on more than once, the trade is usually worth it.
+> A little on day one. That is the tax. After that, the value is still a hypothesis until measured: less re-explanation, fewer blind retries, cleaner handoff recovery, and clearer stop/inspect/redesign decisions. For anything you will work on more than once, the trade may be worth it; verify it with artifacts rather than assuming it.
 
 ### Can I adopt this mid-project, or is it only for new repos?
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { collectEvidence } from './evidence.js';
 import { evidenceChainExitCode, formatEvidenceChainReport, verifyEvidenceChain } from './evidence-chain.js';
 import { EXTERNAL_SCORER_ADAPTERS, loadEvaluationSource, renderEvaluationEnvelope, renderImportedEvaluationEnvelope, validateEvaluationEnvelopeFile, writeEvaluationEnvelope, writeImportedEvaluationEnvelope, type ExternalScorerAdapter } from './evaluation.js';
 import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, analyzeEvolutionLoop, compareEvolutionLoop, recordEvolutionAttempt, renderEvolutionAnalysis, renderEvolutionComparison, validateEvolutionLoopDir, writeEvolutionLoop, type EvolutionAnalysisFormat, type EvolutionCompareFormat, type EvolutionDecision, type EvolutionStrategy } from './evolution.js';
+import { measureEvolutionAnalysisEfficiency, renderEvolutionEfficiencyReport } from './evolution-efficiency.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { computeMetrics, formatMetrics, parseSinceDate } from './metrics.js';
 import { computeStudy, renderStudyMarkdown, validateStudyReport, writeStudyOutput } from './study.js';
@@ -1985,7 +1986,7 @@ function evalCommand(args: string[]): void {
 }
 
 function printEvolutionUsage(stream: 'stdout' | 'stderr' = 'stderr'): void {
-  printUsage('Usage: osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>] | osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text> [--repair-hypothesis <text>] [--target-metric <name>] [--expected-gain <number>] [--actual-delta <number>] [--tokens-total <integer>] [--estimated-usd <number>] [--usage-source <source>] [--usage-unavailable-reason <text>] | osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>] | osc evolve analyze <loop-dir> [--format <terminal|markdown|json>] [--out <path>] [--plateau-threshold <n>] | osc evolve check <loop-dir>', stream);
+  printUsage('Usage: osc evolve init <run-or-plan> [--out <dir>] [--strategy <manual|greedy|tournament|novelty|map_elites|custom>] | osc evolve record <loop-dir> --run <run-packet> [--evaluation <evaluation-json>] [--receipt <dispatch-receipt.json>] [--evidence <path>]... --decision <promote|reject|retry|block> [--score <0..1>] --rationale <text> [--repair-hypothesis <text>] [--target-metric <name>] [--expected-gain <number>] [--actual-delta <number>] [--tokens-total <integer>] [--estimated-usd <number>] [--usage-source <source>] [--usage-unavailable-reason <text>] | osc evolve compare <loop-dir> [--a <attempt-id|run-id|frontier>] [--b <attempt-id|run-id|frontier>] [--format <terminal|markdown|json>] [--out <path>] | osc evolve analyze <loop-dir> [--format <terminal|markdown|json>] [--out <path>] [--plateau-threshold <n>] [--compact] [--efficiency] | osc evolve check <loop-dir>', stream);
 }
 
 function takeEvolutionValue(args: string[], index: number, flag: string): string {
@@ -2305,6 +2306,8 @@ function evolutionCommand(args: string[]): void {
     let format: EvolutionAnalysisFormat = 'terminal';
     let outPath: string | undefined;
     let plateauThreshold: number | undefined;
+    let compact = false;
+    let efficiency = false;
     for (let i = 0; i < rest.length; i += 1) {
       const flag = rest[i];
       switch (flag) {
@@ -2328,6 +2331,12 @@ function evolutionCommand(args: string[]): void {
           i += 1;
           break;
         }
+        case '--compact':
+          compact = true;
+          break;
+        case '--efficiency':
+          efficiency = true;
+          break;
         default:
           console.error(`Unknown option for evolve analyze: ${flag}`);
           printEvolutionUsage();
@@ -2338,11 +2347,13 @@ function evolutionCommand(args: string[]): void {
       const loopDir = resolve(sourceOrPath);
       const root = evolutionRootFor(loopDir);
       const analysis = analyzeEvolutionLoop(loopDir, { plateauThreshold }, root);
-      const rendered = renderEvolutionAnalysis(analysis, format);
+      const rendered = efficiency
+        ? renderEvolutionEfficiencyReport(measureEvolutionAnalysisEfficiency(analysis), format)
+        : renderEvolutionAnalysis(analysis, format, { compact });
       if (outPath) {
         const resolvedOut = resolve(outPath);
         writeFileSync(resolvedOut, rendered, 'utf8');
-        console.log(`Wrote evolution analysis: ${resolvedOut}`);
+        console.log(`Wrote evolution ${efficiency ? 'efficiency report' : 'analysis'}: ${resolvedOut}`);
       } else {
         process.stdout.write(rendered.endsWith('\n') ? rendered : `${rendered}\n`);
       }

--- a/src/evolution-efficiency.ts
+++ b/src/evolution-efficiency.ts
@@ -1,0 +1,451 @@
+import {
+  EVOLUTION_EFFICIENCY_REPORT_SCHEMA,
+  buildEvolutionControllerSignal,
+  renderEvolutionAnalysis,
+  type EvolutionAnalysisFormat,
+  type EvolutionAnalysisResult,
+  type EvolutionControllerSignal,
+} from './evolution.js';
+
+function bytes(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function roundRatio(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Number(value.toFixed(6));
+}
+
+function present(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'string') return value.trim().length > 0;
+  return value !== null && value !== undefined;
+}
+
+function isNoOpRetryAttempt(attempt: EvolutionAnalysisResult['currentAttempt']): boolean {
+  return attempt.decision === 'retry' && attempt.repairHypothesis?.actualDelta === 0;
+}
+
+export interface EvolutionEfficiencyModeMetrics {
+  label: 'full' | 'compact';
+  outputBytes: number;
+  usefulDecisionFields: number;
+  outputBytesPerUsefulDecisionField: number;
+  evidenceBytesPerActionRecommendation: number;
+  nextActionPacketBytes: number;
+  requiredControlFieldsPresent: number;
+  requiredControlFieldsTotal: number;
+  requiredControlFieldRatio: number;
+  requiredControlFieldsPerKb: number;
+}
+
+export interface EvolutionEfficiencyTarget {
+  id: string;
+  label: string;
+  baselineBytes: number;
+  compactBytes: number;
+  reductionRatio: number;
+  requiredFields: string[];
+  requiredFieldsPreserved: boolean;
+  achievedAtLeastOnePointFiveX: boolean;
+  classification: 'strong' | 'marginal';
+  publicSummaryCounted: boolean;
+}
+
+export interface EvolutionAnalysisEfficiencyReport {
+  schema: typeof EVOLUTION_EFFICIENCY_REPORT_SCHEMA;
+  scope: 'diagnostic';
+  stability: 'experimental';
+  loop: EvolutionAnalysisResult['loop'];
+  definition: {
+    primary: string;
+    secondary: string;
+  };
+  baseline: EvolutionEfficiencyModeMetrics;
+  compact: EvolutionEfficiencyModeMetrics;
+  improvement: {
+    outputByteReductionRatio: number;
+    outputBytesPerUsefulDecisionFieldReductionRatio: number;
+    compactUsesAtMostTwoThirdsBaselineBytes: boolean;
+    requiredControlFieldsPreserved: boolean;
+    renderedCompactControlFieldsPresent: number;
+    renderedCompactControlFieldsTotal: number;
+    renderedCompactControlFieldsPreserved: boolean;
+    achievedAtLeastOnePointFiveX: boolean;
+  };
+  telemetry: EvolutionControllerSignal['usageReceipt']['completeness'];
+  blindRetriesPrevented: number;
+  analyzeToRecommendation: {
+    stepCount: number;
+    steps: string[];
+  };
+  targets: EvolutionEfficiencyTarget[];
+  additionalTargetsAtLeastOnePointFiveX: number;
+  publicSummaryTargetsAtLeastOnePointFiveX: number;
+  marginalTargets: string[];
+  warnings: string[];
+  caveats: string[];
+}
+
+function requiredControlFieldChecks(signal: EvolutionControllerSignal): Array<{ field: string; present: boolean }> {
+  return [
+    { field: 'action', present: present(signal.action) },
+    { field: 'summary', present: present(signal.summary) },
+    { field: 'reasons', present: present(signal.reasons) },
+    { field: 'resume.currentAttemptId', present: true },
+    { field: 'resume.frontierAttemptId', present: true },
+    { field: 'resume.currentEvaluation', present: true },
+    { field: 'plateau.status', present: present(signal.plateau.status) },
+    { field: 'plateau.noImprovementCount', present: present(signal.plateau.noImprovementCount) },
+    { field: 'acceptance.currentPass', present: present(signal.acceptance.currentPass) },
+    { field: 'acceptance.currentTotal', present: present(signal.acceptance.currentTotal) },
+    { field: 'acceptance.remainingFailures', present: true },
+    { field: 'requiredNextFields', present: present(signal.requiredNextFields) },
+    { field: 'usageReceipt.completeness', present: present(signal.usageReceipt.completeness) },
+    { field: 'evidenceRefs', present: true },
+    { field: 'boundaryNotes', present: present(signal.boundaryNotes) },
+  ];
+}
+
+function usefulDecisionFieldCount(signal: EvolutionControllerSignal): number {
+  return requiredControlFieldChecks(signal).filter((field) => field.present).length;
+}
+
+function modeEfficiencyMetrics(label: 'full' | 'compact', output: string, signal: EvolutionControllerSignal): EvolutionEfficiencyModeMetrics {
+  const outputBytes = bytes(output);
+  const required = requiredControlFieldChecks(signal);
+  const usefulFields = usefulDecisionFieldCount(signal);
+  const evidenceBytes = bytes(signal.evidenceRefs.join('\n'));
+  const nextActionPacketBytes = bytes(JSON.stringify(signal));
+  const presentCount = required.filter((field) => field.present).length;
+  const totalCount = required.length;
+  return {
+    label,
+    outputBytes,
+    usefulDecisionFields: usefulFields,
+    outputBytesPerUsefulDecisionField: roundRatio(outputBytes / Math.max(1, usefulFields)),
+    evidenceBytesPerActionRecommendation: evidenceBytes,
+    nextActionPacketBytes,
+    requiredControlFieldsPresent: presentCount,
+    requiredControlFieldsTotal: totalCount,
+    requiredControlFieldRatio: roundRatio(presentCount / totalCount),
+    requiredControlFieldsPerKb: roundRatio(presentCount / Math.max(1, outputBytes / 1024)),
+  };
+}
+
+function lineStartingWith(text: string, prefix: string): string {
+  return text.split('\n').find((line) => line.startsWith(prefix)) ?? '';
+}
+
+function linesStartingWith(text: string, prefixes: string[]): string {
+  return text
+    .split('\n')
+    .filter((line) => prefixes.some((prefix) => line.startsWith(prefix)))
+    .join('\n');
+}
+
+function sectionFromHeading(text: string, heading: string): string {
+  const lines = text.split('\n');
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start < 0) return '';
+  const rest = lines.slice(start + 1);
+  const next = rest.findIndex((line) => {
+    const trimmed = line.trim();
+    return trimmed.length > 0 && !line.startsWith(' ') && !line.startsWith('|') && !line.startsWith('- ') && !line.startsWith('>') && !trimmed.startsWith('`');
+  });
+  return [lines[start], ...(next >= 0 ? rest.slice(0, next) : rest)].join('\n').trim();
+}
+
+function markdownSection(text: string, heading: string): string {
+  const pattern = new RegExp(`^${heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'm');
+  const match = text.match(pattern);
+  if (!match || match.index === undefined) return '';
+  const afterStart = match.index + match[0].length;
+  const after = text.slice(afterStart);
+  const next = after.search(/^##\s+/m);
+  return `${match[0]}${next >= 0 ? after.slice(0, next) : after}`.trim();
+}
+
+function hasSignalPath(signal: EvolutionControllerSignal, path: string): boolean {
+  switch (path) {
+    case 'action':
+      return present(signal.action);
+    case 'summary':
+      return present(signal.summary);
+    case 'reasons':
+      return present(signal.reasons);
+    case 'resume.currentAttemptId':
+      return Object.hasOwn(signal.resume, 'currentAttemptId');
+    case 'resume.frontierAttemptId':
+      return Object.hasOwn(signal.resume, 'frontierAttemptId');
+    case 'resume.currentEvaluation':
+      return Object.hasOwn(signal.resume, 'currentEvaluation');
+    case 'plateau.status':
+      return present(signal.plateau.status);
+    case 'plateau.noImprovementCount':
+      return present(signal.plateau.noImprovementCount);
+    case 'acceptance.currentPass':
+      return present(signal.acceptance.currentPass);
+    case 'acceptance.currentTotal':
+      return present(signal.acceptance.currentTotal);
+    case 'acceptance.remainingFailures':
+      return Object.hasOwn(signal.acceptance, 'remainingFailures');
+    case 'acceptance.remainingFailureIds':
+      return Object.hasOwn(signal.acceptance, 'remainingFailureIds');
+    case 'requiredNextFields':
+      return present(signal.requiredNextFields);
+    case 'usageReceipt.completeness':
+      return present(signal.usageReceipt.completeness);
+    case 'evidenceRefs':
+      return Object.hasOwn(signal, 'evidenceRefs');
+    case 'boundaryNotes':
+      return present(signal.boundaryNotes);
+    default:
+      return false;
+  }
+}
+
+function includesAll(text: string, values: string[]): boolean {
+  return values.every((value) => text.includes(value));
+}
+
+function displayed(value: string | null): string {
+  return value ?? '—';
+}
+
+function snippetContainsField(snippet: string, field: string, signal: EvolutionControllerSignal): boolean {
+  switch (field) {
+    case 'action':
+      return snippet.includes(signal.action);
+    case 'summary':
+      return snippet.includes(signal.summary);
+    case 'reasons':
+      return includesAll(snippet, signal.reasons);
+    case 'resume.currentAttemptId':
+      return snippet.includes(displayed(signal.resume.currentAttemptId)) || snippet.includes('"currentAttemptId"');
+    case 'resume.frontierAttemptId':
+      return snippet.includes(displayed(signal.resume.frontierAttemptId)) || snippet.includes('"frontierAttemptId"');
+    case 'resume.currentEvaluation':
+      return snippet.includes(displayed(signal.resume.currentEvaluation)) || snippet.includes('"currentEvaluation"');
+    case 'plateau.status':
+      return snippet.includes(signal.plateau.status);
+    case 'plateau.noImprovementCount':
+      return snippet.includes(String(signal.plateau.noImprovementCount)) || snippet.includes('"noImprovementCount"');
+    case 'acceptance.currentPass':
+      return snippet.includes(String(signal.acceptance.currentPass)) || snippet.includes('"currentPass"');
+    case 'acceptance.currentTotal':
+      return snippet.includes(String(signal.acceptance.currentTotal)) || snippet.includes('"currentTotal"');
+    case 'acceptance.remainingFailures':
+      return signal.acceptance.remainingFailureIds.length === 0
+        ? snippet.includes('remaining=—') || snippet.includes('- —') || snippet.includes('[]')
+        : includesAll(snippet, signal.acceptance.remainingFailureIds);
+    case 'acceptance.remainingFailureIds':
+      return signal.acceptance.remainingFailureIds.length === 0 ? snippet.includes('[]') : includesAll(snippet, signal.acceptance.remainingFailureIds);
+    case 'requiredNextFields':
+      return includesAll(snippet, signal.requiredNextFields);
+    case 'usageReceipt.completeness':
+      return snippet.includes(`completeness=${signal.usageReceipt.completeness.present}/${signal.usageReceipt.completeness.total}`)
+        || snippet.includes(`completeness ${signal.usageReceipt.completeness.present}/${signal.usageReceipt.completeness.total}`)
+        || snippet.includes('"completeness"');
+    case 'evidenceRefs':
+      return signal.evidenceRefs.length === 0 ? snippet.includes('Evidence refs: —') || snippet.includes('[]') : includesAll(snippet, signal.evidenceRefs);
+    case 'boundaryNotes':
+      return includesAll(snippet, signal.boundaryNotes);
+    default:
+      return false;
+  }
+}
+
+function requiredRenderedControlFieldChecks(output: string, signal: EvolutionControllerSignal): Array<{ field: string; present: boolean }> {
+  const remainingIds = signal.acceptance.remainingFailureIds;
+  return [
+    { field: 'action', present: output.includes(`Action: ${signal.action}`) },
+    { field: 'summary', present: output.includes(signal.summary) },
+    { field: 'reasons', present: includesAll(output, signal.reasons) },
+    { field: 'resume.currentAttemptId', present: output.includes(`current=${displayed(signal.resume.currentAttemptId)}`) },
+    { field: 'resume.frontierAttemptId', present: output.includes(`frontier=${displayed(signal.resume.frontierAttemptId)}`) },
+    { field: 'resume.currentEvaluation', present: output.includes(`evaluation=${displayed(signal.resume.currentEvaluation)}`) },
+    { field: 'plateau.status', present: output.includes(`Plateau: ${signal.plateau.status}`) },
+    { field: 'plateau.noImprovementCount', present: output.includes(`no-improve=${signal.plateau.noImprovementCount}`) },
+    { field: 'acceptance.currentPass', present: output.includes(`Acceptance: ${signal.acceptance.currentPass}/${signal.acceptance.currentTotal} pass`) },
+    { field: 'acceptance.currentTotal', present: output.includes(`Acceptance: ${signal.acceptance.currentPass}/${signal.acceptance.currentTotal} pass`) },
+    { field: 'acceptance.remainingFailures', present: remainingIds.length === 0 ? output.includes('remaining=—') : includesAll(output, remainingIds) },
+    { field: 'requiredNextFields', present: includesAll(output, signal.requiredNextFields) },
+    { field: 'usageReceipt.completeness', present: output.includes(`completeness=${signal.usageReceipt.completeness.present}/${signal.usageReceipt.completeness.total}`) },
+    { field: 'evidenceRefs', present: signal.evidenceRefs.length === 0 ? output.includes('Evidence refs: —') : includesAll(output, signal.evidenceRefs) },
+    { field: 'boundaryNotes', present: includesAll(output, signal.boundaryNotes) },
+  ];
+}
+
+function classifyTarget(reductionRatio: number): 'strong' | 'marginal' {
+  return reductionRatio >= 2 ? 'strong' : 'marginal';
+}
+
+function efficiencyTarget(id: string, label: string, baseline: string, compact: string, requiredFields: string[], signal: EvolutionControllerSignal): EvolutionEfficiencyTarget {
+  const baselineBytes = bytes(baseline);
+  const compactBytes = bytes(compact);
+  const reductionRatio = roundRatio(baselineBytes / Math.max(1, compactBytes));
+  const requiredFieldsPreserved = requiredFields.every((field) => hasSignalPath(signal, field) && snippetContainsField(compact, field, signal));
+  const achievedAtLeastOnePointFiveX = reductionRatio >= 1.5 && requiredFieldsPreserved;
+  const classification = classifyTarget(reductionRatio);
+  return {
+    id,
+    label,
+    baselineBytes,
+    compactBytes,
+    reductionRatio,
+    requiredFields,
+    requiredFieldsPreserved,
+    achievedAtLeastOnePointFiveX,
+    classification,
+    publicSummaryCounted: achievedAtLeastOnePointFiveX && classification === 'strong',
+  };
+}
+
+function measureAdditionalEfficiencyTargets(analysis: EvolutionAnalysisResult, signal: EvolutionControllerSignal): EvolutionEfficiencyTarget[] {
+  const fullTerminal = renderEvolutionAnalysis(analysis, 'terminal', { compact: false });
+  const compactTerminal = renderEvolutionAnalysis(analysis, 'terminal', { compact: true });
+  const fullMarkdown = renderEvolutionAnalysis(analysis, 'markdown', { compact: false });
+  const compactMarkdown = renderEvolutionAnalysis(analysis, 'markdown', { compact: true });
+  const fullJson = renderEvolutionAnalysis(analysis, 'json', { compact: false });
+  const compactJson = renderEvolutionAnalysis(analysis, 'json', { compact: true });
+  const criteriaJson = JSON.stringify(analysis.criteria, null, 2);
+  const remainingFailuresJson = JSON.stringify(signal.acceptance.remainingFailures, null, 2);
+  const deltaJson = JSON.stringify({ currentVsPrevious: analysis.currentVsPrevious, currentVsFrontier: analysis.currentVsFrontier }, null, 2);
+  const resumeJson = JSON.stringify(signal.resume, null, 2);
+
+  return [
+    efficiencyTarget('target.markdown.full_to_compact', 'Full markdown analysis -> compact markdown controller signal', fullMarkdown, compactMarkdown, ['action', 'summary', 'requiredNextFields', 'boundaryNotes'], signal),
+    efficiencyTarget('target.json.full_to_controller_signal', 'Full JSON analysis -> controller-signal JSON', fullJson, compactJson, ['action', 'summary', 'resume.currentAttemptId', 'requiredNextFields', 'boundaryNotes'], signal),
+    efficiencyTarget('target.terminal.control_section_to_usage_receipt', 'Terminal current-attempt control block -> compact usage receipt line', sectionFromHeading(fullTerminal, 'Current attempt control'), lineStartingWith(compactTerminal, 'Usage:'), ['usageReceipt.completeness'], signal),
+    efficiencyTarget('target.terminal.sensitivity_to_acceptance', 'Terminal score-sensitivity table -> compact acceptance line', sectionFromHeading(fullTerminal, 'Score sensitivity'), lineStartingWith(compactTerminal, 'Acceptance:'), ['acceptance.currentPass', 'acceptance.currentTotal', 'acceptance.remainingFailures'], signal),
+    efficiencyTarget('target.terminal.previous_delta_to_plateau', 'Terminal previous-delta table -> compact plateau line', sectionFromHeading(fullTerminal, 'Current vs previous AC delta'), lineStartingWith(compactTerminal, 'Plateau:'), ['plateau.status', 'plateau.noImprovementCount'], signal),
+    efficiencyTarget('target.terminal.frontier_delta_to_resume', 'Terminal frontier-delta table -> compact resume/acceptance lines', sectionFromHeading(fullTerminal, 'Current vs frontier AC delta'), linesStartingWith(compactTerminal, ['Resume:', 'Acceptance:']), ['resume.currentAttemptId', 'resume.frontierAttemptId', 'acceptance.currentPass', 'acceptance.currentTotal'], signal),
+    efficiencyTarget('target.terminal.packet_to_action_block', 'Terminal next-action packet block -> compact action/required/boundary lines', sectionFromHeading(fullTerminal, 'Next action packet'), linesStartingWith(compactTerminal, ['Action:', 'Required:', 'Boundary:']), ['action', 'requiredNextFields', 'boundaryNotes'], signal),
+    efficiencyTarget('target.markdown.control_to_compact_bullets', 'Markdown plateau/control/recommendation sections -> compact action/plateau/usage bullets', [markdownSection(fullMarkdown, '## Plateau / stagnation'), markdownSection(fullMarkdown, '## Current attempt control'), markdownSection(fullMarkdown, '## Recommendation')].join('\n\n'), linesStartingWith(compactMarkdown, ['- Action:', '- Plateau:', '- Usage receipt:']), ['action', 'plateau.status', 'usageReceipt.completeness'], signal),
+    efficiencyTarget('target.markdown.delta_tables_to_failures', 'Markdown AC delta tables -> compact remaining-failures section', [markdownSection(fullMarkdown, '## Current vs previous AC delta'), markdownSection(fullMarkdown, '## Current vs frontier AC delta')].join('\n\n'), markdownSection(compactMarkdown, '## Remaining failures'), ['acceptance.remainingFailures'], signal),
+    efficiencyTarget('target.markdown.packet_sections_to_compact_required', 'Markdown packet/checklist/evidence/boundary sections -> compact required fields line', markdownSection(fullMarkdown, '## Next action packet'), compactMarkdown.split('\n').find((line) => line.startsWith('- Required next fields:')) ?? '', ['requiredNextFields'], signal),
+    efficiencyTarget('target.json.criteria_to_remaining_failures', 'Full JSON criteria array -> remaining-failures JSON', criteriaJson, remainingFailuresJson, ['acceptance.remainingFailures'], signal),
+    efficiencyTarget('target.json_deltas_to_resume', 'Full JSON AC deltas -> resume JSON', deltaJson, resumeJson, ['resume.currentAttemptId', 'resume.frontierAttemptId', 'resume.currentEvaluation'], signal),
+  ];
+}
+
+function blindRetriesPreventedByRecommendation(analysis: EvolutionAnalysisResult): number {
+  if (analysis.recommendation.action === 'continue') return 0;
+  if (!isNoOpRetryAttempt(analysis.currentAttempt)) return 0;
+  return analysis.nextActionPacket.acceptance.remainingFailures.length > 0 ? 1 : 0;
+}
+
+export function measureEvolutionAnalysisEfficiency(analysis: EvolutionAnalysisResult): EvolutionAnalysisEfficiencyReport {
+  const signal = buildEvolutionControllerSignal(analysis);
+  const fullOutput = renderEvolutionAnalysis(analysis, 'terminal', { compact: false });
+  const compactOutput = renderEvolutionAnalysis(analysis, 'terminal', { compact: true });
+  const baseline = modeEfficiencyMetrics('full', fullOutput, signal);
+  const compact = modeEfficiencyMetrics('compact', compactOutput, signal);
+  const targets = measureAdditionalEfficiencyTargets(analysis, signal);
+  const outputByteReductionRatio = roundRatio(baseline.outputBytes / Math.max(1, compact.outputBytes));
+  const bytesPerFieldReductionRatio = roundRatio(baseline.outputBytesPerUsefulDecisionField / Math.max(1, compact.outputBytesPerUsefulDecisionField));
+  const requiredControlFieldsPreserved = compact.requiredControlFieldsPresent >= baseline.requiredControlFieldsPresent
+    && compact.requiredControlFieldsTotal === baseline.requiredControlFieldsTotal;
+  const renderedCompactChecks = requiredRenderedControlFieldChecks(compactOutput, signal);
+  const renderedCompactControlFieldsPresent = renderedCompactChecks.filter((field) => field.present).length;
+  const renderedCompactControlFieldsTotal = renderedCompactChecks.length;
+  const renderedCompactControlFieldsPreserved = renderedCompactControlFieldsPresent === renderedCompactControlFieldsTotal;
+  const compactUsesAtMostTwoThirdsBaselineBytes = compact.outputBytes <= baseline.outputBytes * (2 / 3);
+  const warnings = [
+    ...(compact.outputBytes > baseline.outputBytes * (2 / 3) ? ['Compact output is not yet <= 66.7% of baseline output bytes.'] : []),
+    ...(signal.usageReceipt.completeness.missing.length > 0 ? [`Usage telemetry incomplete: missing ${signal.usageReceipt.completeness.missing.join(', ')}.`] : []),
+    ...(analysis.nextActionPacket.evidenceRefs.length === 0 ? ['No safe evidence refs are present in the next-action packet.'] : []),
+  ];
+  return {
+    schema: EVOLUTION_EFFICIENCY_REPORT_SCHEMA,
+    scope: 'diagnostic',
+    stability: 'experimental',
+    loop: analysis.loop,
+    definition: {
+      primary: 'Same or better workflow-control decision fields with compact output using <= 66.7% of baseline analysis bytes.',
+      secondary: 'At least 1.5x fewer output bytes per useful decision field while preserving required controller fields.',
+    },
+    baseline,
+    compact,
+    improvement: {
+      outputByteReductionRatio,
+      outputBytesPerUsefulDecisionFieldReductionRatio: bytesPerFieldReductionRatio,
+      compactUsesAtMostTwoThirdsBaselineBytes,
+      requiredControlFieldsPreserved,
+      renderedCompactControlFieldsPresent,
+      renderedCompactControlFieldsTotal,
+      renderedCompactControlFieldsPreserved,
+      achievedAtLeastOnePointFiveX: outputByteReductionRatio >= 1.5 && requiredControlFieldsPreserved && renderedCompactControlFieldsPreserved,
+    },
+    telemetry: signal.usageReceipt.completeness,
+    blindRetriesPrevented: blindRetriesPreventedByRecommendation(analysis),
+    analyzeToRecommendation: {
+      stepCount: 4,
+      steps: [
+        'load loop/frontier/attempts',
+        'read safe evaluation envelopes',
+        'compute plateau/criteria deltas',
+        'emit controller recommendation',
+      ],
+    },
+    targets,
+    additionalTargetsAtLeastOnePointFiveX: targets.filter((target) => target.achievedAtLeastOnePointFiveX).length,
+    publicSummaryTargetsAtLeastOnePointFiveX: targets.filter((target) => target.publicSummaryCounted).length,
+    marginalTargets: targets.filter((target) => target.achievedAtLeastOnePointFiveX && target.classification === 'marginal').map((target) => target.id),
+    warnings,
+    caveats: [
+      'This efficiency report is diagnostic/experimental and should not be treated as a stable public proof surface.',
+      'Efficiency here is controller-output overhead, not model intelligence, task correctness, productivity, or benchmark proof.',
+      'Evidence bytes are safe reference bytes, not a score; evidence volume is not treated as quality.',
+      'Token/cost telemetry completeness reports missing receipts instead of imputing costs.',
+    ],
+  };
+}
+
+export function renderEvolutionEfficiencyReport(report: EvolutionAnalysisEfficiencyReport, format: EvolutionAnalysisFormat = 'terminal'): string {
+  if (format === 'json') return `${JSON.stringify(report, null, 2)}\n`;
+  const lines = [
+    format === 'markdown' ? `# Evolution efficiency: ${report.loop.loopDir}` : `Evolution Efficiency: ${report.loop.loopDir}`,
+    `Scope: ${report.scope}/${report.stability}`,
+    '',
+    `Primary definition: ${report.definition.primary}`,
+    `Secondary definition: ${report.definition.secondary}`,
+    '',
+    '| Metric | Baseline | Compact |',
+    '|---|---:|---:|',
+    `| Output bytes | ${report.baseline.outputBytes} | ${report.compact.outputBytes} |`,
+    `| Output bytes / useful decision field | ${report.baseline.outputBytesPerUsefulDecisionField} | ${report.compact.outputBytesPerUsefulDecisionField} |`,
+    `| Evidence bytes / action recommendation | ${report.baseline.evidenceBytesPerActionRecommendation} | ${report.compact.evidenceBytesPerActionRecommendation} |`,
+    `| Next-action packet bytes | ${report.baseline.nextActionPacketBytes} | ${report.compact.nextActionPacketBytes} |`,
+    `| Required control fields present | ${report.baseline.requiredControlFieldsPresent}/${report.baseline.requiredControlFieldsTotal} | ${report.compact.requiredControlFieldsPresent}/${report.compact.requiredControlFieldsTotal} |`,
+    `| Required control fields / KB | ${report.baseline.requiredControlFieldsPerKb} | ${report.compact.requiredControlFieldsPerKb} |`,
+    '',
+    `Output byte reduction ratio: ${report.improvement.outputByteReductionRatio}x`,
+    `Bytes/useful-field reduction ratio: ${report.improvement.outputBytesPerUsefulDecisionFieldReductionRatio}x`,
+    `Compact <= 66.7% baseline bytes: ${report.improvement.compactUsesAtMostTwoThirdsBaselineBytes ? 'yes' : 'no'}`,
+    `Required fields preserved: ${report.improvement.requiredControlFieldsPreserved ? 'yes' : 'no'}`,
+    `Rendered compact required fields preserved: ${report.improvement.renderedCompactControlFieldsPreserved ? 'yes' : 'no'} (${report.improvement.renderedCompactControlFieldsPresent}/${report.improvement.renderedCompactControlFieldsTotal})`,
+    `Achieved >=1.5x measured output efficiency: ${report.improvement.achievedAtLeastOnePointFiveX ? 'yes' : 'no'}`,
+    `Token/cost telemetry completeness: ${report.telemetry.present}/${report.telemetry.total}${report.telemetry.missing.length > 0 ? ` (missing ${report.telemetry.missing.join(', ')})` : ''}`,
+    `Blind retries prevented in this fixture: ${report.blindRetriesPrevented}`,
+    `Analyze input to actionable recommendation: ${report.analyzeToRecommendation.stepCount} step(s) (${report.analyzeToRecommendation.steps.join(' -> ')})`,
+    `Additional diagnostic >=1.5x targets found: ${report.additionalTargetsAtLeastOnePointFiveX}/${report.targets.length}`,
+    `Public-summary strong targets: ${report.publicSummaryTargetsAtLeastOnePointFiveX}/${report.targets.length}`,
+    '',
+    'Additional measured targets',
+    '| Target | Baseline bytes | Compact bytes | Ratio | Preserved | Classification | Public-summary counted |',
+    '|---|---:|---:|---:|---|---|---|',
+    ...report.targets.map((target) => `| ${target.id} | ${target.baselineBytes} | ${target.compactBytes} | ${target.reductionRatio}x | ${target.requiredFieldsPreserved ? 'yes' : 'no'} | ${target.classification} | ${target.publicSummaryCounted ? 'yes' : 'no'} |`),
+    '',
+    'Marginal targets',
+    ...(report.marginalTargets.length > 0 ? report.marginalTargets.map((target) => `- ${target}`) : ['- none']),
+    '',
+    'Warnings',
+    ...(report.warnings.length > 0 ? report.warnings.map((warning) => `- ${warning}`) : ['- none']),
+    '',
+    'Caveats',
+    ...report.caveats.map((caveat) => `- ${caveat}`),
+  ];
+  return `${lines.join('\n')}\n`;
+}

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -8,6 +8,8 @@ export const EVOLUTION_LOOP_SCHEMA = 'open-scaffold.evolution-loop.v1';
 export const EVOLUTION_ATTEMPT_SCHEMA = 'open-scaffold.evolution-attempt.v1';
 export const EVOLUTION_FRONTIER_SCHEMA = 'open-scaffold.evolution-frontier.v1';
 export const EVOLUTION_NEXT_ACTION_PACKET_SCHEMA = 'open-scaffold.evolution-next-action-packet.v1';
+export const EVOLUTION_CONTROLLER_SIGNAL_SCHEMA = 'open-scaffold.evolution-controller-signal.v1';
+export const EVOLUTION_EFFICIENCY_REPORT_SCHEMA = 'open-scaffold.evolution-efficiency-report.v1';
 const RUN_SCHEMA = 'open-scaffold.run.v1';
 const EVALUATION_SCHEMA = 'open-scaffold.evaluation.v1';
 const DISPATCH_RECEIPT_SCHEMA = 'open-scaffold.dispatch-receipt.v1';
@@ -1034,6 +1036,41 @@ export interface EvolutionNextActionPacket {
   boundaryNotes: string[];
 }
 
+export interface EvolutionControllerSignal {
+  schema: typeof EVOLUTION_CONTROLLER_SIGNAL_SCHEMA;
+  action: EvolutionAnalysisRecommendationAction;
+  summary: string;
+  reasons: string[];
+  resume: {
+    currentAttemptId: string | null;
+    frontierAttemptId: string | null;
+    currentEvaluation: string | null;
+  };
+  plateau: EvolutionNextActionPacket['plateau'];
+  acceptance: {
+    currentPass: number;
+    currentTotal: number;
+    remainingFailureIds: string[];
+    remainingFailures: EvolutionNextActionPacket['acceptance']['remainingFailures'];
+  };
+  requiredNextFields: string[];
+  usageReceipt: {
+    totalTokens: number | null;
+    estimatedUsd: number | null;
+    source: string | null;
+    unavailableReason: string | null;
+    completeness: {
+      present: number;
+      total: number;
+      missing: string[];
+      ratio: number;
+    };
+  };
+  warnings: string[];
+  evidenceRefs: string[];
+  boundaryNotes: string[];
+}
+
 export interface EvolutionAnalysisResult {
   kind: 'analysis';
   loop: { loopDir: string; loopId: string | null; objective: string | null; strategy: string | null; attemptCount: number };
@@ -1052,6 +1089,10 @@ export interface EvolutionAnalysisResult {
 
 export interface EvolutionAnalyzeOptions {
   plateauThreshold?: number;
+}
+
+export interface EvolutionAnalysisRenderOptions {
+  compact?: boolean;
 }
 
 function normalizeReason(value: string): string {
@@ -1310,7 +1351,11 @@ function attemptSummary(root: string, attempt: EvolutionCompareAttempt | null) {
   };
 }
 
-function recommendAnalysis(plateau: EvolutionAnalysisResult['plateau'], criteria: EvolutionAnalysisCriterion[], currentTotal: number): EvolutionAnalysisResult['recommendation'] {
+function isNoOpRetryAttempt(attempt: EvolutionAnalysisResult['currentAttempt']): boolean {
+  return attempt.decision === 'retry' && attempt.repairHypothesis?.actualDelta === 0;
+}
+
+function recommendAnalysis(plateau: EvolutionAnalysisResult['plateau'], criteria: EvolutionAnalysisCriterion[], currentTotal: number, currentAttempt: EvolutionAnalysisResult['currentAttempt']): EvolutionAnalysisResult['recommendation'] {
   if (currentTotal === 0) {
     return { action: 'inspect_scorer', summary: 'No current acceptance-criteria evidence is available; inspect the scorer or evaluation envelope before retrying.', reasons: ['no_current_acceptance_criteria'] };
   }
@@ -1336,6 +1381,13 @@ function recommendAnalysis(plateau: EvolutionAnalysisResult['plateau'], criteria
   }
   if (plateau.status === 'regressed') {
     return { action: 'inspect_scorer', summary: 'Latest score is below the best recorded score; inspect scorer/evidence before continuing.', reasons: ['score_regressed'] };
+  }
+  if (remaining.length > 0 && isNoOpRetryAttempt(currentAttempt)) {
+    return {
+      action: 'inspect_scorer',
+      summary: 'The current retry reported actual delta 0 while criteria still fail; inspect the scorer/evidence or change the repair hypothesis before another attempt.',
+      reasons: ['no_op_retry', 'remaining_failures'],
+    };
   }
   return { action: 'continue', summary: 'Score or acceptance-criteria evidence is still moving; one more bounded attempt may be useful.', reasons: ['still_moving'] };
 }
@@ -1561,10 +1613,10 @@ export function analyzeEvolutionLoop(loopDir: string, options: EvolutionAnalyzeO
     frontierTotal: frontierCounts.total,
     remainingFailures: currentCounts.remainingFailures,
   };
-  const recommendation = recommendAnalysis(plateau, criteria, currentCounts.total);
   const currentAttemptResult = attemptSummary(analysisRoot, currentAttempt);
   const previousAttemptResult = attemptSummary(analysisRoot, previousAttempt);
   const frontierAttemptResult = attemptSummary(analysisRoot, frontierAttempt);
+  const recommendation = recommendAnalysis(plateau, criteria, currentCounts.total, currentAttemptResult);
   const nextActionPacket = buildNextActionPacket(analysisRoot, loopInfo, plateau, currentAttemptResult, frontierAttemptResult, acceptanceSummary, criteria, recommendation);
   return {
     kind: 'analysis',
@@ -1605,6 +1657,118 @@ function impossibleLabel(criterion: EvolutionAnalysisCriterion): string {
     ...criterion.reasons.filter((reason) => !priority.includes(reason)),
   ];
   return ordered.join(',');
+}
+
+function bytes(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function roundRatio(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Number(value.toFixed(6));
+}
+
+function usageCompleteness(usage: EvolutionAttemptUsageSummary | null): EvolutionControllerSignal['usageReceipt']['completeness'] {
+  const missing: string[] = [];
+  if (usage?.totalTokens === null || usage?.totalTokens === undefined) missing.push('total_tokens');
+  if (usage?.estimatedUsd === null || usage?.estimatedUsd === undefined) missing.push('estimated_usd');
+  if (!meaningfulString(usage?.source) && !meaningfulString(usage?.unavailableReason)) missing.push('source_or_unavailable_reason');
+  const total = 3;
+  const present = total - missing.length;
+  return { present, total, missing, ratio: roundRatio(present / total) };
+}
+
+function evidenceBudgetWarning(packet: EvolutionNextActionPacket): string | null {
+  const evidenceBytes = bytes(packet.evidenceRefs.join('\n'));
+  if (packet.evidenceRefs.length > 5) return `Evidence packet carries ${packet.evidenceRefs.length} refs; compact before handoff if the next context is small.`;
+  if (evidenceBytes > 512) return `Evidence refs use ${evidenceBytes} byte(s); pass refs/digests rather than raw evidence text.`;
+  return null;
+}
+
+export function buildEvolutionControllerSignal(analysis: EvolutionAnalysisResult): EvolutionControllerSignal {
+  const packet = analysis.nextActionPacket;
+  const usage = packet.currentAttemptControl.usage;
+  const warnings = [
+    packet.currentAttemptControl.budgetWarning,
+    evidenceBudgetWarning(packet),
+    ...(usageCompleteness(usage).missing.length > 0 ? [`Usage receipt incomplete: missing ${usageCompleteness(usage).missing.join(', ')}.`] : []),
+  ].filter((warning): warning is string => Boolean(warning));
+  return {
+    schema: EVOLUTION_CONTROLLER_SIGNAL_SCHEMA,
+    action: packet.recommendedAction,
+    summary: packet.summary,
+    reasons: packet.reasons,
+    resume: {
+      currentAttemptId: packet.resumeFrom.currentAttemptId,
+      frontierAttemptId: packet.resumeFrom.frontierAttemptId,
+      currentEvaluation: packet.resumeFrom.currentEvaluation,
+    },
+    plateau: packet.plateau,
+    acceptance: {
+      currentPass: packet.acceptance.currentPass,
+      currentTotal: packet.acceptance.currentTotal,
+      remainingFailureIds: packet.acceptance.remainingFailures.map((criterion) => criterion.id),
+      remainingFailures: packet.acceptance.remainingFailures,
+    },
+    requiredNextFields: packet.requiredNextFields,
+    usageReceipt: {
+      totalTokens: usage?.totalTokens ?? null,
+      estimatedUsd: usage?.estimatedUsd ?? null,
+      source: usage?.source ?? null,
+      unavailableReason: usage?.unavailableReason ?? null,
+      completeness: usageCompleteness(usage),
+    },
+    warnings,
+    evidenceRefs: packet.evidenceRefs,
+    boundaryNotes: packet.boundaryNotes,
+  };
+}
+
+function renderCompactAnalysisTerminal(analysis: EvolutionAnalysisResult): string {
+  const signal = buildEvolutionControllerSignal(analysis);
+  const remaining = signal.acceptance.remainingFailures.length > 0
+    ? signal.acceptance.remainingFailures.map((criterion) => `${criterion.id}:${criterion.status}${criterion.impossible ? ':impossible' : ''}:${criterion.sensitivity}`).join(', ')
+    : '—';
+  const lines = [
+    `Evolution Control: ${analysis.loop.loopDir}`,
+    `Action: ${signal.action}`,
+    `Why: ${signal.reasons.join(', ') || '—'} — ${signal.summary}`,
+    `Resume: current=${signal.resume.currentAttemptId ?? '—'} | frontier=${signal.resume.frontierAttemptId ?? '—'} | evaluation=${signal.resume.currentEvaluation ?? '—'}`,
+    `Plateau: ${signal.plateau.status} | no-improve=${signal.plateau.noImprovementCount} | current=${formatScore(signal.plateau.currentScore)} | best=${formatScore(signal.plateau.bestScore)}`,
+    `Acceptance: ${signal.acceptance.currentPass}/${signal.acceptance.currentTotal} pass | remaining=${remaining}`,
+    `Required: ${signal.requiredNextFields.join(', ')}`,
+    `Usage: tokens=${formatInteger(signal.usageReceipt.totalTokens)} | usd=${formatUsd(signal.usageReceipt.estimatedUsd)} | source=${signal.usageReceipt.source ?? signal.usageReceipt.unavailableReason ?? '—'} | completeness=${signal.usageReceipt.completeness.present}/${signal.usageReceipt.completeness.total}`,
+    ...(signal.warnings.length > 0 ? signal.warnings.map((warning) => `Warning: ${warning}`) : []),
+    `Evidence refs: ${signal.evidenceRefs.join(', ') || '—'}`,
+    `Boundary: ${signal.boundaryNotes.join(' ')}`,
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function renderCompactAnalysisMarkdown(analysis: EvolutionAnalysisResult): string {
+  const signal = buildEvolutionControllerSignal(analysis);
+  const lines = [
+    `# Evolution control: ${analysis.loop.loopDir}`,
+    '',
+    `- Action: \`${signal.action}\``,
+    `- Why: ${signal.reasons.join(', ') || '—'} — ${signal.summary}`,
+    `- Resume: current \`${signal.resume.currentAttemptId ?? '—'}\`; frontier \`${signal.resume.frontierAttemptId ?? '—'}\`; evaluation \`${signal.resume.currentEvaluation ?? '—'}\``,
+    `- Plateau: \`${signal.plateau.status}\`; no-improve ${signal.plateau.noImprovementCount}; current ${formatScore(signal.plateau.currentScore)}; best ${formatScore(signal.plateau.bestScore)}`,
+    `- Acceptance: ${signal.acceptance.currentPass}/${signal.acceptance.currentTotal} pass; remaining ${signal.acceptance.remainingFailureIds.map((id) => `\`${id}\``).join(', ') || '—'}`,
+    `- Required next fields: ${signal.requiredNextFields.map((field) => `\`${field}\``).join(', ')}`,
+    `- Usage receipt: tokens ${formatInteger(signal.usageReceipt.totalTokens)}; usd ${formatUsd(signal.usageReceipt.estimatedUsd)}; source ${signal.usageReceipt.source ?? signal.usageReceipt.unavailableReason ?? '—'}; completeness ${signal.usageReceipt.completeness.present}/${signal.usageReceipt.completeness.total}`,
+    ...(signal.warnings.length > 0 ? signal.warnings.map((warning) => `- Warning: ${warning}`) : []),
+    `- Evidence refs: ${signal.evidenceRefs.map((ref) => `\`${ref}\``).join(', ') || '—'}`,
+    '',
+    '## Remaining failures',
+    '',
+    ...(signal.acceptance.remainingFailures.length > 0 ? signal.acceptance.remainingFailures.map((criterion) => `- \`${criterion.id}\`: ${criterion.status}; sensitivity ${criterion.sensitivity}; impossible ${criterion.impossible ? 'yes' : 'no'} — ${criterion.text}`) : ['- —']),
+    '',
+    '## Boundaries',
+    '',
+    ...signal.boundaryNotes.map((note) => `- ${note}`),
+  ];
+  return `${lines.join('\n')}\n`;
 }
 
 function renderAnalysisTerminal(analysis: EvolutionAnalysisResult): string {
@@ -1747,7 +1911,12 @@ function renderAnalysisMarkdown(analysis: EvolutionAnalysisResult): string {
   return `${lines.join('\n')}\n`;
 }
 
-export function renderEvolutionAnalysis(analysis: EvolutionAnalysisResult, format: EvolutionAnalysisFormat = 'terminal'): string {
+export function renderEvolutionAnalysis(analysis: EvolutionAnalysisResult, format: EvolutionAnalysisFormat = 'terminal', options: EvolutionAnalysisRenderOptions = {}): string {
+  if (options.compact) {
+    if (format === 'json') return `${JSON.stringify(buildEvolutionControllerSignal(analysis), null, 2)}\n`;
+    if (format === 'markdown') return renderCompactAnalysisMarkdown(analysis);
+    return renderCompactAnalysisTerminal(analysis);
+  }
   if (format === 'json') return `${JSON.stringify(analysis, null, 2)}\n`;
   if (format === 'markdown') return renderAnalysisMarkdown(analysis);
   return renderAnalysisTerminal(analysis);

--- a/tests/cli-evolution.test.ts
+++ b/tests/cli-evolution.test.ts
@@ -493,6 +493,26 @@ describe('osc evolve CLI', () => {
     expect(json.nextActionPacket.requiredNextFields).toContain('redesigned_criterion_scorer_or_artifact_shape');
     expect(json.criteria.find((criterion: { id: string }) => criterion.id === 'AC3')).toMatchObject({ impossible: true, sensitivity: 'none' });
 
+    const compact = execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--compact'], { cwd: root, encoding: 'utf8' });
+    expect(compact).toContain('Evolution Control: plateau-loop');
+    expect(compact).toContain('Action: redesign');
+    expect(compact).toContain('AC3:fail:impossible:none');
+    expect(compact.length).toBeLessThan(terminal.length);
+
+    const efficiency = JSON.parse(execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--efficiency', '--format', 'json'], { cwd: root, encoding: 'utf8' }));
+    expect(efficiency.schema).toBe('open-scaffold.evolution-efficiency-report.v1');
+    expect(efficiency.scope).toBe('diagnostic');
+    expect(efficiency.stability).toBe('experimental');
+    expect(efficiency.improvement.outputByteReductionRatio).toBeGreaterThanOrEqual(1.5);
+    expect(efficiency.improvement.achievedAtLeastOnePointFiveX).toBe(true);
+    expect(efficiency.improvement.renderedCompactControlFieldsPreserved).toBe(true);
+    expect(efficiency.additionalTargetsAtLeastOnePointFiveX).toBeGreaterThanOrEqual(10);
+    expect(efficiency.publicSummaryTargetsAtLeastOnePointFiveX).toBeGreaterThanOrEqual(10);
+    expect(efficiency.publicSummaryTargetsAtLeastOnePointFiveX).toBeLessThan(efficiency.additionalTargetsAtLeastOnePointFiveX);
+    expect(efficiency.marginalTargets).toContain('target.terminal.packet_to_action_block');
+    expect(efficiency.targets).toHaveLength(12);
+    expect(efficiency.caveats.join('\n')).toContain('not model intelligence');
+
     const output = execFileSync(tsx, [cli, 'evolve', 'analyze', outDir, '--format', 'markdown', '--out', reportPath], { cwd: root, encoding: 'utf8' });
     expect(output).toContain('Wrote evolution analysis:');
     const report = readFileSync(reportPath, 'utf8');

--- a/tests/cli-evolution.test.ts
+++ b/tests/cli-evolution.test.ts
@@ -526,7 +526,7 @@ describe('osc evolve CLI', () => {
     expect(readFileSync(join(outDir, 'loop.json'), 'utf8')).toBe(before.loop);
     expect(readFileSync(join(outDir, 'attempts.jsonl'), 'utf8')).toBe(before.attempts);
     expect(readFileSync(join(outDir, 'frontier.json'), 'utf8')).toBe(before.frontier);
-  });
+  }, 15000);
 
   it('renders inspect_scorer next-action packets through the CLI', () => {
     const { root, outDir } = writeInspectCliLoop();

--- a/tests/evolution.test.ts
+++ b/tests/evolution.test.ts
@@ -15,6 +15,7 @@ import {
   validateEvolutionLoopDir,
   writeEvolutionLoop,
 } from '../src/evolution.js';
+import { measureEvolutionAnalysisEfficiency, renderEvolutionEfficiencyReport } from '../src/evolution-efficiency.js';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const evolutionDemoRoot = join(repoRoot, 'examples/evolution-ledger-demo');
@@ -374,6 +375,27 @@ function writeOrdinaryFailureLoop(privateRefs = false) {
       rationale: index === 0 ? 'Initial score frontier.' : 'Retry did not move score, but remaining failure is reachable.',
       ...(index === 0 ? {} : retryControl(runId, index)),
       now: new Date(`2026-05-31T09:${String(10 + index).padStart(2, '0')}:00.000Z`),
+    }, root);
+  }
+  return { root, outDir };
+}
+
+function writeNoOpRetryLoop() {
+  const root = tempRepo();
+  const planPath = writePlan(root);
+  const outDir = join(root, '.osc/evolution/no-op-retry-loop');
+  writeEvolutionLoop(planPath, outDir, root, { now: new Date('2026-06-03T12:00:00.000Z'), strategy: 'greedy' });
+  for (const [index, runId] of ['attempt-a', 'attempt-b'].entries()) {
+    const runPath = writeRunPacket(root, runId);
+    const evalPath = writeOrdinaryFailureEvaluation(root, runId);
+    recordEvolutionAttempt(outDir, {
+      runPath,
+      evaluationPath: evalPath,
+      decision: index === 0 ? 'promote' : 'retry',
+      score: index === 0 ? 0.7 : 0.71,
+      rationale: index === 0 ? 'Initial score frontier.' : 'Retry nudged score but produced actual delta 0 on the target metric.',
+      ...(index === 0 ? {} : retryControl(runId, index)),
+      now: new Date(`2026-06-03T12:${String(10 + index).padStart(2, '0')}:00.000Z`),
     }, root);
   }
   return { root, outDir };
@@ -789,6 +811,58 @@ describe('evolution analysis', () => {
     expect(readFileSync(join(root, 'docs/evidence/attempt-d-evaluation.json'), 'utf8')).toBe(before.evaluation);
   });
 
+  it('renders a compact controller signal and computes efficiency ratios without hiding required fields', () => {
+    const { root, outDir } = writePlateauLoop();
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+
+    const full = renderEvolutionAnalysis(analysis, 'terminal');
+    const compact = renderEvolutionAnalysis(analysis, 'terminal', { compact: true });
+    const compactJson = JSON.parse(renderEvolutionAnalysis(analysis, 'json', { compact: true }));
+    const report = measureEvolutionAnalysisEfficiency(analysis);
+    const renderedReport = renderEvolutionEfficiencyReport(report, 'terminal');
+
+    expect(compact.length).toBeLessThan(full.length);
+    expect(report.compact.outputBytes).toBeLessThanOrEqual(report.baseline.outputBytes * (2 / 3));
+    expect(report.improvement.outputByteReductionRatio).toBeGreaterThanOrEqual(1.5);
+    expect(report.improvement.achievedAtLeastOnePointFiveX).toBe(true);
+    expect(report.improvement.renderedCompactControlFieldsPreserved).toBe(true);
+    expect(report.scope).toBe('diagnostic');
+    expect(report.stability).toBe('experimental');
+    expect(report.additionalTargetsAtLeastOnePointFiveX).toBeGreaterThanOrEqual(10);
+    expect(report.publicSummaryTargetsAtLeastOnePointFiveX).toBeGreaterThanOrEqual(10);
+    expect(report.publicSummaryTargetsAtLeastOnePointFiveX).toBeLessThan(report.additionalTargetsAtLeastOnePointFiveX);
+    expect(report.targets).toHaveLength(12);
+    expect(report.targets.every((target) => target.requiredFieldsPreserved)).toBe(true);
+    expect(report.targets.find((target) => target.id === 'target.markdown.control_to_compact_bullets')?.requiredFields).not.toContain('summary');
+    expect(report.targets.find((target) => target.id === 'target.terminal.packet_to_action_block')).toMatchObject({ classification: 'marginal', publicSummaryCounted: false });
+    expect(report.marginalTargets).toContain('target.terminal.packet_to_action_block');
+    expect(report.baseline.requiredControlFieldsPresent).toBe(report.compact.requiredControlFieldsPresent);
+    expect(report.compact.requiredControlFieldRatio).toBe(1);
+    expect(report.telemetry).toMatchObject({ present: 2, total: 3, missing: ['estimated_usd'] });
+    expect(report.analyzeToRecommendation.stepCount).toBe(4);
+
+    expect(compact).toContain('Action: redesign');
+    expect(compact).toContain('Required: redesigned_criterion_scorer_or_artifact_shape');
+    expect(compact).toContain('AC3:fail:impossible:none');
+    expect(compact).toContain('Usage: tokens=1,003');
+    expect(compact).toContain('Boundary:');
+    expect(compactJson).toMatchObject({
+      schema: 'open-scaffold.evolution-controller-signal.v1',
+      action: 'redesign',
+      acceptance: {
+        remainingFailureIds: ['AC3'],
+      },
+    });
+    expect(compactJson.requiredNextFields).toContain('usage_receipt_or_unavailable_reason');
+    expect(renderedReport).toContain('Evolution Efficiency: plateau-loop');
+    expect(renderedReport).toContain('Scope: diagnostic/experimental');
+    expect(renderedReport).toContain('Rendered compact required fields preserved: yes');
+    expect(renderedReport).toContain('Public-summary strong targets:');
+    expect(renderedReport).toContain('Marginal targets');
+    expect(renderedReport).toContain('Achieved >=1.5x measured output efficiency: yes');
+    expect(renderedReport).toContain('Efficiency here is controller-output overhead');
+  });
+
   it('builds a stop packet that routes all-pass loops to human closeout instead of approval by score', () => {
     const root = tempRepo();
     const planPath = writePlan(root);
@@ -820,6 +894,26 @@ describe('evolution analysis', () => {
     ]);
     expect(analysis.nextActionPacket.handoffChecklist.join('\n')).toContain('frontier score is not acceptance approval');
     expect(analysis.nextActionPacket.boundaryNotes.join('\n')).toContain('does not spawn runtimes');
+  });
+
+  it('routes no-op retry attempts away from blind continuation even when score still moved', () => {
+    const { root, outDir } = writeNoOpRetryLoop();
+
+    const analysis = analyzeEvolutionLoop(outDir, {}, root);
+    const report = measureEvolutionAnalysisEfficiency(analysis);
+
+    expect(analysis.plateau.status).toBe('improving');
+    expect(analysis.currentAttempt).toMatchObject({
+      decision: 'retry',
+      repairHypothesis: { actualDelta: 0, targetMetric: 'accepted_ac_count' },
+    });
+    expect(analysis.recommendation).toMatchObject({
+      action: 'inspect_scorer',
+      reasons: expect.arrayContaining(['no_op_retry']),
+    });
+    expect(analysis.recommendation.summary).toContain('actual delta 0');
+    expect(analysis.nextActionPacket.handoffChecklist.join('\n')).toContain('Inspect scorer/evaluation coverage');
+    expect(report.blindRetriesPrevented).toBe(1);
   });
 
   it('uses current-attempt blocker metadata for recommendation instead of stale frontier metadata', () => {
@@ -908,6 +1002,10 @@ describe('evolution analysis', () => {
       },
     });
     expect(analysis.nextActionPacket.handoffChecklist.join('\n')).toContain('AC3');
+
+    const compact = renderEvolutionAnalysis(analysis, 'terminal', { compact: true });
+    expect(compact).toContain('AC3:missing_current:unknown');
+    expect(compact).toContain('Action: inspect_scorer');
   });
 
   it('does not classify ordinary reachable failure reasons as impossible redesign-only blockers', () => {
@@ -935,6 +1033,8 @@ describe('evolution analysis', () => {
     const ac2 = analysis.criteria.find((criterion) => criterion.id === 'AC2');
     const terminal = renderEvolutionAnalysis(analysis, 'terminal');
     const markdown = renderEvolutionAnalysis(analysis, 'markdown');
+    const compact = renderEvolutionAnalysis(analysis, 'terminal', { compact: true });
+    const efficiency = renderEvolutionEfficiencyReport(measureEvolutionAnalysisEfficiency(analysis), 'json');
 
     expect(ac2?.evidence).toEqual([]);
     expect(terminal).not.toContain('/private/scorer.md');
@@ -947,6 +1047,16 @@ describe('evolution analysis', () => {
     expect(markdown).not.toContain('.osc/research/private-scorer.md');
     expect(markdown).not.toContain('../raw-scorer.log');
     expect(markdown).not.toContain('docs/../../.osc-dev/notes.md');
+    expect(compact).not.toContain('/private/scorer.md');
+    expect(compact).not.toContain('file:///private/scorer.md');
+    expect(compact).not.toContain('.osc/research/private-scorer.md');
+    expect(compact).not.toContain('../raw-scorer.log');
+    expect(compact).not.toContain('docs/../../.osc-dev/notes.md');
+    expect(efficiency).not.toContain('/private/scorer.md');
+    expect(efficiency).not.toContain('file:///private/scorer.md');
+    expect(efficiency).not.toContain('.osc/research/private-scorer.md');
+    expect(efficiency).not.toContain('../raw-scorer.log');
+    expect(efficiency).not.toContain('docs/../../.osc-dev/notes.md');
   });
 
   it('does not read or render unsafe evaluation refs from hand-written attempt journals', () => {
@@ -976,10 +1086,11 @@ describe('evolution analysis', () => {
     const terminal = renderEvolutionAnalysis(analysis, 'terminal');
     const markdown = renderEvolutionAnalysis(analysis, 'markdown');
     const json = renderEvolutionAnalysis(analysis, 'json');
+    const compact = renderEvolutionAnalysis(analysis, 'json', { compact: true });
 
     expect(analysis.currentAttempt.evaluation).toBeNull();
     expect(analysis.nextActionPacket.evidenceRefs).not.toContain('.osc-dev/private-evaluation.json');
-    for (const output of [terminal, markdown, json]) {
+    for (const output of [terminal, markdown, json, compact]) {
       expect(output).not.toContain('.osc-dev/private-evaluation.json');
       expect(output).not.toContain('Private criterion');
       expect(output).not.toContain('Private rationale');
@@ -1019,10 +1130,11 @@ describe('evolution analysis', () => {
     const terminal = renderEvolutionAnalysis(analysis, 'terminal');
     const markdown = renderEvolutionAnalysis(analysis, 'markdown');
     const json = renderEvolutionAnalysis(analysis, 'json');
+    const compact = renderEvolutionAnalysis(analysis, 'json', { compact: true });
 
     expect(analysis.currentAttempt.evaluation).toBeNull();
     expect(analysis.nextActionPacket.evidenceRefs).not.toContain('docs/evidence/private-evaluation-link.json');
-    for (const output of [terminal, markdown, json]) {
+    for (const output of [terminal, markdown, json, compact]) {
       expect(output).not.toContain('private-evaluation-link.json');
       expect(output).not.toContain('Private symlinked criterion');
       expect(output).not.toContain('Private symlink rationale');

--- a/tests/public-positioning.test.ts
+++ b/tests/public-positioning.test.ts
@@ -133,6 +133,24 @@ describe('public work-record positioning', () => {
     expect(trace).not.toMatch(/trust score|compliance-grade|tamper-proof|certif(y|ies|ied)/i);
   });
 
+  it('keeps efficiency positioning benchmark-neutral and artifact-measured', () => {
+    const readme = read('README.md');
+    const evolution = read('docs/EVOLUTION_LOOP.md');
+    const methodology = read('docs/EVIDENCE_METHODOLOGY.md');
+    const faq = read('docs/FAQ.md');
+    const combined = [readme, evolution, methodology, faq].join('\n');
+
+    expect(combined).toContain('does not make models smarter');
+    expect(combined).toContain('is not benchmark proof');
+    expect(combined).toContain('workflow control');
+    expect(combined).toContain('before/after artifact');
+    expect(combined).toContain('diagnostic');
+    expect(combined).toContain('experimental');
+    expect(evolution).toContain('osc evolve analyze .osc/evolution/demo-loop --efficiency');
+    expect(methodology).toContain('output bytes per useful decision field');
+    expect(faq).toContain('token/cost savings require receipts');
+  });
+
   it('positions comparison tools as adjacent layers rather than enemies', () => {
     const comparison = read('docs/COMPARISON.md');
 

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('e04f819d868a98f49cec31e21634fd2ab9ce3e3259efc5ee54dad9a48ca728b6');
+    expect(hash(planIssueSnapshot)).toBe('0e2f320225da537dd9b9c5119d5486aea35cf0110577c6c93311ac540763ed92');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('32a0a8261494920e76e7fcf10b0c3bfa4878428cccbe7d334ad6ce703b3a0073');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary

- Adds compact `osc evolve analyze --compact` controller output for terminal handoff packets.
- Adds diagnostic/experimental `--efficiency` reporting with rendered-field preservation checks.
- Keeps token/cost and benchmark/productivity claims explicitly scoped.
- Moves efficiency-report machinery into `src/evolution-efficiency.ts`.
- Documents the strong-target vs marginal-target boundary for the near-threshold row.

## Verification

- `git diff --check`
- public-safety added-line scan for local/private identifiers
- `npm test -- --run tests/evolution.test.ts tests/cli-evolution.test.ts tests/public-positioning.test.ts tests/section-parser.test.ts`
- `npm run build`
- `./verify.sh --strict` (`9 pass, 0 fail, 1 warn`; worktree immutability skipped in linked worktree)

## Risk / gates

- `--efficiency` is diagnostic/experimental, not a stable public proof surface.
- Missing token/cost receipts still block token/cost-savings claims.
- No merge, npm publish, release, or package-sync action is authorized by this PR.
