### PR TITLE
fix: fail closed on non-executable run packets

### DIFF
--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -147,7 +147,7 @@ function defersVerificationOutsideRun(step: string): boolean {
 function looksLikeExecutableVerification(step: string): boolean {
   const trimmed = step.trim();
   return /^(?:run|execute|verify|validate|check|test)\b/i.test(trimmed)
-    || /(?:^|[`\s])(?:npm|pnpm|yarn|npx|node|tsx|python3?|pytest|cargo|make|bash|sh|git|gh|\.\/)[^`\s]*/i.test(trimmed);
+    || /(?:^|[`\s])(?:npm|pnpm|yarn|npx|node|tsx|python3?|pytest|cargo|make|bash|sh|git|gh|osc|\.\/)[^`\s]*/i.test(trimmed);
 }
 
 function verificationBlockers(plan: ParsedPlan): string[] {

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -140,6 +140,28 @@ function blockingOpenQuestions(plan: ParsedPlan): string[] {
   return plan.openQuestions.filter(isBlockingOpenQuestion);
 }
 
+function defersVerificationOutsideRun(step: string): boolean {
+  return /\b(external runner|run externally|runs externally|will be run externally|after (?:the )?(?:model )?turn|after your turn|later by|operator will run|someone else will run)\b/i.test(step);
+}
+
+function looksLikeExecutableVerification(step: string): boolean {
+  const trimmed = step.trim();
+  return /^(?:run|execute|verify|validate|check|test)\b/i.test(trimmed)
+    || /(?:^|[`\s])(?:npm|pnpm|yarn|npx|node|tsx|python3?|pytest|cargo|make|bash|sh|git|gh|\.\/)[^`\s]*/i.test(trimmed);
+}
+
+function verificationBlockers(plan: ParsedPlan): string[] {
+  if (plan.verificationSteps.length === 0) return ['missing verification steps'];
+  const blockers: string[] = [];
+  if (plan.verificationSteps.some(defersVerificationOutsideRun)) {
+    blockers.push('verification steps defer execution outside the run packet');
+  }
+  if (!plan.verificationSteps.some(looksLikeExecutableVerification)) {
+    blockers.push('missing executable verification command');
+  }
+  return blockers;
+}
+
 function missionBlocker(root: string): string | null {
   const missionPath = join(root, 'MISSION.md');
   if (!existsSync(missionPath)) return 'undefined mission';
@@ -154,7 +176,7 @@ function contextQuality(root: string, plan: ParsedPlan): PackageQuality {
   if (mission) blockers.push(mission);
   if (!plan.goal.trim()) blockers.push('missing goal');
   if (plan.acceptanceCriteria.length === 0) blockers.push('missing acceptance criteria');
-  if (plan.verificationSteps.length === 0) blockers.push('missing verification steps');
+  blockers.push(...verificationBlockers(plan));
   const openQuestions = blockingOpenQuestions(plan);
   if (openQuestions.length) blockers.push('blocking open questions present');
   return {
@@ -189,6 +211,7 @@ function promptForGroup(plan: ParsedPlan, groupName: string, tasks: string, runI
     '- Follow the plan and its amendments; do not silently expand scope.',
     '- If scope changes, propose an amendment instead of editing the original plan.',
     '- Produce evidence tied to acceptance criteria, not vibes.',
+    '- Run the verification steps before final handoff. If a step cannot run, record the exact command, exit status, and stderr; do not treat an external runner or later operator step as verification.',
     '- This generic prompt does not spawn agents; paste it into your selected runtime.',
     '- Treat chat threads as operator-surface bindings, not canonical task/run identity.',
     '- If blocking open questions exist, stop and clarify before implementation.',
@@ -328,6 +351,9 @@ export function previewRunArtifacts(root: string, plan: ParsedPlan, mode: Artifa
 
 export function createRunArtifacts(root: string, plan: ParsedPlan, mode: ArtifactMode = 'run', options: RunArtifactOptions = {}): RunArtifacts {
   const preview = buildRunArtifacts(root, plan, mode, options);
+  if (!preview.manifest.packageQuality.executable) {
+    throw new Error(`Run package is not executable: ${preview.manifest.packageQuality.blockers.join('; ')}`);
+  }
   mkdirSync(join(preview.runDir, 'prompts'), { recursive: true });
 
   const promptPaths: string[] = [];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1664,6 +1664,13 @@ function createArtifacts(args: string[], mode: ArtifactMode): void {
     process.exit(2);
   }
 
+  const preview = previewRunArtifacts(artifactRoot, plan, mode, artifactOptions);
+  if (!preview.manifest.packageQuality.executable) {
+    console.error(`Run package is not executable: ${preview.manifest.packageQuality.blockers.join('; ')}`);
+    console.error('No files were written. Clarify or repair the plan before creating run artifacts.');
+    process.exit(1);
+  }
+
   const run = createRunArtifacts(artifactRoot, plan, mode, artifactOptions);
   console.log(`Created ${mode} artifacts:`);
   console.log(`  Run: ${run.runDir}`);

--- a/src/evolution.ts
+++ b/src/evolution.ts
@@ -507,7 +507,7 @@ export type EvolutionCompareResult =
 
 function normalizeCompareAttempt(attempt: Record<string, unknown>): EvolutionCompareAttempt {
   const attemptId = asString(attempt.attempt_id);
-  if (!attemptId) throw new Error('Evolution attempt is missing attempt_id.');
+  if (!attemptId) throw new Error('missing attempt_id');
   const boundaryValue = isRecord(attempt.boundary) ? attempt.boundary : {};
   return {
     attemptId,
@@ -527,6 +527,17 @@ function normalizeCompareAttempt(attempt: Record<string, unknown>): EvolutionCom
     usage: readAttemptUsage(attempt),
     boundary: boundaryValue,
   };
+}
+
+function normalizeCompareAttempts(attemptsPath: string): EvolutionCompareAttempt[] {
+  return readAttempts(attemptsPath).map((attempt, index) => {
+    try {
+      return normalizeCompareAttempt(attempt);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`invalid-evolution-ledger: attempts.jsonl line ${index + 1} is ${message}. Use osc evolve record to write attempt records.`);
+    }
+  });
 }
 
 function readAttemptRepairHypothesis(attempt: Record<string, unknown>): EvolutionAttemptRepairHypothesis | null {
@@ -740,7 +751,7 @@ export function compareEvolutionLoop(loopDir: string, options: EvolutionCompareO
   if (!isRecord(frontier) || frontier.schema !== EVOLUTION_FRONTIER_SCHEMA) {
     throw new Error(`Evolution frontier must declare schema: ${EVOLUTION_FRONTIER_SCHEMA}`);
   }
-  const attempts = readAttempts(attemptsPath).map(normalizeCompareAttempt);
+  const attempts = normalizeCompareAttempts(attemptsPath);
   const strategy = isRecord(loop.strategy) ? asString(loop.strategy.name) : null;
   const loopInfo = {
     loopDir: basename(absoluteLoopDir),
@@ -1553,7 +1564,7 @@ export function analyzeEvolutionLoop(loopDir: string, options: EvolutionAnalyzeO
   if (!isRecord(frontier) || frontier.schema !== EVOLUTION_FRONTIER_SCHEMA) {
     throw new Error(`Evolution frontier must declare schema: ${EVOLUTION_FRONTIER_SCHEMA}`);
   }
-  const attempts = readAttempts(attemptsPath).map(normalizeCompareAttempt);
+  const attempts = normalizeCompareAttempts(attemptsPath);
   const strategy = isRecord(loop.strategy) ? asString(loop.strategy.name) : null;
   const loopInfo = {
     loopDir: basename(absoluteLoopDir),

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -681,6 +681,23 @@ function numberedItems(text: string): string[] {
     .filter(Boolean);
 }
 
+function orderedOrBulletItems(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^(?:\d+\.|[-*])\s+/.test(line))
+    .map((line) => line.replace(/^(?:\d+\.|[-*])\s+/, '').trim())
+    .filter(Boolean);
+}
+
+function firstSection(sections: Map<string, string>, names: string[]): string {
+  for (const name of names) {
+    const body = sections.get(name);
+    if (body !== undefined) return body;
+  }
+  return '';
+}
+
 function parseExecutionStrategy(text: string): ExecutionStrategy | undefined {
   if (!text.trim()) return undefined;
   const groups: ExecutionGroup[] = [];
@@ -726,7 +743,7 @@ export function parsePlanFile(path: string): ParsedPlan {
     sections,
     filesToTouch: bulletItems(sections.get('Files to touch') ?? ''),
     acceptanceCriteria: bulletItems(sections.get('Acceptance criteria') ?? ''),
-    verificationSteps: numberedItems(sections.get('Verification steps') ?? ''),
+    verificationSteps: orderedOrBulletItems(firstSection(sections, ['Verification steps', 'Verification'])),
     openQuestions: bulletItems(sections.get('Open questions') ?? ''),
     executionStrategy: parseExecutionStrategy(sections.get('Execution strategy') ?? ''),
   };

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -144,6 +144,20 @@ describe('run artifact generation', () => {
     expect(() => createRunArtifacts(root, deferringPlan as any, 'run')).toThrow(/verification steps defer execution outside the run packet/);
   });
 
+  it('recognizes labeled osc commands as executable verification', () => {
+    const root = tempRepo();
+    const labeledOscPlan = {
+      ...plan,
+      slug: '004-labeled-osc-verification',
+      verificationSteps: ['**Search:** Run `osc runtimes search omx`. Verify output includes the adapter.'],
+    };
+
+    const preview = previewRunArtifacts(root, labeledOscPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(true);
+    expect(preview.manifest.packageQuality.blockers).toEqual([]);
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -108,18 +108,40 @@ describe('run artifact generation', () => {
     expect(prompt).toContain('- Executor: omx-codex');
   });
 
-  it('marks packages with missing executable context as requiring clarification before dispatch', () => {
+  it('previews packages with missing executable context as requiring clarification before dispatch', () => {
     const root = tempRepo();
 
-    const run = createRunArtifacts(root, ambiguousPlan as any, 'run', { executor: 'omc-claude', harnessSkill: '/deep-interview' });
-    const manifest = JSON.parse(readFileSync(run.manifestPath, 'utf8'));
+    const preview = previewRunArtifacts(root, ambiguousPlan as any, 'run', { executor: 'omc-claude', harnessSkill: '/deep-interview' });
 
-    expect(manifest.packageQuality.executable).toBe(false);
-    expect(manifest.packageQuality.requiredAction).toBe('clarify-or-deep-interview-before-dispatch');
-    expect(manifest.packageQuality.blockers).toContain('missing goal');
-    expect(manifest.packageQuality.blockers).toContain('missing acceptance criteria');
-    expect(manifest.packageQuality.blockers).toContain('missing verification steps');
-    expect(manifest.packageQuality.blockers).toContain('blocking open questions present');
+    expect(preview.manifest.packageQuality.executable).toBe(false);
+    expect(preview.manifest.packageQuality.requiredAction).toBe('clarify-or-deep-interview-before-dispatch');
+    expect(preview.manifest.packageQuality.blockers).toContain('missing goal');
+    expect(preview.manifest.packageQuality.blockers).toContain('missing acceptance criteria');
+    expect(preview.manifest.packageQuality.blockers).toContain('missing verification steps');
+    expect(preview.manifest.packageQuality.blockers).toContain('blocking open questions present');
+  });
+
+  it('refuses to write non-executable run artifacts', () => {
+    const root = tempRepo();
+
+    expect(() => createRunArtifacts(root, ambiguousPlan as any, 'run', { executor: 'omc-claude', harnessSkill: '/deep-interview' }))
+      .toThrow(/Run package is not executable/);
+    expect(existsSync(join(root, '.osc/runs'))).toBe(false);
+  });
+
+  it('blocks verification steps that defer proof to an external runner', () => {
+    const root = tempRepo();
+    const deferringPlan = {
+      ...plan,
+      slug: '003-defers-proof',
+      verificationSteps: ['External runner executes the scorer after the model turn.'],
+    };
+
+    const preview = previewRunArtifacts(root, deferringPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(false);
+    expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
+    expect(() => createRunArtifacts(root, deferringPlan as any, 'run')).toThrow(/verification steps defer execution outside the run packet/);
   });
 
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {

--- a/tests/cli-evolution.test.ts
+++ b/tests/cli-evolution.test.ts
@@ -545,6 +545,19 @@ describe('osc evolve CLI', () => {
     expect(markdown).toContain('Inspect scorer/evaluation coverage before recording another attempt.');
   });
 
+  it('fail-closes evolve analyze when attempts.jsonl contains malformed attempt records', () => {
+    const { root, planPath } = tempRepo();
+    const outDir = join(root, '.osc/evolution/bad-ledger');
+    execFileSync(tsx, [cli, 'evolve', 'init', planPath, '--out', outDir], { cwd: root, encoding: 'utf8' });
+    writeFileSync(join(outDir, 'attempts.jsonl'), JSON.stringify({ schema: 'open-scaffold.evolution-attempt.v1', generation: 1, run_id: 'manual-without-attempt-id' }) + '\n');
+
+    const result = spawnSync(tsx, [cli, 'evolve', 'analyze', outDir], { cwd: root, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('invalid-evolution-ledger');
+    expect(result.stderr).toContain('attempts.jsonl line 1 is missing attempt_id');
+  });
+
   it('rejects unknown strategies and prints evolve usage', () => {
     const { root, planPath } = tempRepo();
     const result = spawnSync(tsx, [cli, 'evolve', 'init', planPath, '--strategy', 'magical'], { cwd: root, encoding: 'utf8' });

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -26,6 +26,7 @@ function filesUnder(root: string): string[] {
 }
 
 function writeRuntimeSelectionPlan(target: string, goal = 'Demo runtime selection.') {
+  writeFileSync(join(target, 'MISSION.md'), '# Mission\n\nRuntime selection packet test.\n');
   const planPath = join(target, '.osc/plans/active/001-demo.md');
   writeFileSync(planPath, `# Plan: 001-demo
 
@@ -55,7 +56,7 @@ ${goal}
 
 ## Verification steps
 
-1. Inspect run packet.
+1. Check run packet.
 
 ## Open questions
 

--- a/tests/cli-run-dry-run.test.ts
+++ b/tests/cli-run-dry-run.test.ts
@@ -208,6 +208,30 @@ describe('osc run --dry-run', () => {
     expect(existsSync(join(target, '.osc/runs'))).toBe(false);
   });
 
+  it('refuses to write non-executable run artifacts in normal mode', () => {
+    const target = initializedScaffold();
+    const planPath = writePlan(target, '002-bad-dry-run', invalidPlan);
+
+    const result = spawnSync(tsx, [cli, 'run', planPath], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Run package is not executable');
+    expect(result.stderr).toContain('missing verification steps');
+    expect(existsSync(join(target, '.osc/runs'))).toBe(false);
+  });
+
+  it('treats external-runner verification as a write-mode blocker', () => {
+    const target = initializedScaffold();
+    const deferringPlan = validPlan.replace('1. Run npm test.\n2. Run ./verify.sh --strict.', '1. External runner executes the scorer after this turn.');
+    const planPath = writePlan(target, '003-defers-proof', deferringPlan);
+
+    const result = spawnSync(tsx, [cli, 'run', planPath], { cwd: target, encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('verification steps defer execution outside the run packet');
+    expect(existsSync(join(target, '.osc/runs'))).toBe(false);
+  });
+
   it('treats an undefined mission as a dry-run blocker', () => {
     const target = scaffoldWithUnsetMission();
     const planPath = writePlan(target, '001-dry-run-demo', validPlan);

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -104,6 +104,18 @@ describe('open-scaffold parser', () => {
     expect(plan.executionStrategy?.groups.map((g) => g.name)).toEqual(['Group A', 'Group B']);
   });
 
+  it('accepts the common Verification heading alias and bullet verification checks', () => {
+    const root = tempRepo();
+    const path = join(root, '.osc/plans/active/002-verification-alias.md');
+    writeFileSync(path, samplePlan
+      .replace('# Plan: sample', '# Plan: 002-verification-alias')
+      .replace('## Verification steps\n\n1. Run `npm test`.\n2. Expected: pass.', '## Verification\n\n- Run `npm test`.\n- Run `./verify.sh --standard`.'));
+
+    const plan = parsePlanFile(path);
+
+    expect(plan.verificationSteps).toEqual(['Run `npm test`.', 'Run `./verify.sh --standard`.']);
+  });
+
   it('uses the local scaffold date for evidence note filenames', () => {
     const previousTz = process.env.TZ;
     process.env.TZ = 'Pacific/Kiritimati';


### PR DESCRIPTION
## Summary
- Fail closed before writing `osc run` artifacts when the run packet is not executable.
- Block verification steps that defer proof to an external runner or later operator step.
- Parse `## Verification` as a valid alias for `## Verification steps`, including bullet lists.
- Make malformed evolution attempt ledgers fail with line-numbered `invalid-evolution-ledger` errors.

## Verification
- `npm run build`
- `npm test -- --run`
- `./verify.sh --strict`
- `git diff --check`

## Risk / gates
- Keeps `osc run --dry-run` preview behavior available for inspecting blockers without writing artifacts.
- No runtime spawning, release, publish, or merge in this PR.
