### PR TITLE
chore: close efficiency reset plan

### DIFF
--- a/.osc/plans/done/150-open-scaffold-efficiency-reset.md
+++ b/.osc/plans/done/150-open-scaffold-efficiency-reset.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 

--- a/.osc/plans/done/150-open-scaffold-efficiency-reset.md
+++ b/.osc/plans/done/150-open-scaffold-efficiency-reset.md
@@ -30,13 +30,13 @@ Add public-safe measurement and compact controller output for `osc evolve analyz
 
 ## Acceptance criteria
 
-- [ ] Efficiency is explicitly defined in code and docs as controller signal per report/evidence overhead, with no benchmark or model-intelligence claim.
-- [ ] A local public-safe harness reports before/after metrics including output bytes per useful decision field, evidence bytes per action recommendation, token/cost telemetry completeness, blind retries prevented, next-action packet compactness, analyze-to-recommendation steps, and required-control-field ratio.
-- [ ] Compact/default analysis output is materially smaller while preserving required control fields, missing-current criteria, boundary notes, and safe evidence refs.
-- [ ] Retry recommendations require a measurable repair hypothesis and no-op/blind retry fixtures are routed away from blind continuation.
-- [ ] Tests prove private/unsafe refs do not leak and stop/redesign/inspect/continue recommendations remain boundary-safe.
-- [ ] Any 1.5x efficiency result is computed by code from before/after artifacts, not asserted manually.
-- [ ] The efficiency harness finds at least 10 additional measured full-to-compact controller targets that preserve required fields and clear the 1.5x byte-reduction threshold, or reports the miss explicitly.
+- [x] Efficiency is explicitly defined in code and docs as controller signal per report/evidence overhead, with no benchmark or model-intelligence claim. Evidence: `src/evolution-efficiency.ts`, `docs/EVIDENCE_METHODOLOGY.md`, `docs/EVOLUTION_LOOP.md`, `README.md`.
+- [x] A local public-safe harness reports before/after metrics including output bytes per useful decision field, evidence bytes per action recommendation, token/cost telemetry completeness, blind retries prevented, next-action packet compactness, analyze-to-recommendation steps, and required-control-field ratio. Evidence: `src/evolution-efficiency.ts`, `src/cli.ts`, `tests/evolution.test.ts`, `tests/cli-evolution.test.ts`.
+- [x] Compact/default analysis output is materially smaller while preserving required control fields, missing-current criteria, boundary notes, and safe evidence refs. Evidence: `src/evolution.ts`, `src/evolution-efficiency.ts`, `tests/evolution.test.ts`.
+- [x] Retry recommendations require a measurable repair hypothesis and no-op/blind retry fixtures are routed away from blind continuation. Evidence: `src/evolution.ts`, `tests/evolution.test.ts`, `tests/cli-evolution.test.ts`.
+- [x] Tests prove private/unsafe refs do not leak and stop/redesign/inspect/continue recommendations remain boundary-safe. Evidence: `tests/evolution.test.ts`, `tests/cli-evolution.test.ts`, `tests/public-positioning.test.ts`.
+- [x] Any 1.5x efficiency result is computed by code from before/after artifacts, not asserted manually. Evidence: `src/evolution-efficiency.ts`, `tests/evolution.test.ts`.
+- [x] The efficiency harness finds at least 10 additional measured full-to-compact controller targets that preserve required fields and clear the 1.5x byte-reduction threshold, or reports the miss explicitly. Evidence: `src/evolution-efficiency.ts`, `tests/evolution.test.ts`, `docs/EVOLUTION_LOOP.md`.
 
 ## Verification steps
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-04: closed 150-open-scaffold-efficiency-reset — close efficiency reset after merged controller diagnostics and run-packet gates
 - 2026-06-03: closed 144-next-action-packet-npx-release-sync — published open-scaffold@0.30.1, verified npm latest/fresh npx, and created GitHub Release v0.30.1
 - 2026-06-03: closed 143-framework-value-next-action-packet — PR #175 merged; next-action packet shipped as workflow-neutral handoff guidance
 - 2026-06-03: closed 142-private-pilot-usage-and-evolve-control — landed evolve repair hypotheses and usage telemetry

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('0e2f320225da537dd9b9c5119d5486aea35cf0110577c6c93311ac540763ed92');
+    expect(hash(planIssueSnapshot)).toBe('050e049f357e0e3ce93c2a0ec8b449975ae0009d63bbee44551288be5817a8cc');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('32a0a8261494920e76e7fcf10b0c3bfa4878428cccbe7d334ad6ce703b3a0073');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary
- move plan 150 from active to done
- align its internal status with the done stage
- stamp the mission changelog for the merged efficiency/reset work

## Verification
- `git diff --check`
- `./verify.sh --strict`
- `npm run build`
- `npm test -- --run tests/validation.test.ts tests/cli-plan-stats.test.ts tests/cli-lifecycle-parity.test.ts`

## Risk / gates
- Plan-state hygiene only; no package publish, release, or runtime behavior change.
