### PR TITLE
fix: allow explicit rejection of deferred verification

### DIFF
--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -140,8 +140,12 @@ function blockingOpenQuestions(plan: ParsedPlan): string[] {
   return plan.openQuestions.filter(isBlockingOpenQuestion);
 }
 
+const DEFERRED_VERIFICATION_RE = /\b(external runner|run externally|runs externally|will be run externally|after (?:the )?(?:model )?turn|after your turn|later by|operator will run|someone else will run|later operator)\b/i;
+const REJECTS_DEFERRED_VERIFICATION_RE = /\b(do not|don't|does not|doesn't|must not|cannot|can't|not|never)\b.{0,120}\b(external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b|\b(external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(does not count|doesn't count|do not count|not verification|is not verification|cannot count|can't count|must not count|fail closed|fails closed)\b/i;
+
 function defersVerificationOutsideRun(step: string): boolean {
-  return /\b(external runner|run externally|runs externally|will be run externally|after (?:the )?(?:model )?turn|after your turn|later by|operator will run|someone else will run)\b/i.test(step);
+  if (!DEFERRED_VERIFICATION_RE.test(step)) return false;
+  return !REJECTS_DEFERRED_VERIFICATION_RE.test(step);
 }
 
 function looksLikeExecutableVerification(step: string): boolean {

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -145,8 +145,11 @@ const EXTERNAL_RUNNER_WILL_RUN_RE = /\b(?:external runner|later operator|operato
 const FORBIDS_IN_RUN_VERIFICATION_RE = /\b(?:do not|don't|must not|never)\s+run\b/i;
 const REJECTS_DEFERRED_VERIFICATION_RE = /\b(?:do not|don't|does not|doesn't|must not|cannot|can't|never)\s+(?:count|treat|accept|use)\b.{0,120}\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:verification|proof)\b|\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:does not|doesn't|do not|don't|must not|cannot|can't|never)\s+count\b.{0,120}\b(?:verification|proof)?\b|\b(?:external runner|later operator)\b.{0,120}\b(?:not verification|is not verification|not proof|is not proof)\b/i;
 
+const IN_RUN_VERIFICATION_ACTION_RE = /^(?:run|execute|verify|validate|check|test)\b/i;
+
 function defersVerificationOutsideRun(step: string): boolean {
   if (!DEFERRED_VERIFICATION_RE.test(step)) return false;
+  if (REJECTS_DEFERRED_VERIFICATION_RE.test(step) && IN_RUN_VERIFICATION_ACTION_RE.test(step.trim())) return false;
   if (EXTERNAL_RUNNER_WILL_RUN_RE.test(step)) return true;
   if (FORBIDS_IN_RUN_VERIFICATION_RE.test(step)) return true;
   return !REJECTS_DEFERRED_VERIFICATION_RE.test(step);
@@ -154,10 +157,10 @@ function defersVerificationOutsideRun(step: string): boolean {
 
 function looksLikeExecutableVerification(step: string): boolean {
   const trimmed = step.trim();
-  if (REJECTS_DEFERRED_VERIFICATION_RE.test(trimmed) && !/^(?:run|execute|verify|validate|check|test)\b/i.test(trimmed)) {
+  if (REJECTS_DEFERRED_VERIFICATION_RE.test(trimmed) && !IN_RUN_VERIFICATION_ACTION_RE.test(trimmed)) {
     return false;
   }
-  return /^(?:run|execute|verify|validate|check|test)\b/i.test(trimmed)
+  return IN_RUN_VERIFICATION_ACTION_RE.test(trimmed)
     || /(?:^|[`\s])(?:npm|pnpm|yarn|npx|node|tsx|python3?|pytest|cargo|make|bash|sh|git|gh|osc|\.\/)[^`\s]*/i.test(trimmed);
 }
 

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -154,6 +154,9 @@ function defersVerificationOutsideRun(step: string): boolean {
 
 function looksLikeExecutableVerification(step: string): boolean {
   const trimmed = step.trim();
+  if (REJECTS_DEFERRED_VERIFICATION_RE.test(trimmed) && !/^(?:run|execute|verify|validate|check|test)\b/i.test(trimmed)) {
+    return false;
+  }
   return /^(?:run|execute|verify|validate|check|test)\b/i.test(trimmed)
     || /(?:^|[`\s])(?:npm|pnpm|yarn|npx|node|tsx|python3?|pytest|cargo|make|bash|sh|git|gh|osc|\.\/)[^`\s]*/i.test(trimmed);
 }

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -146,10 +146,21 @@ const FORBIDS_IN_RUN_VERIFICATION_RE = /\b(?:do not|don't|must not|never)\s+run\
 const REJECTS_DEFERRED_VERIFICATION_RE = /\b(?:do not|don't|does not|doesn't|must not|cannot|can't|never)\s+(?:count|treat|accept|use)\b.{0,120}\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:verification|proof)\b|\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:does not|doesn't|do not|don't|must not|cannot|can't|never)\s+count\b.{0,120}\b(?:verification|proof)?\b|\b(?:external runner|later operator)\b.{0,120}\b(?:not verification|is not verification|not proof|is not proof)\b/i;
 
 const IN_RUN_VERIFICATION_ACTION_RE = /^(?:run|execute|verify|validate|check|test)\b/i;
+const EXECUTABLE_COMMAND_TOKEN_RE = /(?:^|[`\s])(?:npm|pnpm|yarn|npx|node|tsx|python3?|pytest|cargo|make|bash|sh|git|gh|osc|\.\/)[^`\s]*/i;
+
+function hasInRunCommandBeforeDeferredMarker(step: string): boolean {
+  const deferredMatch = DEFERRED_VERIFICATION_RE.exec(step);
+  const inRunText = deferredMatch ? step.slice(0, deferredMatch.index) : step;
+  return EXECUTABLE_COMMAND_TOKEN_RE.test(inRunText);
+}
 
 function defersVerificationOutsideRun(step: string): boolean {
   if (!DEFERRED_VERIFICATION_RE.test(step)) return false;
-  if (REJECTS_DEFERRED_VERIFICATION_RE.test(step) && IN_RUN_VERIFICATION_ACTION_RE.test(step.trim())) return false;
+  if (
+    REJECTS_DEFERRED_VERIFICATION_RE.test(step)
+    && IN_RUN_VERIFICATION_ACTION_RE.test(step.trim())
+    && hasInRunCommandBeforeDeferredMarker(step)
+  ) return false;
   if (EXTERNAL_RUNNER_WILL_RUN_RE.test(step)) return true;
   if (FORBIDS_IN_RUN_VERIFICATION_RE.test(step)) return true;
   return !REJECTS_DEFERRED_VERIFICATION_RE.test(step);
@@ -161,7 +172,7 @@ function looksLikeExecutableVerification(step: string): boolean {
     return false;
   }
   return IN_RUN_VERIFICATION_ACTION_RE.test(trimmed)
-    || /(?:^|[`\s])(?:npm|pnpm|yarn|npx|node|tsx|python3?|pytest|cargo|make|bash|sh|git|gh|osc|\.\/)[^`\s]*/i.test(trimmed);
+    || EXECUTABLE_COMMAND_TOKEN_RE.test(trimmed);
 }
 
 function verificationBlockers(plan: ParsedPlan): string[] {

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -141,11 +141,13 @@ function blockingOpenQuestions(plan: ParsedPlan): string[] {
 }
 
 const DEFERRED_VERIFICATION_RE = /\b(external runner|run externally|runs externally|will be run externally|after (?:the )?(?:model )?turn|after your turn|later by|operator will run|someone else will run|later operator)\b/i;
+const EXTERNAL_RUNNER_WILL_RUN_RE = /\b(?:external runner|later operator|operator|someone else)\b.{0,80}\b(?:will run|runs|executes|will execute)\b|\b(?:will be run externally|run externally|runs externally|later by)\b/i;
 const FORBIDS_IN_RUN_VERIFICATION_RE = /\b(?:do not|don't|must not|never)\s+run\b/i;
 const REJECTS_DEFERRED_VERIFICATION_RE = /\b(?:do not|don't|does not|doesn't|must not|cannot|can't|never)\s+(?:count|treat|accept|use)\b.{0,120}\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:verification|proof)\b|\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:does not|doesn't|do not|don't|must not|cannot|can't|never)\s+count\b.{0,120}\b(?:verification|proof)?\b|\b(?:external runner|later operator)\b.{0,120}\b(?:not verification|is not verification|not proof|is not proof)\b/i;
 
 function defersVerificationOutsideRun(step: string): boolean {
   if (!DEFERRED_VERIFICATION_RE.test(step)) return false;
+  if (EXTERNAL_RUNNER_WILL_RUN_RE.test(step)) return true;
   if (FORBIDS_IN_RUN_VERIFICATION_RE.test(step)) return true;
   return !REJECTS_DEFERRED_VERIFICATION_RE.test(step);
 }

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -141,7 +141,7 @@ function blockingOpenQuestions(plan: ParsedPlan): string[] {
 }
 
 const DEFERRED_VERIFICATION_RE = /\b(external runner|run externally|runs externally|will be run externally|after (?:the )?(?:model )?turn|after your turn|later by|operator will run|someone else will run|later operator)\b/i;
-const REJECTS_DEFERRED_VERIFICATION_RE = /\b(do not|don't|does not|doesn't|must not|cannot|can't|not|never)\b.{0,120}\b(external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b|\b(external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(does not count|doesn't count|do not count|not verification|is not verification|cannot count|can't count|must not count|fail closed|fails closed)\b/i;
+const REJECTS_DEFERRED_VERIFICATION_RE = /\b(?:do not|don't|does not|doesn't|must not|cannot|can't|never)\s+(?:count|treat|accept|use)\b.{0,120}\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:verification|proof)\b|\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:does not|doesn't|do not|don't|must not|cannot|can't|never)\s+count\b.{0,120}\b(?:verification|proof)?\b|\b(?:external runner|later operator)\b.{0,120}\b(?:not verification|is not verification|not proof|is not proof)\b/i;
 
 function defersVerificationOutsideRun(step: string): boolean {
   if (!DEFERRED_VERIFICATION_RE.test(step)) return false;

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -147,18 +147,26 @@ const REJECTS_DEFERRED_VERIFICATION_RE = /\b(?:do not|don't|does not|doesn't|mus
 
 const IN_RUN_VERIFICATION_ACTION_RE = /^(?:run|execute|verify|validate|check|test)\b/i;
 const EXECUTABLE_COMMAND_TOKEN_RE = /(?:^|[`\s])(?:npm|pnpm|yarn|npx|node|tsx|python3?|pytest|cargo|make|bash|sh|git|gh|osc|\.\/)[^`\s]*/i;
+const IN_RUN_ACTION_BEFORE_DEFERRED_RE = /(?:^|[:;.-]\s*|\*\*[^*]+:\*\*\s*)(?:run|execute|verify|validate|check|test)\b/i;
+
+function inRunTextBeforeDeferredMarker(step: string): string {
+  const deferredMatch = DEFERRED_VERIFICATION_RE.exec(step);
+  return deferredMatch ? step.slice(0, deferredMatch.index) : step;
+}
 
 function hasInRunCommandBeforeDeferredMarker(step: string): boolean {
-  const deferredMatch = DEFERRED_VERIFICATION_RE.exec(step);
-  const inRunText = deferredMatch ? step.slice(0, deferredMatch.index) : step;
-  return EXECUTABLE_COMMAND_TOKEN_RE.test(inRunText);
+  return EXECUTABLE_COMMAND_TOKEN_RE.test(inRunTextBeforeDeferredMarker(step));
+}
+
+function hasInRunActionBeforeDeferredMarker(step: string): boolean {
+  return IN_RUN_ACTION_BEFORE_DEFERRED_RE.test(inRunTextBeforeDeferredMarker(step));
 }
 
 function defersVerificationOutsideRun(step: string): boolean {
   if (!DEFERRED_VERIFICATION_RE.test(step)) return false;
   if (
     REJECTS_DEFERRED_VERIFICATION_RE.test(step)
-    && IN_RUN_VERIFICATION_ACTION_RE.test(step.trim())
+    && hasInRunActionBeforeDeferredMarker(step)
     && hasInRunCommandBeforeDeferredMarker(step)
   ) return false;
   if (EXTERNAL_RUNNER_WILL_RUN_RE.test(step)) return true;
@@ -168,7 +176,11 @@ function defersVerificationOutsideRun(step: string): boolean {
 
 function looksLikeExecutableVerification(step: string): boolean {
   const trimmed = step.trim();
-  if (REJECTS_DEFERRED_VERIFICATION_RE.test(trimmed) && !IN_RUN_VERIFICATION_ACTION_RE.test(trimmed)) {
+  if (
+    REJECTS_DEFERRED_VERIFICATION_RE.test(trimmed)
+    && !IN_RUN_VERIFICATION_ACTION_RE.test(trimmed)
+    && !(hasInRunActionBeforeDeferredMarker(trimmed) && hasInRunCommandBeforeDeferredMarker(trimmed))
+  ) {
     return false;
   }
   return IN_RUN_VERIFICATION_ACTION_RE.test(trimmed)

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -141,10 +141,12 @@ function blockingOpenQuestions(plan: ParsedPlan): string[] {
 }
 
 const DEFERRED_VERIFICATION_RE = /\b(external runner|run externally|runs externally|will be run externally|after (?:the )?(?:model )?turn|after your turn|later by|operator will run|someone else will run|later operator)\b/i;
+const FORBIDS_IN_RUN_VERIFICATION_RE = /\b(?:do not|don't|must not|never)\s+run\b/i;
 const REJECTS_DEFERRED_VERIFICATION_RE = /\b(?:do not|don't|does not|doesn't|must not|cannot|can't|never)\s+(?:count|treat|accept|use)\b.{0,120}\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:verification|proof)\b|\b(?:external runner|run externally|runs externally|after (?:the )?(?:model )?turn|after your turn|later operator|operator will run|someone else will run)\b.{0,120}\b(?:does not|doesn't|do not|don't|must not|cannot|can't|never)\s+count\b.{0,120}\b(?:verification|proof)?\b|\b(?:external runner|later operator)\b.{0,120}\b(?:not verification|is not verification|not proof|is not proof)\b/i;
 
 function defersVerificationOutsideRun(step: string): boolean {
   if (!DEFERRED_VERIFICATION_RE.test(step)) return false;
+  if (FORBIDS_IN_RUN_VERIFICATION_RE.test(step)) return true;
   return !REJECTS_DEFERRED_VERIFICATION_RE.test(step);
 }
 

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -162,13 +162,26 @@ function hasInRunActionBeforeDeferredMarker(step: string): boolean {
   return IN_RUN_ACTION_BEFORE_DEFERRED_RE.test(inRunTextBeforeDeferredMarker(step));
 }
 
+function hasCommandBoundaryBeforeDeferredMarker(step: string): boolean {
+  return /[.;]\s*(?:do not|don't|does not|doesn't|must not|cannot|can't|never)?/i.test(inRunTextBeforeDeferredMarker(step));
+}
+
+function hasRunnableAntiDeferralPolicy(step: string): boolean {
+  return REJECTS_DEFERRED_VERIFICATION_RE.test(step)
+    && hasInRunActionBeforeDeferredMarker(step)
+    && hasInRunCommandBeforeDeferredMarker(step)
+    && hasCommandBoundaryBeforeDeferredMarker(step);
+}
+
 function defersVerificationOutsideRun(step: string): boolean {
   if (!DEFERRED_VERIFICATION_RE.test(step)) return false;
+  if (hasRunnableAntiDeferralPolicy(step)) return false;
   if (
     REJECTS_DEFERRED_VERIFICATION_RE.test(step)
     && hasInRunActionBeforeDeferredMarker(step)
     && hasInRunCommandBeforeDeferredMarker(step)
-  ) return false;
+    && !hasCommandBoundaryBeforeDeferredMarker(step)
+  ) return true;
   if (EXTERNAL_RUNNER_WILL_RUN_RE.test(step)) return true;
   if (FORBIDS_IN_RUN_VERIFICATION_RE.test(step)) return true;
   return !REJECTS_DEFERRED_VERIFICATION_RE.test(step);
@@ -179,7 +192,7 @@ function looksLikeExecutableVerification(step: string): boolean {
   if (
     REJECTS_DEFERRED_VERIFICATION_RE.test(trimmed)
     && !IN_RUN_VERIFICATION_ACTION_RE.test(trimmed)
-    && !(hasInRunActionBeforeDeferredMarker(trimmed) && hasInRunCommandBeforeDeferredMarker(trimmed))
+    && !hasRunnableAntiDeferralPolicy(trimmed)
   ) {
     return false;
   }

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -245,6 +245,20 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toEqual([]);
   });
 
+  it('still blocks action-word steps when real proof is deferred outside the run packet', () => {
+    const root = tempRepo();
+    const deferringPlan = {
+      ...plan,
+      slug: '011-action-word-but-external-proof',
+      verificationSteps: ['Run no local tests; the external runner will run `npm test` after your turn and does not count as verification.'],
+    };
+
+    const preview = previewRunArtifacts(root, deferringPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(false);
+    expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -231,6 +231,20 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toContain('missing executable verification command');
   });
 
+  it('allows a runnable in-run verification step to reject later external proof', () => {
+    const root = tempRepo();
+    const runnablePolicyPlan = {
+      ...plan,
+      slug: '010-run-and-reject-external-proof',
+      verificationSteps: ['Run `npm test`; do not count tests an external runner runs after your turn as verification.'],
+    };
+
+    const preview = previewRunArtifacts(root, runnablePolicyPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(true);
+    expect(preview.manifest.packageQuality.blockers).toEqual([]);
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -259,6 +259,20 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
   });
 
+  it('allows labeled runnable in-run commands to reject later external proof', () => {
+    const root = tempRepo();
+    const labeledPlan = {
+      ...plan,
+      slug: '012-labeled-run-and-reject-external-proof',
+      verificationSteps: ['**Local:** Run `npm test`; do not count tests an external runner runs after your turn as verification.'],
+    };
+
+    const preview = previewRunArtifacts(root, labeledPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(true);
+    expect(preview.manifest.packageQuality.blockers).toEqual([]);
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -175,6 +175,20 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toEqual([]);
   });
 
+  it('still blocks instructions that explicitly say not to run verification because an external runner will run it', () => {
+    const root = tempRepo();
+    const deferringPlan = {
+      ...plan,
+      slug: '006-do-not-run-defers-proof',
+      verificationSteps: ['Do not run `npm test`; the external runner will run it after your turn.'],
+    };
+
+    const preview = previewRunArtifacts(root, deferringPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(false);
+    expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -203,6 +203,20 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
   });
 
+  it('still blocks external-only commands even when they disclaim the external result', () => {
+    const root = tempRepo();
+    const deferringPlan = {
+      ...plan,
+      slug: '008-external-only-command-disclaims-deferral',
+      verificationSteps: ['External runner will run `npm test` after your turn and does not count as verification.'],
+    };
+
+    const preview = previewRunArtifacts(root, deferringPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(false);
+    expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -189,6 +189,20 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
   });
 
+  it('still blocks non-runnable deferred steps even when they disclaim the external result', () => {
+    const root = tempRepo();
+    const deferringPlan = {
+      ...plan,
+      slug: '007-do-not-run-disclaims-deferral',
+      verificationSteps: ['Do not run `npm test`; the external runner will run it after your turn and does not count as verification.'],
+    };
+
+    const preview = previewRunArtifacts(root, deferringPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(false);
+    expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -158,6 +158,23 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toEqual([]);
   });
 
+  it('allows verification policy text that rejects deferred external proof', () => {
+    const root = tempRepo();
+    const scorerPlan = {
+      ...plan,
+      slug: '005-scorer-in-loop',
+      verificationSteps: [
+        'Run `cargo run -p m2000-v3-conformance --quiet -- artifact --json-out reports/result.json` before final handoff.',
+        'If the scorer command cannot run, record exact command, exit status, and stderr; do not count a later operator or external runner as verification.',
+      ],
+    };
+
+    const preview = previewRunArtifacts(root, scorerPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(true);
+    expect(preview.manifest.packageQuality.blockers).toEqual([]);
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -273,6 +273,20 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toEqual([]);
   });
 
+  it('keeps commands scheduled after the model turn blocked even when disclaimed', () => {
+    const root = tempRepo();
+    const deferringPlan = {
+      ...plan,
+      slug: '013-command-after-turn-disclaimed',
+      verificationSteps: ['Run `npm test` after your turn does not count as verification.'],
+    };
+
+    const preview = previewRunArtifacts(root, deferringPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(false);
+    expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -217,6 +217,20 @@ describe('run artifact generation', () => {
     expect(preview.manifest.packageQuality.blockers).toContain('verification steps defer execution outside the run packet');
   });
 
+  it('does not treat deferred-proof rejection policy text as executable by itself', () => {
+    const root = tempRepo();
+    const policyOnlyPlan = {
+      ...plan,
+      slug: '009-policy-only-is-not-executable',
+      verificationSteps: ['Do not count a later operator running `npm test` as verification.'],
+    };
+
+    const preview = previewRunArtifacts(root, policyOnlyPlan as any, 'run');
+
+    expect(preview.manifest.packageQuality.executable).toBe(false);
+    expect(preview.manifest.packageQuality.blockers).toContain('missing executable verification command');
+  });
+
   it('allows non-blocking open questions while only blocking explicit BLOCKING questions', () => {
     const root = tempRepo();
     const planWithFutureQuestion = {


### PR DESCRIPTION
## Summary
- keep blocking verification steps that defer proof to an external runner or later operator
- allow verification-policy text that explicitly rejects that deferred proof as invalid
- add regression coverage for scorer-in-loop verification steps that say not to count later operator/external-runner verification

## Verification
- `npm run build`
- `npm test -- --run tests/artifacts.test.ts tests/cli-run-dry-run.test.ts`
- `git diff --check`
- `./verify.sh --strict`

## Risk / gates
- No 2000m-specific scorer rule added.
- No package publish or release.
