### PR TITLE
chore: close framework cleanup plan

### DIFF
--- a/.osc/plans/done/151-framework-cleanup-shrink.md
+++ b/.osc/plans/done/151-framework-cleanup-shrink.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-06: closed 151-framework-cleanup-shrink — Merged PR #183 after green CI, latest-head Codex clean/thread-zero review, and owner approval; close the framework cleanup shrink slice.
 - 2026-06-04: closed 150-open-scaffold-efficiency-reset — close efficiency reset after merged controller diagnostics and run-packet gates
 - 2026-06-03: closed 144-next-action-packet-npx-release-sync — published open-scaffold@0.30.1, verified npm latest/fresh npx, and created GitHub Release v0.30.1
 - 2026-06-03: closed 143-framework-value-next-action-packet — PR #175 merged; next-action packet shipped as workflow-neutral handoff guidance

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('91d6d6ec442e357ce7f6f4a72d0fb00d8a0404f46471b8e48c9ca63ccfcaf001');
+    expect(hash(planIssueSnapshot)).toBe('71a7c18ccd2969913939be30b15f88218fc71436347ee5edde60851b4fe615b3');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('32a0a8261494920e76e7fcf10b0c3bfa4878428cccbe7d334ad6ce703b3a0073');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary
- Moves the completed framework cleanup shrink plan from active to done.
- Stamps the mission changelog with the PR #183 close decision.
- Updates the live-corpus plan-validation snapshot hash for the closed plan set.

## Verification
- `git diff --check`
- `./verify.sh --strict`
- `npm test -- --run`
- `npm run build`

## Risk / gates
- Closeout-only follow-up for merged PR #183.
- No package publish, release, deploy, or npm registry change.
