### PR TITLE
chore: prepare 0.31.0 framework cleanup release

### DIFF
--- a/.osc/plans/active/152-framework-cleanup-package-sync.md
+++ b/.osc/plans/active/152-framework-cleanup-package-sync.md
@@ -1,0 +1,54 @@
+# Plan: 152-framework-cleanup-package-sync
+
+## Status
+
+active
+
+## Context
+
+PR #183 merged the framework cleanup shrink and PR #184 closed its Open Scaffold plan state on `main`. The change is package-visible: the maintained TypeScript surface is reduced, several historical/experimental commands are removed or repositioned, and shipped docs/help now point clean-clone users at committed migration guidance. `package.json`, npm `latest`, and GitHub Latest Release are still at `0.30.1`, so a release-sync slice is needed before `npx open-scaffold@latest` reflects the merged cleanup.
+
+## Goal
+
+Publish `open-scaffold@0.31.0` with dist-tag `latest`, verify the fresh package from outside the repo, create GitHub Release `v0.31.0` marked Latest, and close the release-sync evidence trail.
+
+## Constraints / Out of scope
+
+- Do not publish a mature `1.0` line; this remains pre-1.0 hardening.
+- Do not claim runtime execution, model improvement, compliance certification, benchmark proof, or production readiness.
+- Do not introduce product/code changes beyond package-version, release-truth docs, changelog/evidence, and release closeout hygiene.
+- Use trusted publishing through `.github/workflows/publish-npm.yml`; do not add npm tokens or secrets.
+- Keep GitHub Release and npm publication owner-approved and verified before claiming live status.
+
+## Files to touch
+
+- `package.json` and `package-lock.json` — bump package version to `0.31.0`.
+- `docs/CHANGELOG.md` — add the adoption-facing `v0.31.0` release entry.
+- `docs/STABILITY.md`, `docs/VERSION_TRUTH.md`, `README.md`, and `ROADMAP.md` — align the forward-moving pre-1.0 line with `v0.31.x` and the framework cleanup shrink.
+- `.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md` — release-sync evidence note.
+- `.osc/plans/active/152-framework-cleanup-package-sync.md` — this release-sync plan, later moved to done after publication proof.
+
+## Acceptance criteria
+
+- [ ] `package.json`, `package-lock.json`, and the root lockfile package version all read `0.31.0`.
+- [ ] Release-truth docs distinguish candidate repo state from live npm/GitHub Release state before publish, then record verified live state after publish.
+- [ ] Local release gates pass: `git diff --check`, `npm ci`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [ ] Release-sync PR CI is green and review/thread state is clean before merge.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.31.0` with `latest`, and fresh isolated-cache `npx open-scaffold@latest` proves the reduced package surface from outside the repository.
+- [ ] GitHub Release `v0.31.0` exists, targets the merged `origin/main` release commit, is marked Latest, and uses release notes grounded in verified PR/evidence facts.
+
+## Verification steps
+
+1. `node -p "require('./package.json').version"` plus package-lock checks — expected `0.31.0` everywhere.
+2. `npm view open-scaffold version dist-tags --json --prefer-online` — expected `0.30.1` before publish and `0.31.0` after trusted publishing.
+3. `git diff --check` — expected no whitespace errors.
+4. `npm ci` — expected install success and zero vulnerabilities.
+5. `./verify.sh --strict` — expected no failures; an active release-plan warning is acceptable before closeout only if documented.
+6. `npm test -- --run` and `npm run build` — expected pass.
+7. `npm run osc -- doctor --check secret-scan` — expected no issues.
+8. `npm pack --dry-run --json` and `npm publish --dry-run --tag latest` — expected package `open-scaffold@0.31.0` and successful dry-run.
+9. After merge/publish: trusted publishing workflow success, registry `0.31.0/latest`, fresh isolated-cache `npx` smoke, GitHub Release `v0.31.0` Latest, and this plan closed to `done`.
+
+## Open questions
+
+- None. The owner approved a publish after PR #183/#184 merged; use `0.31.0` because the cleanup changes the pre-1.0 package surface beyond a patch repair.

--- a/.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md
+++ b/.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md
@@ -14,7 +14,7 @@ The package-visible change is a narrowed/reduced Open Scaffold CLI/source surfac
 - Source closeout PR: https://github.com/graphanov/open-scaffold/pull/184.
 - Release-sync plan: `.osc/plans/active/152-framework-cleanup-package-sync.md`.
 - Run ID / run packet: N/A for this scoped package/release sync.
-- Branch / PR: `release/0.31.0-framework-cleanup-sync`; PR pending.
+- Branch / PR: `release/0.31.0-framework-cleanup-sync` / https://github.com/graphanov/open-scaffold/pull/185.
 
 ## Verification
 
@@ -38,7 +38,7 @@ Candidate gates before PR-ready:
 - [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
 - [x] `npm pack --dry-run --json` payload inspection after cleaning ignored local build residue — PASS for `open-scaffold@0.31.0`; entry count 198; no stale removed-command `dist/*` modules; no Python `__pycache__` files.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.31.0` with tag `latest`.
-- [ ] Release candidate PR CI and review/thread gate — pending.
+- [ ] Release candidate PR CI and review/thread gate — CI green on initial PR head; Codex requested the actual PR URL in this evidence note, so follow-up review remains pending.
 
 Post-merge/publication gates after owner-approved follow-through:
 

--- a/.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md
+++ b/.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md
@@ -1,0 +1,63 @@
+# Release / Evidence Note: 152-framework-cleanup-package-sync
+
+## Summary
+
+Release-sync candidate for publishing the merged framework cleanup shrink as `open-scaffold@0.31.0`.
+
+The package-visible change is a narrowed/reduced Open Scaffold CLI/source surface after PR #183, with shipped migration breadcrumbs and preserved protected core behavior. This release remains pre-1.0 hardening: it does not claim runtime execution, model improvement, benchmark proof, compliance certification, production readiness, or a mature 1.0 contract.
+
+## Traceability
+
+- Roadmap / issue / task: framework cleanup shrink / package public-surface sync after PR #183 and PR #184.
+- Source plan: `.osc/plans/done/151-framework-cleanup-shrink.md`.
+- Source PR: https://github.com/graphanov/open-scaffold/pull/183.
+- Source closeout PR: https://github.com/graphanov/open-scaffold/pull/184.
+- Release-sync plan: `.osc/plans/active/152-framework-cleanup-package-sync.md`.
+- Run ID / run packet: N/A for this scoped package/release sync.
+- Branch / PR: `release/0.31.0-framework-cleanup-sync`; PR pending.
+
+## Verification
+
+Baseline live-truth inspection before release-sync edits:
+
+- `git fetch --prune origin && git checkout main && git pull --ff-only origin main` — PASS: local `main` up to date at `4dd438097440874f8d5e4044a620bb6d1599e4e7` before candidate branch.
+- `git status --short --branch` — PASS: clean `main...origin/main` before candidate branch.
+- `node -p "require('./package.json').version"` — PASS: `0.30.1` before candidate bump.
+- `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before candidate bump: `0.30.1`, `latest: 0.30.1`.
+- `gh release list --repo graphanov/open-scaffold --limit 5` — PASS before candidate bump: `v0.30.1 — Evolution handoff packet release` was Latest.
+- `gh pr list --repo graphanov/open-scaffold --state open --json number,title,headRefName,url` — PASS: no open PRs before candidate branch.
+
+Candidate gates before PR-ready:
+
+- [x] Version alignment — PASS: `0.31.0 / 0.31.0 / 0.31.0` for `package.json`, `package-lock.json`, and lockfile root package version.
+- [x] `npm ci` — PASS: installed 88 packages; npm audit found 0 vulnerabilities.
+- [x] `git diff --check` — PASS.
+- [x] `./verify.sh --strict` — PASS with expected active-release-plan warning: 9 pass / 0 fail / 1 warn while this release-sync plan remains active before public proof.
+- [x] `npm test -- --run` — PASS: 43 files / 484 tests.
+- [x] `npm run build` — PASS: core TypeScript build and runtime-omx build.
+- [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
+- [x] `npm pack --dry-run --json` payload inspection after cleaning ignored local build residue — PASS for `open-scaffold@0.31.0`; entry count 198; no stale removed-command `dist/*` modules; no Python `__pycache__` files.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.31.0` with tag `latest`.
+- [ ] Release candidate PR CI and review/thread gate — pending.
+
+Post-merge/publication gates after owner-approved follow-through:
+
+- [ ] Sync clean `main` after release PR merge.
+- [ ] Main CI for release commit.
+- [ ] Post-merge local publish gates.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.31.0` with dist-tag `latest`.
+- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.31.0`, `latest: 0.31.0`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory passes.
+- [ ] Fresh isolated-cache smoke proves removed/repositioned command guidance from the published package.
+- [ ] GitHub Release `v0.31.0` exists, targets the release commit, and is marked Latest.
+- [ ] This plan is closed to `done` with final public proof.
+
+## Outcome
+
+Pending. The release-sync branch prepares `open-scaffold@0.31.0`; npm publication and GitHub Release movement are not yet claimed until verified after PR merge and trusted publishing.
+
+## Follow-up
+
+- Merge the release-sync PR only after CI/review gates pass.
+- Dispatch trusted publishing for `0.31.0` with npm tag `latest` after the release-sync commit lands on `main`.
+- Verify npm/latest, fresh `npx`, GitHub Release Latest, and close this plan to `done` after public proof.

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ For the one-screen version, see [`docs/examples/evolution-loop-compare.md`](docs
 
 ## Current pre-1.0 hardening line
 
-Open Scaffold is usable, but it is still in active credibility and adoption hardening. The forward-moving package line is `v0.30.x` after the blueprint security/adoption package sync: stable enough to try on real repos, honest enough not to pretend every workflow, runtime boundary, and public surface is final.
+Open Scaffold is usable, but it is still in active credibility and adoption hardening. The forward-moving package line is `v0.31.x` after the framework cleanup shrink: stable enough to try on real repos, honest enough not to pretend every workflow, runtime boundary, and public surface is final.
 
 Stable enough to rely on today:
 
@@ -335,7 +335,7 @@ Use cases the current contract supports today:
 - teams that want PRs to carry intent, evidence, and approval state;
 - consulting or audit-sensitive delivery where later readers need to reconstruct what happened.
 
-Publication truth lives outside git, and the two public surfaces move separately. Check `npm view open-scaffold version dist-tags --json` to see which package `npx open-scaffold@latest` installs. Check the GitHub Release marked **Latest** to see which release note GitHub highlights. The historical `v1.0.5` / `v1.0.x` tags remain published history; the current forward-moving line is `v0.30.x` after the blueprint security/adoption package sync and remains pre-1.0 until the protocol and product surface earn a real 1.0 again. See [`docs/VERSION_TRUTH.md`](docs/VERSION_TRUTH.md), [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
+Publication truth lives outside git, and the two public surfaces move separately. Check `npm view open-scaffold version dist-tags --json` to see which package `npx open-scaffold@latest` installs. Check the GitHub Release marked **Latest** to see which release note GitHub highlights. The historical `v1.0.5` / `v1.0.x` tags remain published history; the current forward-moving line is `v0.31.x` after the framework cleanup shrink and remains pre-1.0 until the protocol and product surface earn a mature stability claim. See [`docs/VERSION_TRUTH.md`](docs/VERSION_TRUTH.md), [`docs/STABILITY.md`](docs/STABILITY.md), [`docs/CHANGELOG.md`](docs/CHANGELOG.md), and the landing page [`docs/index.html`](docs/index.html).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -393,7 +393,7 @@ Acceptance criteria:
 
 ### Milestone 18 — historical v1.0.0 stability launch
 
-Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel was intentionally corrected back to pre-1.0 hardening; after the blueprint security/adoption package sync, that current hardening line is `v0.30.x` until the public product surface earns a mature 1.0 contract.
+Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel was intentionally corrected back to pre-1.0 hardening; after the framework cleanup shrink, that current hardening line is `v0.31.x` until the public product surface earns a mature 1.0 contract.
 
 Goal: make the adoption contract explicit before the first major-release experiment.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,25 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.31.0 — Framework cleanup shrink release
+
+Status: release candidate in repo until owner-approved trusted publishing and GitHub Release follow-through complete.
+
+Highlights:
+
+- Publishes the framework cleanup shrink from PR #183 plus closeout PR #184 to the public `npx open-scaffold@latest` package surface.
+- Reduces the maintained TypeScript source surface from the 20,890 LOC baseline to 12,520 LOC while preserving the protected repo-native work-record loop and runtime-neutral boundaries.
+- Repositions removed or contracted commands behind shipped migration/help docs such as `docs/COMMAND_MATURITY.md` instead of ignored local evidence paths.
+- Keeps Open Scaffold pre-1.0: this release tightens and reduces package-visible surfaces, and users depending on experimental/lab command shapes should pin exact versions and read the migration notes.
+
+Evidence:
+
+- Source plan: `.osc/plans/done/151-framework-cleanup-shrink.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/183
+- Closeout PR: https://github.com/graphanov/open-scaffold/pull/184
+- Release-sync plan: `.osc/plans/active/152-framework-cleanup-package-sync.md`
+- Release-sync evidence note: `.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md`
+
 ## v0.30.1 — Evolution handoff packet release
 
 Status: published to npm as `open-scaffold@0.30.1`; GitHub Release `v0.30.1` is Latest after owner-approved trusted publishing and release follow-through.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -2,13 +2,13 @@
 
 This page defines Open Scaffold's current package contract and maturity boundary.
 
-The short version: Open Scaffold is on a pre-1.0 hardening line (`v0.30.x` after the blueprint security/adoption package sync) because the protocol is useful but the public product surface, runtime boundary, and adoption story are still moving quickly. The stable-enough core is the repo-native work-record loop — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus adoption/review/trust helpers such as `osc first-run`, `osc pr check`, adapter trust inspection, schema registry inspection, and read-only work-record commands such as `osc compare` and `osc trace` that help humans inspect recorded work without launching runtimes. Runtime launch, provider-specific automation, evaluation helpers, dashboards, and external cockpit transports remain opt-in lab/experimental surfaces unless a later release explicitly promotes them.
+The short version: Open Scaffold is on a pre-1.0 hardening line (`v0.31.x` after the framework cleanup shrink) because the protocol is useful but the public product surface, runtime boundary, and adoption story are still moving quickly. The stable-enough core is the repo-native work-record loop — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus adoption/review/trust helpers such as `osc first-run`, `osc pr check`, adapter trust inspection, schema registry inspection, and read-only work-record commands such as `osc compare` and `osc trace` that help humans inspect recorded work without launching runtimes. Runtime launch, provider-specific automation, evaluation helpers, dashboards, and external cockpit transports remain opt-in lab/experimental surfaces unless a later release explicitly promotes them.
 
 The historical `v1.0.x` packages and GitHub Releases remain available for provenance. They are not erased, but they should not set the current expectation that Open Scaffold has fully earned a mature 1.0 contract.
 
 ## Release status
 
-- Current cadence: pre-1.0 hardening on the `v0.30.x` line.
+- Current cadence: pre-1.0 hardening on the `v0.31.x` line.
 - Historical note: `v1.0.x` exists as a previously published launch line (most recent tag: `v1.0.5`) and remains immutable package/release history.
 - Current repository package version: check `package.json`.
 - Live npm package truth: check `npm view open-scaffold version dist-tags --json`.
@@ -101,7 +101,7 @@ Future work can explore those areas only through explicit plans, evidence, safet
 
 ## Versioning policy
 
-Open Scaffold uses npm package versions as public distribution coordinates. The current `v0.30.x` line is intentionally pre-1.0: it communicates that the core work-record pattern is usable and the security/adoption package surface has hardened, but the product is still earning its long-term stable contract.
+Open Scaffold uses npm package versions as public distribution coordinates. The current `v0.31.x` line is intentionally pre-1.0: it communicates that the core work-record pattern is usable and the framework cleanup has narrowed/reduced the package surface, but the product is still earning its long-term stable contract.
 
 The previously published `v1.0.x` packages remain immutable historical artifacts. They should be treated as an over-eager launch line, not as a reason to force every future change through mature-1.0 pressure. A future real 1.0 should be cut only after the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives feel durable enough to sustain that promise.
 

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -2,11 +2,11 @@
 
 This page is the canonical reconciliation between the current package version and the historical git tag line. Check it when the numbers look contradictory.
 
-## Current line: `v0.30.x` (pre-1.0 hardening)
+## Current line: `v0.31.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.30.1`.
-- **npm latest:** `0.30.1` with dist-tag `latest` after trusted publishing run `26901169778`; run `npm view open-scaffold version dist-tags --json` for live confirmation.
-- **GitHub Release latest:** `v0.30.1` is marked **Latest** after the evolution handoff packet release.
+- **Current `package.json` version:** `0.31.0`.
+- **npm latest:** `0.30.1` with dist-tag `latest` until the owner-approved `0.31.0` trusted publishing run completes; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** `v0.30.1` is marked **Latest** until the `v0.31.0` GitHub Release follow-through completes.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.
@@ -15,18 +15,18 @@ Do not treat the repository version alone as proof of npm publication or GitHub 
 
 - **Most recent historical tag:** `v1.0.5` — published as `open-scaffold@1.0.5` on the historical `v1.0.x` launch line.
 - **Status:** immutable historical artifacts. The `v1.0.x` packages remain available on npm for provenance; they are not erased.
-- **Why it is not the current line:** the `v1.0.x` launch was premature. The project reset to a pre-1.0 hardening cadence at `v0.20.0` to earn the long-term stable contract honestly; `v0.30.x` continues that pre-1.0 hardening line after the OSB security/adoption package sync. A future real 1.0 requires the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives to feel durable enough to sustain that promise.
+- **Why it is not the current line:** the `v1.0.x` launch was premature. The project reset to a pre-1.0 hardening cadence at `v0.20.0` to earn the long-term stable contract honestly; `v0.31.x` continues that pre-1.0 hardening line after the framework cleanup shrink. A future real 1.0 requires the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives to feel durable enough to sustain that promise.
 
 ## Stable vs experimental in the current line
 
-The `v0.30.x` line defines a stable-enough core (the repo-native work-record loop, the Status + seven content-heading plan schema, lifecycle helpers, first-run onboarding, PR-native structural checks, adapter trust inspection, command/schema registries, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). See [`docs/STABILITY.md`](STABILITY.md) for the full listing.
+The `v0.31.x` line defines a stable-enough core (the repo-native work-record loop, the Status + seven content-heading plan schema, lifecycle helpers, first-run onboarding, PR-native structural checks, adapter trust inspection, command/schema registries, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). The framework cleanup shrink removed or repositioned older experimental helpers from the live reduced CLI; pin older package versions if you depend on those exact command shapes. See [`docs/STABILITY.md`](STABILITY.md) for the full listing.
 
 ## Summary
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.30.1` |
-| Current package line | `v0.30.x` (pre-1.0) |
+| `package.json` version | `0.31.0` |
+| Current package line | `v0.31.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |
 | npm live truth | `npm view open-scaffold version` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.30.1",
+      "version": "0.31.0",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('71a7c18ccd2969913939be30b15f88218fc71436347ee5edde60851b4fe615b3');
+    expect(hash(planIssueSnapshot)).toBe('511e05119e3fc0a8a17b0a0fc6b396cd296103ede5a2e0d4f2f3de8198628642');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('32a0a8261494920e76e7fcf10b0c3bfa4878428cccbe7d334ad6ce703b3a0073');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('2ac029e1ea4fed0e4d8ea65e560833764298ebe8e3fa9933a27300df82a9a6ca');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Prepares `open-scaffold@0.31.0` for the framework cleanup shrink release.
- Adds the adoption-facing `v0.31.0` changelog entry and aligns README, stability, version-truth, and roadmap wording to the new pre-1.0 hardening line.
- Adds the release-sync plan/evidence trail for publishing PR #183/#184 to npm and GitHub Releases.

## Verification
- `node -p "require('./package.json').version"` / package-lock checks — `0.31.0` everywhere
- `npm ci` — PASS, 88 packages, 0 vulnerabilities
- `git diff --check` — PASS
- `./verify.sh --strict` — PASS with expected active-release-plan warning: 9 pass / 0 fail / 1 warn
- `npm test -- --run` — PASS, 43 files / 484 tests
- `npm run build` — PASS
- `npm run osc -- doctor --check secret-scan` — PASS
- `npm pack --dry-run --json` — PASS for `open-scaffold@0.31.0`, 198 files after cleaning ignored local build residue; no stale removed-command `dist/*` modules and no Python `__pycache__`
- `npm publish --dry-run --tag latest` — PASS

## Risk / gates
- This PR does not publish npm, create a GitHub Release, deploy, or announce anything by itself.
- After merge, the owner-approved follow-through is trusted publishing for `0.31.0` with npm tag `latest`, fresh `npx` verification, GitHub Release `v0.31.0` marked Latest, and final release-plan closeout.
