### PR TITLE
chore: close 0.31.0 release sync

### DIFF
--- a/.osc/plans/done/152-framework-cleanup-package-sync.md
+++ b/.osc/plans/done/152-framework-cleanup-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
@@ -26,16 +26,16 @@ Publish `open-scaffold@0.31.0` with dist-tag `latest`, verify the fresh package 
 - `docs/CHANGELOG.md` — add the adoption-facing `v0.31.0` release entry.
 - `docs/STABILITY.md`, `docs/VERSION_TRUTH.md`, `README.md`, and `ROADMAP.md` — align the forward-moving pre-1.0 line with `v0.31.x` and the framework cleanup shrink.
 - `.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md` — release-sync evidence note.
-- `.osc/plans/active/152-framework-cleanup-package-sync.md` — this release-sync plan, later moved to done after publication proof.
+- `.osc/plans/done/152-framework-cleanup-package-sync.md` — this release-sync plan, moved to done after publication proof.
 
 ## Acceptance criteria
 
-- [ ] `package.json`, `package-lock.json`, and the root lockfile package version all read `0.31.0`.
-- [ ] Release-truth docs distinguish candidate repo state from live npm/GitHub Release state before publish, then record verified live state after publish.
-- [ ] Local release gates pass: `git diff --check`, `npm ci`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
-- [ ] Release-sync PR CI is green and review/thread state is clean before merge.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.31.0` with `latest`, and fresh isolated-cache `npx open-scaffold@latest` proves the reduced package surface from outside the repository.
-- [ ] GitHub Release `v0.31.0` exists, targets the merged `origin/main` release commit, is marked Latest, and uses release notes grounded in verified PR/evidence facts.
+- [x] `package.json`, `package-lock.json`, and the root lockfile package version all read `0.31.0`.
+- [x] Release-truth docs distinguish candidate repo state from live npm/GitHub Release state before publish, then record verified live state after publish.
+- [x] Local release gates pass: `git diff --check`, `npm ci`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Release-sync PR CI is green and review/thread state is clean before merge.
+- [x] Trusted publishing workflow publishes `open-scaffold@0.31.0` with `latest`, and fresh isolated-cache `npx open-scaffold@latest` proves the reduced package surface from outside the repository.
+- [x] GitHub Release `v0.31.0` exists, targets the merged `origin/main` release commit, is marked Latest, and uses release notes grounded in verified PR/evidence facts.
 
 ## Verification steps
 

--- a/.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md
+++ b/.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Release-sync candidate for publishing the merged framework cleanup shrink as `open-scaffold@0.31.0`.
+Release-sync evidence for publishing the merged framework cleanup shrink as `open-scaffold@0.31.0`.
 
 The package-visible change is a narrowed/reduced Open Scaffold CLI/source surface after PR #183, with shipped migration breadcrumbs and preserved protected core behavior. This release remains pre-1.0 hardening: it does not claim runtime execution, model improvement, benchmark proof, compliance certification, production readiness, or a mature 1.0 contract.
 
@@ -12,7 +12,7 @@ The package-visible change is a narrowed/reduced Open Scaffold CLI/source surfac
 - Source plan: `.osc/plans/done/151-framework-cleanup-shrink.md`.
 - Source PR: https://github.com/graphanov/open-scaffold/pull/183.
 - Source closeout PR: https://github.com/graphanov/open-scaffold/pull/184.
-- Release-sync plan: `.osc/plans/active/152-framework-cleanup-package-sync.md`.
+- Release-sync plan: `.osc/plans/done/152-framework-cleanup-package-sync.md`.
 - Run ID / run packet: N/A for this scoped package/release sync.
 - Branch / PR: `release/0.31.0-framework-cleanup-sync` / https://github.com/graphanov/open-scaffold/pull/185.
 
@@ -38,26 +38,24 @@ Candidate gates before PR-ready:
 - [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
 - [x] `npm pack --dry-run --json` payload inspection after cleaning ignored local build residue — PASS for `open-scaffold@0.31.0`; entry count 198; no stale removed-command `dist/*` modules; no Python `__pycache__` files.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.31.0` with tag `latest`.
-- [ ] Release candidate PR CI and review/thread gate — CI green on initial PR head; Codex requested the actual PR URL in this evidence note, so follow-up review remains pending.
+- [x] Release candidate PR CI and review/thread gate — PASS: PR #185 CI green; latest-head Codex clean at `2026-06-06T15:18:32Z`; review threads unresolved count `0` after fixed/outdated thread resolution.
 
 Post-merge/publication gates after owner-approved follow-through:
 
-- [ ] Sync clean `main` after release PR merge.
-- [ ] Main CI for release commit.
-- [ ] Post-merge local publish gates.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.31.0` with dist-tag `latest`.
-- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.31.0`, `latest: 0.31.0`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory passes.
-- [ ] Fresh isolated-cache smoke proves removed/repositioned command guidance from the published package.
-- [ ] GitHub Release `v0.31.0` exists, targets the release commit, and is marked Latest.
-- [ ] This plan is closed to `done` with final public proof.
+- [x] Sync clean `main` after release PR merge — PASS: local `main` fast-forwarded to `origin/main` at `b50f2b272b302c5b12118912c47880046eeb33e3`.
+- [x] Main CI for release commit — PASS: https://github.com/graphanov/open-scaffold/actions/runs/27066136409.
+- [x] Post-merge local publish gates — PASS: `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Trusted publishing workflow publishes `open-scaffold@0.31.0` with dist-tag `latest` — PASS: https://github.com/graphanov/open-scaffold/actions/runs/27066187879.
+- [x] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.31.0`, `latest: 0.31.0`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory passes.
+- [x] Fresh isolated-cache smoke proves removed/repositioned command guidance from the published package: `osc work --help` exits `2` and points to `docs/COMMAND_MATURITY.md`.
+- [x] GitHub Release `v0.31.0` exists, targets `b50f2b272b302c5b12118912c47880046eeb33e3`, and is marked Latest: https://github.com/graphanov/open-scaffold/releases/tag/v0.31.0.
+- [x] This plan is closed to `done` with final public proof.
 
 ## Outcome
 
-Pending. The release-sync branch prepares `open-scaffold@0.31.0`; npm publication and GitHub Release movement are not yet claimed until verified after PR merge and trusted publishing.
+Published and verified. `open-scaffold@0.31.0` is live on npm with dist-tag `latest`, fresh isolated-cache `npx open-scaffold@latest` passes, and GitHub Release `v0.31.0` is marked Latest at the release commit.
 
 ## Follow-up
 
-- Merge the release-sync PR only after CI/review gates pass.
-- Dispatch trusted publishing for `0.31.0` with npm tag `latest` after the release-sync commit lands on `main`.
-- Verify npm/latest, fresh `npx`, GitHub Release Latest, and close this plan to `done` after public proof.
+- None for this release-sync slice after closeout PR merge. Future package-visible changes still require separate owner-approved release follow-through.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-07: closed 152-framework-cleanup-package-sync — Published open-scaffold@0.31.0, verified npm/latest and fresh npx, and created GitHub Release v0.31.0 as Latest.
 - 2026-06-06: closed 151-framework-cleanup-shrink — Merged PR #183 after green CI, latest-head Codex clean/thread-zero review, and owner approval; close the framework cleanup shrink slice.
 - 2026-06-04: closed 150-open-scaffold-efficiency-reset — close efficiency reset after merged controller diagnostics and run-packet gates
 - 2026-06-03: closed 144-next-action-packet-npx-release-sync — published open-scaffold@0.30.1, verified npm latest/fresh npx, and created GitHub Release v0.30.1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.31.0 — Framework cleanup shrink release
 
-Status: release candidate in repo until owner-approved trusted publishing and GitHub Release follow-through complete.
+Status: published to npm as `open-scaffold@0.31.0`; GitHub Release `v0.31.0` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
@@ -20,12 +20,13 @@ Evidence:
 - Source plan: `.osc/plans/done/151-framework-cleanup-shrink.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/183
 - Closeout PR: https://github.com/graphanov/open-scaffold/pull/184
-- Release-sync plan: `.osc/plans/active/152-framework-cleanup-package-sync.md`
+- Release-sync plan: `.osc/plans/done/152-framework-cleanup-package-sync.md`
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/185
 - Release-sync evidence note: `.osc/releases/2026-06-06-152-framework-cleanup-package-sync.md`
 
 ## v0.30.1 — Evolution handoff packet release
 
-Status: published to npm as `open-scaffold@0.30.1`; GitHub Release `v0.30.1` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.30.1`; GitHub Release `v0.30.1` was Latest after owner-approved trusted publishing and release follow-through, then was superseded by `v0.31.0`.
 
 Highlights:
 
@@ -43,7 +44,7 @@ Evidence:
 
 ## v0.30.0 — Blueprint security and adoption release
 
-Status: published to npm as `open-scaffold@0.30.0`; GitHub Release `v0.30.0` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.30.0`; GitHub Release `v0.30.0` was Latest after owner-approved trusted publishing and release follow-through, then was superseded by `v0.30.1`.
 
 Highlights:
 
@@ -78,7 +79,7 @@ Evidence:
 
 ## v0.20.3 — Canonical section parser package sync
 
-Status: published to npm as `open-scaffold@0.20.3`; GitHub Release `v0.20.3` is Latest after owner-preapproved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.20.3`; GitHub Release `v0.20.3` was Latest after owner-preapproved trusted publishing and release follow-through, then was superseded by `v0.20.4`.
 
 Highlights:
 
@@ -96,7 +97,7 @@ Evidence:
 
 ## v0.20.2 — Methodology and reviewer evidence package sync
 
-Status: published to npm as `open-scaffold@0.20.2`; GitHub Release `v0.20.2` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.20.2`; GitHub Release `v0.20.2` was Latest after owner-approved trusted publishing and release follow-through, then was superseded by `v0.20.3`.
 
 Highlights:
 

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -5,8 +5,8 @@ This page is the canonical reconciliation between the current package version an
 ## Current line: `v0.31.x` (pre-1.0 hardening)
 
 - **Current `package.json` version:** `0.31.0`.
-- **npm latest:** `0.30.1` with dist-tag `latest` until the owner-approved `0.31.0` trusted publishing run completes; run `npm view open-scaffold version dist-tags --json` for live confirmation.
-- **GitHub Release latest:** `v0.30.1` is marked **Latest** until the `v0.31.0` GitHub Release follow-through completes.
+- **npm latest:** `0.31.0` with dist-tag `latest` after owner-approved trusted publishing; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** `v0.31.0` is marked **Latest** after GitHub Release follow-through.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('511e05119e3fc0a8a17b0a0fc6b396cd296103ede5a2e0d4f2f3de8198628642');
+    expect(hash(planIssueSnapshot)).toBe('9d6ba69433e1307fda1ca43bc74a95e2c82898479f25d92d547bedb6d252757e');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('2ac029e1ea4fed0e4d8ea65e560833764298ebe8e3fa9933a27300df82a9a6ca');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary

- closes the `152-framework-cleanup-package-sync` plan after npm/GitHub Release proof is live
- updates the release evidence note, changelog, and version truth docs from candidate/pending to published/latest
- pins the live-corpus snapshot after moving the release-sync plan to `done/`

## Verification

- `git diff --check` — PASS
- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn
- `npm test -- --run` — PASS, 43 files / 484 tests
- `npm run build` — PASS
- `npm run osc -- doctor --check secret-scan` — PASS

## Public proof

- npm: `open-scaffold@0.31.0`, `latest: 0.31.0`
- Fresh isolated-cache `npx --yes open-scaffold@latest --help` — PASS
- Fresh isolated-cache removed-command smoke: `osc work --help` exits `2` with migration guidance to `docs/COMMAND_MATURITY.md`
- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.31.0
- Release target commit: `b50f2b272b302c5b12118912c47880046eeb33e3`
