### PR TITLE
docs: prepare harness release readiness

### DIFF
--- a/.osc/plans/active/159-harness-release-readiness.md
+++ b/.osc/plans/active/159-harness-release-readiness.md
@@ -2,18 +2,18 @@
 
 ## Status
 
-backlog
+active
 
 ## PR association
 
-- Planned PR slot: #197, or the next available GitHub PR number.
+- Expected GitHub PR slot: #199, unless another PR is opened first.
 - Branch: `docs/harness-release-readiness`.
 - Title: `docs: prepare harness release readiness`.
-- Base: fresh `main` after PR #195 and PR #196, unless Daniel chooses to release a smaller earlier milestone.
+- Base: fresh `main` after PRs #194, #195, #196, #197, and #198 are merged.
 
 ## Context
 
-Release polish should come after the harness is real. PR #192 creates the foundation, PR #193/#194 make the runtime and feedback loop work, PR #195 tests reproduction, and PR #196 makes `$team`/control-room contracts operational. Only then should public docs, command maturity, package notes, and release surfaces say Open Scaffold is a functioning AI work harness.
+Release polish follows the working harness chain. PR #192 created the command foundation, PRs #194-#195 made the runtime and feedback loop usable, PR #196 tested reproduction, PR #197 made `$team`/control-room contracts operational, and the #198 closeout moved the reproduction plan to `done/`. This slice makes public docs, command maturity, package notes, and release gates match that real state without overclaiming.
 
 ## Goal
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use it when AI-assisted work needs **control**, **clarity**, **reviewability**, 
 
 It does not replace your agent, IDE, task tracker, CI, or compliance process. Those tools do the work or run the program. Open Scaffold records what was asked, what was handed off, what came back, what was checked, and what humans approved. For the boundary between structural evidence and process assurance, see [`docs/AUDITABILITY.md`](docs/AUDITABILITY.md) and [`docs/TRUST_BOUNDARIES.md`](docs/TRUST_BOUNDARIES.md).
 
-Open Scaffold does not make models smarter and one fixture is not universal benchmark proof. The current value claim under test is narrower: workflow control, handoff recovery, governance, and measured controller-output efficiency. Any efficiency claim needs a diagnostic/experimental before/after artifact such as `osc evolve analyze --efficiency` or a source-labeled proof manifest checked with `osc prove compare`; do not promote token, cost, or quality wins from prose alone. See [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) for the bounded naked-Codex comparison fixture.
+Open Scaffold does not make models smarter and one fixture is not universal benchmark proof. The current value claim under test is narrower: workflow control, handoff recovery, owner-gate clarity, and measured controller-output efficiency. Any efficiency claim needs a diagnostic/experimental before/after artifact such as `osc evolve analyze --efficiency` or a source-labeled proof manifest checked with `osc prove compare`; do not promote token, cost, or quality wins from prose alone. See [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) for the bounded naked-Codex comparison fixture.
 
 **First command for an existing repo:**
 
@@ -67,7 +67,15 @@ MISSION.md                         why this repo exists
 
 Open Scaffold is also a small-command harness for AI-assisted work:
 
-> Open Scaffold helps clarify the task, plan it in the repo, run controlled AI workers, preserve evidence, learn from feedback, and test whether the workflow actually helped.
+> Open Scaffold helps clarify the task, plan it in the repo, package controlled AI work, coordinate worker lanes, preserve evidence, learn from feedback, and test whether the workflow actually helped.
+
+A new reader only needs the shape below:
+
+```text
+clarify -> plan -> work or team -> evidence -> feedback -> retry/lesson -> benchmark readout
+```
+
+The harness writes files and status. It does not silently take over your repo.
 
 The human-facing grammar is intentionally small:
 
@@ -108,7 +116,16 @@ osc bench suite --mode simulated --out .osc/bench/simulated-runtime-smoke
 osc bench handoff-lab --out .osc/bench/handoff-lab-15
 ```
 
-Humans still own merge, publish, release, deployment, and approval gates. Open Scaffold core packages work and records receipts; adapters or humans execute it. Read more in [`docs/HARNESS_COMMANDS.md`](docs/HARNESS_COMMANDS.md), [`docs/HARNESS_ARCHITECTURE.md`](docs/HARNESS_ARCHITECTURE.md), [`docs/FEEDBACK_IMPROVEMENT_LOOP.md`](docs/FEEDBACK_IMPROVEMENT_LOOP.md), [`docs/HARNESS_REPRODUCIBILITY.md`](docs/HARNESS_REPRODUCIBILITY.md), [`docs/HANDOFF_COMPILER.md`](docs/HANDOFF_COMPILER.md), [`docs/CONTROL_ROOM_FOUNDATION.md`](docs/CONTROL_ROOM_FOUNDATION.md), and the source-prototype migration roadmap in [`docs/JOHN_LOMEIN_MIGRATION_ROADMAP.md`](docs/JOHN_LOMEIN_MIGRATION_ROADMAP.md).
+Humans still own merge, publish, release, deployment, and approval gates. Open Scaffold core packages work and records receipts; adapters or humans execute it.
+
+Current harness readiness in this source checkout:
+
+- `$interview`, `$plan`, no-spawn `$work`, `$team`, feedback, and simulated benchmark receipts are implemented and covered by tests.
+- `$work --allow-spawn`, live Codex/adapter runs, and broad reproduction claims remain experimental and owner-gated.
+- Open Scaffold-run reproduction evidence is currently `partially_reproduced`; broad Open Scaffold > naked Codex dominance remains `mixed_not_proven`. See [`docs/HARNESS_REPRODUCIBILITY.md`](docs/HARNESS_REPRODUCIBILITY.md) and `.osc/releases/2026-06-09-harness-reproduction-proof-parity.md`.
+- npm publish and GitHub Release updates are separate owner decisions, not automatic consequences of this docs/readiness work.
+
+Read more in [`docs/HARNESS_COMMANDS.md`](docs/HARNESS_COMMANDS.md), [`docs/HARNESS_ARCHITECTURE.md`](docs/HARNESS_ARCHITECTURE.md), [`docs/FEEDBACK_IMPROVEMENT_LOOP.md`](docs/FEEDBACK_IMPROVEMENT_LOOP.md), [`docs/HARNESS_REPRODUCIBILITY.md`](docs/HARNESS_REPRODUCIBILITY.md), [`docs/HANDOFF_COMPILER.md`](docs/HANDOFF_COMPILER.md), [`docs/CONTROL_ROOM_FOUNDATION.md`](docs/CONTROL_ROOM_FOUNDATION.md), and the source-prototype migration roadmap in [`docs/JOHN_LOMEIN_MIGRATION_ROADMAP.md`](docs/JOHN_LOMEIN_MIGRATION_ROADMAP.md).
 
 ---
 
@@ -381,7 +398,7 @@ Stable enough to rely on today:
 Still experimental:
 
 - Runtime profiles and runtime-selection helpers beyond no-spawn run-packet metadata.
-- `osc dispatch`, MCP, glass cockpit webhooks, runtime packages, and Python parser packaging. Historical/repositioned surfaces such as `osc work --dry-run`, local task database helpers, and TUI/web dashboards are not live maintained CLI commands after the framework cleanup.
+- `osc dispatch`, MCP, control-room webhook experiments, runtime packages, and Python parser packaging. Historical/repositioned surfaces such as `osc work --dry-run`, local task database helpers, and TUI/web dashboards are not live maintained CLI commands after the framework cleanup.
 
 Future / not included:
 
@@ -458,7 +475,7 @@ Skip it for:
 - [`docs/PR_REVIEW_WITH_OSC.md`](docs/PR_REVIEW_WITH_OSC.md) — `osc pr check` and fork-safe PR workflow template.
 - [`docs/TRUST_BOUNDARIES.md`](docs/TRUST_BOUNDARIES.md) — dispatch, adapter, evidence, webhook, PR-check, and runtime trust boundaries.
 - [`docs/RUNTIME_BETA_LANE.md`](docs/RUNTIME_BETA_LANE.md) — current Codex/OMX beta lane and no-overclaim boundaries.
-- [`docs/COMMAND_MATURITY.md`](docs/COMMAND_MATURITY.md) — historical/repositioned command maturity language for the reduced `osc help` surface.
+- [`docs/COMMAND_MATURITY.md`](docs/COMMAND_MATURITY.md) — current command-readiness guide for stable, lab, advanced, and future CLI surfaces.
 - [`docs/SCHEMA_REGISTRY.md`](docs/SCHEMA_REGISTRY.md) — emitted artifact schema IDs and owners.
 - [`docs/ADOPTION_PROOF_INDEX.md`](docs/ADOPTION_PROOF_INDEX.md) — honest adoption-proof labels and reproduction requirements.
 - [`docs/MINIMUM_VIABLE_SCAFFOLD.md`](docs/MINIMUM_VIABLE_SCAFFOLD.md) — smallest practical day-one adoption path.

--- a/docs/COMMAND_MATURITY.md
+++ b/docs/COMMAND_MATURITY.md
@@ -1,19 +1,21 @@
 # Command maturity
 
-Status: historical/repositioned guidance after the framework cleanup. The previous command-maturity registry in `src/command-maturity.ts` and the `osc commands` / `osc commands --json` surfaces were removed from the reduced maintained CLI. Current command grouping is rendered by:
+Status: current public command-readiness guide after the framework cleanup and harness migration.
+
+The top-level command list is rendered by:
 
 ```bash
 osc help
 ```
 
-Open Scaffold commands should still be presented by maturity so first-time users see the stable path before lab, advanced, historical, or migration surfaces.
+This page explains how to read that help. It does not make an experimental runtime path stable.
 
 ## Labels
 
-- `stable` — day-one/day-two workflow path. Expected to be safe for normal users and docs examples.
-- `lab` — useful but still proving product shape or runtime boundary.
+- `stable` — day-one/day-two workflow path. Safe for normal docs examples and normal repository use.
+- `lab` — useful backend surface, but still proving product shape, runtime behavior, or evidence value.
 - `advanced` — specialized maintenance, analysis, or power-user surface.
-- `future` — documented direction, not implemented stable behavior.
+- `future` — direction only; not implemented as stable behavior.
 
 ## Rules
 
@@ -24,7 +26,7 @@ Open Scaffold commands should still be presented by maturity so first-time users
 
 ## Stable path today
 
-The stable day-one/day-two path is:
+The stable day-one/day-two path is the repo work record:
 
 ```bash
 osc first-run --non-interactive --slug <slug> --mission <text> --goal <text>
@@ -58,27 +60,48 @@ osc harness '$interview ...'
 osc harness '$plan ...'
 osc harness '$work ...'
 osc harness '$team ...'
+osc harness status <run-id>
+osc harness answer <run-id> --gate <id> --answer <text>
 osc feedback record <run-id> ...
 osc feedback analyze <run-id>
 osc bench suite --mode simulated --out .osc/bench/simulated-runtime-smoke
 osc bench handoff-lab --out .osc/bench/handoff-lab-15
 ```
 
-These commands are backend/CI/repro surfaces. They are not a revival of `osc work ...` as the main UX, and they do not grant runtime spawn, merge, publish, or release authority.
+Help should return without side effects for:
+
+```bash
+osc harness --help
+osc feedback --help
+osc bench --help
+osc bench suite --help
+osc bench handoff-lab --help
+```
+
+Current maturity:
+
+| Surface | Current maturity | Why |
+| --- | --- | --- |
+| `$interview` via `osc harness` | lab backend | Writes clarification drafts and gates; useful, but not the default day-one path. |
+| `$plan` via `osc harness` | lab backend | Writes/proposes plans through the harness route; normal `osc plan` remains the stable path. |
+| no-spawn `$work` | lab backend | Writes work packages, status, receipts, gates, feedback, retries, and handoff files without launching a runtime by default. |
+| `$work --allow-spawn` | experimental | May launch an external adapter only with explicit backend authority and trust checks; live runtime behavior is not called stable. |
+| `$team` | lab backend | Coordinates worker-lane records, shared evidence, gates, and feedback; useful for control-room surfaces but not a stable autonomous team runner. |
+| `osc feedback record/analyze` | lab backend | Records repair signals and accepted-improvement input; not approval. |
+| `osc bench suite` / `osc bench handoff-lab` | lab backend | Writes reproduction receipts and reports; broad claims stay blocked unless strict proof gates clear. |
+
+These commands are backend/CI/repro surfaces. They are not a revival of `osc work ...` as the main UX, and they do not grant runtime spawn, merge, publish, release, deploy, or force-push authority.
 
 ## Removed / repositioned command migration notes
 
-Framework cleanup removed several lab, analytics, and convenience commands from the
-maintained CLI surface. Clean clones and npm installs should use this shipped page as
-the migration breadcrumb; run-local break/removal ledgers under `.osc/runs/` are
-evidence artifacts, not package documentation.
+Framework cleanup removed several lab, analytics, and convenience commands from the maintained CLI surface. Clean clones and npm installs should use this shipped page as the migration breadcrumb; run-local break/removal ledgers under `.osc/runs/` are evidence artifacts, not package documentation.
 
 | Removed or repositioned surface | Current route |
 |---|---|
 | `osc plan wizard`, `osc plan graph`, `osc plan stats` | Use explicit plan files, `osc plan new`, `osc plan validate`, `osc plan move`, and the `.osc/plans/` folder-as-status workflow. |
-| `osc evidence compact` | Use release/evidence notes, `osc evidence collect`, `osc trace`, and `osc verify --evidence-chain` for durable proof. |
+| `osc evidence compact` | Use release/evidence notes, `osc evidence collect`, `osc trace`, and `osc verify --evidence-chain` for durable evidence. |
 | `osc task ...` | Use GitHub Issues, Kanban, or another external task tracker, then bind work back to `.osc` plans and run packets. |
-| `osc eval import/check` | Use `osc eval init` only to scaffold a plan-based evaluation envelope; scorer import/check workflows are no longer a maintained live surface. |
-| `osc status --dashboard`, `osc dashboard` | Use `osc status`, cockpit events, PR comments, and evidence notes instead of local dashboard modes. |
-| `osc work` | Use `osc start` or `osc run --dry-run` to create explicit handoff/run packets; runtime execution remains adapter/orchestrator-owned. |
+| `osc eval import/check` | Use `osc eval init` only to scaffold a plan-based evaluation record; scorer import/check workflows are no longer a maintained live surface. |
+| `osc status --dashboard`, `osc dashboard` | Use `osc status`, status events, PR comments, and evidence notes instead of local dashboard modes. |
+| `osc work` | Use `osc start`, `osc run --dry-run`, or the harness backend `$work` route. Runtime execution remains adapter/orchestrator-owned. |
 | `osc metrics`, `osc study`, broad `osc doctor` checks, resume helpers | Keep broad analysis, observational studies, and resume/handoff proof in docs/evidence unless a smaller maintained command exists. For bounded scaffolded-vs-control receipt comparisons, use `osc prove compare`; the full `osc ab` controlled-study surface remains documentation-only/future. |

--- a/docs/CONTROL_ROOM_FOUNDATION.md
+++ b/docs/CONTROL_ROOM_FOUNDATION.md
@@ -6,7 +6,7 @@ This document describes the product direction. It does not mean this PR ships a 
 
 ## Direction
 
-A future Open Scaffold control room could feel like a small work cockpit:
+A future Open Scaffold control room could feel like a small status room:
 
 ```text
 left rail        center                  right rail

--- a/docs/HARNESS_ARCHITECTURE.md
+++ b/docs/HARNESS_ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 Open Scaffold's harness is a transport-agnostic work-record layer for AI-assisted work.
 
+In plain terms: it turns a request into repo files a human can inspect later — plan, work package, status, evidence links, gates, feedback, and post-run notes.
+
 It is not a Codex-only plugin and not an autonomous agent. The core receives a command, writes repo-local truth, emits status/events, and hands bounded work to an adapter or human-controlled runtime.
 
 ## Layer diagram
@@ -143,7 +145,7 @@ Adapters own:
 
 `$work` refuses to launch an adapter unless the command includes explicit backend authority such as `--allow-spawn`. Without that flag, it still writes a dry-run receipt so the handoff is reviewable.
 
-A successful process exit is not enough. Runtime stdout must end with exactly one standalone marker:
+A successful process exit is not enough. Runtime stdout must end with exactly one standalone marker. These marker strings are adapter wire protocol, not product branding:
 
 - `LOMEIN_COMPLETE` → completed receipt, still not owner approval or correctness proof.
 - `LOMEIN_NEEDS_HUMAN` → pending human gate; the gate answer resumes the same run as task input.
@@ -169,3 +171,19 @@ All worker lanes stay inside one `.osc/runs/<run-id>/` directory. Worker evidenc
 A worker gate such as `worker-review-needs-human` appears in the shared `pendingHumanGates` list. Answering it through `osc harness answer` updates the same team run; the answer is task input, not approval.
 
 This keeps the core portable across CLI, Codex plugin, Hermes, and future app surfaces while preserving owner authority.
+
+## Release-readiness boundary
+
+Implemented now:
+
+- `$interview` writes a clarification/work-package draft and missing-context gates.
+- `$plan` writes or proposes repo-native plan files.
+- `$work` writes controlled work packages, dry-run/runtime receipts, human gates, feedback, retry links, and optional handoff packets.
+- `$team` writes shared worker-lane status, gates, evidence links, feedback, and postflight under one run folder.
+- `osc bench` writes simulated/live reproduction receipts and handoff-lab reports.
+
+Still experimental or owner-gated:
+
+- Live runtime spawning through `$work --allow-spawn`.
+- Full live reproduction suites and broad Open Scaffold > naked Codex claims.
+- npm publish, GitHub Release changes, merge, release, deploy, and force-push actions.

--- a/docs/HARNESS_COMMANDS.md
+++ b/docs/HARNESS_COMMANDS.md
@@ -1,6 +1,14 @@
 # Harness command surface
 
-Open Scaffold now has a small command grammar for human-facing chat, plugin, CLI, and future app surfaces:
+Open Scaffold now has a small command grammar for human-facing chat, plugin, CLI, and future app surfaces.
+
+The plain model is:
+
+```text
+clarify the task -> write the plan -> package work -> record evidence -> learn from feedback -> test the claim
+```
+
+The harness writes repo files and status events. It does not make the agent smarter, prove the work is correct, or move owner approval gates.
 
 | Command | Use it for | What Open Scaffold records |
 | --- | --- | --- |
@@ -13,7 +21,7 @@ The product UX is the four `$commands`. The `osc` CLI is the backend surface for
 
 ## CLI backend
 
-Use the backend when a shell, CI job, Codex plugin, Hermes worker, or future desktop app needs a deterministic call:
+Use the backend when a shell, CI job, Codex plugin, Hermes worker, or future desktop app needs a deterministic call. Help is available at `osc harness --help`, `osc feedback --help`, and `osc bench --help`:
 
 ```bash
 osc harness '$interview "tighten the task"' --json
@@ -43,7 +51,7 @@ The receipt records adapter name, command summary, timeout, exit state, final ma
 
 ## Runtime marker contract
 
-A spawned runtime must end stdout with exactly one final standalone marker line:
+A spawned runtime must end stdout with exactly one final standalone marker line. These marker names are adapter wire strings kept for compatibility, not Open Scaffold product branding or human-facing commands:
 
 | Marker | Meaning |
 | --- | --- |
@@ -84,7 +92,7 @@ osc bench suite --mode simulated --out .osc/bench/simulated-runtime-smoke
 osc bench handoff-lab --out .osc/bench/handoff-lab-15
 ```
 
-The backend commands write repo-local receipts. They do not spawn Codex from core, rank models, certify correctness, or grant owner approval.
+The backend commands write repo-local receipts. They do not spawn Codex from core, rank models, certify correctness, or grant owner approval. In the current maturity model, simulated benchmark and feedback commands are useful backend tools; live runtime runs with `--allow-spawn` remain experimental and require an explicit operator decision.
 
 Accepted improvements live under `.osc/improvements/applied/`. `$work` and `$team` only load them when `--inherit-improvements` is passed, and the loader filters by the current intent instead of injecting every old lesson.
 

--- a/docs/HARNESS_REPRODUCIBILITY.md
+++ b/docs/HARNESS_REPRODUCIBILITY.md
@@ -2,6 +2,28 @@
 
 The harness includes local benchmark/reproduction machinery so Open Scaffold can test whether the workflow helped. It does not turn a smoke test into a broad model or framework claim.
 
+## Current Open Scaffold-run verdict
+
+Current committed readout: `partially_reproduced`.
+
+Evidence note: `.osc/releases/2026-06-09-harness-reproduction-proof-parity.md`.
+
+What reproduced:
+
+- One representative live fixture showed a clean quality-preserving faster harness lane.
+- The representative aggregate had slightly better harness quality and wall-clock duration.
+- The handoff lab found a budget-passing deterministic candidate.
+
+What did not reproduce cleanly:
+
+- Targeted compact handoff did not reproduce the source efficiency win in the rerun.
+- Runtime token receipts were unavailable from the live Codex adapter output, so token/cost efficiency is not proven.
+- Representative live included dirty/blocked lanes.
+- Ablations did not isolate a harness-specific causal effect.
+- Fixture count stayed below the broad proof gate.
+
+Broad dominance remains `mixed_not_proven`. Do not claim Open Scaffold broadly beats naked Codex from the current evidence.
+
 ## Backend commands
 
 ```bash

--- a/docs/JOHN_LOMEIN_MIGRATION_ROADMAP.md
+++ b/docs/JOHN_LOMEIN_MIGRATION_ROADMAP.md
@@ -23,13 +23,13 @@ Open Scaffold has landed the harness runtime chain through reproduction proof an
 | Reproduction proof PR | graphanov/open-scaffold#196 |
 | Team/control-room adapter PR | graphanov/open-scaffold#197 |
 | Closed plans | `.osc/plans/done/154-harness-command-surface.md`, `.osc/plans/done/155-controlled-runtime-parity.md`, `.osc/plans/done/156-feedback-handoff-improvement-parity.md`, `.osc/plans/done/157-reproduction-proof-parity.md`, `.osc/plans/done/158-team-control-room-adapter-parity.md` |
-| Status | Plans 154-158 are merged; the next remaining roadmap plan is `.osc/plans/backlog/159-harness-release-readiness.md`. |
+| Status | Plans 154-158 are merged; plan 159 is active at `.osc/plans/active/159-harness-release-readiness.md`. |
 | What it proves | Open Scaffold now has the `$interview`, `$plan`, `$work`, and `$team` command surface, controlled runtime receipts, feedback/improvement loop, handoff lab, benchmark/proof-gate machinery, and team/control-room status contracts. |
 | What it does not prove yet | Public package/release readiness is not complete, and broad dominance claims remain gated by Open Scaffold-run proof evidence. |
 
 The important boundary is this:
 
-> PR #192 was the foundation PR. PRs #194-#197 landed the runtime, feedback/handoff, reproduction, and team/control-room slices. Plan 159 is the remaining release-readiness step; it still does not authorize npm publish, GitHub Release updates, or broad dominance claims without owner gates.
+> PR #192 was the foundation PR. PRs #194-#197 landed the runtime, feedback/handoff, reproduction, and team/control-room slices. Plan 159 is the active release-readiness step; it still does not authorize npm publish, GitHub Release updates, or broad dominance claims without owner gates.
 
 ## End state
 
@@ -61,7 +61,7 @@ GitHub may assign a different number if another PR is opened first. The PR numbe
 | #195 | `156-feedback-handoff-improvement-parity` | `feat/feedback-handoff-improvement-parity` | `feat: wire feedback and handoff improvement loop` | Make feedback, repair hypotheses, accepted improvements, retries, and compact handoffs part of real `$work`/`$team` flows. | Merged; plan 156 moved to `done/`. |
 | #196 | `157-reproduction-proof-parity` | `feat/harness-reproduction-proof-parity` | `feat: reproduce source prototype proof lanes` | Run Open Scaffold-owned reproduction suites: targeted handoff, representative live fixtures, ablations, and strict proof report. | Merged; plan 157 moved to `done/`. |
 | #197 | `158-team-control-room-adapter-parity` | `feat/team-control-room-adapter-parity` | `feat: add team and control-room adapter contracts` | Make `$team` a real coordinated multi-worker harness and expose transport/status contracts for Hermes/plugin/desktop surfaces. | Merged; plan 158 moved to `done/`. |
-| Next slot | `159-harness-release-readiness` | `docs/harness-release-readiness` | `docs: prepare harness release readiness` | Polish public docs, examples, command maturity, package/release notes, and owner gates after the harness actually works. | Fresh install/help smoke and release-readiness checks pass; publish/release remain owner-gated. |
+| #199 expected | `159-harness-release-readiness` | `docs/harness-release-readiness` | `docs: prepare harness release readiness` | Polish public docs, examples, command maturity, package/release notes, and owner gates after the harness actually works. | Help/build/test/strict/secret-scan checks pass; publish/release remain owner-gated. |
 
 ## When each PR starts
 

--- a/docs/PROOF_HARNESS.md
+++ b/docs/PROOF_HARNESS.md
@@ -6,7 +6,7 @@ Status: lab/experimental, source-labeled, bounded comparison surface.
 
 The command does not run Codex, call an LLM, rank models, approve work, or certify correctness. It reads a committed manifest plus source-labeled receipts and renders the comparison honestly, including ties and regressions.
 
-For Open Scaffold-owned reproduction runs, use `osc bench suite` and `osc bench handoff-lab` instead. `osc prove` compares checked-in proof receipts; `osc bench` creates local reproduction evidence and must still report `reproduced`, `partially_reproduced`, or `not_reproduced` without promoting source-prototype evidence into Open Scaffold proof.
+For Open Scaffold-owned reproduction runs, use `osc bench suite` and `osc bench handoff-lab` instead. `osc prove` compares checked-in proof receipts; `osc bench` creates local reproduction evidence and must still report `reproduced`, `partially_reproduced`, or `not_reproduced` without promoting source-prototype evidence into Open Scaffold proof. The current Open Scaffold-run harness migration verdict is summarized in [`HARNESS_REPRODUCIBILITY.md`](HARNESS_REPRODUCIBILITY.md): `partially_reproduced`, with broad dominance still `mixed_not_proven`.
 
 ```bash
 osc prove check examples/proof/scaffold-vs-naked-codex/manifest.json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -828,8 +828,13 @@ function harnessCommand(args: string[]): void {
   }
 }
 
+function feedbackHelp(): string {
+  return 'Usage: osc feedback record|analyze ...\n  osc feedback record <run-id> --source <human|tests|reviewer|benchmark|runtime|codex|hermes> --verdict <pass|retry|reject|block|improve> --scope <run|plan|command|docs|benchmark|runtime> --what-happened <text> --why-it-matters <text> [--repair-hypothesis <text>] [--evidence-path <path>]... --next-action <text> [--json]\n  osc feedback analyze <run-id> [--json]\n\nFeedback is task input and repair signal. It is not owner approval.';
+}
+
 function feedbackCommand(args: string[]): void {
-  const sub = args[0] ?? die('Usage: osc feedback record|analyze ...', 2);
+  if (isHelpArg(args[0])) { console.log(feedbackHelp()); return; }
+  const sub = args[0] ?? die(feedbackHelp(), 2);
   const json = has(args, '--json');
   try {
     if (sub === 'record') {
@@ -859,11 +864,16 @@ function feedbackCommand(args: string[]): void {
     if (error instanceof Error) die(error.message, 2);
     throw error;
   }
-  die('Usage: osc feedback record|analyze ...', 2);
+  die(feedbackHelp(), 2);
+}
+
+function benchHelp(): string {
+  return 'Usage: osc bench suite|handoff-lab ...\n  osc bench suite [--mode simulated|live] [--fixture <id>]... [--include-ablations] [--ablation-fixture <id>]... [--allow-spawn] [--adapter <id>] [--timeout-ms <n>] [--max-log-bytes <n>] [--model <id>] [--effort <level>] [--out <dir>] [--json]\n  osc bench handoff-lab [--out <dir>] [--json]\n\nBench commands write local reproduction receipts. They do not grant broad proof or owner approval.';
 }
 
 function benchCommand(args: string[]): void {
-  const sub = args[0] ?? die('Usage: osc bench suite|handoff-lab ...', 2);
+  if (isHelpArg(args[0])) { console.log(benchHelp()); return; }
+  const sub = args[0] ?? die(benchHelp(), 2);
   if (sub === 'suite' && isHelpArg(args[1])) {
     console.log('Usage: osc bench suite [--mode simulated|live] [--fixture <id>]... [--include-ablations] [--ablation-fixture <id>]... [--allow-spawn] [--adapter <id>] [--timeout-ms <n>] [--max-log-bytes <n>] [--model <id>] [--effort <level>] [--out <dir>] [--json]');
     return;
@@ -920,7 +930,7 @@ function benchCommand(args: string[]): void {
     if (error instanceof Error) die(error.message, 2);
     throw error;
   }
-  die('Usage: osc bench suite|handoff-lab ...', 2);
+  die(benchHelp(), 2);
 }
 
 function removed(command: string): never {

--- a/tests/cli-harness-backend.test.ts
+++ b/tests/cli-harness-backend.test.ts
@@ -76,6 +76,23 @@ describe('CLI harness backend', () => {
     expect(existsSync(join(root, '.osc/bench/handoff-lab-15/aggregate.json'))).toBe(false);
   });
 
+  it('prints top-level backend help for feedback and bench without running commands', () => {
+    const root = tempScaffold();
+    const feedback = spawnSync(tsx, [cli, 'feedback', '--help'], { cwd: root, encoding: 'utf8' });
+
+    expect(feedback.status).toBe(0);
+    expect(feedback.stdout).toContain('Usage: osc feedback record|analyze');
+    expect(feedback.stdout).toContain('osc feedback record <run-id>');
+    expect(feedback.stdout).toContain('not owner approval');
+
+    const bench = spawnSync(tsx, [cli, 'bench', '--help'], { cwd: root, encoding: 'utf8' });
+    expect(bench.status).toBe(0);
+    expect(bench.stdout).toContain('Usage: osc bench suite|handoff-lab');
+    expect(bench.stdout).toContain('osc bench suite [--mode simulated|live]');
+    expect(bench.stdout).toContain('do not grant broad proof or owner approval');
+    expect(existsSync(join(root, '.osc/bench/simulated-runtime-smoke/aggregate.json'))).toBe(false);
+  });
+
   it('runs simulated benchmark and handoff-lab backend smokes', () => {
     const root = tempScaffold();
     const suite = spawnSync(tsx, [cli, 'bench', 'suite', '--mode', 'simulated', '--out', '.osc/bench/simulated-runtime-smoke'], { cwd: root, encoding: 'utf8' });

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -11,7 +11,8 @@ const cleanupBaselineLoc = 20_890;
 // Feedback/handoff parity adds the real retry, repair-hypothesis, handoff, and team feedback wiring instead of leaving those as standalone lab primitives.
 // Reproduction proof parity adds live benchmark lane packaging, clean-completion/proof-gate logic, benchmark feedback wiring, lane-specific live prompts, collision-safe run ids, and adapter token-usage capture.
 // Team/control-room parity adds shared worker-lane status, adapter metadata, worker gates, and transport-neutral event projections.
-const cleanupTargetLoc = 15_555;
+// Harness release readiness adds top-level feedback/bench help so public command maturity docs match real CLI behavior.
+const cleanupTargetLoc = 15_565;
 const cleanupTargetFiles = 38;
 
 interface MaintainedSourceFile {
@@ -54,7 +55,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_555);
+    expect(cleanupTargetLoc).toBe(15_565);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('8a5f3a88e090b6d8ee154f43c55dd6a3a9e4d0da4c6bfd334b9123e5133a6b6e');
+    expect(hash(planIssueSnapshot)).toBe('965a4d8ef23afaf943374c3aae9dc0b57024bc530de822d151446002d3a285ff');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('0d25d1956dadf23eabaca3fea00baa7098217737a6455dcf69fc75b7fa341c98');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary

- Prepares the harness release-readiness slice for plan `159-harness-release-readiness`.
- Moves plan 159 from backlog to active and updates the migration roadmap to reflect the current PR slot.
- Makes public docs clearer for first-time readers without calling the live runtime path stable.
- Adds top-level CLI help for `osc feedback --help` and `osc bench --help` so command maturity docs match real command behavior.

## Public docs/readiness changes

- README now gives a first-minute harness shape: clarify -> plan -> work/team -> evidence -> feedback -> retry/lesson -> benchmark readout.
- Harness docs separate implemented repo-file/status behavior from experimental live runtime spawning.
- Command maturity now lists stable, lab, experimental, and future surfaces with concrete owner boundaries.
- Repro/proof docs point to the Open Scaffold-run evidence note and keep the verdict explicit.
- Control-room docs stay directional; this PR does not ship a desktop app.
- Source-prototype marker names are described as adapter wire protocol, not Open Scaffold product branding.

## Current harness maturity

Implemented/lab-backed in this source checkout:

- `$interview`, `$plan`, no-spawn `$work`, `$team`, feedback record/analyze, simulated bench, and handoff-lab receipts.
- Shared worker-lane status/evidence/gate/feedack records for `$team`.
- Transport-neutral CLI/backend surfaces consumable by CLI, chat/plugin, Hermes, or future UI layers.

Still not called stable:

- `$work --allow-spawn` and live external-adapter runs.
- Full live reproduction suites.
- Broad Open Scaffold > naked Codex claims.

## Reproduction verdict and evidence link

Current Open Scaffold-run verdict: `partially_reproduced`.

Evidence note:

- `.osc/releases/2026-06-09-harness-reproduction-proof-parity.md`

Broad dominance remains `mixed_not_proven`; this PR does not strengthen that claim.

## What is still experimental

- Live runtime spawning through external adapters.
- Full live reproduction / cost-bearing proof suites.
- Runtime token/cost efficiency until trusted adapter token receipts are available.
- Future control-room UI beyond transport-neutral status/event contracts.

## Package/release surface assessment

Checked surfaces today:

- `package.json`: `0.31.0`
- npm `open-scaffold` latest: `0.31.0`
- GitHub Latest Release: `v0.31.0 — Framework cleanup shrink release`

This PR is docs/readiness + small CLI help parity. It does not publish npm and does not create or update a GitHub Release. Package/release follow-through remains an explicit owner gate.

## Verification commands/results

- Command/help smokes — PASS:
  - `node dist/cli.js --help`
  - `node dist/cli.js harness --help`
  - `node dist/cli.js feedback --help`
  - `node dist/cli.js bench --help`
  - `node dist/cli.js bench suite --help`
  - `node dist/cli.js bench handoff-lab --help`
  - temp-repo `$interview` -> `waiting_on_human`
  - temp-repo `$plan` -> `completed`
  - temp-repo `$work` -> `ready`
  - temp-repo `$team` -> `waiting_on_human`
  - feedback record/analyze smoke -> `retry`, 1 repair hypothesis
- Plain-language / overclaim audit — PASS: `hard_jargon_failures=0`; proof terms reviewed and kept only for commands, evidence, proof-gates, or explicit no-overclaim boundaries.
- Static added-line scan — PASS: 0 hardcoded-secret, shell-injection, dangerous-eval, unsafe-deserialization hits.
- `npm run build` — PASS.
- `npm test -- tests/cli-harness-backend.test.ts --run` — PASS, 1 file / 6 tests.
- `npm test` — PASS, 52 files / 553 tests.
- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn.
- `git diff --check` — PASS.
- `git diff --cached --check` — PASS.
- `node dist/cli.js doctor --check secret-scan` — PASS.
- Independent review — PASS; no blockers after staged diff review.

## Remaining owner gates

- Owner review and merge.
- npm publish remains owner-gated.
- GitHub Release create/update remains owner-gated.
- Full live reproduction remains owner-gated for runtime/cost.
- Any broad dominance claim remains gated by future Open Scaffold-run proof evidence.

## Authority note

No npm publish, no GitHub Release, and no merge authority are granted by this PR.
