### PR TITLE
docs: close harness release readiness plan

### DIFF
--- a/.osc/plans/done/159-harness-release-readiness.md
+++ b/.osc/plans/done/159-harness-release-readiness.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## PR association
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-10: closed 159-harness-release-readiness — PR #199 merged; harness release-readiness docs and command help parity are in main while npm publish and GitHub Release remain owner-gated.
 - 2026-06-10: closed 157-reproduction-proof-parity — PR #196 merged; reproduction proof parity shipped with Open Scaffold-owned bench suite, handoff lab, proof-gate, and benchmark feedback evidence.
 - 2026-06-09: closed 158-team-control-room-adapter-parity — Implemented team/control-room adapter contracts with shared lanes, gates, feedback, events, and docs.
 - 2026-06-09: closed 156-feedback-handoff-improvement-parity — Close feedback handoff improvement parity slice.

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('965a4d8ef23afaf943374c3aae9dc0b57024bc530de822d151446002d3a285ff');
+    expect(hash(planIssueSnapshot)).toBe('b5a1bdc2b0c886e5ff08cd904d1a5be6e957b8a180e6846559c9d831e1beb81a');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('0d25d1956dadf23eabaca3fea00baa7098217737a6455dcf69fc75b7fa341c98');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary

- Closes plan `159-harness-release-readiness` after PR #199 merged.
- Moves the plan from `.osc/plans/active/` to `.osc/plans/done/`.
- Sets the plan `## Status` body to `done`.
- Adds the close stamp to `MISSION.md`.
- Updates the live plan-corpus hash for the active-to-done move.

## Plan closed

- `.osc/plans/done/159-harness-release-readiness.md`
- Status: `done`

## Verification commands/results

- `git diff --check` — PASS
- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn
- `npm test -- --run tests/section-parser.test.ts` — PASS, 1 file / 7 tests
- `npm test` — PASS, 52 files / 553 tests
- `npm run build` — PASS
- `node dist/cli.js doctor --check secret-scan` — PASS
- `git diff --cached --check` — PASS
- Added-line safety scan — PASS, 0 secret/shell/eval/deserialization hits
- Independent staged-diff review — PASS, no blockers

## Remaining owner gates

- Owner review and merge of this closeout PR.
- npm publish remains separately owner-gated.
- GitHub Release creation/update remains separately owner-gated.
- Full live reproduction and any broad dominance claim remain gated by future owner-approved proof work.

## Authority note

This PR only closes the repo plan after PR #199. It does not publish npm, create or update a GitHub Release, merge itself, deploy anything, or move release authority into the harness.
