### PR TITLE
chore: prepare 0.31.1 harness readiness release

### DIFF
--- a/.osc/plans/active/160-harness-release-readiness-package-sync.md
+++ b/.osc/plans/active/160-harness-release-readiness-package-sync.md
@@ -1,0 +1,53 @@
+# Plan: 160-harness-release-readiness-package-sync
+
+## Status
+
+active
+
+## Context
+
+The harness release-readiness work and plan closeout are now on `main`. The repo has clearer public docs plus package-visible CLI help parity for `osc feedback --help` and `osc bench --help`, but npm and GitHub Latest Release still point at `0.31.0`. The owner approved publishing the next package and GitHub Release.
+
+## Goal
+
+Publish `open-scaffold@0.31.1` with dist-tag `latest`, verify the fresh package from outside the repo, create GitHub Release `v0.31.1` marked Latest, and close the release-sync evidence trail without upgrading the project to a 1.0 promise.
+
+## Constraints / Out of scope
+
+- Keep this as a pre-1.0 patch release on the `v0.31.x` hardening line.
+- Do not claim full live runtime stability, cost/token proof, broad benchmark dominance, compliance certification, or production readiness.
+- Use trusted publishing through `.github/workflows/publish-npm.yml`; do not add npm tokens or secrets.
+- Keep the release grounded in merged repo facts: harness docs/readiness, command-help parity, and plan closeout.
+- GitHub Release and npm publication are owner-approved for this slice, but future releases still need separate owner approval.
+
+## Files to touch
+
+- `package.json` and `package-lock.json` — bump package version to `0.31.1`.
+- `docs/CHANGELOG.md` — add the adoption-facing `v0.31.1` release entry.
+- `docs/VERSION_TRUTH.md` — distinguish repo candidate state from live npm/GitHub surfaces before publish, then record verified live truth after publish.
+- `.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md` — release-sync evidence note.
+- `.osc/plans/done/160-harness-release-readiness-package-sync.md` — this plan, moved to done after publication proof.
+
+## Acceptance criteria
+
+- [ ] `package.json`, `package-lock.json`, and the root lockfile package version all read `0.31.1`.
+- [ ] Release-truth docs distinguish candidate repo state from live npm/GitHub Release state before publish, then record verified live state after publish.
+- [ ] Local release gates pass: `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [ ] Release-sync PR CI is green and review/thread state is clean before merge.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.31.1` with `latest`, and fresh isolated-cache `npx open-scaffold@latest` proves the package surface from outside the repository.
+- [ ] GitHub Release `v0.31.1` exists, targets the merged `origin/main` release commit, is marked Latest, and uses release notes grounded in verified PR/evidence facts.
+
+## Verification steps
+
+1. `node -p "require('./package.json').version"` plus package-lock checks — expected `0.31.1` everywhere.
+2. `npm view open-scaffold version dist-tags --json --prefer-online` — expected `0.31.0` before publish and `0.31.1` after trusted publishing.
+3. `git diff --check` — expected no whitespace errors.
+4. `./verify.sh --strict` — expected no failures and no warnings.
+5. `npm test -- --run` and `npm run build` — expected pass.
+6. `npm run osc -- doctor --check secret-scan` — expected no issues.
+7. `npm pack --dry-run --json` and `npm publish --dry-run --tag latest` — expected package `open-scaffold@0.31.1` and successful dry-run.
+8. After merge/publish: trusted publishing workflow success, registry `0.31.1/latest`, fresh isolated-cache `npx` smoke, GitHub Release `v0.31.1` Latest, and this plan closed to `done`.
+
+## Open questions
+
+- None. The owner approved publishing after the harness readiness closeout; use `0.31.1` because this is a patch release for package-visible docs/help readiness on the existing `v0.31.x` line.

--- a/.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md
+++ b/.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md
@@ -13,7 +13,7 @@ The package-visible change is small and deliberate: public docs now explain curr
 - Source PRs: #192, #194, #195, #196, #197, #198, #199, and #200 in `graphanov/open-scaffold`.
 - Release-sync plan: `.osc/plans/active/160-harness-release-readiness-package-sync.md` before public proof; move to `done/` after publication proof.
 - Run ID / run packet: N/A for this scoped package/release sync.
-- Branch / PR: `release/0.31.1-harness-readiness-sync` / PR pending.
+- Branch / PR: `release/0.31.1-harness-readiness-sync` / https://github.com/graphanov/open-scaffold/pull/201.
 
 ## Verification
 

--- a/.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md
+++ b/.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md
@@ -1,0 +1,60 @@
+# Release / Evidence Note: 160-harness-release-readiness-package-sync
+
+## Summary
+
+Release-sync evidence for publishing the merged harness release-readiness work as `open-scaffold@0.31.1`.
+
+The package-visible change is small and deliberate: public docs now explain current harness maturity more plainly, and the shipped CLI includes top-level help parity for `osc feedback --help` and `osc bench --help`. This release remains pre-1.0 hardening. It does not claim full live runtime stability, cost/token proof, broad benchmark dominance, compliance certification, production readiness, or a mature 1.0 contract.
+
+## Traceability
+
+- Roadmap / issue / task: harness migration release-readiness package sync after the final harness docs/readiness PR and plan closeout.
+- Source plans: `.osc/plans/done/154-harness-command-surface.md`, `.osc/plans/done/155-controlled-runtime-parity.md`, `.osc/plans/done/156-feedback-handoff-improvement-parity.md`, `.osc/plans/done/157-reproduction-proof-parity.md`, `.osc/plans/done/158-team-control-room-adapter-parity.md`, and `.osc/plans/done/159-harness-release-readiness.md`.
+- Source PRs: #192, #194, #195, #196, #197, #198, #199, and #200 in `graphanov/open-scaffold`.
+- Release-sync plan: `.osc/plans/active/160-harness-release-readiness-package-sync.md` before public proof; move to `done/` after publication proof.
+- Run ID / run packet: N/A for this scoped package/release sync.
+- Branch / PR: `release/0.31.1-harness-readiness-sync` / PR pending.
+
+## Verification
+
+Baseline live-truth inspection before release-sync edits:
+
+- `git fetch --prune origin && git switch main && git pull --ff-only origin main` — PASS: local `main` up to date after PR #200 merge at `ea1ecd6ddde7fc38b5d0988033ad5f0e7f6cee04`.
+- `git status --short --branch` — PASS: clean `main...origin/main` before candidate branch.
+- `node -p "require('./package.json').version"` — PASS: `0.31.0` before candidate bump.
+- `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before candidate bump: `0.31.0`, `latest: 0.31.0`.
+- `gh release list --repo graphanov/open-scaffold --limit 3` — PASS before candidate bump: `v0.31.0 — Framework cleanup shrink release` is Latest.
+
+Candidate gates before PR-ready:
+
+- [x] Version alignment — PASS: `0.31.1 / 0.31.1 / 0.31.1` for `package.json`, `package-lock.json`, and lockfile root package version.
+- [x] `npm ci` — PASS: installed 88 packages; npm audit found 0 vulnerabilities.
+- [x] `git diff --check` — PASS.
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
+- [x] `npm test -- --run tests/section-parser.test.ts` — PASS: 1 file / 7 tests after intentional live-corpus hash updates.
+- [x] `npm test -- --run` — PASS: 52 files / 553 tests.
+- [x] `npm run build` — PASS: core TypeScript build and runtime-omx build.
+- [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
+- [x] `npm pack --dry-run --json` payload inspection after rebuilding — PASS for `open-scaffold@0.31.1`; entry count 236; no `__pycache__`/`.pyc` files; required CLI/docs files present.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.31.1` with tag `latest`.
+- [ ] Release candidate PR CI and review/thread gate.
+
+Post-merge/publication gates after owner-approved follow-through:
+
+- [ ] Sync clean `main` after release PR merge.
+- [ ] Main CI for release commit.
+- [ ] Post-merge local publish gates.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.31.1` with dist-tag `latest`.
+- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.31.1`, `latest: 0.31.1`.
+- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory passes.
+- [ ] Fresh isolated-cache smokes for `osc feedback --help` and `osc bench --help` pass from the published package.
+- [ ] GitHub Release `v0.31.1` exists, targets the merged `origin/main` release commit, and is marked Latest.
+- [ ] This plan is closed to `done` with final public proof.
+
+## Outcome
+
+Pending. This branch prepares the candidate package/release truth. Public npm and GitHub Release proof must be recorded after the release-sync PR merges and trusted publishing completes.
+
+## Follow-up
+
+- After publish and GitHub Release creation, update this note, `docs/CHANGELOG.md`, and `docs/VERSION_TRUTH.md` from candidate/pending to published/latest, then close plan `160-harness-release-readiness-package-sync`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,25 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.31.1 — Harness release readiness package sync
+
+Status: release candidate in repo. `package.json` is prepared for `open-scaffold@0.31.1`, while live npm and GitHub Latest Release remain at `0.31.0` until owner-approved trusted publishing and GitHub Release follow-through complete.
+
+Highlights:
+
+- Prepares the final harness migration docs/readiness work from PR #199 plus plan closeout from PR #200 for the public `npx open-scaffold@latest` package surface.
+- Makes top-level help for `osc feedback --help` and `osc bench --help` available in the package so the command maturity docs match real CLI behavior.
+- Keeps the harness release honest: current reproduction remains `partially_reproduced`, broad dominance remains `mixed_not_proven`, and live runtime spawning stays experimental/owner-gated.
+- Keeps Open Scaffold pre-1.0: this is a patch release for package-visible readiness/docs/help, not a 1.0 maturity claim.
+
+Evidence:
+
+- Source plan: `.osc/plans/done/159-harness-release-readiness.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/199
+- Source closeout PR: https://github.com/graphanov/open-scaffold/pull/200
+- Release-sync plan: `.osc/plans/active/160-harness-release-readiness-package-sync.md`
+- Release-sync evidence note: `.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md`
+
 ## v0.31.0 — Framework cleanup shrink release
 
 Status: published to npm as `open-scaffold@0.31.0`; GitHub Release `v0.31.0` is Latest after owner-approved trusted publishing and release follow-through.

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -4,9 +4,9 @@ This page is the canonical reconciliation between the current package version an
 
 ## Current line: `v0.31.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.31.0`.
-- **npm latest:** `0.31.0` with dist-tag `latest` after owner-approved trusted publishing; run `npm view open-scaffold version dist-tags --json` for live confirmation.
-- **GitHub Release latest:** `v0.31.0` is marked **Latest** after GitHub Release follow-through.
+- **Current `package.json` version:** `0.31.1` release candidate in the repository.
+- **npm latest:** `0.31.0` with dist-tag `latest` until owner-approved trusted publishing for `0.31.1` completes; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** `v0.31.0` is marked **Latest** until GitHub Release follow-through for `v0.31.1` completes.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.
@@ -19,13 +19,13 @@ Do not treat the repository version alone as proof of npm publication or GitHub 
 
 ## Stable vs experimental in the current line
 
-The `v0.31.x` line defines a stable-enough core (the repo-native work-record loop, the Status + seven content-heading plan schema, lifecycle helpers, first-run onboarding, PR-native structural checks, adapter trust inspection, command/schema registries, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). The framework cleanup shrink removed or repositioned older experimental helpers from the live reduced CLI; pin older package versions if you depend on those exact command shapes. See [`docs/STABILITY.md`](STABILITY.md) for the full listing.
+The `v0.31.x` line defines a stable-enough core (the repo-native work-record loop, the Status + seven content-heading plan schema, lifecycle helpers, first-run onboarding, PR-native structural checks, adapter trust inspection, command/schema registries, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). The `0.31.1` candidate publishes harness-readiness docs and command-help parity on top of the `0.31.0` framework cleanup line, but it does not change the pre-1.0 boundary. Pin older package versions if you depend on exact command shapes.
 
 ## Summary
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.31.0` |
+| `package.json` version | `0.31.1` candidate; npm latest remains `0.31.0` until publish |
 | Current package line | `v0.31.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,9 +244,9 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('b5a1bdc2b0c886e5ff08cd904d1a5be6e957b8a180e6846559c9d831e1beb81a');
+    expect(hash(planIssueSnapshot)).toBe('7c5a07ccf98ae4d1bd5c6625f498019bc06f86cc5144f01e0373f096a7c97b2e');
     expect(scaffold.failures).toEqual([]);
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('0d25d1956dadf23eabaca3fea00baa7098217737a6455dcf69fc75b7fa341c98');
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('60c4f8c59c490213148c726d731e40c41ae8330d3e9f73fe9e22261d7b821c85');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Bumps `open-scaffold` from `0.31.0` to `0.31.1` for the harness release-readiness package sync.
- Adds release-sync plan `160-harness-release-readiness-package-sync` and candidate evidence note.
- Updates changelog and version-truth docs to show candidate repo state while live npm/GitHub Release remain at `0.31.0` until trusted publishing completes.
- Keeps the release pre-1.0 and avoids claims of full live runtime stability, broad benchmark dominance, compliance, production readiness, or 1.0 maturity.

## Verification

- `npm ci` — PASS, 0 vulnerabilities
- `git diff --check` — PASS
- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn
- `npm test -- --run tests/section-parser.test.ts` — PASS, 1 file / 7 tests
- `npm test -- --run` — PASS, 52 files / 553 tests
- `npm run build` — PASS
- `npm run osc -- doctor --check secret-scan` — PASS
- `npm pack --dry-run --json` — PASS, `open-scaffold@0.31.1`, 236 files, no `__pycache__`/`.pyc`, required CLI/docs files present
- `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.31.1`
- Added-line safety scan — PASS, 0 secret/shell/eval/deserialization hits
- Independent staged-diff review — PASS, no blockers

## Release gates

After this PR merges:

- Run post-merge publish gates on clean `main`.
- Dispatch `.github/workflows/publish-npm.yml` with `expected-version=0.31.1` and `npm-tag=latest`.
- Verify npm registry and fresh isolated-cache `npx` command help.
- Create GitHub Release `v0.31.1` marked Latest against the release commit.
- Update release truth and close plan 160 after public proof exists.

No npm token/secrets are added by this PR.
