### PR TITLE
chore: close 0.31.1 harness release sync

### DIFF
--- a/.osc/plans/done/160-harness-release-readiness-package-sync.md
+++ b/.osc/plans/done/160-harness-release-readiness-package-sync.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
-The harness release-readiness work and plan closeout are now on `main`. The repo has clearer public docs plus package-visible CLI help parity for `osc feedback --help` and `osc bench --help`, but npm and GitHub Latest Release still point at `0.31.0`. The owner approved publishing the next package and GitHub Release.
+At plan start, the harness release-readiness work and plan closeout were on `main`. The repo had clearer public docs plus package-visible CLI help parity for `osc feedback --help` and `osc bench --help`, while npm and GitHub Latest Release still pointed at `0.31.0`. The owner approved publishing the next package and GitHub Release; the release follow-through now points npm `latest` and GitHub Latest Release at `0.31.1`.
 
 ## Goal
 
@@ -30,12 +30,12 @@ Publish `open-scaffold@0.31.1` with dist-tag `latest`, verify the fresh package 
 
 ## Acceptance criteria
 
-- [ ] `package.json`, `package-lock.json`, and the root lockfile package version all read `0.31.1`.
-- [ ] Release-truth docs distinguish candidate repo state from live npm/GitHub Release state before publish, then record verified live state after publish.
-- [ ] Local release gates pass: `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
-- [ ] Release-sync PR CI is green and review/thread state is clean before merge.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.31.1` with `latest`, and fresh isolated-cache `npx open-scaffold@latest` proves the package surface from outside the repository.
-- [ ] GitHub Release `v0.31.1` exists, targets the merged `origin/main` release commit, is marked Latest, and uses release notes grounded in verified PR/evidence facts.
+- [x] `package.json`, `package-lock.json`, and the root lockfile package version all read `0.31.1`.
+- [x] Release-truth docs distinguish candidate repo state from live npm/GitHub Release state before publish, then record verified live state after publish.
+- [x] Local release gates pass: `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Release-sync PR CI is green and review/thread state is clean before merge.
+- [x] Trusted publishing workflow publishes `open-scaffold@0.31.1` with `latest`, and fresh isolated-cache `npx open-scaffold@latest` proves the package surface from outside the repository.
+- [x] GitHub Release `v0.31.1` exists, targets the merged `origin/main` release commit, is marked Latest, and uses release notes grounded in verified PR/evidence facts.
 
 ## Verification steps
 

--- a/.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md
+++ b/.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md
@@ -11,7 +11,7 @@ The package-visible change is small and deliberate: public docs now explain curr
 - Roadmap / issue / task: harness migration release-readiness package sync after the final harness docs/readiness PR and plan closeout.
 - Source plans: `.osc/plans/done/154-harness-command-surface.md`, `.osc/plans/done/155-controlled-runtime-parity.md`, `.osc/plans/done/156-feedback-handoff-improvement-parity.md`, `.osc/plans/done/157-reproduction-proof-parity.md`, `.osc/plans/done/158-team-control-room-adapter-parity.md`, and `.osc/plans/done/159-harness-release-readiness.md`.
 - Source PRs: #192, #194, #195, #196, #197, #198, #199, and #200 in `graphanov/open-scaffold`.
-- Release-sync plan: `.osc/plans/active/160-harness-release-readiness-package-sync.md` before public proof; move to `done/` after publication proof.
+- Release-sync plan: `.osc/plans/done/160-harness-release-readiness-package-sync.md`.
 - Run ID / run packet: N/A for this scoped package/release sync.
 - Branch / PR: `release/0.31.1-harness-readiness-sync` / https://github.com/graphanov/open-scaffold/pull/201.
 
@@ -37,24 +37,24 @@ Candidate gates before PR-ready:
 - [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
 - [x] `npm pack --dry-run --json` payload inspection after rebuilding — PASS for `open-scaffold@0.31.1`; entry count 236; no `__pycache__`/`.pyc` files; required CLI/docs files present.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.31.1` with tag `latest`.
-- [ ] Release candidate PR CI and review/thread gate.
+- [x] Release candidate PR CI and review/thread gate — PASS: PR #201 CI green, evidence/plan checks green, latest-head Codex clean, and unresolved current Codex threads `0`.
 
 Post-merge/publication gates after owner-approved follow-through:
 
-- [ ] Sync clean `main` after release PR merge.
-- [ ] Main CI for release commit.
-- [ ] Post-merge local publish gates.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.31.1` with dist-tag `latest`.
-- [ ] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.31.1`, `latest: 0.31.1`.
-- [ ] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory passes.
-- [ ] Fresh isolated-cache smokes for `osc feedback --help` and `osc bench --help` pass from the published package.
-- [ ] GitHub Release `v0.31.1` exists, targets the merged `origin/main` release commit, and is marked Latest.
-- [ ] This plan is closed to `done` with final public proof.
+- [x] Sync clean `main` after release PR merge — PASS: local `main` fast-forwarded to `origin/main` at `42c6a3506dbc36c3ea748c633990c5e9bc02f4c1`.
+- [x] Main CI for release commit — PASS: https://github.com/graphanov/open-scaffold/actions/runs/27259171710.
+- [x] Post-merge local publish gates — PASS: `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Trusted publishing workflow publishes `open-scaffold@0.31.1` with dist-tag `latest` — PASS: https://github.com/graphanov/open-scaffold/actions/runs/27259297262.
+- [x] `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.31.1`, `latest: 0.31.1`.
+- [x] Fresh isolated-cache `npx --yes open-scaffold@latest --help` from an external temp directory passes.
+- [x] Fresh isolated-cache smokes for `osc feedback --help` and `osc bench --help` pass from the published package.
+- [x] GitHub Release `v0.31.1` exists, targets `42c6a3506dbc36c3ea748c633990c5e9bc02f4c1`, and is marked Latest: https://github.com/graphanov/open-scaffold/releases/tag/v0.31.1.
+- [x] This plan is closed to `done` with final public proof.
 
 ## Outcome
 
-Pending. This branch prepares the candidate package/release truth. Public npm and GitHub Release proof must be recorded after the release-sync PR merges and trusted publishing completes.
+Published and verified. `open-scaffold@0.31.1` is live on npm with dist-tag `latest`, fresh isolated-cache `npx open-scaffold@latest` and help smokes pass, and GitHub Release `v0.31.1` is marked Latest at the release commit.
 
 ## Follow-up
 
-- After publish and GitHub Release creation, update this note, `docs/CHANGELOG.md`, and `docs/VERSION_TRUTH.md` from candidate/pending to published/latest, then close plan `160-harness-release-readiness-package-sync`.
+- None for this release-sync slice after closeout PR merge. Future package-visible changes still require separate owner-approved release follow-through.

--- a/MISSION.md
+++ b/MISSION.md
@@ -29,6 +29,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-10: closed 160-harness-release-readiness-package-sync — Published open-scaffold@0.31.1, verified npm/latest and fresh npx help smokes, and created GitHub Release v0.31.1 as Latest.
 - 2026-06-10: closed 159-harness-release-readiness — PR #199 merged; harness release-readiness docs and command help parity are in main while npm publish and GitHub Release remain owner-gated.
 - 2026-06-10: closed 157-reproduction-proof-parity — PR #196 merged; reproduction proof parity shipped with Open Scaffold-owned bench suite, handoff lab, proof-gate, and benchmark feedback evidence.
 - 2026-06-09: closed 158-team-control-room-adapter-parity — Implemented team/control-room adapter contracts with shared lanes, gates, feedback, events, and docs.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,11 +6,11 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.31.1 — Harness release readiness package sync
 
-Status: release candidate in repo. `package.json` is prepared for `open-scaffold@0.31.1`, while live npm and GitHub Latest Release remain at `0.31.0` until owner-approved trusted publishing and GitHub Release follow-through complete.
+Status: published to npm as `open-scaffold@0.31.1`; GitHub Release `v0.31.1` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
-- Prepares the final harness migration docs/readiness work from PR #199 plus plan closeout from PR #200 for the public `npx open-scaffold@latest` package surface.
+- Publishes the final harness migration docs/readiness work from PR #199 plus plan closeout from PR #200 to the public `npx open-scaffold@latest` package surface.
 - Makes top-level help for `osc feedback --help` and `osc bench --help` available in the package so the command maturity docs match real CLI behavior.
 - Keeps the harness release honest: current reproduction remains `partially_reproduced`, broad dominance remains `mixed_not_proven`, and live runtime spawning stays experimental/owner-gated.
 - Keeps Open Scaffold pre-1.0: this is a patch release for package-visible readiness/docs/help, not a 1.0 maturity claim.
@@ -20,12 +20,13 @@ Evidence:
 - Source plan: `.osc/plans/done/159-harness-release-readiness.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/199
 - Source closeout PR: https://github.com/graphanov/open-scaffold/pull/200
-- Release-sync plan: `.osc/plans/active/160-harness-release-readiness-package-sync.md`
+- Release-sync plan: `.osc/plans/done/160-harness-release-readiness-package-sync.md`
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/201
 - Release-sync evidence note: `.osc/releases/2026-06-10-160-harness-release-readiness-package-sync.md`
 
 ## v0.31.0 — Framework cleanup shrink release
 
-Status: published to npm as `open-scaffold@0.31.0`; GitHub Release `v0.31.0` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.31.0`; GitHub Release `v0.31.0` was Latest after owner-approved trusted publishing and release follow-through, then was superseded by `v0.31.1`.
 
 Highlights:
 

--- a/docs/VERSION_TRUTH.md
+++ b/docs/VERSION_TRUTH.md
@@ -4,9 +4,9 @@ This page is the canonical reconciliation between the current package version an
 
 ## Current line: `v0.31.x` (pre-1.0 hardening)
 
-- **Current `package.json` version:** `0.31.1` release candidate in the repository.
-- **npm latest:** `0.31.0` with dist-tag `latest` until owner-approved trusted publishing for `0.31.1` completes; run `npm view open-scaffold version dist-tags --json` for live confirmation.
-- **GitHub Release latest:** `v0.31.0` is marked **Latest** until GitHub Release follow-through for `v0.31.1` completes.
+- **Current `package.json` version:** `0.31.1`.
+- **npm latest:** `0.31.1` with dist-tag `latest` after owner-approved trusted publishing; run `npm view open-scaffold version dist-tags --json` for live confirmation.
+- **GitHub Release latest:** `v0.31.1` is marked **Latest** after GitHub Release follow-through.
 - **Maturity:** pre-1.0 hardening. The core work-record protocol is usable, but the public product surface, runtime boundary, and adoption story are still moving. See [`docs/STABILITY.md`](STABILITY.md) for the full stable-vs-experimental boundary.
 
 Do not treat the repository version alone as proof of npm publication or GitHub Release movement. Verify the registry and release surfaces separately.
@@ -19,13 +19,13 @@ Do not treat the repository version alone as proof of npm publication or GitHub 
 
 ## Stable vs experimental in the current line
 
-The `v0.31.x` line defines a stable-enough core (the repo-native work-record loop, the Status + seven content-heading plan schema, lifecycle helpers, first-run onboarding, PR-native structural checks, adapter trust inspection, command/schema registries, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). The `0.31.1` candidate publishes harness-readiness docs and command-help parity on top of the `0.31.0` framework cleanup line, but it does not change the pre-1.0 boundary. Pin older package versions if you depend on exact command shapes.
+The `v0.31.x` line defines a stable-enough core (the repo-native work-record loop, the Status + seven content-heading plan schema, lifecycle helpers, first-run onboarding, PR-native structural checks, adapter trust inspection, command/schema registries, and read-only commands such as `osc compare` and `osc trace`) alongside explicitly experimental surfaces (runtime launch, dashboards, cockpit transports, evaluation helpers, MCP interface). `0.31.1` publishes harness-readiness docs and command-help parity on top of the `0.31.0` framework cleanup line, but it does not change the pre-1.0 boundary. Pin older package versions if you depend on exact command shapes.
 
 ## Summary
 
 | Surface | Value |
 |---|---|
-| `package.json` version | `0.31.1` candidate; npm latest remains `0.31.0` until publish |
+| `package.json` version | `0.31.1` |
 | Current package line | `v0.31.x` (pre-1.0) |
 | Most recent historical tag | `v1.0.5` |
 | Historical package line | `v1.0.x` (over-eager launch; not current) |

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('7c5a07ccf98ae4d1bd5c6625f498019bc06f86cc5144f01e0373f096a7c97b2e');
+    expect(hash(planIssueSnapshot)).toBe('68cdf3850cdfecef11991fc235961c174f3f9a10f62526504fdf53fe0664e843');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('60c4f8c59c490213148c726d731e40c41ae8330d3e9f73fe9e22261d7b821c85');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);


### PR DESCRIPTION
## Summary

- Closes release-sync plan `160-harness-release-readiness-package-sync` after public proof exists.
- Moves the plan to `.osc/plans/done/` and sets status to `done`.
- Updates the release evidence note, changelog, and version-truth docs from candidate/pending to published/latest.
- Records that `open-scaffold@0.31.1` is live on npm and GitHub Release `v0.31.1` is Latest.

## Public proof

- npm `open-scaffold@latest`: `0.31.1`
- Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/27259297262
- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.31.1
- Release commit: `42c6a3506dbc36c3ea748c633990c5e9bc02f4c1`
- Fresh isolated-cache `npx` smokes passed:
  - `npx --yes open-scaffold@latest --help`
  - `npx --yes --package open-scaffold@latest osc feedback --help`
  - `npx --yes --package open-scaffold@latest osc bench --help`
  - `npx --yes --package open-scaffold@latest osc --version` -> `0.31.1`

## Verification

- `git diff --check` — PASS
- `./verify.sh --strict` — PASS, 10 pass / 0 fail / 0 warn
- `npm test -- --run tests/section-parser.test.ts` — PASS, 1 file / 7 tests
- `npm test -- --run` — PASS, 52 files / 553 tests
- `npm run build` — PASS
- `npm run osc -- doctor --check secret-scan` — PASS
- `git diff --cached --check` — PASS
- Added-line safety scan — PASS, 0 secret/shell/eval/deserialization hits
- Independent staged-diff review — PASS after stale-truth wording fix

## Boundaries

- This closes the `0.31.1` release-sync evidence trail.
- Open Scaffold remains pre-1.0.
- This does not claim full live runtime stability, broad benchmark dominance, compliance, production readiness, or 1.0 maturity.
