### PR TITLE
feat: proof harness v2 — plan 163 activation and usage receipt ledger

### DIFF
--- a/.osc/plans/active/163-proof-harness-v2-amendment-1.md
+++ b/.osc/plans/active/163-proof-harness-v2-amendment-1.md
@@ -1,0 +1,25 @@
+# Amendment 1: 163-proof-harness-v2
+
+## Parent
+
+163-proof-harness-v2
+
+## Date
+
+2026-06-10
+
+## Learning
+
+Three things got clearer since the plan was committed. First, the evolve loop is the undersold feature: the 2000m v1 postmortem showed both lanes burning five blind generations past a plateau because nothing flagged it, and `osc evolve analyze` now detects exactly that (plateau, probe-only/impossible ACs, stop/redesign recommendations) — so the retry-trap benchmark is not just a measurement, it is the evolve showcase, with the postmortem as the documented before-picture. Second, benchmark results should not be only code and text: a visual substrate (a game) makes blinded judging tangible, gives multi-slice a product shape, and produces demoable output — and the 2000m postmortem already prescribed a replay/viewer track for headless artifacts. Third, the owner currently runs on a Claude subscription with no API credits, so cost is measured in captured token counts, not billed dollars.
+
+## New direction
+
+Three preregistered mechanism benchmarks — cold-resume, retry-trap, multi-slice — run on one shared visual substrate: a seeded canvas game with a deterministic event-log replay format, specified and scored in an independent benchmark repo (per the 2026-06-01 correction: open-scaffold hosts no benchmark-specific fixtures or scorers). Three arms per benchmark: A naked model, B naked plus a one-page minimal checklist (the control the June 3 reset doc called for), C open-scaffold with the evolve loop driving record/analyze/stop decisions. Execution lane: Claude headless (`claude -p`) on the owner's subscription. Every run captures token usage from the CLI's JSON usage fields, wall time, turn count, and completion state into committed receipts; mechanical ACs score only from deterministic replays, aesthetic quality goes only to a blinded vision judge over screenshots; results render in a replay viewer and comparison dashboard, not just tables.
+
+## Impact on acceptance criteria
+
+- AC1 (cold-resume), AC2 (retry-trap), AC3 (multi-slice): intent unchanged; all three now share the seeded-game substrate and run three arms instead of two (adds the minimal-checklist control, resolving that open question). AC2 additionally reports the scaffold arm's `osc evolve analyze` recommendation trace alongside tokens-before-correct-stop.
+- AC4 (raw data traceability): unchanged; receipts JSONL additionally records `usage_source: claude-cli-subscription` and omits billed USD rather than inventing it — token counts are the budget metric, consistent with the evolution-loop usage contract.
+- AC5 (README headline numbers): unchanged.
+- Files to touch deviates: benchmark fixtures, scorer, preregistration, runner, and dashboard live in the independent benchmark repo (`harness-bench`), not `examples/proof/`; open-scaffold keeps `src/usage.ts`, generic receipt-ingestion glue, and `docs/PROOF_HARNESS.md`.
+- Open questions resolved: minimal-checklist control arm is in; lane is Claude-first (codex/OMX lane deferred); judge model decision deferred to preregistration review before any scored run.

--- a/.osc/plans/active/163-proof-harness-v2.md
+++ b/.osc/plans/active/163-proof-harness-v2.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-backlog
+active
 
 ## Context
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -28,6 +28,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-10: Lock the v2 design: the three mechanism benchmarks run on one shared visual substrate (a seeded canvas game with deterministic event-log replays) built in an independent benchmark repo per the 2026-06-01 correction; arms are naked, naked+minimal-checklist, and open-scaffold with the evolve loop as the retry-trap instrument; execution lane is Claude headless on subscription, so budget is recorded as captured token counts from CLI usage fields, never invented USD. — see .osc/plans/active/163-proof-harness-v2-amendment-1.md
 - 2026-06-10: closed 161-harness-identity-pivot — harness identity pivot and docs<=25 shipped via PR #205
 - 2026-06-10: closed 162-surface-collapse-and-resume — osc resume + one-screen surface shipped via PR #204
 - 2026-06-10: ratified the harness-identity pivot — the harness is the product, the work record is its substrate; supersedes the 2026-05-15 orchestration stance — see .osc/plans/done/161-harness-identity-pivot.md

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -231,8 +231,8 @@ export function aggregateUsage(receipts: UsageReceipt[]): UsageLedger {
     row.numTurns += receipt.num_turns ?? 0;
     row.durationMs += receipt.duration_ms ?? 0;
 
-    // Cost honesty: if ANY receipt in the group lacks a numeric cost, null the group
-    const hasCost = typeof receipt.total_cost_usd === 'number';
+    // Cost honesty: if ANY receipt in the group lacks a numeric cost, null the group.
+    const hasCost = typeof receipt.total_cost_usd === 'number' && !receipt.usage_source.includes('subscription');
     if (!hasCost) {
       groupCostComplete.set(key, false);
     }

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -136,8 +136,8 @@ export function parseUsageReceipts(jsonl: string): { receipts: UsageReceipt[]; i
         total_cost_usd = null;
       } else {
         const n = asFiniteNumber(raw);
-        if (n === null) {
-          issues.push(`line ${lineNum}: total_cost_usd must be a finite number or null`);
+        if (n === null || n < 0) {
+          issues.push(`line ${lineNum}: total_cost_usd must be a non-negative finite number or null`);
           continue;
         }
         total_cost_usd = n;

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -43,8 +43,8 @@ export interface UsageLedgerRow {
   outputTokens: number;
   cacheCreationInputTokens: number;
   cacheReadInputTokens: number;
-  numTurns: number;
-  durationMs: number;
+  numTurns: number | null;
+  durationMs: number | null;
   /** null unless EVERY receipt in the group carries a numeric total_cost_usd */
   costUsdTotal: number | null;
 }
@@ -228,8 +228,8 @@ export function aggregateUsage(receipts: UsageReceipt[]): UsageLedger {
     row.outputTokens += receipt.usage.output_tokens ?? 0;
     row.cacheCreationInputTokens += receipt.usage.cache_creation_input_tokens ?? 0;
     row.cacheReadInputTokens += receipt.usage.cache_read_input_tokens ?? 0;
-    row.numTurns += receipt.num_turns ?? 0;
-    row.durationMs += receipt.duration_ms ?? 0;
+    row.numTurns = row.numTurns === null || receipt.num_turns === undefined ? null : row.numTurns + receipt.num_turns;
+    row.durationMs = row.durationMs === null || receipt.duration_ms === undefined ? null : row.durationMs + receipt.duration_ms;
 
     // Cost honesty: if ANY receipt in the group lacks a numeric cost, null the group.
     const hasCost = typeof receipt.total_cost_usd === 'number' && !receipt.usage_source.includes('subscription');

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -90,9 +90,8 @@ function parseUsageTokens(raw: unknown): { tokens: UsageTokens; valid: boolean }
 export function parseUsageReceipts(jsonl: string): { receipts: UsageReceipt[]; issues: string[] } {
   const receipts: UsageReceipt[] = [];
   const issues: string[] = [];
-
   const lines = jsonl.split('\n');
-  for (let i = 0; i < lines.length; i++) {
+  lineLoop: for (let i = 0; i < lines.length; i++) {
     const line = lines[i].trim();
     if (line.length === 0) continue;
     const lineNum = i + 1;
@@ -163,12 +162,13 @@ export function parseUsageReceipts(jsonl: string): { receipts: UsageReceipt[]; i
     if (seed !== undefined) receipt.seed = seed;
     const replicate = asNonNegativeInteger(parsed.replicate);
     if (replicate !== undefined) receipt.replicate = replicate;
-    const duration_ms = asNonNegativeInteger(parsed.duration_ms);
-    if (duration_ms !== undefined) receipt.duration_ms = duration_ms;
-    const duration_api_ms = asNonNegativeInteger(parsed.duration_api_ms);
-    if (duration_api_ms !== undefined) receipt.duration_api_ms = duration_api_ms;
-    const num_turns = asNonNegativeInteger(parsed.num_turns);
-    if (num_turns !== undefined) receipt.num_turns = num_turns;
+    for (const key of ['duration_ms', 'duration_api_ms', 'num_turns'] as const) {
+      if (Object.hasOwn(parsed, key)) {
+        const value = asNonNegativeInteger(parsed[key]);
+        if (value === undefined) { issues.push(`line ${lineNum}: ${key} must be a non-negative integer`); continue lineLoop; }
+        receipt[key] = value;
+      }
+    }
 
     if (total_cost_usd !== undefined) receipt.total_cost_usd = total_cost_usd;
 

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,277 @@
+// usage.ts — benchmark-neutral usage-receipt ledger
+// Ingests run-receipt JSONL, aggregates per (benchmark, task_id, arm),
+// and renders a markdown table.
+//
+// Cost honesty rule: USD totals are NEVER summed from partial data. The
+// evolution-loop contract forbids invented USD figures — if any receipt in a
+// group is missing or null for total_cost_usd, the entire group's costUsdTotal
+// is null. This mirrors the telemetry-completeness discipline in evolution.ts.
+
+export interface UsageTokens {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+export interface UsageReceipt {
+  run_id: string;
+  benchmark?: string;
+  task_id?: string;
+  arm?: string;
+  seed?: number;
+  replicate?: number;
+  phase?: string;
+  model?: string;
+  started_at?: string;
+  duration_ms?: number;
+  duration_api_ms?: number;
+  num_turns?: number;
+  usage: UsageTokens;
+  total_cost_usd?: number | null;
+  usage_source: string;
+  session_id?: string;
+  schema?: string;
+}
+
+export interface UsageLedgerRow {
+  benchmark: string;
+  task_id: string;
+  arm: string;
+  runCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  numTurns: number;
+  durationMs: number;
+  /** null unless EVERY receipt in the group carries a numeric total_cost_usd */
+  costUsdTotal: number | null;
+}
+
+export interface UsageLedger {
+  rows: UsageLedgerRow[];
+  issues: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function asNonNegativeInteger(value: unknown): number | undefined {
+  if (typeof value !== 'number') return undefined;
+  if (!Number.isInteger(value) || value < 0) return undefined;
+  return value;
+}
+
+function parseUsageTokens(raw: unknown): { tokens: UsageTokens; valid: boolean } {
+  if (!isRecord(raw)) return { tokens: {}, valid: false };
+  const tokens: UsageTokens = {};
+  let hasAtLeastOne = false;
+  for (const key of ['input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens'] as const) {
+    if (Object.hasOwn(raw, key)) {
+      const parsed = asNonNegativeInteger(raw[key]);
+      if (parsed === undefined) return { tokens: {}, valid: false };
+      tokens[key] = parsed;
+      hasAtLeastOne = true;
+    }
+  }
+  return { tokens, valid: hasAtLeastOne };
+}
+
+export function parseUsageReceipts(jsonl: string): { receipts: UsageReceipt[]; issues: string[] } {
+  const receipts: UsageReceipt[] = [];
+  const issues: string[] = [];
+
+  const lines = jsonl.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    const lineNum = i + 1;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      issues.push(`line ${lineNum}: invalid JSON`);
+      continue;
+    }
+
+    if (!isRecord(parsed)) {
+      issues.push(`line ${lineNum}: expected a JSON object`);
+      continue;
+    }
+
+    const run_id = asString(parsed.run_id);
+    if (!run_id) {
+      issues.push(`line ${lineNum}: missing required field run_id`);
+      continue;
+    }
+
+    const usage_source = asString(parsed.usage_source);
+    if (!usage_source) {
+      issues.push(`line ${lineNum}: missing required field usage_source`);
+      continue;
+    }
+
+    const { tokens, valid: usageValid } = parseUsageTokens(parsed.usage);
+    if (!usageValid) {
+      issues.push(`line ${lineNum}: usage object must be present with at least one non-negative integer token field`);
+      continue;
+    }
+
+    // total_cost_usd: accept null, a finite number, or absent
+    let total_cost_usd: number | null | undefined;
+    if (Object.hasOwn(parsed, 'total_cost_usd')) {
+      const raw = parsed.total_cost_usd;
+      if (raw === null) {
+        total_cost_usd = null;
+      } else {
+        const n = asFiniteNumber(raw);
+        if (n === null) {
+          issues.push(`line ${lineNum}: total_cost_usd must be a finite number or null`);
+          continue;
+        }
+        total_cost_usd = n;
+      }
+    }
+
+    const receipt: UsageReceipt = {
+      run_id,
+      usage: tokens,
+      usage_source,
+    };
+
+    if (typeof parsed.benchmark === 'string') receipt.benchmark = parsed.benchmark;
+    if (typeof parsed.task_id === 'string') receipt.task_id = parsed.task_id;
+    if (typeof parsed.arm === 'string') receipt.arm = parsed.arm;
+    if (typeof parsed.model === 'string') receipt.model = parsed.model;
+    if (typeof parsed.started_at === 'string') receipt.started_at = parsed.started_at;
+    if (typeof parsed.phase === 'string') receipt.phase = parsed.phase;
+    if (typeof parsed.session_id === 'string') receipt.session_id = parsed.session_id;
+    if (typeof parsed.schema === 'string') receipt.schema = parsed.schema;
+
+    const seed = asNonNegativeInteger(parsed.seed);
+    if (seed !== undefined) receipt.seed = seed;
+    const replicate = asNonNegativeInteger(parsed.replicate);
+    if (replicate !== undefined) receipt.replicate = replicate;
+    const duration_ms = asNonNegativeInteger(parsed.duration_ms);
+    if (duration_ms !== undefined) receipt.duration_ms = duration_ms;
+    const duration_api_ms = asNonNegativeInteger(parsed.duration_api_ms);
+    if (duration_api_ms !== undefined) receipt.duration_api_ms = duration_api_ms;
+    const num_turns = asNonNegativeInteger(parsed.num_turns);
+    if (num_turns !== undefined) receipt.num_turns = num_turns;
+
+    if (total_cost_usd !== undefined) receipt.total_cost_usd = total_cost_usd;
+
+    receipts.push(receipt);
+  }
+
+  return { receipts, issues };
+}
+
+type GroupKey = string;
+
+function groupKey(receipt: UsageReceipt): GroupKey {
+  return `${receipt.benchmark ?? ''}\0${receipt.task_id ?? ''}\0${receipt.arm ?? ''}`;
+}
+
+export function aggregateUsage(receipts: UsageReceipt[]): UsageLedger {
+  const issues: string[] = [];
+  const rowMap = new Map<GroupKey, UsageLedgerRow>();
+  const groupCostComplete = new Map<GroupKey, boolean>();
+  const seenRunIds = new Map<string, number>();
+
+  for (const receipt of receipts) {
+    const idx = seenRunIds.get(receipt.run_id);
+    if (idx !== undefined) {
+      issues.push(`duplicate run_id: ${receipt.run_id}`);
+    } else {
+      seenRunIds.set(receipt.run_id, receipts.indexOf(receipt));
+    }
+
+    // Flag subscription receipts that carry a numeric USD cost
+    if (receipt.usage_source.includes('subscription') && typeof receipt.total_cost_usd === 'number') {
+      issues.push(`run_id ${receipt.run_id}: usage_source contains "subscription" but total_cost_usd is ${receipt.total_cost_usd} (inconsistent billing claim)`);
+    }
+
+    const key = groupKey(receipt);
+    let row = rowMap.get(key);
+    if (!row) {
+      row = {
+        benchmark: receipt.benchmark ?? '',
+        task_id: receipt.task_id ?? '',
+        arm: receipt.arm ?? '',
+        runCount: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        numTurns: 0,
+        durationMs: 0,
+        costUsdTotal: 0,
+      };
+      rowMap.set(key, row);
+      groupCostComplete.set(key, true);
+    }
+
+    row.runCount += 1;
+    row.inputTokens += receipt.usage.input_tokens ?? 0;
+    row.outputTokens += receipt.usage.output_tokens ?? 0;
+    row.cacheCreationInputTokens += receipt.usage.cache_creation_input_tokens ?? 0;
+    row.cacheReadInputTokens += receipt.usage.cache_read_input_tokens ?? 0;
+    row.numTurns += receipt.num_turns ?? 0;
+    row.durationMs += receipt.duration_ms ?? 0;
+
+    // Cost honesty: if ANY receipt in the group lacks a numeric cost, null the group
+    const hasCost = typeof receipt.total_cost_usd === 'number';
+    if (!hasCost) {
+      groupCostComplete.set(key, false);
+    }
+    if (hasCost && groupCostComplete.get(key)) {
+      row.costUsdTotal = (row.costUsdTotal ?? 0) + (receipt.total_cost_usd as number);
+    }
+  }
+
+  // Apply cost honesty rule: zero out groups that aren't fully costed
+  for (const [key, complete] of groupCostComplete) {
+    const row = rowMap.get(key);
+    if (row && !complete) {
+      row.costUsdTotal = null;
+    }
+  }
+
+  // Stable sort: benchmark, then task_id, then arm
+  const rows = [...rowMap.values()].sort((a, b) => {
+    const bCmp = a.benchmark.localeCompare(b.benchmark);
+    if (bCmp !== 0) return bCmp;
+    const tCmp = a.task_id.localeCompare(b.task_id);
+    if (tCmp !== 0) return tCmp;
+    return a.arm.localeCompare(b.arm);
+  });
+
+  return { rows, issues };
+}
+
+export function renderUsageLedger(ledger: UsageLedger): string {
+  const lines: string[] = [];
+  lines.push('| benchmark | task_id | arm | runs | input_tokens | output_tokens | cache_creation_tokens | cache_read_tokens | num_turns | duration_ms | cost_usd |');
+  lines.push('|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|');
+
+  for (const row of ledger.rows) {
+    const cost = row.costUsdTotal === null ? 'null' : row.costUsdTotal.toFixed(6);
+    lines.push(
+      `| ${row.benchmark} | ${row.task_id} | ${row.arm} | ${row.runCount} | ${row.inputTokens} | ${row.outputTokens} | ${row.cacheCreationInputTokens} | ${row.cacheReadInputTokens} | ${row.numTurns} | ${row.durationMs} | ${cost} |`,
+    );
+  }
+
+  return `${lines.join('\n')}\n`;
+}

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -39,10 +39,10 @@ export interface UsageLedgerRow {
   task_id: string;
   arm: string;
   runCount: number;
-  inputTokens: number;
-  outputTokens: number;
-  cacheCreationInputTokens: number;
-  cacheReadInputTokens: number;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheCreationInputTokens: number | null;
+  cacheReadInputTokens: number | null;
   numTurns: number | null;
   durationMs: number | null;
   /** null unless EVERY receipt in the group carries a numeric total_cost_usd */
@@ -183,7 +183,7 @@ type GroupKey = string;
 function groupKey(receipt: UsageReceipt): GroupKey {
   return `${receipt.benchmark ?? ''}\0${receipt.task_id ?? ''}\0${receipt.arm ?? ''}`;
 }
-
+const sumKnown = (total: number | null, value: number | undefined): number | null => (total === null || value === undefined ? null : total + value);
 export function aggregateUsage(receipts: UsageReceipt[]): UsageLedger {
   const issues: string[] = [];
   const rowMap = new Map<GroupKey, UsageLedgerRow>();
@@ -224,12 +224,12 @@ export function aggregateUsage(receipts: UsageReceipt[]): UsageLedger {
     }
 
     row.runCount += 1;
-    row.inputTokens += receipt.usage.input_tokens ?? 0;
-    row.outputTokens += receipt.usage.output_tokens ?? 0;
-    row.cacheCreationInputTokens += receipt.usage.cache_creation_input_tokens ?? 0;
-    row.cacheReadInputTokens += receipt.usage.cache_read_input_tokens ?? 0;
-    row.numTurns = row.numTurns === null || receipt.num_turns === undefined ? null : row.numTurns + receipt.num_turns;
-    row.durationMs = row.durationMs === null || receipt.duration_ms === undefined ? null : row.durationMs + receipt.duration_ms;
+    row.inputTokens = sumKnown(row.inputTokens, receipt.usage.input_tokens);
+    row.outputTokens = sumKnown(row.outputTokens, receipt.usage.output_tokens);
+    row.cacheCreationInputTokens = sumKnown(row.cacheCreationInputTokens, receipt.usage.cache_creation_input_tokens);
+    row.cacheReadInputTokens = sumKnown(row.cacheReadInputTokens, receipt.usage.cache_read_input_tokens);
+    row.numTurns = sumKnown(row.numTurns, receipt.num_turns);
+    row.durationMs = sumKnown(row.durationMs, receipt.duration_ms);
 
     // Cost honesty: if ANY receipt in the group lacks a numeric cost, null the group.
     const hasCost = typeof receipt.total_cost_usd === 'number' && !receipt.usage_source.includes('subscription');

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -15,8 +15,9 @@ const cleanupBaselineLoc = 20_890;
 // Surface collapse and resume (plan 162) adds the read-only resume packet compiler, the core/full help split, and the shared packet redaction helper.
 // Codex hardening for plan 162 redacts JSON/run/plan identifiers, missing-plan errors, workspace paths, .osc/run/evidence/lesson symlinks and unsafe lesson roots/stores, mission/plan-file/stage/root symlinks, and fixes final evidence-before-verify resume guidance.
 // Docs-tranche downstream template hardening adds a standard-tier task/run template so generated scaffolds avoid broken links to max-tier docs.
-const cleanupTargetLoc = 16_091;
-const cleanupTargetFiles = 39;
+// 163: +src/usage.ts usage-receipt ledger (+277 LOC, +1 file)
+const cleanupTargetLoc = 16_368;
+const cleanupTargetFiles = 40;
 
 interface MaintainedSourceFile {
   path: string;
@@ -58,7 +59,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(16_091);
+    expect(cleanupTargetLoc).toBe(16_368);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,7 +244,7 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    expect(hash(planIssueSnapshot)).toBe('e6ada4ed20e4d014ddf10687d4cc5e6407c50470f376e6a3496beff5be63a3b7');
+    expect(hash(planIssueSnapshot)).toBe('078e2bf30510e4859ae1176ac982148b97fd0ec104e46124b457d462576ad8ab');
     expect(scaffold.failures).toEqual([]);
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('60c4f8c59c490213148c726d731e40c41ae8330d3e9f73fe9e22261d7b821c85');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -163,7 +163,7 @@ describe('aggregateUsage', () => {
     ].join('\n'));
     const ledger = aggregateUsage(receipts);
     expect(ledger.rows).toHaveLength(1);
-    expect([ledger.rows[0].runCount, ledger.rows[0].inputTokens, ledger.rows[0].outputTokens, ledger.rows[0].numTurns, ledger.rows[0].durationMs]).toEqual([2, 400, 600, null, null]);
+    expect([ledger.rows[0].runCount, ledger.rows[0].inputTokens, ledger.rows[0].outputTokens, ledger.rows[0].cacheCreationInputTokens, ledger.rows[0].cacheReadInputTokens, ledger.rows[0].numTurns, ledger.rows[0].durationMs]).toEqual([2, 400, 600, null, null, null, null]);
   });
 
   it('keeps separate groups for different arms', () => {
@@ -319,8 +319,8 @@ describe('renderUsageLedger', () => {
     const expected = [
       '| benchmark | task_id | arm | runs | input_tokens | output_tokens | cache_creation_tokens | cache_read_tokens | num_turns | duration_ms | cost_usd |',
       '|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|',
-      '| bench-a | T1 | ctrl | 1 | 100 | 200 | 0 | 0 | 14 | 184211 | null |',
-      '| bench-a | T1 | scaf | 1 | 150 | 250 | 0 | 0 | 14 | 184211 | null |',
+      '| bench-a | T1 | ctrl | 1 | 100 | 200 | null | null | 14 | 184211 | null |',
+      '| bench-a | T1 | scaf | 1 | 150 | 250 | null | null | 14 | 184211 | null |',
       '',
     ].join('\n');
     expect(output).toBe(expected);

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -133,11 +133,11 @@ describe('parseUsageReceipts', () => {
     expect(receipts[0].usage.cache_read_input_tokens).toBeUndefined();
   });
 
-  it('rejects receipts where total_cost_usd is a non-finite value', () => {
-    const line = JSON.stringify({ ...baseReceipt, total_cost_usd: 'free' });
-    const { receipts, issues } = parseUsageReceipts(line);
-    expect(issues).toHaveLength(1);
-    expect(receipts).toHaveLength(0);
+  it('rejects receipts where total_cost_usd is non-finite or negative', () => {
+    for (const total_cost_usd of ['free', -0.01]) {
+      const { receipts, issues } = parseUsageReceipts(JSON.stringify({ ...baseReceipt, total_cost_usd }));
+      expect([issues.length, receipts.length]).toEqual([1, 0]);
+    }
   });
 
   it('accepts total_cost_usd as a numeric value', () => {

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -158,14 +158,12 @@ describe('parseUsageReceipts', () => {
 describe('aggregateUsage', () => {
   it('groups by benchmark, task_id, arm and sums tokens across receipts', () => {
     const { receipts } = parseUsageReceipts([
-      JSON.stringify({ ...baseReceipt, run_id: 'r1', usage: { input_tokens: 100, output_tokens: 200 } }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', usage: { input_tokens: 100, output_tokens: 200 }, num_turns: undefined, duration_ms: undefined }),
       JSON.stringify({ ...baseReceipt, run_id: 'r2', usage: { input_tokens: 300, output_tokens: 400 } }),
     ].join('\n'));
     const ledger = aggregateUsage(receipts);
     expect(ledger.rows).toHaveLength(1);
-    expect(ledger.rows[0].runCount).toBe(2);
-    expect(ledger.rows[0].inputTokens).toBe(400);
-    expect(ledger.rows[0].outputTokens).toBe(600);
+    expect([ledger.rows[0].runCount, ledger.rows[0].inputTokens, ledger.rows[0].outputTokens, ledger.rows[0].numTurns, ledger.rows[0].durationMs]).toEqual([2, 400, 600, null, null]);
   });
 
   it('keeps separate groups for different arms', () => {

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -211,12 +211,12 @@ describe('aggregateUsage', () => {
     expect(ledger.rows[0].costUsdTotal).toBeNull();
   });
 
-  it('flags subscription receipts that carry a numeric total_cost_usd', () => {
+  it('flags subscription receipts that carry a numeric total_cost_usd and keeps cost unknown', () => {
     const { receipts } = parseUsageReceipts(
       JSON.stringify({ ...baseReceipt, run_id: 'r1', usage_source: 'claude-cli-subscription', total_cost_usd: 1.23 }),
     );
     const ledger = aggregateUsage(receipts);
-    expect(ledger.issues.some((i) => i.includes('subscription') && i.includes('inconsistent billing claim'))).toBe(true);
+    expect([ledger.issues.some((i) => i.includes('subscription') && i.includes('inconsistent billing claim')), ledger.rows[0].costUsdTotal]).toEqual([true, null]);
   });
 
   it('does not flag subscription receipts with null total_cost_usd', () => {

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -108,11 +108,11 @@ describe('parseUsageReceipts', () => {
     expect(receipts).toHaveLength(0);
   });
 
-  it('rejects receipts where a token field is negative', () => {
-    const line = JSON.stringify({ ...baseReceipt, usage: { input_tokens: -1 } });
-    const { receipts, issues } = parseUsageReceipts(line);
-    expect(issues).toHaveLength(1);
-    expect(receipts).toHaveLength(0);
+  it('rejects receipts where token or timing fields are malformed', () => {
+    for (const patch of [{ usage: { input_tokens: -1 } }, { duration_ms: -1 }, { num_turns: 'bad' }]) {
+      const { receipts, issues } = parseUsageReceipts(JSON.stringify({ ...baseReceipt, ...patch }));
+      expect([issues.length, receipts.length]).toEqual([1, 0]);
+    }
   });
 
   it('rejects receipts where a token field is a non-integer', () => {

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateUsage, parseUsageReceipts, renderUsageLedger } from '../src/usage.js';
+
+const baseReceipt = {
+  schema: 'harness-bench.receipt.v1',
+  run_id: 'retry-trap.T1.C-scaffold.s4242.r1.attempt-2',
+  benchmark: 'retry-trap',
+  task_id: 'T1',
+  arm: 'C-scaffold',
+  seed: 4242,
+  replicate: 1,
+  phase: 'attempt-2',
+  model: 'claude-sonnet-4-6',
+  started_at: '2026-06-10T20:00:00Z',
+  duration_ms: 184211,
+  duration_api_ms: 121000,
+  num_turns: 14,
+  usage: { input_tokens: 1204, output_tokens: 8311, cache_creation_input_tokens: 22050, cache_read_input_tokens: 310400 },
+  total_cost_usd: null,
+  usage_source: 'claude-cli-subscription',
+  session_id: 'abc123',
+  exit: { subtype: 'success', is_error: false },
+  workspace: 'results/workspaces/foo',
+  result_digest: 'sha256:abc',
+};
+
+describe('parseUsageReceipts', () => {
+  it('parses a well-formed JSONL receipt', () => {
+    const jsonl = JSON.stringify(baseReceipt);
+    const { receipts, issues } = parseUsageReceipts(jsonl);
+    expect(issues).toHaveLength(0);
+    expect(receipts).toHaveLength(1);
+    const r = receipts[0];
+    expect(r.run_id).toBe('retry-trap.T1.C-scaffold.s4242.r1.attempt-2');
+    expect(r.benchmark).toBe('retry-trap');
+    expect(r.task_id).toBe('T1');
+    expect(r.arm).toBe('C-scaffold');
+    expect(r.usage.input_tokens).toBe(1204);
+    expect(r.usage.output_tokens).toBe(8311);
+    expect(r.usage.cache_creation_input_tokens).toBe(22050);
+    expect(r.usage.cache_read_input_tokens).toBe(310400);
+    expect(r.total_cost_usd).toBeNull();
+    expect(r.usage_source).toBe('claude-cli-subscription');
+    expect(r.num_turns).toBe(14);
+    expect(r.duration_ms).toBe(184211);
+  });
+
+  it('is tolerant of unknown schema strings', () => {
+    const line = JSON.stringify({ ...baseReceipt, schema: 'some-other-schema.v99' });
+    const { receipts, issues } = parseUsageReceipts(line);
+    expect(issues).toHaveLength(0);
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].schema).toBe('some-other-schema.v99');
+  });
+
+  it('is tolerant of unknown extra fields', () => {
+    const line = JSON.stringify({ ...baseReceipt, extra_field: 'ignored', another: 42 });
+    const { receipts, issues } = parseUsageReceipts(line);
+    expect(issues).toHaveLength(0);
+    expect(receipts).toHaveLength(1);
+  });
+
+  it('skips blank lines silently', () => {
+    const jsonl = `${JSON.stringify(baseReceipt)}\n\n${JSON.stringify({ ...baseReceipt, run_id: 'run-2' })}`;
+    const { receipts, issues } = parseUsageReceipts(jsonl);
+    expect(issues).toHaveLength(0);
+    expect(receipts).toHaveLength(2);
+  });
+
+  it('captures malformed JSON lines as issues with line numbers', () => {
+    const jsonl = `${JSON.stringify(baseReceipt)}\nnot-json\n${JSON.stringify({ ...baseReceipt, run_id: 'run-2' })}`;
+    const { receipts, issues } = parseUsageReceipts(jsonl);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatch(/line 2/);
+    expect(issues[0]).toMatch(/invalid JSON/);
+    expect(receipts).toHaveLength(2);
+  });
+
+  it('captures non-object JSON lines as issues', () => {
+    const jsonl = '"just a string"';
+    const { receipts, issues } = parseUsageReceipts(jsonl);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatch(/line 1/);
+    expect(receipts).toHaveLength(0);
+  });
+
+  it('rejects receipts missing run_id', () => {
+    const { run_id: _omit, ...noRunId } = baseReceipt;
+    const { receipts, issues } = parseUsageReceipts(JSON.stringify(noRunId));
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatch(/run_id/);
+    expect(receipts).toHaveLength(0);
+  });
+
+  it('rejects receipts missing usage_source', () => {
+    const { usage_source: _omit, ...noSource } = baseReceipt;
+    const { receipts, issues } = parseUsageReceipts(JSON.stringify(noSource));
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatch(/usage_source/);
+    expect(receipts).toHaveLength(0);
+  });
+
+  it('rejects receipts where usage has no token fields', () => {
+    const line = JSON.stringify({ ...baseReceipt, usage: {} });
+    const { receipts, issues } = parseUsageReceipts(line);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatch(/usage/);
+    expect(receipts).toHaveLength(0);
+  });
+
+  it('rejects receipts where a token field is negative', () => {
+    const line = JSON.stringify({ ...baseReceipt, usage: { input_tokens: -1 } });
+    const { receipts, issues } = parseUsageReceipts(line);
+    expect(issues).toHaveLength(1);
+    expect(receipts).toHaveLength(0);
+  });
+
+  it('rejects receipts where a token field is a non-integer', () => {
+    const line = JSON.stringify({ ...baseReceipt, usage: { input_tokens: 1.5 } });
+    const { receipts, issues } = parseUsageReceipts(line);
+    expect(issues).toHaveLength(1);
+    expect(receipts).toHaveLength(0);
+  });
+
+  it('accepts partial usage objects — missing token fields stay undefined', () => {
+    const line = JSON.stringify({ ...baseReceipt, usage: { input_tokens: 100 } });
+    const { receipts, issues } = parseUsageReceipts(line);
+    expect(issues).toHaveLength(0);
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].usage.input_tokens).toBe(100);
+    expect(receipts[0].usage.output_tokens).toBeUndefined();
+    expect(receipts[0].usage.cache_creation_input_tokens).toBeUndefined();
+    expect(receipts[0].usage.cache_read_input_tokens).toBeUndefined();
+  });
+
+  it('rejects receipts where total_cost_usd is a non-finite value', () => {
+    const line = JSON.stringify({ ...baseReceipt, total_cost_usd: 'free' });
+    const { receipts, issues } = parseUsageReceipts(line);
+    expect(issues).toHaveLength(1);
+    expect(receipts).toHaveLength(0);
+  });
+
+  it('accepts total_cost_usd as a numeric value', () => {
+    const line = JSON.stringify({ ...baseReceipt, total_cost_usd: 0.042 });
+    const { receipts, issues } = parseUsageReceipts(line);
+    expect(issues).toHaveLength(0);
+    expect(receipts[0].total_cost_usd).toBe(0.042);
+  });
+
+  it('never throws on any input', () => {
+    const inputs = ['', '\n\n\n', 'null', '[]', '{}', 'garbage{json'];
+    for (const input of inputs) {
+      expect(() => parseUsageReceipts(input)).not.toThrow();
+    }
+  });
+});
+
+describe('aggregateUsage', () => {
+  it('groups by benchmark, task_id, arm and sums tokens across receipts', () => {
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', usage: { input_tokens: 100, output_tokens: 200 } }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r2', usage: { input_tokens: 300, output_tokens: 400 } }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    expect(ledger.rows).toHaveLength(1);
+    expect(ledger.rows[0].runCount).toBe(2);
+    expect(ledger.rows[0].inputTokens).toBe(400);
+    expect(ledger.rows[0].outputTokens).toBe(600);
+  });
+
+  it('keeps separate groups for different arms', () => {
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', arm: 'A', usage: { input_tokens: 10 } }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r2', arm: 'B', usage: { input_tokens: 20 } }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    expect(ledger.rows).toHaveLength(2);
+    const armA = ledger.rows.find((r) => r.arm === 'A');
+    const armB = ledger.rows.find((r) => r.arm === 'B');
+    expect(armA?.inputTokens).toBe(10);
+    expect(armB?.inputTokens).toBe(20);
+  });
+
+  it('cost honesty rule: costUsdTotal is null if any receipt in the group lacks numeric cost', () => {
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', total_cost_usd: 0.5 }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r2', total_cost_usd: null }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    expect(ledger.rows[0].costUsdTotal).toBeNull();
+  });
+
+  it('cost honesty rule: costUsdTotal is summed when all receipts in group carry numeric cost', () => {
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', total_cost_usd: 0.10, usage_source: 'api-key' }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r2', total_cost_usd: 0.20, usage_source: 'api-key' }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    expect(ledger.rows[0].costUsdTotal).toBeCloseTo(0.30, 10);
+  });
+
+  it('cost honesty rule: costUsdTotal is null when cost is absent (undefined) for any receipt', () => {
+    const withoutCost = { ...baseReceipt };
+    // Remove total_cost_usd entirely
+    const { total_cost_usd: _omit, ...noCostField } = withoutCost;
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...noCostField, run_id: 'r1', usage_source: 'api-key', usage: { input_tokens: 10 } }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r2', total_cost_usd: 0.10, usage_source: 'api-key' }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    expect(ledger.rows[0].costUsdTotal).toBeNull();
+  });
+
+  it('flags subscription receipts that carry a numeric total_cost_usd', () => {
+    const { receipts } = parseUsageReceipts(
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', usage_source: 'claude-cli-subscription', total_cost_usd: 1.23 }),
+    );
+    const ledger = aggregateUsage(receipts);
+    expect(ledger.issues.some((i) => i.includes('subscription') && i.includes('inconsistent billing claim'))).toBe(true);
+  });
+
+  it('does not flag subscription receipts with null total_cost_usd', () => {
+    const { receipts } = parseUsageReceipts(
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', usage_source: 'claude-cli-subscription', total_cost_usd: null }),
+    );
+    const ledger = aggregateUsage(receipts);
+    const subscriptionIssues = ledger.issues.filter((i) => i.includes('subscription'));
+    expect(subscriptionIssues).toHaveLength(0);
+  });
+
+  it('flags duplicate run_ids', () => {
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...baseReceipt, run_id: 'dup-run' }),
+      JSON.stringify({ ...baseReceipt, run_id: 'dup-run', arm: 'different-arm' }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    expect(ledger.issues.some((i) => i.includes('duplicate run_id') && i.includes('dup-run'))).toBe(true);
+  });
+
+  it('does not flag distinct run_ids', () => {
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...baseReceipt, run_id: 'r1' }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r2' }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    expect(ledger.issues.filter((i) => i.includes('duplicate'))).toHaveLength(0);
+  });
+
+  it('sorts rows stably: benchmark, then task_id, then arm', () => {
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', benchmark: 'z-bench', task_id: 'T2', arm: 'B', usage: { input_tokens: 1 } }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r2', benchmark: 'a-bench', task_id: 'T1', arm: 'A', usage: { input_tokens: 1 } }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r3', benchmark: 'a-bench', task_id: 'T1', arm: 'B', usage: { input_tokens: 1 } }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r4', benchmark: 'a-bench', task_id: 'T2', arm: 'A', usage: { input_tokens: 1 } }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    const keys = ledger.rows.map((r) => `${r.benchmark}/${r.task_id}/${r.arm}`);
+    expect(keys).toEqual(['a-bench/T1/A', 'a-bench/T1/B', 'a-bench/T2/A', 'z-bench/T2/B']);
+  });
+
+  it('returns empty rows and no issues for empty receipts array', () => {
+    const ledger = aggregateUsage([]);
+    expect(ledger.rows).toHaveLength(0);
+    expect(ledger.issues).toHaveLength(0);
+  });
+});
+
+describe('renderUsageLedger', () => {
+  it('renders a markdown table with header and data rows', () => {
+    const { receipts } = parseUsageReceipts(
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', usage_source: 'api-key', total_cost_usd: 0.123456 }),
+    );
+    const ledger = aggregateUsage(receipts);
+    const output = renderUsageLedger(ledger);
+    expect(output).toContain('| benchmark | task_id | arm |');
+    expect(output).toContain('retry-trap');
+    expect(output).toContain('T1');
+    expect(output).toContain('C-scaffold');
+    expect(output).toContain('1204');
+    expect(output).toContain('8311');
+    expect(output).toContain('22050');
+    expect(output).toContain('310400');
+    expect(output).toContain('0.123456');
+    expect(output.endsWith('\n')).toBe(true);
+  });
+
+  it('renders null cost as "null" in the table', () => {
+    const { receipts } = parseUsageReceipts(
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', total_cost_usd: null }),
+    );
+    const ledger = aggregateUsage(receipts);
+    const output = renderUsageLedger(ledger);
+    expect(output).toContain('| null |');
+  });
+
+  it('renders an empty table body when there are no rows', () => {
+    const ledger = aggregateUsage([]);
+    const output = renderUsageLedger(ledger);
+    const lines = output.trim().split('\n');
+    expect(lines).toHaveLength(2); // header + separator only
+    expect(lines[0]).toContain('benchmark');
+  });
+
+  it('renders raw integer token counts (no thousands separators)', () => {
+    const { receipts } = parseUsageReceipts(
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', usage: { cache_read_input_tokens: 310400 } }),
+    );
+    const ledger = aggregateUsage(receipts);
+    const output = renderUsageLedger(ledger);
+    expect(output).toContain('310400');
+    expect(output).not.toContain('310,400');
+  });
+
+  it('produces stable string output matching expected snapshot', () => {
+    const { receipts } = parseUsageReceipts([
+      JSON.stringify({ ...baseReceipt, run_id: 'r1', benchmark: 'bench-a', task_id: 'T1', arm: 'ctrl', usage: { input_tokens: 100, output_tokens: 200 }, total_cost_usd: null, usage_source: 'claude-cli-subscription' }),
+      JSON.stringify({ ...baseReceipt, run_id: 'r2', benchmark: 'bench-a', task_id: 'T1', arm: 'scaf', usage: { input_tokens: 150, output_tokens: 250 }, total_cost_usd: null, usage_source: 'claude-cli-subscription' }),
+    ].join('\n'));
+    const ledger = aggregateUsage(receipts);
+    const output = renderUsageLedger(ledger);
+    const expected = [
+      '| benchmark | task_id | arm | runs | input_tokens | output_tokens | cache_creation_tokens | cache_read_tokens | num_turns | duration_ms | cost_usd |',
+      '|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|',
+      '| bench-a | T1 | ctrl | 1 | 100 | 200 | 0 | 0 | 14 | 184211 | null |',
+      '| bench-a | T1 | scaf | 1 | 150 | 250 | 0 | 0 | 14 | 184211 | null |',
+      '',
+    ].join('\n');
+    expect(output).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Plan

`.osc/plans/active/163-proof-harness-v2.md` + amendment 1 (evolve-arm showcase, visual substrate, independent benchmark repo, subscription-lane token accounting).

## What's in this branch

- Plan 163 promoted to active with amendment 1 recorded via `osc amend`.
- `src/usage.ts`: benchmark-neutral usage-receipt ledger (parse/aggregate/render) with the cost-honesty rule — USD never summed from partial data; subscription receipts carry null cost. 31 tests.

## Evidence

The benchmark program this plan commissioned was executed in the independent repo: https://github.com/graphanov/harness-bench (preregistration with 8 amendments, raw JSONL receipts, full campaign reports). The claim ledger lands in docs on the sibling branch `166-claim-ledger-repositioning`.

## Verification

`npm run build && npm test && ./verify.sh --strict && git diff --check` — green at each commit on this branch.

## Owner gates / notes

- Merge order note: this branch repins the section-parser corpus hash from its base; sibling branches do the same independently — whichever merges second must re-repin (one-line fix, test output gives the value).
- Plan 163 stays active post-merge until the full-n campaign closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)