### PR TITLE
docs: stage review battery plan

### DIFF
--- a/.osc/plans/backlog/169-review-battery.md
+++ b/.osc/plans/backlog/169-review-battery.md
@@ -1,0 +1,77 @@
+# Plan: 169-review-battery
+
+## Status
+
+backlog
+
+## Context
+
+Plan 168 narrowed Open Scaffold core to the repo-native work record, handoff packets, review/gate judgments, evidence, and close protocol. `osc review` now names the local recorded-attempt analysis front door, while `osc analyze` remains its synonym.
+
+Prior review experiments used fixed factual batteries over recorded work to make cheap/local judges answer concrete questions instead of offering vibes. AC6 already gave `osc gate` an OpenAI-compatible judge endpoint for rulings; this plan stages the sibling product move for `osc review`: an optional external battery mode that reads the record and reports structured review facts.
+
+This exists now because the command name is finally available and stable after the `$`-verb retirement. The work should be designed before implementation because the output may later map into evaluation envelopes and docs tiers.
+
+## Goal
+
+When activated, add an optional review-battery mode to `osc review`:
+
+`osc review <loop-or-run> --judge-endpoint <url> --judge-model <name>`
+
+The mode asks a record-only battery and emits versioned JSON (`open-scaffold.review-battery.v1`) plus markdown. Without `--judge-endpoint`, `osc review` remains the local analysis front door and `osc analyze` remains a synonym.
+
+The battery fields are:
+
+- `work_complete`
+- `attempts_made`
+- `final_criteria_passing`
+- `quality_regressed`
+- `unsatisfiable_requirement`
+- `claimed_vs_actual_mismatch`
+- `recommended_next_action`
+- `why_work_ended`
+
+## Constraints / Out of scope
+
+- This backlog plan does not implement the feature until the owner explicitly activates it.
+- Do not change the default local behavior of `osc review` or `osc analyze` when no judge endpoint is provided.
+- Do not spawn runtimes, execute work, approve retries, merge, publish, release, deploy, or change package versions.
+- The battery must answer from the recorded loop/run only. It must abstain with `unknown` rather than guess when the record is insufficient.
+- The review battery is a structured review aid, not proof of correctness, not human approval, and not compliance certification.
+- Do not invent USD costs; if usage appears, tokens remain the cost metric.
+
+## Files to touch
+
+- `src/reviewer.ts` — add review-battery prompt construction, strict parsing, and tolerance patterns mirroring `parseJudgeRuling` where appropriate.
+- `src/cli.ts` — wire `osc review <loop-or-run> --judge-endpoint <url> --judge-model <name>` while preserving the existing local review/analyze path without endpoint flags.
+- `src/mcp-tools.ts` — add read-only `review_record` MCP tool, mirroring `gate_loop` safety and output patterns.
+- `src/schema-registry.ts` and `docs/SCHEMA_REGISTRY.md` — register `open-scaffold.review-battery.v1`.
+- `tests/reviewer.test.ts` or adjacent focused tests — mock fetch success, malformed responses, unknown/abstain behavior, and endpoint flag validation.
+- `tests/cli-lifecycle-help.test.ts` and `tests/framework-cleanup-metric.test.ts` — update help/LOC pins with rationale if the implementation changes them.
+- `docs/EVOLUTION_LOOP.md`, `docs/MCP.md`, and `README.md` — document the optional battery mode without overclaiming.
+
+## Acceptance criteria
+
+- [ ] `osc review <loop-or-run>` without endpoint flags still runs the current local analysis front door; `osc analyze` still works as a synonym.
+- [ ] `osc review <loop-or-run> --judge-endpoint <url> --judge-model <name>` sends only bounded record context to an OpenAI-compatible endpoint and does not mutate evidence unless an explicit future option is designed.
+- [ ] The command emits JSON with schema `open-scaffold.review-battery.v1` plus markdown output, including every required battery field.
+- [ ] Battery parsing fails closed on malformed endpoint output and uses `unknown` for unsupported or insufficient-record answers instead of guessing.
+- [ ] The MCP `review_record` tool is read-only, mirrors CLI safety boundaries, and cannot spawn runtimes or approve work.
+- [ ] Tests cover success, malformed endpoint output, unknown/abstain behavior, missing/conflicting judge flags, and default local review behavior.
+- [ ] Docs and schema registry describe the feature as a structured review aid, not correctness proof or owner approval.
+
+## Verification steps
+
+1. `npm run build` — TypeScript passes for core and runtime package.
+2. `npm test -- --run tests/reviewer.test.ts tests/cli-lifecycle-help.test.ts tests/mcp-server.test.ts` — focused tests pass.
+3. `npm test` — full suite passes.
+4. `./verify.sh --strict` — 0 fail, 0 warn.
+5. `git diff --check && git diff --cached --check` — whitespace checks pass.
+6. Manual smoke: `osc review <fixture-loop>` still runs local analysis without endpoint flags.
+7. Manual smoke with mocked/local OpenAI-compatible endpoint records `open-scaffold.review-battery.v1` JSON and markdown with `unknown` where the fixture lacks enough evidence.
+
+## Open questions
+
+- Should the public command shape stay as `osc review <loop-or-run> --judge-endpoint <url> --judge-model <name>`, or should the battery mode get an explicit subcommand/flag such as `osc review battery`?
+- Should review-battery answers be recordable as `open-scaffold.evaluation.v1` envelopes, since the fields map closely to evaluation criteria?
+- Should review-3 judge-ladder results gate which endpoint/model tiers the docs recommend, or should docs stay endpoint-neutral until there is broader evidence?

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -244,8 +244,8 @@ This sample must not count as the real section.
 
     const hash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
-    // 168 close: moved dollar-verb retirement and its README-GIF amendment to done with done status.
-    expect(hash(planIssueSnapshot)).toBe('e89e3384c5a38d1047e8a5c820a91078bf21984f2a9260d97bb0a72db62a0648');
+    // 169 planning: staged review-battery backlog plan after dollar-verb retirement.
+    expect(hash(planIssueSnapshot)).toBe('a30456425a4f369b39ad6c669a6853083c7116b501b22a44da39fda901e5336f');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('77d3ca8072b68fddcc790d96171145c744b770bf3f681145bc0fd0c56a77c618');


### PR DESCRIPTION
## Summary

Stages backlog plan `169-review-battery` after the `$`-verb retirement landed.

The plan is planning-only and captures the product design for an optional `osc review` judge-battery mode:

- preserve current local `osc review` / `osc analyze` behavior without endpoint flags;
- add optional `osc review <loop-or-run> --judge-endpoint <url> --judge-model <name>` when activated;
- emit `open-scaffold.review-battery.v1` JSON plus markdown;
- answer fixed record-only fields and abstain with `unknown` rather than guessing;
- add a read-only MCP `review_record` tool;
- keep runtime spawning, approval, publishing, releases, and package version bumps out of scope.

It also records the owner design questions before implementation:

- command shape: endpoint flags vs explicit subcommand;
- whether answers should be recordable as evaluation envelopes;
- whether review-3 judge-ladder results should gate docs recommendations.

## Verification

- `npm run -s osc -- plan validate 169-review-battery --strict` — PASS: 0 issues
- `npm run build` — PASS
- `npm test` — PASS: 46 files / 503 tests
- `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn
- `git diff --check && git diff --cached --check` — PASS
- Public-info scan of added diff lines — PASS: no owner names, handles, email, phone, or local absolute paths introduced

## Gates

This PR does **not** implement the review battery. It only stages the backlog plan and the live-corpus hash repin.

No merge, publish, GitHub Release, runtime spawning, package version bump, or Phase 3 adoption-kit work is authorized by this PR.
