### PR TITLE
chore(release): prepare 0.32.0 package sync

### DIFF
--- a/.osc/plans/active/171-capture-package-sync.md
+++ b/.osc/plans/active/171-capture-package-sync.md
@@ -1,0 +1,57 @@
+# Plan: 171-capture-package-sync
+
+## Status
+
+active
+
+## Context
+
+Plan 170 / PR #215 is now on `main`: `osc capture` is a package-visible CLI command, shipped docs, synthetic fixtures, and hook examples. The live public package surfaces still point at `open-scaffold@0.31.1` and GitHub Release `v0.31.1`, so new adopters using `npx open-scaffold@latest` cannot access `osc capture` yet.
+
+The owner explicitly approved preparing a release-sync PR for `open-scaffold@0.32.0`. This plan prepares the candidate only. npm publishing, GitHub Release creation/Latest movement, and merge remain separate gates.
+
+## Goal
+
+Prepare a verified `open-scaffold@0.32.0` release-sync PR that bumps package metadata, records candidate release truth, passes package/repo gates, and stops before npm publish or GitHub Release creation.
+
+## Constraints / Out of scope
+
+- Keep this as a pre-1.0 release. `0.32.0` means a new public CLI/package surface (`osc capture`), not a 1.0 maturity claim.
+- Do not publish to npm, create or update a GitHub Release, push to `main`, deploy, or move dist-tags in this PR.
+- Do not add npm tokens, secrets, or new trusted-publishing credentials.
+- Do not change product behavior beyond release metadata/docs/evidence required for this package sync.
+- Keep release truth explicit: before owner-approved publication, npm latest and GitHub Latest Release remain `0.31.1`.
+
+## Files to touch
+
+- `package.json` and `package-lock.json` — bump package version to `0.32.0`.
+- `docs/CHANGELOG.md` — add the adoption-facing `v0.32.0` candidate entry while keeping `v0.31.1` as the live Latest until publication.
+- `.osc/plans/active/171-capture-package-sync.md` — this release-sync plan.
+- `.osc/releases/2026-06-13-171-capture-package-sync.md` — candidate release evidence note.
+- `tests/section-parser.test.ts` — only if the live-corpus hash changes after adding this plan/evidence.
+
+## Acceptance criteria
+
+- [x] `package.json`, `package-lock.json`, and the lockfile root package version all read `0.32.0`.
+- [x] Release-truth docs distinguish candidate repo state from live npm/GitHub Release state before publication.
+- [x] Local release gates pass: `npm ci`, `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Package payload inspection confirms `open-scaffold@0.32.0`, includes `dist/cli.js`, `docs/CAPTURE.md`, and `examples/hooks/*`, and excludes `__pycache__`/`.pyc` files.
+- [ ] Release-sync PR is opened against `main`; CI/review state is reported, but merge remains owner-gated.
+- [x] No npm publish, GitHub Release, version tag, deploy, or `main` push occurs in this slice.
+
+## Verification steps
+
+1. `node -p "require('./package.json').version"` plus package-lock checks — expected `0.32.0` everywhere.
+2. `npm view open-scaffold version dist-tags --json --prefer-online` — expected live registry still `0.31.1` / `latest: 0.31.1` before publication.
+3. `npm ci` — expected dependency install succeeds with no dependency drift beyond lockfile version metadata.
+4. `git diff --check` — expected no whitespace errors.
+5. `./verify.sh --strict` — expected no failures and no warnings after any required corpus-hash repin.
+6. `npm test -- --run` and `npm run build` — expected pass.
+7. `npm run osc -- doctor --check secret-scan` — expected no obvious token/webhook strings found.
+8. `npm pack --dry-run --json` — expected package `open-scaffold@0.32.0`; required capture files present; no cache residue.
+9. `npm publish --dry-run --tag latest` — expected dry-run success only, with no actual npm publication.
+10. PR checks and review-thread query — expected green/thread-zero before recommending merge.
+
+## Open questions
+
+- None. The owner approved preparing the `0.32.0` release-sync PR and explicitly withheld npm publish / GitHub Release approval until after the PR is green/merged.

--- a/.osc/plans/active/171-capture-package-sync.md
+++ b/.osc/plans/active/171-capture-package-sync.md
@@ -26,6 +26,7 @@ Prepare a verified `open-scaffold@0.32.0` release-sync PR that bumps package met
 
 - `package.json` and `package-lock.json` — bump package version to `0.32.0`.
 - `docs/CHANGELOG.md` — add the adoption-facing `v0.32.0` candidate entry while keeping `v0.31.1` as the live Latest until publication.
+- `README.md`, `docs/STABILITY.md`, and `ROADMAP.md` — move adoption-facing forward-line wording from `v0.31.x` to `v0.32.x` so the published package is internally consistent.
 - `.osc/plans/active/171-capture-package-sync.md` — this release-sync plan.
 - `.osc/releases/2026-06-13-171-capture-package-sync.md` — candidate release evidence note.
 - `tests/section-parser.test.ts` — only if the live-corpus hash changes after adding this plan/evidence.
@@ -36,7 +37,7 @@ Prepare a verified `open-scaffold@0.32.0` release-sync PR that bumps package met
 - [x] Release-truth docs distinguish candidate repo state from live npm/GitHub Release state before publication.
 - [x] Local release gates pass: `npm ci`, `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
 - [x] Package payload inspection confirms `open-scaffold@0.32.0`, includes `dist/cli.js`, `docs/CAPTURE.md`, and `examples/hooks/*`, and excludes `__pycache__`/`.pyc` files.
-- [ ] Release-sync PR is opened against `main`; CI/review state is reported, but merge remains owner-gated.
+- [x] Release-sync PR is opened against `main`; CI/review state is reported, but merge remains owner-gated.
 - [x] No npm publish, GitHub Release, version tag, deploy, or `main` push occurs in this slice.
 
 ## Verification steps

--- a/.osc/releases/2026-06-13-171-capture-package-sync.md
+++ b/.osc/releases/2026-06-13-171-capture-package-sync.md
@@ -37,7 +37,7 @@ Candidate gates before PR-ready:
 - [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
 - [x] `npm pack --dry-run --json` payload inspection after rebuilding — PASS for `open-scaffold@0.32.0`; entry count 205; required `dist/cli.js`, `dist/capture.js`, `dist/ambient.js`, `docs/CAPTURE.md`, and `examples/hooks/*` files present; no `__pycache__`/`.pyc` files.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.32.0` with tag `latest`; dry-run only.
-- [ ] Release candidate PR CI and review/thread gate — pending PR creation.
+- [x] Release candidate PR opened: https://github.com/graphanov/open-scaffold/pull/216. Local candidate gates are green; latest GitHub CI/review/thread status is intentionally kept as live PR truth rather than a static committed claim.
 
 Post-merge/publication gates after future owner-approved follow-through:
 

--- a/.osc/releases/2026-06-13-171-capture-package-sync.md
+++ b/.osc/releases/2026-06-13-171-capture-package-sync.md
@@ -13,7 +13,7 @@ Release-sync candidate for publishing merged `osc capture` work as `open-scaffol
 - Source PR: https://github.com/graphanov/open-scaffold/pull/215.
 - Release-sync plan: `.osc/plans/active/171-capture-package-sync.md`.
 - Run ID / run packet: N/A for this scoped package/release sync.
-- Branch / PR: `chore/release-0.32.0-package-sync` / PR pending.
+- Branch / PR: `chore/release-0.32.0-package-sync` / https://github.com/graphanov/open-scaffold/pull/216.
 
 ## Verification
 

--- a/.osc/releases/2026-06-13-171-capture-package-sync.md
+++ b/.osc/releases/2026-06-13-171-capture-package-sync.md
@@ -1,0 +1,58 @@
+# Release / Evidence Note: 171-capture-package-sync
+
+## Summary
+
+Release-sync candidate for publishing merged `osc capture` work as `open-scaffold@0.32.0` after owner approval. This candidate bumps package metadata and records release truth only; it does not publish npm, create a GitHub Release, move the `latest` dist-tag, or claim a 1.0 maturity contract.
+
+`0.32.0` is used because `osc capture` is a new package-visible CLI/docs/hooks surface. The release remains pre-1.0 and bounded to observed transcript capture, not runtime spawning, semantic approval, compliance, or production-readiness claims.
+
+## Traceability
+
+- Roadmap / issue / task: package sync for merged plan 170 / `osc capture`.
+- Source plan: `.osc/plans/done/170-ambient-capture.md`.
+- Source PR: https://github.com/graphanov/open-scaffold/pull/215.
+- Release-sync plan: `.osc/plans/active/171-capture-package-sync.md`.
+- Run ID / run packet: N/A for this scoped package/release sync.
+- Branch / PR: `chore/release-0.32.0-package-sync` / PR pending.
+
+## Verification
+
+Baseline live-truth inspection before release-sync edits:
+
+- `git fetch --prune origin && git checkout main && git pull --ff-only origin main` — PASS: local `main` was up to date at PR #215 merge commit `36d62fb7d7ebb2eb84dcfc7d50313537c2602e16` before the release-sync branch.
+- `git status --short --branch` — PASS: clean `main...origin/main` before candidate branch.
+- `node -p "require('./package.json').version"` — PASS before candidate bump: `0.31.1`.
+- `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before candidate bump: `0.31.1`, `latest: 0.31.1`.
+- `gh release list --repo graphanov/open-scaffold --limit 3` — PASS before candidate bump: `v0.31.1 — Harness release readiness package sync` is Latest.
+
+Candidate gates before PR-ready:
+
+- [x] Version alignment — PASS: `0.32.0 / 0.32.0 / 0.32.0` for `package.json`, `package-lock.json`, and lockfile root package version.
+- [x] Live registry check — PASS before publication: `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.31.1`, `latest: 0.31.1`; `open-scaffold@0.32.0` returns 404 / not published.
+- [x] `npm ci` — PASS: install completed successfully. npm audit reports one high-severity dev-dependency issue tracked by existing Dependabot PR #214; `npm audit --omit=dev --json` reports 0 production/runtime vulnerabilities.
+- [x] `git diff --check` — PASS.
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn after the intentional live-corpus hash update.
+- [x] `npm test -- --run` — PASS: 48 files / 534 tests.
+- [x] `npm run build` — PASS: core TypeScript build and runtime-omx build.
+- [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
+- [x] `npm pack --dry-run --json` payload inspection after rebuilding — PASS for `open-scaffold@0.32.0`; entry count 205; required `dist/cli.js`, `dist/capture.js`, `dist/ambient.js`, `docs/CAPTURE.md`, and `examples/hooks/*` files present; no `__pycache__`/`.pyc` files.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.32.0` with tag `latest`; dry-run only.
+- [ ] Release candidate PR CI and review/thread gate — pending PR creation.
+
+Post-merge/publication gates after future owner-approved follow-through:
+
+- [ ] Sync clean `main` after release PR merge.
+- [ ] Main CI for release commit.
+- [ ] Re-run post-merge local publish gates.
+- [ ] Trusted publishing workflow publishes `open-scaffold@0.32.0` with dist-tag `latest`.
+- [ ] Fresh isolated-cache `npx open-scaffold@latest` smokes prove the published package surface.
+- [ ] GitHub Release `v0.32.0` exists, targets the merged release commit, and is marked Latest.
+- [ ] This plan is closed to `done` with final public proof.
+
+## Outcome
+
+Candidate package gates passed locally. No npm publication, GitHub Release, dist-tag movement, deploy, or `main` push has occurred in this release-sync slice.
+
+## Follow-up
+
+- Owner gate after this PR: merge release-sync PR if accepted, then explicitly approve trusted npm publishing and GitHub Release creation for `v0.32.0`.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ not need a work record.
 
 ## Honest limits
 
-Open Scaffold is pre-1.0 (`v0.31.x`) and it does not make your model smarter —
+Open Scaffold is pre-1.0 (`v0.32.x`) and it does not make your model smarter —
 it makes the *loop around the model* disciplined: bounded slices, gated
 execution, compact resumes, receipts for everything. A bounded
 scaffold-vs-naked fixture ships in [`examples/proof/`](examples/proof/) and is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -393,7 +393,7 @@ Acceptance criteria:
 
 ### Milestone 18 — historical v1.0.0 stability launch
 
-Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel was intentionally corrected back to pre-1.0 hardening; after the framework cleanup shrink, that current hardening line is `v0.31.x` until the public product surface earns a mature 1.0 contract.
+Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel was intentionally corrected back to pre-1.0 hardening; after the `osc capture` package sync, that current hardening line is `v0.32.x` until the public product surface earns a mature 1.0 contract.
 
 Goal: make the adoption contract explicit before the first major-release experiment.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ Evidence:
 - Source plan: `.osc/plans/done/170-ambient-capture.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/215
 - Release-sync plan: `.osc/plans/active/171-capture-package-sync.md`
-- Release-sync PR: pending
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/216
 - Release-sync evidence note: `.osc/releases/2026-06-13-171-capture-package-sync.md`
 
 ## v0.31.1 — Harness release readiness package sync

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,25 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.32.0 — Ambient capture package sync
+
+Status: release candidate in repo for `open-scaffold@0.32.0`; live npm `latest` and GitHub Latest Release remain `v0.31.1` until owner-approved trusted publishing and release follow-through complete.
+
+Highlights:
+
+- Publishes merged `osc capture` work from PR #215 to the public `npx open-scaffold@latest` package surface once the release is approved and published.
+- Adds read-only transcript capture for Claude Code, Codex, and generic JSONL into the existing `osc.ambient-work-record.v1` schema.
+- Ships capture docs plus Claude Code/Codex hook examples, with default records written under ignored `.osc/state/ambient/` and Codex notify capture scoped by event `thread-id` / `CODEX_HOME`.
+- Keeps capture explicitly observational: no runtime spawning, no approval, no correctness certification, no compliance claim, and no 1.0 maturity claim.
+
+Evidence:
+
+- Source plan: `.osc/plans/done/170-ambient-capture.md`
+- Source PR: https://github.com/graphanov/open-scaffold/pull/215
+- Release-sync plan: `.osc/plans/active/171-capture-package-sync.md`
+- Release-sync PR: pending
+- Release-sync evidence note: `.osc/releases/2026-06-13-171-capture-package-sync.md`
+
 ## v0.31.1 — Harness release readiness package sync
 
 Status: published to npm as `open-scaffold@0.31.1`; GitHub Release `v0.31.1` is Latest after owner-approved trusted publishing and release follow-through.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -2,7 +2,7 @@
 
 This page is the single home for Open Scaffold's maturity boundary: what is stable, what is experimental, what is future, and what the project does not claim. Other surfaces state their promise once and link here.
 
-The short version: Open Scaffold is on a pre-1.0 line (`v0.31.x`). The stable core is the work loop and its record — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus the handoff/review/gate helpers (`osc first-run`, `osc handoff`, `osc review`, `osc gate`, `osc pr check`, `osc compare`, `osc trace`). Core runtime launch, root adapter dispatch, and the old harness command grammar are not current-package promises.
+The short version: Open Scaffold is on a pre-1.0 line (`v0.32.x`). The stable core is the work loop and its record — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus the handoff/review/gate helpers (`osc first-run`, `osc handoff`, `osc review`, `osc gate`, `osc pr check`, `osc compare`, `osc trace`). Core runtime launch, root adapter dispatch, and the old harness command grammar are not current-package promises.
 
 ## Honest limits
 
@@ -13,11 +13,11 @@ Everything Open Scaffold does not claim, in one place:
 - **The benchmark program is pilot-grade and partly self-run.** One worker model, n=1 cells, owner-built instrument (preregistration, hidden inputs, blind double-implementation, and kill rules as mitigations); replication with humans and larger n is open work. The older bounded `examples/proof/` fixture remains a separate, narrower surface.
 - **It is not a compliance certification, sandbox, or security guarantee.** It produces structural evidence a process can build on; it does not replace the process.
 - **Humans own merge, publish, release, and deployment.** Nothing in the harness self-approves.
-- **Historical `v1.0.x` packages exist** as immutable publication history; the forward line is `v0.31.x` and the next 1.0 will be cut when the contract has earned it.
+- **Historical `v1.0.x` packages exist** as immutable publication history; the forward line is `v0.32.x` and the next 1.0 will be cut when the contract has earned it.
 
 ## Release status
 
-- Current cadence: pre-1.0 hardening on the `v0.31.x` line.
+- Current cadence: pre-1.0 hardening on the `v0.32.x` line.
 - Historical note: `v1.0.x` exists as a previously published launch line (most recent tag: `v1.0.5`) and remains immutable package/release history.
 - Current repository package version: check `package.json`.
 - Live npm package truth: check `npm view open-scaffold version dist-tags --json`.
@@ -109,7 +109,7 @@ Future work can explore those areas only through explicit plans, evidence, safet
 
 ## Versioning policy
 
-Open Scaffold uses npm package versions as public distribution coordinates. The current `v0.31.x` line is intentionally pre-1.0: it communicates that the core work-record pattern is usable and the framework cleanup has narrowed/reduced the package surface, but the product is still earning its long-term stable contract.
+Open Scaffold uses npm package versions as public distribution coordinates. The current `v0.32.x` line is intentionally pre-1.0: it communicates that the core work-record pattern is usable and the framework cleanup has narrowed/reduced the package surface, but the product is still earning its long-term stable contract.
 
 The previously published `v1.0.x` packages remain immutable historical artifacts. They should be treated as an over-eager launch line, not as a reason to force every future change through mature-1.0 pressure. A future real 1.0 should be cut only after the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives feel durable enough to sustain that promise.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.31.1",
+      "version": "0.32.0",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "description": "Runtime-neutral scaffold and prompt/artifact CLI for disciplined AI-agent development.",
   "license": "MIT",
   "repository": {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -246,11 +246,13 @@ This sample must not count as the real section.
 
     // 169 planning: staged review-battery backlog plan after dollar-verb retirement.
     // 170 closeout: moved capture plan to done and added local evidence note.
-    expect(hash(planIssueSnapshot)).toBe('fcba259ea43964013a5a23e4e0847b1398a49e27a8acb6d5f424132eedcf0f8b');
+    // 171 release-sync candidate: active package-sync plan for publishing osc capture as v0.32.0.
+    expect(hash(planIssueSnapshot)).toBe('14ef772b59d40494cf04148f7915fdd185c464d3f7bf166a0c4baa0cc6c5d0fb');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     // 170 review hardening: evidence note refreshed with PR URL, final test count, and Codex-reported total_tokens.
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('2b719557cc593d3f0c8a18536e876fbeb9185bab9f437f1b4bb77ca7b141375e');
+    // 171 release-sync candidate: added v0.32.0 release evidence note with publication gates still pending.
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('09888cbb861ca90060a1fd4ad1cda2f99dc87284da775ab3eceaacfafbc2ff5a');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Prepares `open-scaffold@0.32.0` as the release-sync candidate for merged `osc capture` work from PR #215.
- Bumps `package.json` / `package-lock.json` to `0.32.0`.
- Adds active release-sync plan/evidence and a changelog candidate entry that keeps live npm/GitHub truth at `0.31.1` until owner-approved publication.
- Repins live-corpus hashes with rationale after adding the release-sync artifacts.

## Verification
- `node` version alignment check: package + lockfile root all `0.32.0`
- `npm view open-scaffold version dist-tags --json --prefer-online` → live registry still `0.31.1`, `latest: 0.31.1`
- `npm ci` → pass; prod/runtime audit via `npm audit --omit=dev --json` reports 0 vulnerabilities. npm's full audit still reports the existing dev-dependency issue tracked by Dependabot PR #214.
- `git diff --check`
- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn
- `npm test -- --run` → 48 files / 534 tests
- `npm run build`
- `npm run osc -- doctor --check secret-scan`
- `npm pack --dry-run --json` → `open-scaffold@0.32.0`, 205 entries, required capture files present, no `__pycache__` / `.pyc`
- `npm publish --dry-run --tag latest` → dry-run pass only

## Gates / not done
- No npm publish.
- No GitHub Release creation/update.
- No dist-tag movement.
- No deploy.
- Merge remains owner-gated; publication and release follow-through need separate approval after merge.
