### PR TITLE
chore(release): close 0.32.0 publication proof

### DIFF
--- a/.osc/plans/done/171-capture-package-sync.md
+++ b/.osc/plans/done/171-capture-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 

--- a/.osc/releases/2026-06-13-171-capture-package-sync.md
+++ b/.osc/releases/2026-06-13-171-capture-package-sync.md
@@ -2,18 +2,20 @@
 
 ## Summary
 
-Release-sync candidate for publishing merged `osc capture` work as `open-scaffold@0.32.0` after owner approval. This candidate bumps package metadata and records release truth only; it does not publish npm, create a GitHub Release, move the `latest` dist-tag, or claim a 1.0 maturity contract.
+Published `open-scaffold@0.32.0` as the public `latest` npm package and created GitHub Release `v0.32.0` as Latest after owner-approved release follow-through.
 
-`0.32.0` is used because `osc capture` is a new package-visible CLI/docs/hooks surface. The release remains pre-1.0 and bounded to observed transcript capture, not runtime spawning, semantic approval, compliance, or production-readiness claims.
+`0.32.0` is used because `osc capture` is a new package-visible CLI/docs/hooks surface. The release remains pre-1.0 and bounded to observed transcript capture, not runtime spawning, semantic approval, compliance, production-readiness, or a 1.0 maturity contract.
 
 ## Traceability
 
 - Roadmap / issue / task: package sync for merged plan 170 / `osc capture`.
 - Source plan: `.osc/plans/done/170-ambient-capture.md`.
 - Source PR: https://github.com/graphanov/open-scaffold/pull/215.
-- Release-sync plan: `.osc/plans/active/171-capture-package-sync.md`.
-- Run ID / run packet: N/A for this scoped package/release sync.
-- Branch / PR: `chore/release-0.32.0-package-sync` / https://github.com/graphanov/open-scaffold/pull/216.
+- Release-sync plan: `.osc/plans/done/171-capture-package-sync.md`.
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/216.
+- Release-sync merge commit: `61b858ac79761264ef1b10fb2a2206df13b4f188`.
+- Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/27465464440.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.32.0.
 
 ## Verification
 
@@ -23,13 +25,13 @@ Baseline live-truth inspection before release-sync edits:
 - `git status --short --branch` — PASS: clean `main...origin/main` before candidate branch.
 - `node -p "require('./package.json').version"` — PASS before candidate bump: `0.31.1`.
 - `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before candidate bump: `0.31.1`, `latest: 0.31.1`.
-- `gh release list --repo graphanov/open-scaffold --limit 3` — PASS before candidate bump: `v0.31.1 — Harness release readiness package sync` is Latest.
+- `gh release list --repo graphanov/open-scaffold --limit 3` — PASS before candidate bump: `v0.31.1 — Harness release readiness package sync` was Latest.
 
 Candidate gates before PR-ready:
 
 - [x] Version alignment — PASS: `0.32.0 / 0.32.0 / 0.32.0` for `package.json`, `package-lock.json`, and lockfile root package version.
-- [x] Live registry check — PASS before publication: `npm view open-scaffold version dist-tags --json --prefer-online` reports `0.31.1`, `latest: 0.31.1`; `open-scaffold@0.32.0` returns 404 / not published.
-- [x] `npm ci` — PASS: install completed successfully. npm audit reports one high-severity dev-dependency issue tracked by existing Dependabot PR #214; `npm audit --omit=dev --json` reports 0 production/runtime vulnerabilities.
+- [x] Live registry check before publication — PASS: `npm view open-scaffold version dist-tags --json --prefer-online` reported `0.31.1`, `latest: 0.31.1`; `open-scaffold@0.32.0` returned 404 / not published.
+- [x] `npm ci` — PASS. npm audit reported one high-severity dev-dependency issue tracked by Dependabot PR #214; `npm audit --omit=dev --json` reported 0 production/runtime vulnerabilities.
 - [x] `git diff --check` — PASS.
 - [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn after the intentional live-corpus hash update.
 - [x] `npm test -- --run` — PASS: 48 files / 534 tests.
@@ -37,22 +39,22 @@ Candidate gates before PR-ready:
 - [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
 - [x] `npm pack --dry-run --json` payload inspection after rebuilding — PASS for `open-scaffold@0.32.0`; entry count 205; required `dist/cli.js`, `dist/capture.js`, `dist/ambient.js`, `docs/CAPTURE.md`, and `examples/hooks/*` files present; no `__pycache__`/`.pyc` files.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.32.0` with tag `latest`; dry-run only.
-- [x] Release candidate PR opened: https://github.com/graphanov/open-scaffold/pull/216. Local candidate gates are green; latest GitHub CI/review/thread status is intentionally kept as live PR truth rather than a static committed claim.
+- [x] Release-sync PR opened and merged: https://github.com/graphanov/open-scaffold/pull/216. CI passed, Codex latest-head review was clean, and unresolved current review threads were 0 before merge.
 
-Post-merge/publication gates after future owner-approved follow-through:
+Post-merge/publication gates after owner-approved follow-through:
 
-- [ ] Sync clean `main` after release PR merge.
-- [ ] Main CI for release commit.
-- [ ] Re-run post-merge local publish gates.
-- [ ] Trusted publishing workflow publishes `open-scaffold@0.32.0` with dist-tag `latest`.
-- [ ] Fresh isolated-cache `npx open-scaffold@latest` smokes prove the published package surface.
-- [ ] GitHub Release `v0.32.0` exists, targets the merged release commit, and is marked Latest.
-- [ ] This plan is closed to `done` with final public proof.
+- [x] Sync clean `main` after release PR merge — PASS at `61b858ac79761264ef1b10fb2a2206df13b4f188`.
+- [x] Main CI for release commit — PASS for product `ci`; Dependabot failed separately because PR #214 already exists for `esbuild@0.28.1` (`pull_request_exists_for_latest_version`).
+- [x] Re-run post-merge local publish gates — PASS: version checks, `npm ci`, production audit, `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, secret scan, pack dry-run, and publish dry-run.
+- [x] Trusted publishing workflow published `open-scaffold@0.32.0` with dist-tag `latest` — PASS: https://github.com/graphanov/open-scaffold/actions/runs/27465464440.
+- [x] Fresh isolated-cache `npx open-scaffold@latest` smokes prove the published package surface — PASS for top-level help and `capture --help`.
+- [x] GitHub Release `v0.32.0` exists, targets merged commit `61b858ac79761264ef1b10fb2a2206df13b4f188`, and is marked Latest — PASS: https://github.com/graphanov/open-scaffold/releases/tag/v0.32.0.
+- [x] This plan is closed to `done` with final public proof.
 
 ## Outcome
 
-Candidate package gates passed locally. No npm publication, GitHub Release, dist-tag movement, deploy, or `main` push has occurred in this release-sync slice.
+`open-scaffold@0.32.0` is published on npm with dist-tag `latest`, fresh `npx open-scaffold@latest` smokes passed, and GitHub Release `v0.32.0` is Latest. No deploy was performed and no 1.0 maturity claim was made.
 
 ## Follow-up
 
-- Owner gate after this PR: merge release-sync PR if accepted, then explicitly approve trusted npm publishing and GitHub Release creation for `v0.32.0`.
+- Dependabot PR #214 remains open for the existing dev-dependency security update (`esbuild@0.28.1`).

--- a/MISSION.md
+++ b/MISSION.md
@@ -48,6 +48,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-13: closed 171-capture-package-sync — Published open-scaffold@0.32.0 to npm latest and created GitHub Release v0.32.0 as Latest.
 - 2026-06-13: closed 170-ambient-capture — Shipped osc capture ambient transcript extraction with claude-code, codex, and generic JSONL parsers; verified against owner-local real transcripts.
 - 2026-06-12: closed 168-dollar-verb-retirement — retired the dollar-verb harness/dispatch layer, made osc review the recorded-attempt analysis front door, and removed the outdated README GIF
 - 2026-06-12: Owner added README first-screen cleanup: remove the outdated resume screencast GIF from README and delete the obsolete tracked GIF asset in this slice. — see .osc/plans/done/168-dollar-verb-retirement-amendment-1.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,11 +6,11 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.32.0 — Ambient capture package sync
 
-Status: release candidate in repo for `open-scaffold@0.32.0`; live npm `latest` and GitHub Latest Release remain `v0.31.1` until owner-approved trusted publishing and release follow-through complete.
+Status: published to npm as `open-scaffold@0.32.0`; GitHub Release `v0.32.0` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
-- Publishes merged `osc capture` work from PR #215 to the public `npx open-scaffold@latest` package surface once the release is approved and published.
+- Publishes merged `osc capture` work from PR #215 to the public `npx open-scaffold@latest` package surface.
 - Adds read-only transcript capture for Claude Code, Codex, and generic JSONL into the existing `osc.ambient-work-record.v1` schema.
 - Ships capture docs plus Claude Code/Codex hook examples, with default records written under ignored `.osc/state/ambient/` and Codex notify capture scoped by event `thread-id` / `CODEX_HOME`.
 - Keeps capture explicitly observational: no runtime spawning, no approval, no correctness certification, no compliance claim, and no 1.0 maturity claim.
@@ -19,13 +19,13 @@ Evidence:
 
 - Source plan: `.osc/plans/done/170-ambient-capture.md`
 - Source PR: https://github.com/graphanov/open-scaffold/pull/215
-- Release-sync plan: `.osc/plans/active/171-capture-package-sync.md`
+- Release-sync plan: `.osc/plans/done/171-capture-package-sync.md`
 - Release-sync PR: https://github.com/graphanov/open-scaffold/pull/216
 - Release-sync evidence note: `.osc/releases/2026-06-13-171-capture-package-sync.md`
 
 ## v0.31.1 — Harness release readiness package sync
 
-Status: published to npm as `open-scaffold@0.31.1`; GitHub Release `v0.31.1` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.31.1`; GitHub Release `v0.31.1` was Latest after owner-approved trusted publishing and release follow-through, then was superseded by `v0.32.0`.
 
 Highlights:
 

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -246,12 +246,12 @@ This sample must not count as the real section.
 
     // 169 planning: staged review-battery backlog plan after dollar-verb retirement.
     // 170 closeout: moved capture plan to done and added local evidence note.
-    // 171 release-sync candidate: active package-sync plan for publishing osc capture as v0.32.0.
-    expect(hash(planIssueSnapshot)).toBe('14ef772b59d40494cf04148f7915fdd185c464d3f7bf166a0c4baa0cc6c5d0fb');
+    // 171 release closeout: moved package-sync plan to done after npm/GitHub Release publication proof.
+    expect(hash(planIssueSnapshot)).toBe('e3fcec1d420d1028af71196ba77ee2733376e204408394e4a53fb5b67ee2e90c');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     // 170 review hardening: evidence note refreshed with PR URL, final test count, and Codex-reported total_tokens.
-    // 171 release-sync candidate: added v0.32.0 release evidence note with publication gates still pending.
+    // 171 release closeout: finalized v0.32.0 publication evidence note; release-warning set unchanged.
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('09888cbb861ca90060a1fd4ad1cda2f99dc87284da775ab3eceaacfafbc2ff5a');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });


### PR DESCRIPTION
## Summary
- Closes the `171-capture-package-sync` plan now that `open-scaffold@0.32.0` is published on npm and GitHub Release `v0.32.0` is Latest.
- Updates changelog/evidence truth from candidate state to published/latest state.
- Repins the live corpus hash after moving the release-sync plan from `active/` to `done/`.

## Verification
- `git diff --check`
- `./verify.sh --strict` → 10 pass / 0 fail / 0 warn
- `npm test -- tests/section-parser.test.ts` → 7 passed
- `npm test -- --run` → 48 files / 534 tests
- `npm run build`
- `npm run osc -- doctor --check secret-scan`

## Public proof
- npm: `open-scaffold@0.32.0`, `latest` → `0.32.0`
- Trusted publishing workflow: https://github.com/graphanov/open-scaffold/actions/runs/27465464440
- Fresh isolated-cache `npx open-scaffold@latest --help` and `npx open-scaffold@latest capture --help` passed
- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.32.0

## Gates
- No deploy.
- No 1.0 maturity claim.
