### PR TITLE
chore(release): prepare public readiness package sync

### DIFF
--- a/.osc/plans/active/172-public-readiness-package-sync.md
+++ b/.osc/plans/active/172-public-readiness-package-sync.md
@@ -1,0 +1,57 @@
+# Plan: 172-public-readiness-package-sync
+
+## Status
+
+active
+
+## Context
+
+PR #219 hardened Open Scaffold's public readiness messaging on `main`: README, mission, FAQ, proof-harness docs, Start Here, package metadata, first-run output, and regression tests now describe Open Scaffold as a pre-1.0 repo-native work-record layer with bounded proof claims.
+
+The live public package still advertises the old npm metadata from `open-scaffold@0.32.0`, so users installing through npm do not yet see the corrected package description and keywords. The owner explicitly pre-approved the full release follow-through for this package sync: merge, npm trusted publishing, GitHub Release creation/Latest movement, and public verification for the scoped `0.32.1` release.
+
+## Goal
+
+Publish `open-scaffold@0.32.1` and create GitHub Release `v0.32.1` as Latest so the npm package and GitHub release surfaces match the public-readiness hardening now on `main`.
+
+## Constraints / Out of scope
+
+- Keep this as a pre-1.0 patch release for public positioning/package metadata; do not claim production readiness, compliance certification, broad adoption, or a mature 1.0 contract.
+- Do not add product behavior beyond package/release metadata and evidence required for this release sync.
+- Use the existing trusted-publishing workflow; do not add npm tokens, secrets, or new publish credentials.
+- No deployment, announcement, paid promotion, or public launch campaign is included.
+- Plan `163-proof-harness-v2` remains active and unsatisfied; this slice does not generate new benchmark proof.
+
+## Files to touch
+
+- `package.json` and `package-lock.json` — bump package version to `0.32.1` while preserving the public-readiness metadata from PR #219.
+- `docs/CHANGELOG.md` — add the adoption-facing `v0.32.1` release-sync entry and mark `v0.32.0` as superseded after publication.
+- `.osc/plans/active/172-public-readiness-package-sync.md` — this release-sync plan until publication proof exists.
+- `.osc/releases/2026-06-15-172-public-readiness-package-sync.md` — candidate and final publication evidence.
+- `tests/section-parser.test.ts` — update live-corpus hashes if the plan/evidence/changelog changes require it.
+
+## Acceptance criteria
+
+- [ ] `package.json`, `package-lock.json`, and the lockfile root package version all read `0.32.1`.
+- [ ] Candidate release docs distinguish repo candidate state from live npm/GitHub Release state before publication, and final closeout records npm/GitHub proof after publication.
+- [ ] Local release gates pass: `npm ci`, `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [ ] Package payload inspection confirms `open-scaffold@0.32.1`, includes `dist/cli.js`, README/docs, and package metadata carrying the pre-1.0 work-record positioning.
+- [ ] Release-sync PR is opened, reviewed, merged, npm trusted publishing succeeds, fresh isolated-cache `npx open-scaffold@latest --version` returns `0.32.1`, fresh `--help` smokes pass, and GitHub Release `v0.32.1` is Latest.
+- [ ] No unrelated proof-harness, runtime-controller, benchmark, deployment, or announcement scope is included.
+
+## Verification steps
+
+1. `node -p "require('./package.json').version"` plus package-lock checks — expected `0.32.1` everywhere.
+2. `npm view open-scaffold version description keywords dist-tags --json --prefer-online` — before publication expected live package still `0.32.0` with old metadata; after publication expected `0.32.1` plus public-readiness metadata.
+3. `npm ci` — expected dependency install succeeds with no unexpected lockfile drift.
+4. `git diff --check` — expected no whitespace errors.
+5. `./verify.sh --strict` — expected no failures and no warnings after any required corpus-hash update.
+6. `npm test -- --run` and `npm run build` — expected pass.
+7. `npm run osc -- doctor --check secret-scan` — expected no obvious token/webhook strings found.
+8. `npm pack --dry-run --json` — expected package `open-scaffold@0.32.1` with required CLI/docs payload present and no cache residue.
+9. `npm publish --dry-run --tag latest` — expected dry-run success before real trusted publishing.
+10. PR checks, Codex/latest-head review, review-thread query, trusted publishing workflow, npm registry check, fresh isolated-cache `npx open-scaffold@latest --version`, help smokes, and GitHub Release inspection — expected green/public proof.
+
+## Open questions
+
+- None. The owner explicitly pre-approved merge, npm publish, GitHub Release creation/Latest movement, and public verification for this scoped release sync.

--- a/.osc/releases/2026-06-15-172-public-readiness-package-sync.md
+++ b/.osc/releases/2026-06-15-172-public-readiness-package-sync.md
@@ -1,0 +1,49 @@
+# Release / Evidence Note: 172-public-readiness-package-sync
+
+## Summary
+
+Release-sync candidate for `open-scaffold@0.32.1`. This patch release publishes the public-readiness hardening from PR #219 plus the clean Dependabot lockfile update from PR #218 to npm/GitHub release surfaces, so public package metadata matches the repo's current pre-1.0, proof-boundary-aware positioning.
+
+## Traceability
+
+- Roadmap / issue / task: owner-approved package sync after PR #219 public-readiness hardening and PR #218 dev-dependency lockfile update.
+- Source PRs: https://github.com/graphanov/open-scaffold/pull/219 and https://github.com/graphanov/open-scaffold/pull/218.
+- Release-sync plan: `.osc/plans/active/172-public-readiness-package-sync.md` until publication proof exists.
+- Run ID / run packet: N/A; scoped release/package sync with local and GitHub workflow verification.
+- Branch / PR: `release/public-readiness-0.32.1`; https://github.com/graphanov/open-scaffold/pull/220.
+
+## Verification
+
+Baseline live-truth inspection before release-sync edits:
+
+- `git fetch --prune origin && git checkout main && git pull --ff-only origin main` — PASS: local `main` fast-forwarded through PR #219 merge commit `3705667e50723747c7c4a0fdb121f61a07497638`, then PR #218 merge commit `936c2ce9e880dbbc427c566d7cf1adf075eb5d4e`.
+- `git status --short --branch` — PASS: clean `main...origin/main` before candidate branch.
+- `node -p "require('./package.json').version"` — PASS before candidate bump: `0.32.0`.
+- `npm view open-scaffold version description keywords dist-tags --json --prefer-online` — PASS before candidate bump: live registry still `0.32.0` with old package metadata and `latest: 0.32.0`.
+- `gh release list --repo graphanov/open-scaffold --limit 3` — PASS before candidate bump: `v0.32.0 — Ambient capture package sync` was Latest.
+- PR #219 post-merge `main` CI — PASS.
+- PR #218 pre-merge checks and post-merge `main` CI — PASS.
+
+Candidate gates before PR-ready:
+
+- [x] Version alignment — PASS: `0.32.1 / 0.32.1 / 0.32.1` for `package.json`, `package-lock.json`, and lockfile root package version.
+- [x] Live registry check before publication — PASS: `open-scaffold@0.32.1` returned 404 / not published; current live registry reports `0.32.0`, `latest: 0.32.0`, and old metadata.
+- [x] `npm ci` — PASS: 51 packages installed/audited; 0 vulnerabilities.
+- [x] `git diff --check` — PASS.
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn after the intentional live-corpus hash update.
+- [x] `npm test -- --run` — PASS: 48 files / 535 tests.
+- [x] `npm run build` — PASS: core TypeScript build and runtime-omx build.
+- [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
+- [x] `npm pack --dry-run --json` payload inspection — PASS for `open-scaffold@0.32.1`; entry count 205; required `dist/cli.js`, `README.md`, `docs/CHANGELOG.md`, `docs/PROOF_HARNESS.md`, `docs/STABILITY.md`, and `docs/START_HERE.md` present; no `__pycache__`/`.pyc` files.
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.32.1` with tag `latest`; dry-run only.
+- [ ] Release-sync PR opened, merged, npm trusted publishing run completed, fresh `npx open-scaffold@latest --version` returns `0.32.1`, fresh help smokes passed, and GitHub Release `v0.32.1` created as Latest — pending.
+
+## Outcome
+
+Candidate in progress. Publication, GitHub Release creation/Latest movement, final closeout, and public verification are owner-preapproved for this scoped release sync, but not yet executed in this evidence note.
+
+## Follow-up
+
+- Open and merge the release-sync PR after candidate gates pass.
+- Dispatch trusted publishing for `open-scaffold@0.32.1` with npm tag `latest`.
+- Verify npm registry metadata, fresh isolated-cache `npx open-scaffold@latest --version` plus help smokes, GitHub Release `v0.32.1` as Latest, and then close this plan with final proof.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,26 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.32.1 — Public-readiness package sync
+
+Status: `v0.32.1` release-sync entry. The authoritative live package/release state is npm plus GitHub Releases; packaged changelog files are immutable once published.
+
+Highlights:
+
+- Publishes the PR #219 public-readiness hardening to the public `npx open-scaffold@latest` package surface.
+- Updates npm package metadata to describe Open Scaffold as a pre-1.0 repo-native work-record CLI for AI-agent handoff, evidence, and review.
+- Keeps the proof boundary explicit: this is not production-readiness, compliance certification, broad adoption proof, mature 1.0 status, or universal benchmark superiority.
+- Includes the PR #218 development-dependency lockfile refresh before publication.
+
+Evidence:
+
+- Source PRs: https://github.com/graphanov/open-scaffold/pull/219 and https://github.com/graphanov/open-scaffold/pull/218
+- Release-sync plan: `.osc/plans/active/172-public-readiness-package-sync.md`
+- Release-sync evidence note: `.osc/releases/2026-06-15-172-public-readiness-package-sync.md`
+
 ## v0.32.0 — Ambient capture package sync
 
-Status: published to npm as `open-scaffold@0.32.0`; GitHub Release `v0.32.0` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.32.0` with GitHub Release `v0.32.0`; later release supersession is determined by npm plus GitHub Releases.
 
 Highlights:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.32.0",
+      "version": "0.32.1",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Pre-1.0 repo-native work-record CLI for AI-agent handoff, evidence, and review.",
   "license": "MIT",
   "repository": {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -248,13 +248,15 @@ This sample must not count as the real section.
     // 170 closeout: moved capture plan to done and added local evidence note.
     // 171 release closeout: moved package-sync plan to done after npm/GitHub Release publication proof.
     // public-readiness-hardening: added done plan and release note for bounded public readiness copy.
-    expect(hash(planIssueSnapshot)).toBe('ec0e019e95b92820adde7334b70ddab5b074c4dafe2dad7de7a5d577e4c04a89');
+    // 172 release candidate: added active public-readiness package-sync plan.
+    expect(hash(planIssueSnapshot)).toBe('5cb202c35cc1763eb7feda96fa8e96f90092611548c6861acffd22efc045c9e3');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     // 170 review hardening: evidence note refreshed with PR URL, final test count, and Codex-reported total_tokens.
     // 171 release closeout: finalized v0.32.0 publication evidence note; release-warning set unchanged.
     // public-readiness-hardening: release note added with no new release warnings.
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('dd1b7451952cb18163aede013ae50b17de6c0511430c9ac66349af6e9cff57f1');
+    // 172 release candidate: release note added with no new release warnings.
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('69c2c3f35a7e509d9c3d23e4ee20b5ddb1d8c13f28dad7f242843b04c3d74f37');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Prepares `open-scaffold@0.32.1` so npm/GitHub release surfaces can publish the public-readiness hardening from PR #219.
- Keeps the release explicitly pre-1.0 and proof-boundary-aware: no production-readiness, compliance, broad-adoption, mature-1.0, or universal benchmark claim.
- Includes the already-merged PR #218 dev-dependency lockfile refresh before publication.

## Files touched
- `package.json`, `package-lock.json` — bump root package/version lock to `0.32.1`.
- `docs/CHANGELOG.md` — add the `v0.32.1` candidate entry and keep live truth at `v0.32.0` until publication follow-through completes.
- `.osc/plans/active/172-public-readiness-package-sync.md` — release-sync plan remains active until public publication proof exists.
- `.osc/releases/2026-06-15-172-public-readiness-package-sync.md` — candidate release evidence.
- `tests/section-parser.test.ts` — live-corpus hash update for the added plan/evidence.

## Verification
- `node` package/lock version check — PASS: `0.32.1 / 0.32.1 / 0.32.1`.
- `npm view open-scaffold@0.32.1 version --prefer-online` — PASS: 404/not published before release.
- `npm view open-scaffold version description keywords dist-tags --json --prefer-online` — PASS: live package remains `0.32.0` with old metadata before publication.
- `npm ci` — PASS: 51 packages installed/audited; 0 vulnerabilities.
- `git diff --check` — PASS.
- `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
- `npm test -- --run` — PASS: 48 files / 535 tests.
- `npm run build` — PASS.
- `npm run osc -- doctor --check secret-scan` — PASS.
- `npm pack --dry-run --json` payload inspection — PASS for `open-scaffold@0.32.1`; 205 files; required CLI/docs files present; no `__pycache__`/`.pyc` residue.
- `npm publish --dry-run --tag latest` — PASS; dry-run only.
- Public added-line safety scan — PASS for configured private markers/token patterns.

## Release gates
- Owner has pre-approved merge, trusted npm publishing with dist-tag `latest`, GitHub Release `v0.32.1` creation/Latest movement, and public verification for this scoped release sync.
- This PR still performs no actual npm publish or GitHub Release creation by itself; those happen after merge from clean `main` via the trusted-publishing workflow and `gh release` follow-through.

## Known gaps / out of scope
- Plan `163-proof-harness-v2` remains active and unsatisfied; this release sync does not create new benchmark proof.
- No deployment, announcement, paid promotion, runtime-controller work, or launch campaign is included.
