### PR TITLE
docs(release): close 0.32.1 public readiness sync

### DIFF
--- a/.osc/plans/done/172-public-readiness-package-sync.md
+++ b/.osc/plans/done/172-public-readiness-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-active
+done
 
 ## Context
 
@@ -26,18 +26,18 @@ Publish `open-scaffold@0.32.1` and create GitHub Release `v0.32.1` as Latest so 
 
 - `package.json` and `package-lock.json` — bump package version to `0.32.1` while preserving the public-readiness metadata from PR #219.
 - `docs/CHANGELOG.md` — add the adoption-facing `v0.32.1` release-sync entry and mark `v0.32.0` as superseded after publication.
-- `.osc/plans/active/172-public-readiness-package-sync.md` — this release-sync plan until publication proof exists.
+- `.osc/plans/done/172-public-readiness-package-sync.md` — completed release-sync plan after publication proof.
 - `.osc/releases/2026-06-15-172-public-readiness-package-sync.md` — candidate and final publication evidence.
 - `tests/section-parser.test.ts` — update live-corpus hashes if the plan/evidence/changelog changes require it.
 
 ## Acceptance criteria
 
-- [ ] `package.json`, `package-lock.json`, and the lockfile root package version all read `0.32.1`.
-- [ ] Candidate release docs distinguish repo candidate state from live npm/GitHub Release state before publication, and final closeout records npm/GitHub proof after publication.
-- [ ] Local release gates pass: `npm ci`, `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
-- [ ] Package payload inspection confirms `open-scaffold@0.32.1`, includes `dist/cli.js`, README/docs, and package metadata carrying the pre-1.0 work-record positioning.
-- [ ] Release-sync PR is opened, reviewed, merged, npm trusted publishing succeeds, fresh isolated-cache `npx open-scaffold@latest --version` returns `0.32.1`, fresh `--help` smokes pass, and GitHub Release `v0.32.1` is Latest.
-- [ ] No unrelated proof-harness, runtime-controller, benchmark, deployment, or announcement scope is included.
+- [x] `package.json`, `package-lock.json`, and the lockfile root package version all read `0.32.1`.
+- [x] Candidate release docs distinguish repo candidate state from live npm/GitHub Release state before publication, and final closeout records npm/GitHub proof after publication.
+- [x] Local release gates pass: `npm ci`, `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Package payload inspection confirms `open-scaffold@0.32.1`, includes `dist/cli.js`, README/docs, and package metadata carrying the pre-1.0 work-record positioning.
+- [x] Release-sync PR is opened, reviewed, merged, npm trusted publishing succeeds, fresh isolated-cache `npx open-scaffold@latest --version` returns `0.32.1`, fresh `--help` smokes pass, and GitHub Release `v0.32.1` is Latest.
+- [x] No unrelated proof-harness, runtime-controller, benchmark, deployment, or announcement scope is included.
 
 ## Verification steps
 

--- a/.osc/releases/2026-06-13-171-capture-package-sync.md
+++ b/.osc/releases/2026-06-13-171-capture-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Published `open-scaffold@0.32.0` as the public `latest` npm package and created GitHub Release `v0.32.0` as Latest after owner-approved release follow-through.
+Published `open-scaffold@0.32.0` as the public `latest` npm package and created GitHub Release `v0.32.0` as Latest after owner-approved release follow-through. It was later superseded by `v0.32.1`.
 
 `0.32.0` is used because `osc capture` is a new package-visible CLI/docs/hooks surface. The release remains pre-1.0 and bounded to observed transcript capture, not runtime spawning, semantic approval, compliance, production-readiness, or a 1.0 maturity contract.
 
@@ -48,12 +48,12 @@ Post-merge/publication gates after owner-approved follow-through:
 - [x] Re-run post-merge local publish gates — PASS: version checks, `npm ci`, production audit, `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, secret scan, pack dry-run, and publish dry-run.
 - [x] Trusted publishing workflow published `open-scaffold@0.32.0` with dist-tag `latest` — PASS: https://github.com/graphanov/open-scaffold/actions/runs/27465464440.
 - [x] Fresh isolated-cache `npx open-scaffold@latest` smokes prove the published package surface — PASS for top-level help and `capture --help`.
-- [x] GitHub Release `v0.32.0` exists, targets merged commit `61b858ac79761264ef1b10fb2a2206df13b4f188`, and is marked Latest — PASS: https://github.com/graphanov/open-scaffold/releases/tag/v0.32.0.
+- [x] GitHub Release `v0.32.0` exists, targets merged commit `61b858ac79761264ef1b10fb2a2206df13b4f188`, and was marked Latest at publication time before `v0.32.1` superseded it — PASS: https://github.com/graphanov/open-scaffold/releases/tag/v0.32.0.
 - [x] This plan is closed to `done` with final public proof.
 
 ## Outcome
 
-`open-scaffold@0.32.0` is published on npm with dist-tag `latest`, fresh `npx open-scaffold@latest` smokes passed, and GitHub Release `v0.32.0` is Latest. No deploy was performed and no 1.0 maturity claim was made.
+`open-scaffold@0.32.0` was published on npm with dist-tag `latest`, fresh `npx open-scaffold@latest` smokes passed, and GitHub Release `v0.32.0` was Latest until superseded by `v0.32.1`. No deploy was performed and no 1.0 maturity claim was made.
 
 ## Follow-up
 

--- a/.osc/releases/2026-06-15-172-public-readiness-package-sync.md
+++ b/.osc/releases/2026-06-15-172-public-readiness-package-sync.md
@@ -2,15 +2,17 @@
 
 ## Summary
 
-Release-sync candidate for `open-scaffold@0.32.1`. This patch release publishes the public-readiness hardening from PR #219 plus the clean Dependabot lockfile update from PR #218 to npm/GitHub release surfaces, so public package metadata matches the repo's current pre-1.0, proof-boundary-aware positioning.
+`open-scaffold@0.32.1` is published as npm `latest`, and GitHub Release `v0.32.1 — Public-readiness package sync` is published as Latest. This patch release publishes the public-readiness hardening from PR #219 plus the clean Dependabot lockfile update from PR #218 to npm/GitHub release surfaces, so public package metadata matches the repo's current pre-1.0, proof-boundary-aware positioning.
 
 ## Traceability
 
 - Roadmap / issue / task: owner-approved package sync after PR #219 public-readiness hardening and PR #218 dev-dependency lockfile update.
 - Source PRs: https://github.com/graphanov/open-scaffold/pull/219 and https://github.com/graphanov/open-scaffold/pull/218.
-- Release-sync plan: `.osc/plans/active/172-public-readiness-package-sync.md` until publication proof exists.
-- Run ID / run packet: N/A; scoped release/package sync with local and GitHub workflow verification.
-- Branch / PR: `release/public-readiness-0.32.1`; https://github.com/graphanov/open-scaffold/pull/220.
+- Release-sync plan: `.osc/plans/done/172-public-readiness-package-sync.md`.
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/220.
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/27569365137.
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.32.1.
+- Target commit: `ea701e76b6e0a00974f09e830eafca129e2a4460`.
 
 ## Verification
 
@@ -24,10 +26,10 @@ Baseline live-truth inspection before release-sync edits:
 - PR #219 post-merge `main` CI — PASS.
 - PR #218 pre-merge checks and post-merge `main` CI — PASS.
 
-Candidate gates before PR-ready:
+Candidate and PR gates before merge:
 
 - [x] Version alignment — PASS: `0.32.1 / 0.32.1 / 0.32.1` for `package.json`, `package-lock.json`, and lockfile root package version.
-- [x] Live registry check before publication — PASS: `open-scaffold@0.32.1` returned 404 / not published; current live registry reports `0.32.0`, `latest: 0.32.0`, and old metadata.
+- [x] Live registry check before publication — PASS: `open-scaffold@0.32.1` returned 404 / not published; current live registry reported `0.32.0`, `latest: 0.32.0`, and old metadata.
 - [x] `npm ci` — PASS: 51 packages installed/audited; 0 vulnerabilities.
 - [x] `git diff --check` — PASS.
 - [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn after the intentional live-corpus hash update.
@@ -36,14 +38,33 @@ Candidate gates before PR-ready:
 - [x] `npm run osc -- doctor --check secret-scan` — PASS: `PASS secret-scan: no obvious token/webhook strings found.`
 - [x] `npm pack --dry-run --json` payload inspection — PASS for `open-scaffold@0.32.1`; entry count 205; required `dist/cli.js`, `README.md`, `docs/CHANGELOG.md`, `docs/PROOF_HARNESS.md`, `docs/STABILITY.md`, and `docs/START_HERE.md` present; no `__pycache__`/`.pyc` files.
 - [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.32.1` with tag `latest`; dry-run only.
-- [ ] Release-sync PR opened, merged, npm trusted publishing run completed, fresh `npx open-scaffold@latest --version` returns `0.32.1`, fresh help smokes passed, and GitHub Release `v0.32.1` created as Latest — pending.
+- [x] PR #220 checks — PASS: `ci`, `Validate changed plans`, `Validate evidence notes`, and `Structural Open Scaffold PR check`; skipped mirrors were non-blocking.
+- [x] PR #220 latest-head Codex review — PASS: latest clean artifact at `2026-06-15T18:51:53Z` for head `cecddc9413`; unresolved current review threads `0`.
+- [x] PR #220 merge — PASS: squash-merged to `main` as `ea701e76b6e0a00974f09e830eafca129e2a4460`.
+
+Post-merge and publication gates:
+
+- [x] Post-merge local `main` — PASS: fast-forwarded to `ea701e76b6e0a00974f09e830eafca129e2a4460`.
+- [x] Post-merge `main` CI — PASS: `ci` completed successfully for `ea701e76b6e0a00974f09e830eafca129e2a4460`.
+- [x] `npm ci` — PASS: 51 packages installed/audited; 0 vulnerabilities.
+- [x] `git diff --check` — PASS.
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
+- [x] `npm test -- --run` — PASS: 48 files / 535 tests.
+- [x] `npm run build` — PASS.
+- [x] `npm run osc -- doctor --check secret-scan` — PASS.
+- [x] `npm pack --dry-run --json` — PASS for `open-scaffold@0.32.1`; 205 files; required CLI/docs present; no `__pycache__`, `.pyc`, or `.DS_Store` residue; shasum `8fc5125a854b37bb2f8667af7690464af9829176`.
+- [x] `npm publish --dry-run --tag latest` — PASS.
+- [x] Trusted publishing workflow — PASS: run `27569365137`, job `Publish package`, conclusion `success`.
+- [x] npm registry verification — PASS: `open-scaffold@0.32.1`, `latest: 0.32.1`, description `Pre-1.0 repo-native work-record CLI for AI-agent handoff, evidence, and review.`, proof-boundary keywords present.
+- [x] Fresh isolated-cache `npx open-scaffold@latest --version` — PASS: `0.32.1`.
+- [x] Fresh isolated-cache `npx open-scaffold@latest --help` — PASS: help exposed `osc` and `first-run`.
+- [x] Fresh isolated-cache `npx open-scaffold@latest first-run --non-interactive ...` — PASS: created mission/plan/evidence skeleton and printed evidence-chain, proof-harness, stability, production-readiness, and semantic-correctness boundary guidance.
+- [x] GitHub Release `v0.32.1` — PASS: published as Latest, target `ea701e76b6e0a00974f09e830eafca129e2a4460`.
 
 ## Outcome
 
-Candidate in progress. Publication, GitHub Release creation/Latest movement, final closeout, and public verification are owner-preapproved for this scoped release sync, but not yet executed in this evidence note.
+Complete. Public package, GitHub Release, shipped docs, and first-run output now expose the public-readiness hardening from PR #219 under `open-scaffold@0.32.1` / `v0.32.1`.
 
 ## Follow-up
 
-- Open and merge the release-sync PR after candidate gates pass.
-- Dispatch trusted publishing for `open-scaffold@0.32.1` with npm tag `latest`.
-- Verify npm registry metadata, fresh isolated-cache `npx open-scaffold@latest --version` plus help smokes, GitHub Release `v0.32.1` as Latest, and then close this plan with final proof.
+- This closeout moves the release-sync plan to `.osc/plans/done/172-public-readiness-package-sync.md`, updates adoption-facing release truth, and leaves proof-harness v2 work out of scope.

--- a/MISSION.md
+++ b/MISSION.md
@@ -52,6 +52,7 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-15: closed 172-public-readiness-package-sync — Published open-scaffold@0.32.1 to npm latest and created GitHub Release v0.32.1 as Latest.
 - 2026-06-15: closed public-readiness-hardening — hardened public readiness messaging
 - 2026-06-13: closed 171-capture-package-sync — Published open-scaffold@0.32.0 to npm latest and created GitHub Release v0.32.0 as Latest.
 - 2026-06-13: closed 170-ambient-capture — Shipped osc capture ambient transcript extraction with claude-code, codex, and generic JSONL parsers; verified against owner-local real transcripts.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.32.1 — Public-readiness package sync
 
-Status: `v0.32.1` release-sync entry. The authoritative live package/release state is npm plus GitHub Releases; packaged changelog files are immutable once published.
+Status: published to npm as `open-scaffold@0.32.1`; GitHub Release `v0.32.1` is Latest after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 
@@ -18,12 +18,15 @@ Highlights:
 Evidence:
 
 - Source PRs: https://github.com/graphanov/open-scaffold/pull/219 and https://github.com/graphanov/open-scaffold/pull/218
-- Release-sync plan: `.osc/plans/active/172-public-readiness-package-sync.md`
+- Release-sync plan: `.osc/plans/done/172-public-readiness-package-sync.md`
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/220
 - Release-sync evidence note: `.osc/releases/2026-06-15-172-public-readiness-package-sync.md`
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/27569365137
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.32.1
 
 ## v0.32.0 — Ambient capture package sync
 
-Status: published to npm as `open-scaffold@0.32.0` with GitHub Release `v0.32.0`; later release supersession is determined by npm plus GitHub Releases.
+Status: published to npm as `open-scaffold@0.32.0`; GitHub Release `v0.32.0` was Latest after owner-approved trusted publishing and release follow-through, then was superseded by `v0.32.1`.
 
 Highlights:
 

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -248,14 +248,14 @@ This sample must not count as the real section.
     // 170 closeout: moved capture plan to done and added local evidence note.
     // 171 release closeout: moved package-sync plan to done after npm/GitHub Release publication proof.
     // public-readiness-hardening: added done plan and release note for bounded public readiness copy.
-    // 172 release candidate: added active public-readiness package-sync plan.
-    expect(hash(planIssueSnapshot)).toBe('5cb202c35cc1763eb7feda96fa8e96f90092611548c6861acffd22efc045c9e3');
+    // 172 release closeout: moved public-readiness package-sync plan to done after npm/GitHub Release publication proof.
+    expect(hash(planIssueSnapshot)).toBe('34ddba9dc873591913b74027cd71e82fab4a42a2e2b444192d05a7126c79a92e');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     // 170 review hardening: evidence note refreshed with PR URL, final test count, and Codex-reported total_tokens.
     // 171 release closeout: finalized v0.32.0 publication evidence note; release-warning set unchanged.
     // public-readiness-hardening: release note added with no new release warnings.
-    // 172 release candidate: release note added with no new release warnings.
+    // 172 release closeout: finalized v0.32.1 publication evidence note; release-warning set unchanged.
     expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('69c2c3f35a7e509d9c3d23e4ee20b5ddb1d8c13f28dad7f242843b04c3d74f37');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });


### PR DESCRIPTION
## Summary
- Closes the `172-public-readiness-package-sync` plan now that `open-scaffold@0.32.1` is published and GitHub Release `v0.32.1` is Latest.
- Finalizes the `0.32.1` evidence note with trusted-publishing, npm registry, fresh `npx`, first-run, and GitHub Release proof.
- Updates adoption-facing release truth so `v0.32.1` is the current Latest and `v0.32.0` is described as superseded.

## Files touched
- `.osc/plans/done/172-public-readiness-package-sync.md` — moved from active to done, marked done, acceptance criteria checked.
- `.osc/releases/2026-06-15-172-public-readiness-package-sync.md` — finalized publication proof.
- `.osc/releases/2026-06-13-171-capture-package-sync.md` — marks `v0.32.0` as superseded by `v0.32.1`.
- `docs/CHANGELOG.md`, `MISSION.md` — adoption-facing release truth and mission changelog.
- `tests/section-parser.test.ts` — updates the live-corpus plan hash after the active→done move.

## Verification
- Public added-line safety scan — PASS.
- `git diff --check` — PASS.
- `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
- `npm test -- --run tests/section-parser.test.ts` — PASS: 1 file / 7 tests.
- `npm test -- --run` — PASS: 48 files / 535 tests.
- `npm run build` — PASS.
- `npm run osc -- doctor --check secret-scan` — PASS.

## Release proof referenced
- npm `open-scaffold@0.32.1`, `latest -> 0.32.1`.
- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/27569365137.
- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.32.1.
