### PR TITLE
ci: use maintained CLI in stale-plan workflow

### DIFF
--- a/.github/workflows/stale-plans.yml
+++ b/.github/workflows/stale-plans.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Build CLI
         run: npm run build
 
-      - name: Capture scaffold metrics
-        run: node dist/cli.js metrics --json --verbose > scaffold-metrics.json
+      - name: Capture scaffold status
+        run: node dist/cli.js status --json > scaffold-status.json
 
       - name: Detect stale active plans
         id: stale

--- a/tests/github-actions-workflows.test.ts
+++ b/tests/github-actions-workflows.test.ts
@@ -23,6 +23,14 @@ describe('GitHub Actions workflow templates', () => {
     expect(workflow).toContain("grep -v -- '-amendment-'");
   });
 
+  it('keeps the stale active plans workflow on maintained CLI surfaces', () => {
+    const workflow = read('.github/workflows/stale-plans.yml');
+
+    expect(workflow).toContain('node dist/cli.js status --json > scaffold-status.json');
+    expect(workflow).not.toContain('node dist/cli.js metrics');
+    expect(workflow).not.toContain('scaffold-metrics.json');
+  });
+
   it('checks out workflows with authenticated fetch and public fallback', () => {
     for (const workflowPath of [
       '.github/workflows/ci.yml',


### PR DESCRIPTION
## Summary
- replace the stale active-plan workflow's retired `osc metrics` invocation with maintained `osc status --json`
- add a workflow regression test so the stale-plan workflow cannot reintroduce the removed metrics command or `scaffold-metrics.json`

## Verification
- `grep -RIn "node dist/cli.js metrics\|scaffold-metrics.json\|Capture scaffold metrics" .github/workflows docs README.md package.json` returned no matches
- YAML parsed for all `.github/workflows/*.yml` via Ruby Psych
- `npm run build`
- `node dist/cli.js status --json` parsed with `scaffold`, `summary`, and `validation` keys
- `npm test -- --run tests/github-actions-workflows.test.ts`
- `./verify.sh --strict`
- `npm test -- --run`
- `npm run -s osc -- doctor --check secret-scan`
- `git diff --check`

## Risk / Gates
- CI-only change; no package version, release, publish, or public-product-surface update.
- Owner review required before merge.
