### PR TITLE
docs: polish v1 public positioning

### DIFF
--- a/.osc/plans/done/v1-public-positioning-polish.md
+++ b/.osc/plans/done/v1-public-positioning-polish.md
@@ -1,0 +1,52 @@
+# Plan: v1-public-positioning-polish
+
+## Status
+
+done
+
+## Context
+
+A public-release reader must be able to answer three questions in the first minute: what Open Scaffold is, who it is for, and what it offers now. The current repo mostly has the right story, but first-touch docs still mix older identities: harness/product language, agent-orchestrated development, control-room examples, pre-1.0/v1 history, and handoff/resume command drift. This slice makes the public product contract unambiguous without publishing npm, moving GitHub Releases, or claiming mature production/compliance readiness.
+
+## Goal
+
+Make Open Scaffold read as one product everywhere a public v1 candidate reader is likely to enter: a repo-native work record for AI-assisted work, offering ambient capture, handoff/resume, review/gate, and evidence boundaries for developers and teams whose AI work must survive sessions, PRs, and audits.
+
+## Constraints / Out of scope
+
+- No npm publish, GitHub Release create/update, website deployment, merge, force-push, or launch announcement.
+- No new runtime/spawning/controller promise; runtime execution remains outside core.
+- No broad benchmark, production-readiness, compliance, or cheap-model dominance claim.
+- No rewrite of append-only historical changelog entries except adding clarifying current-context notes where needed.
+
+## Files to touch
+
+- `README.md` — sharpen the first-screen offering, deduplicate key docs, fix anchors, soften overclaims.
+- `MISSION.md`, `ROADMAP.md` — align canonical identity and v1/history wording with the current work-record product.
+- `AGENTS.md`, `CLAUDE.md` — keep paired agent entrypoints aligned with product identity and command aliases.
+- `docs/START_HERE.md`, `docs/STABILITY.md`, `docs/FAQ.md`, `docs/index.html`, `LLM_QUICKSTART.md`, `docs/examples/README.md`, `docs/EXAMPLES.md` — remove first-touch ambiguity about audience, commands, and runtime boundaries.
+- `docs/TRUST_BOUNDARIES.md`, `docs/OPEN_SCAFFOLD_SYSTEM.md`, `docs/WORKFLOW.md` — clarify system boundary without old agent-OS/control-plane framing.
+- `tests/public-positioning.test.ts`, `tests/reduced-cli-docs.test.ts`, `tests/cli-lifecycle-help.test.ts` — add guards so the public identity and retired-command boundaries stay fixed.
+
+## Acceptance criteria
+
+- [x] First-touch docs consistently define Open Scaffold as a repo-native work record / record-handoff-review layer for AI-assisted work.
+- [x] Target audience is explicit: developers and teams using AI agents on work that needs context recovery, review, evidence, PR/client/audit traceability, or multi-session handoff.
+- [x] Runtime/harness/control-room material is labeled as external, historical, or advanced; it is not the public product offering.
+- [x] `osc handoff`, `osc review`, and `osc gate` are the public front door; `osc resume` is consistently described as the read-only alias/back-compat entry used by agent bootstraps.
+- [x] v1/readiness wording separates the current package truth (`v0.32.x` pre-1.0 line and historical `v1.0.x` artifacts) from the product contract being prepared.
+- [x] Tests fail if duplicate README key-doc links, stale first-touch command docs, or incomplete retired-command shims return.
+
+## Verification steps
+
+1. `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/cli-lifecycle-help.test.ts tests/first-run-docs.test.ts tests/package-payload.test.ts` — targeted public-surface guards pass.
+2. `npm test -- --run` — full suite passes.
+3. `npm run build` — package build passes.
+4. `./verify.sh --strict` — repository protocol verification passes.
+5. `git diff --check` — no whitespace errors.
+6. `npm run -s osc -- --help`, `npm run -s osc -- help --all`, and retired-command smoke checks — help and migration boundaries match the docs.
+7. `npm pack --dry-run --json` — package payload still builds without dogfood residue.
+
+## Open questions
+
+- Whether the eventual public v1 release should be a package version change is an owner/publish gate. This slice prepares the product identity and release-readiness wording but does not publish or move release surfaces.

--- a/.osc/releases/2026-06-18-v1-public-positioning-polish.md
+++ b/.osc/releases/2026-06-18-v1-public-positioning-polish.md
@@ -25,7 +25,7 @@ This note records local release-readiness evidence only. It does not claim merge
 - Retired-command smoke loop for `work dispatch adapter metrics dashboard task study ab harness` — each exited `2` and included `removed/repositioned` plus `docs/STABILITY.md#command-maturity`.
 - Added-line public-safety scan over the diff — passed for local paths, personal names/emails/phone, and known Discord IDs.
 - `npm run -s osc -- doctor --check secret-scan` — `PASS secret-scan: no obvious token/webhook strings found.`
-- `npm pack --dry-run --json` — passed after prepack build; package payload contained `224` files, dry-run package size `387021` bytes.
+- `npm pack --dry-run --json` — passed after prepack build; package payload contained `224` files, dry-run package size `387096` bytes.
 
 ## Outcome
 

--- a/.osc/releases/2026-06-18-v1-public-positioning-polish.md
+++ b/.osc/releases/2026-06-18-v1-public-positioning-polish.md
@@ -11,7 +11,7 @@ This note records local release-readiness evidence only. It does not claim merge
 - Roadmap / issue / task: owner-scoped public v1 positioning polish request in this session.
 - Plan: `.osc/plans/done/v1-public-positioning-polish.md` after close.
 - Run ID / run packet: `N/A` — documentation/code polish executed directly on branch, no external runtime package was dispatched.
-- Branch / PR: local branch `docs/v1-public-positioning-polish`; PR pending owner decision.
+- Branch / PR: `docs/v1-public-positioning-polish`, https://github.com/graphanov/open-scaffold/pull/225; merge remains pending owner decision.
 
 ## Verification
 

--- a/.osc/releases/2026-06-18-v1-public-positioning-polish.md
+++ b/.osc/releases/2026-06-18-v1-public-positioning-polish.md
@@ -16,16 +16,16 @@ This note records local release-readiness evidence only. It does not claim merge
 ## Verification
 
 - `npm run -s osc -- plan validate .osc/plans/done/v1-public-positioning-polish.md --strict` — `0 issues found`.
-- Targeted public/readiness tests: `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/package-payload.test.ts tests/section-parser.test.ts` — passed: `6 passed`, `58 tests passed`.
+- Targeted public/readiness tests: `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/package-payload.test.ts tests/section-parser.test.ts` — passed: `6 passed`, `68 tests passed`.
 - `npm run build` — passed (`build:core` and `build:runtime-omx`).
-- `npm test -- --run` — passed: `48 passed`, `545 tests passed`.
+- `npm test -- --run` — passed: `48 passed`, `555 tests passed`.
 - `./verify.sh --strict` — passed: `10 pass, 0 fail, 0 warn`.
 - `git diff --check` — passed with no output.
 - `npm run -s osc -- --help` and `npm run -s osc -- help --all` — rendered successfully.
 - Retired-command smoke loop for `work dispatch adapter metrics dashboard task study ab harness` — each exited `2` and included `removed/repositioned` plus `docs/STABILITY.md#command-maturity`.
 - Added-line public-safety scan over the diff — passed for local paths, personal names/emails/phone, and known Discord IDs.
 - `npm run -s osc -- doctor --check secret-scan` — `PASS secret-scan: no obvious token/webhook strings found.`
-- `npm pack --dry-run --json` — passed after prepack build; package payload contained `224` files, dry-run package size `387002` bytes.
+- `npm pack --dry-run --json` — passed after prepack build; package payload contained `224` files, dry-run package size `387011` bytes.
 
 ## Outcome
 

--- a/.osc/releases/2026-06-18-v1-public-positioning-polish.md
+++ b/.osc/releases/2026-06-18-v1-public-positioning-polish.md
@@ -1,0 +1,39 @@
+# Release / Evidence Note: v1-public-positioning-polish
+
+## Summary
+
+Polished Open Scaffold's public product identity so first-touch surfaces consistently describe it as a repo-native work record for AI-assisted work: ambient capture, handoff/resume, review/gate, and evidence boundaries. Removed or labeled older harness/control-room/runtime language from the release path, clarified the current `v0.32.x` pre-1.0 package truth versus historical `v1.0.x` artifacts, and added tests that guard the public positioning and retired-command boundaries.
+
+This note records local release-readiness evidence only. It does not claim merge, npm publication, GitHub Release movement, website deployment, or launch approval.
+
+## Traceability
+
+- Roadmap / issue / task: owner-scoped public v1 positioning polish request in this session.
+- Plan: `.osc/plans/done/v1-public-positioning-polish.md` after close.
+- Run ID / run packet: `N/A` — documentation/code polish executed directly on branch, no external runtime package was dispatched.
+- Branch / PR: local branch `docs/v1-public-positioning-polish`; PR pending owner decision.
+
+## Verification
+
+- `npm run -s osc -- plan validate .osc/plans/done/v1-public-positioning-polish.md --strict` — `0 issues found`.
+- Targeted public/readiness tests: `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/package-payload.test.ts tests/section-parser.test.ts` — passed: `6 passed`, `57 tests passed`.
+- `npm run build` — passed (`build:core` and `build:runtime-omx`).
+- `npm test -- --run` — passed: `48 passed`, `544 tests passed`.
+- `./verify.sh --strict` — passed: `10 pass, 0 fail, 0 warn`.
+- `git diff --check` — passed with no output.
+- `npm run -s osc -- --help` and `npm run -s osc -- help --all` — rendered successfully.
+- Retired-command smoke loop for `work dispatch adapter metrics dashboard task study ab harness` — each exited `2` and included `removed/repositioned` plus `docs/STABILITY.md#command-maturity`.
+- Added-line public-safety scan over the diff — passed for local paths, personal names/emails/phone, and known Discord IDs.
+- `npm run -s osc -- doctor --check secret-scan` — `PASS secret-scan: no obvious token/webhook strings found.`
+- `npm pack --dry-run --json` — passed after prepack build; package payload contained `224` files, dry-run package size `387002` bytes.
+
+## Outcome
+
+The branch now has a coherent public v1-candidate product story across README, mission, start docs, agent entrypoints, docs landing page, examples, stability/version truth, trust boundaries, workflow docs, and CLI help. The public offer is one thing: repo-native records, handoff/resume, review/gate, and evidence for AI-assisted work that must survive sessions, PRs, clients, audits, or repeated attempts.
+
+Out of scope remains unchanged: Open Scaffold still does not run agents, host orchestration, certify compliance, prove production readiness, publish npm, move GitHub Release Latest, merge, deploy, or launch publicly without owner approval.
+
+## Follow-up
+
+- Owner gate: decide whether to commit/push/open a PR from `docs/v1-public-positioning-polish`.
+- Owner gate: decide any later package/version/release train. Current live surfaces remain `open-scaffold@0.32.1` on npm and GitHub Latest `v0.32.1` until explicitly changed.

--- a/.osc/releases/2026-06-18-v1-public-positioning-polish.md
+++ b/.osc/releases/2026-06-18-v1-public-positioning-polish.md
@@ -16,9 +16,9 @@ This note records local release-readiness evidence only. It does not claim merge
 ## Verification
 
 - `npm run -s osc -- plan validate .osc/plans/done/v1-public-positioning-polish.md --strict` — `0 issues found`.
-- Targeted public/readiness tests: `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/package-payload.test.ts tests/section-parser.test.ts` — passed: `6 passed`, `57 tests passed`.
+- Targeted public/readiness tests: `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/package-payload.test.ts tests/section-parser.test.ts` — passed: `6 passed`, `58 tests passed`.
 - `npm run build` — passed (`build:core` and `build:runtime-omx`).
-- `npm test -- --run` — passed: `48 passed`, `544 tests passed`.
+- `npm test -- --run` — passed: `48 passed`, `545 tests passed`.
 - `./verify.sh --strict` — passed: `10 pass, 0 fail, 0 warn`.
 - `git diff --check` — passed with no output.
 - `npm run -s osc -- --help` and `npm run -s osc -- help --all` — rendered successfully.

--- a/.osc/releases/2026-06-18-v1-public-positioning-polish.md
+++ b/.osc/releases/2026-06-18-v1-public-positioning-polish.md
@@ -16,16 +16,16 @@ This note records local release-readiness evidence only. It does not claim merge
 ## Verification
 
 - `npm run -s osc -- plan validate .osc/plans/done/v1-public-positioning-polish.md --strict` — `0 issues found`.
-- Targeted public/readiness tests: `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/package-payload.test.ts tests/section-parser.test.ts` — passed: `6 passed`, `68 tests passed`.
+- Targeted public/readiness tests: `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/package-payload.test.ts tests/section-parser.test.ts` — passed: `6 passed`, `69 tests passed`.
 - `npm run build` — passed (`build:core` and `build:runtime-omx`).
-- `npm test -- --run` — passed: `48 passed`, `555 tests passed`.
+- `npm test -- --run` — passed: `48 passed`, `556 tests passed`.
 - `./verify.sh --strict` — passed: `10 pass, 0 fail, 0 warn`.
 - `git diff --check` — passed with no output.
 - `npm run -s osc -- --help` and `npm run -s osc -- help --all` — rendered successfully.
 - Retired-command smoke loop for `work dispatch adapter metrics dashboard task study ab harness` — each exited `2` and included `removed/repositioned` plus `docs/STABILITY.md#command-maturity`.
 - Added-line public-safety scan over the diff — passed for local paths, personal names/emails/phone, and known Discord IDs.
 - `npm run -s osc -- doctor --check secret-scan` — `PASS secret-scan: no obvious token/webhook strings found.`
-- `npm pack --dry-run --json` — passed after prepack build; package payload contained `224` files, dry-run package size `387011` bytes.
+- `npm pack --dry-run --json` — passed after prepack build; package payload contained `224` files, dry-run package size `387021` bytes.
 
 ## Outcome
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 # Agent Instructions
 
-This is the [open-scaffold](https://github.com/graphanov/open-scaffold) product repository: a harness for AI-assisted work that keeps the whole work record — mission, plans, run records, evidence, feedback, lessons — in git-tracked files. The repo dogfoods its own protocol.
+This is the [open-scaffold](https://github.com/graphanov/open-scaffold) product repository: a repo-native work-record CLI/protocol for AI-assisted work that keeps mission, plans, run records, evidence, feedback, and lessons in git-tracked files. The repo dogfoods its own protocol.
 
 ## Layered architecture
 
@@ -10,7 +10,7 @@ Open Scaffold core owns the repo-native work record, handoff packets, review/gat
 
 ## Open Scaffold protocol
 
-1. Before any work, run `osc resume` (source checkout: `npm run osc -- resume`) and follow the packet: it states the goal, acceptance criteria, and next bounded action.
+1. Before any work, run `osc handoff` (source checkout alias: `npm run osc -- resume`) and follow the packet: it states the goal, acceptance criteria, and next bounded action.
 2. The CLI writes the files — never hand-write plans, amendments, evidence skeletons, or close records.
 3. New work: `osc plan new <slug> --stage active`; clarify fuzzy intent in the operator surface or an external runtime, then promote the result into the plan.
 4. Scope change: `osc amend <slug> --message "what changed"`. Committed plans are immutable.
@@ -21,6 +21,10 @@ Open Scaffold core owns the repo-native work record, handoff packets, review/gat
 9. Failures become feedback with a repair hypothesis; retry from recorded facts instead of looping blind.
 10. Chat is working context, not truth. If it matters, it goes in a repo file.
 11. Compliance gate: run `./verify.sh --quick --quiet` before non-trivial changes; on a non-zero exit, stop and fix the mission or plan first.
+## Compliance check behavior
+
+On exit 0 of the compliance gate, proceed silently. On exit 1, hard-block on the first failing check: if the mission is undefined (`<!-- mission:unset -->` or `TODO: define mission` present), help the user define it before anything else; if the mission is defined but no plan exists, create one with the user before implementation. The user can always override explicitly. Without shell access, check those two conditions by reading `MISSION.md` and `.osc/plans/` directly.
+
 ## Working on open-scaffold itself
 
 - `MISSION.md` — goals, non-goals, and a changelog of every scope pivot. `ROADMAP.md` — milestones and the self-dogfood chain.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 # Project Context
 
-This is the [open-scaffold](https://github.com/graphanov/open-scaffold) product repository: a harness for AI-assisted work that keeps the whole work record — mission, plans, run records, evidence, feedback, lessons — in git-tracked files. The repo dogfoods its own protocol. Read this file first, then run the protocol below.
+This is the [open-scaffold](https://github.com/graphanov/open-scaffold) product repository: a repo-native work-record CLI/protocol for AI-assisted work that keeps mission, plans, run records, evidence, feedback, and lessons in git-tracked files. The repo dogfoods its own protocol. Read this file first, then run the protocol below.
 
 ## Layered architecture
 
@@ -10,7 +10,7 @@ Open Scaffold core owns the repo-native work record, handoff packets, review/gat
 
 ## Open Scaffold protocol
 
-1. Before any work, run `osc resume` (source checkout: `npm run osc -- resume`) and follow the packet: it states the goal, acceptance criteria, and next bounded action.
+1. Before any work, run `osc handoff` (source checkout alias: `npm run osc -- resume`) and follow the packet: it states the goal, acceptance criteria, and next bounded action.
 2. The CLI writes the files — never hand-write plans, amendments, evidence skeletons, or close records.
 3. New work: `osc plan new <slug> --stage active`; clarify fuzzy intent in the operator surface or an external runtime, then promote the result into the plan.
 4. Scope change: `osc amend <slug> --message "what changed"`. Committed plans are immutable.

--- a/LLM_QUICKSTART.md
+++ b/LLM_QUICKSTART.md
@@ -40,21 +40,24 @@ Report the exact output. If it fails, fix only the missing structural item it na
 For the next agent, model, teammate, or future self, run:
 
 ```bash
-osc handoff
+npx open-scaffold@latest handoff
 ```
 
-`osc resume` is the original alias and may appear in older agent entrypoints; it compiles the same read-only packet. The packet states the mission, current plan, acceptance criteria, evidence state, and next bounded action.
+`osc handoff` works after a global or local install. `osc resume` is the original alias and may appear in older agent entrypoints; it compiles the same read-only packet. The packet states the mission, current plan, acceptance criteria, evidence state, and next bounded action.
 
 ## Optional source-checkout path
 
-Use this only when developing Open Scaffold itself or when npm is unavailable:
+Use this only when developing Open Scaffold itself or when npm is unavailable. Build the source checkout, then run its CLI from the target repo so the scaffold files land in the project selected in Step 1:
 
 ```bash
-git clone https://github.com/graphanov/open-scaffold open-scaffold
-cd open-scaffold
+TARGET_REPO=/path/to/your/project
+OSC_SOURCE=/tmp/open-scaffold-source
+git clone https://github.com/graphanov/open-scaffold "$OSC_SOURCE"
+cd "$OSC_SOURCE"
 npm install
 npm run build
-node dist/cli.js first-run
+cd "$TARGET_REPO"
+node "$OSC_SOURCE/dist/cli.js" first-run
 ```
 
 ## Stop condition

--- a/LLM_QUICKSTART.md
+++ b/LLM_QUICKSTART.md
@@ -15,15 +15,24 @@ State which mode you're in before step 1.
 
 Ask which repository should receive the work record. If the user is already inside the right repository, use it. If not, help them navigate to or clone their own project repository first. Do **not** clone `graphanov/open-scaffold` unless the user explicitly wants the Open Scaffold source checkout.
 
+For non-interactive coding-agent shells, also collect three first-run answers before running the command:
+
+- `slug`: safe kebab-case plan slug, for example `first-ai-work-record`
+- `mission`: one sentence describing why the target repo exists
+- `goal`: one bounded first task with a visible verification path
+
 ## Step 2 — Create the first work record
 
-Run the guided first action in the target repo:
+Run the guided first action in the target repo. In coding-agent shells, prefer the non-interactive form so the command does not wait for a TTY prompt:
 
 ```bash
-npx open-scaffold@latest first-run
+npx open-scaffold@latest first-run --non-interactive \
+  --slug "<slug>" \
+  --mission "<mission>" \
+  --goal "<goal>"
 ```
 
-The command asks three questions and creates the minimum record: `MISSION.md`, one active plan with acceptance criteria, and an evidence skeleton. The skeleton is not proof of readiness; it is a place to put real command output before closing the slice.
+Those three answers create the minimum record: `MISSION.md`, one active plan with acceptance criteria, and an evidence skeleton. Interactive shells may omit the non-interactive flags and answer the prompts instead. The skeleton is not proof of readiness; it is a place to put real command output before closing the slice.
 
 ## Step 3 — Verify the structural floor
 
@@ -57,7 +66,10 @@ cd "$OSC_SOURCE"
 npm install
 npm run build
 cd "$TARGET_REPO"
-node "$OSC_SOURCE/dist/cli.js" first-run
+node "$OSC_SOURCE/dist/cli.js" first-run --non-interactive \
+  --slug "<slug>" \
+  --mission "<mission>" \
+  --goal "<goal>"
 ```
 
 ## Stop condition

--- a/LLM_QUICKSTART.md
+++ b/LLM_QUICKSTART.md
@@ -1,8 +1,6 @@
 # LLM Quickstart — open-scaffold
 
-You are an LLM helping a human bootstrap a new project from the [open-scaffold](https://github.com/graphanov/open-scaffold) template. Walk the human through the steps below interactively — confirm each step with them before proceeding to the next.
-
-> Already in an existing repo? The fastest path is `npx open-scaffold@latest first-run` (guided), and every later session starts with `osc resume` — the ten-line agent protocol lives in `AGENTS.md`. The template-clone flow below is for starting a brand-new project repository.
+You are an LLM helping a human add Open Scaffold to a project. Keep the product boundary simple: Open Scaffold is a repo-native work record for AI-assisted work. It records mission, plans, handoffs, evidence, review/gate state, and close decisions as files. It does not run the agent, replace a coordinator, or approve merge/publish/release.
 
 ## Capability check
 
@@ -13,71 +11,52 @@ Before anything else, determine whether you can execute shell commands in this s
 
 State which mode you're in before step 1.
 
-## Step 1 — Clone the template
+## Step 1 — Start from the target repo
 
-**Before running any clone command, ask the user what they want to name their project.** The name becomes the folder name, and renaming it after the clone is awkward — you'd have to `cd ..`, rename, `cd` back, and re-run anything that already executed. Do not proceed until you have a name. If the user has no preference, suggest `my-project` as a placeholder and confirm before using it.
+Ask which repository should receive the work record. If the user is already inside the right repository, use it. If not, help them navigate to or clone their own project repository first. Do **not** clone `graphanov/open-scaffold` unless the user explicitly wants the Open Scaffold source checkout.
 
-Then run (replacing `<name>` with the project name you just collected — not the literal string `open-scaffold`):
+## Step 2 — Create the first work record
 
-```bash
-gh repo create <name> --template graphanov/open-scaffold --clone
-cd <name>
-```
-
-Fallback if `gh` is unavailable:
+Run the guided first action in the target repo:
 
 ```bash
-git clone https://github.com/graphanov/open-scaffold <name>
-cd <name>
+npx open-scaffold@latest first-run
 ```
 
-## Step 2 — Initialize the scaffolding
+The command asks three questions and creates the minimum record: `MISSION.md`, one active plan with acceptance criteria, and an evidence skeleton. The skeleton is not proof of readiness; it is a place to put real command output before closing the slice.
 
-Run `./bootstrap.sh`. The script ensures the lazy directories exist (`.osc/state/`, `.osc/research/`, and stage subfolders `active/`, `backlog/`, `done/`, `blocked/` under `.osc/plans/`) and stamps today's date into MISSION.md's changelog.
+## Step 3 — Verify the structural floor
 
-**What happens to MISSION.md depends on how bootstrap was invoked:**
+Run:
 
-- **Interactive (human running this quickstart themselves in a real terminal, or a chat-LLM telling them to):** bootstrap.sh asks three questions — *What is this project?*, *What should it achieve?*, *What should this project NOT do?* — with an example under each. The user can press Enter to skip any question. After the prompts, MISSION.md contains their answers or TODO placeholders, and the `<!-- mission:unset -->` marker is removed.
+```bash
+./verify.sh --quick
+```
 
-- **Non-interactive (coding agent invoking the script via a non-TTY shell — typical for Claude Code, Cursor, Codex CLI, Aider):** bootstrap.sh's interactive prompts are skipped by design. The gate is `[ -t 0 ]` at [bootstrap.sh:17](bootstrap.sh#L17), which is false when an agent runs the script. MISSION.md will still contain the `<!-- mission:unset -->` marker. **This is expected — don't try to work around it.** The downstream session in Step 4 elicits the mission conversationally. It has more context than a bash `read -r` loop and can ask follow-ups, give examples, and iterate — it's a genuinely better interviewer than bootstrap.sh can be.
+Report the exact output. If it fails, fix only the missing structural item it names: mission, plan, or required scaffold files. Do not pretend the scaffold proves implementation quality.
 
-Whichever path fired, confirm bootstrap.sh exited 0 before proceeding.
+## Step 4 — Hand off the next session
 
-## Step 3 — Verify the floor
+For the next agent, model, teammate, or future self, run:
 
-Run `./verify.sh --quick` and report the exit code to the user.
+```bash
+osc handoff
+```
 
-- **If Step 2's interactive path fired:** `verify.sh --quick` should fail on "no plan file" only (mission is defined, the first plan doesn't exist yet). Expected — the next session writes the first plan.
-- **If Step 2's non-interactive path fired:** `verify.sh --quick` will fail on "mission undefined" (progressive disclosure — the plan check is gated behind the mission check, so it won't even run yet). Expected — Step 4 elicits the mission.
+`osc resume` is the original alias and may appear in older agent entrypoints; it compiles the same read-only packet. The packet states the mission, current plan, acceptance criteria, evidence state, and next bounded action.
 
-Either way, report the failing check and proceed to Step 4. A passing `--quick` here would be surprising — if it happens, stop and investigate.
+## Optional source-checkout path
 
-## Step 4 — Hand off
+Use this only when developing Open Scaffold itself or when npm is unavailable:
 
-Ask the user two questions:
-
-1. Which operating mode are you using?
-   - **Orchestrator-led** (Hermes, Claw/OpenClaw, or a custom bot reading Open Scaffold state)
-   - **Claude Code + OMC harness** (`/deep-interview`, `/ralplan`, `/team`, `/ralph`)
-   - **Codex + OMX harness** (clarification, planning, team, retry, and execution workflows)
-   - **Plain agent** (Claude Code, Cursor, Codex, Gemini, Aider — no harness)
-   - **Fully manual** (no agent)
-2. Is your first task clear in your head, or still fuzzy?
-
-Print the matching handoff verbatim, then stop. Each handoff assumes the downstream session may inherit a `mission:unset` MISSION.md and tells it to elicit the mission if needed.
-
-| Mode | Task state | Handoff |
-|---|---|---|
-| Orchestrator-led | Clear | `Tell your orchestrator: "Read MISSION.md, ROADMAP.md, docs/OPEN_SCAFFOLD_SYSTEM.md, docs/TASK_RUN_MODEL.md, docs/GITHUB_WORKFLOW.md, AGENTS.md/CLAUDE.md, and .osc/RULES.md. If MISSION.md is still unset, elicit it first. Then create a bounded plan in .osc/plans/active/ for <task>, preserving the roadmap/task/evidence chain. Do not treat chat/Discord/runtime state as canonical truth."` |
-| Orchestrator-led | Fuzzy | `Tell your orchestrator: "Read MISSION.md, ROADMAP.md, docs/OPEN_SCAFFOLD_SYSTEM.md, docs/TASK_RUN_MODEL.md, docs/GITHUB_WORKFLOW.md, AGENTS.md/CLAUDE.md, and .osc/RULES.md. Run an interview until mission and first task are clear, then write the result as an Open Scaffold plan/spec. If live execution is needed, create/select a task_id and generate a bound run package with osc run <plan> --task-id ... --executor ...; chat/Discord remains only an operator surface."` |
-| OMC harness | Clear | `From Claude Code/OMC, run /ralplan or /autopilot against the Open Scaffold context: "If MISSION.md is still unset, elicit it from me first. Then write or use a plan in .osc/plans/active/ for <task> using .osc/plans/handoff-template.md. If dispatching execution, bind it to a run_id/task_id first; treat OMC runtime state as forensic until promoted into Open Scaffold evidence."` |
-| OMC harness | Fuzzy | `From Claude Code/OMC, run /deep-interview. Tell it: "MISSION.md may be unset and the first task is fuzzy. Clarify both, then promote the result into MISSION.md and an Open Scaffold plan/spec. Do not make OMC runtime state the source of truth."` |
-| OMX harness | Clear | `From Codex/OMX, run $ralplan against the Open Scaffold context: "If MISSION.md is still unset, elicit it from me first. Then write or use a plan in .osc/plans/active/ for <task> using .osc/plans/handoff-template.md. If dispatching execution, bind it to a run_id/task_id first; treat OMX runtime state as forensic until promoted into Open Scaffold evidence."` |
-| OMX harness | Fuzzy | `From Codex/OMX, run $deep-interview. Tell it: "MISSION.md may be unset and the first task is fuzzy. Clarify both, then promote the result into MISSION.md and an Open Scaffold plan/spec. Keep runtime-only question/session state forensic until promoted."` |
-| Plain agent | Clear | `Tell your agent: "My MISSION.md may be unset. Ask me three things if needed: (a) what is this project in one sentence, (b) main outcomes, (c) adjacent features I could plausibly build but am choosing not to. Update MISSION.md with my answers, then write a plan in .osc/plans/active/ for <task> using .osc/plans/handoff-template.md."` |
-| Plain agent | Fuzzy | `Tell your agent: "My MISSION.md may be unset AND my first task is fuzzy. Interview me until both are clear — mission and task — then update MISSION.md and write the plan in .osc/plans/active/ using .osc/plans/handoff-template.md."` |
-| Manual | Either | `Open MISSION.md in your editor and fill in the mission/goals/non-goals. Then run: cp .osc/plans/handoff-template.md .osc/plans/active/my-first-task.md — open the copy and fill in its 7 sections. See ROADMAP.md, docs/OPEN_SCAFFOLD_SYSTEM.md, docs/TASK_RUN_MODEL.md, docs/GITHUB_WORKFLOW.md, .osc/RULES.md, and .osc/plans/WORKFLOW.md for boundaries.` |
+```bash
+git clone https://github.com/graphanov/open-scaffold open-scaffold
+cd open-scaffold
+npm install
+npm run build
+node dist/cli.js first-run
+```
 
 ## Stop condition
 
-Do **not** write the first plan yourself. Do **not** stamp MISSION.md yourself, even if it is still marked `mission:unset`. Both are the next session's job. Your scope ends at: a cloned repo in the user's chosen directory, bootstrap's changelog stamp applied, `verify.sh --quick` honestly reported, and the printed handoff. Then stop.
+Stop when the target repo has a mission, one active plan, a structural verification result, and a handoff packet for the next reader. Do not promise that Open Scaffold has executed the work, certified compliance, or made the project production-ready.

--- a/MISSION.md
+++ b/MISSION.md
@@ -1,35 +1,33 @@
 # Mission
 
-Open Scaffold exists to ensure the level-headed distribution of AI-assisted
-work: every task matched — by difficulty, complexity, and sophistication — to
-the model appropriate for the job, without sacrificing speed, quality, or
-visibility of the work done.
+Open Scaffold exists to keep AI-assisted work in the repository instead of in
+vanishing chat history. It is the repo-native work record for goals, plans,
+attempts, handoffs, evidence, reviews, gates, approvals, and lessons — durable
+files that a fresh session, smaller model, teammate, reviewer, or client can
+read later without inventing what happened.
 
 The mission is timeless; the means are not. Models, schemas, tools, and
 workflows will keep changing with the technology, and everything below this
 paragraph is expected to change with them. What does not change is the
-commitment: work routed to right-sized intelligence, and a record honest enough
-that whoever comes next — a fresh session, a smaller model, a person — can
-trust what happened instead of taking anyone's word for it.
+commitment: AI work should leave an honest, reviewable record so future readers
+can recover context, check claims against evidence, and route expensive frontier
+model effort only where it is actually needed.
 
 ## How the mission is pursued today (subject to change)
 
-Open Scaffold brings lower-tier, cheaper, and locally-hosted models into
-AI-assisted work as bounded reviewers and resumers when the repo record gives
-them enough observed facts to check. It records what agents actually did as
-git-tracked, observed-fact files (the repo-native work record), compiles that
-record into handoff packets a fresh session or a different model can pick up
-without inventing history, and equips small models to review, gate, and feed
-evidence back to the next attempt — so frontier models are spent only where
-frontier capability is needed, and everything around them runs on recorded
-receipts instead of trust. The current public line is intentionally pre-1.0:
-useful for structural records and evidence-backed handoffs, not a mature
-production-readiness guarantee.
+Open Scaffold records what agents actually did as git-tracked, observed-fact
+files, compiles that record into handoff packets a fresh session or a different
+model can pick up without inventing history, and lets cheap or locally-hosted
+models review and gate recorded attempts inside explicit proof boundaries.
+Developers and teams use it when AI work must survive context loss, PR review,
+client delivery, audit-sensitive handoff, or repeated attempts. The current
+public package line remains intentionally pre-1.0: useful for structural records
+and evidence-backed handoffs, not a mature production-readiness guarantee.
 
 ## Goals
 
 - Make the work record ambient: extracted from observed facts (transcripts, receipts, test results, scores) around any workflow — never worker-authored ceremony, never a tax on the model doing the work.
-- Make handoff lossless and cheap: `osc handoff` compiles the record into a packet that lets the next reader — fresh session, smaller model, other vendor, or human — reconstruct what happened instead of hallucinating it.
+- Make handoff compact and evidence-backed: `osc handoff` compiles the record into a packet that lets the next reader — fresh session, smaller model, other vendor, or human — reconstruct what happened from files instead of hallucinating it.
 - Make cheap review real: reviewer profiles for low-tier and locally-hosted models (haiku-class, DeepSeek, Qwen, Ollama/MLX) that read the record, judge claims against evidence, and authorize or block the next attempt via `osc review`/`osc analyze` and `osc gate` — with feedback packets that flow upward to the frontier worker's next attempt.
 - Be an open, vendor-neutral standard for recording and handing off agent work: versioned schemas, plain files, a generic MCP server; no runtime becomes the canonical brain.
 - Claim only what is measured, publish the boundaries, keep public surfaces clear that current evidence is pilot-grade and pre-1.0, and keep the dead claims next to the live ones (evidence: `docs/PROOF_HARNESS.md` and the independent benchmark repo).
@@ -49,9 +47,12 @@ Explicit things this project is NOT trying to do. Legitimate scope discipline st
 
 ## Changelog
 
+Historical entries below preserve the wording used at the time, including superseded identities such as harness, cockpit, or operating-system language. The current product identity is the mission above: repo-native work record, handoff, review/gate, and evidence boundaries.
+
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-18: closed v1-public-positioning-polish — polished v1 public positioning and release-readiness boundaries
 - 2026-06-15: closed 172-public-readiness-package-sync — Published open-scaffold@0.32.1 to npm latest and created GitHub Release v0.32.1 as Latest.
 - 2026-06-15: closed public-readiness-hardening — hardened public readiness messaging
 - 2026-06-13: closed 171-capture-package-sync — Published open-scaffold@0.32.0 to npm latest and created GitHub Release v0.32.0 as Latest.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 **Your AI agent's work belongs in your repo, not its chat history.**
 
-Ambient work records, lossless handoffs, and near-frontier review from cheap and
-local models — for AI-assisted work, with published, pilot-grade evidence and explicit proof boundaries.
+Ambient work records, compact handoffs, and bounded review/gate checks from cheap and
+local models — for AI-assisted work that needs evidence, recovery, and human gates, with pilot-grade proof boundaries.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-black.svg)](LICENSE)
 [![npm](https://img.shields.io/npm/v/open-scaffold.svg)](https://www.npmjs.com/package/open-scaffold)
-[![Works with](https://img.shields.io/badge/Works%20with-Any%20agent-green.svg)](#runtime-neutral-by-design)
+[![Works with](https://img.shields.io/badge/Works%20with-Any%20agent-green.svg)](#vendor-neutral-by-design)
 [![Runtime deps](https://img.shields.io/badge/Runtime%20deps-Zero-blue.svg)](package.json)
 
 </div>
@@ -24,8 +24,7 @@ scrollback buffer, and what it can't reconstruct, it invents.
 
 ## What Open Scaffold does
 
-Open Scaffold keeps a repo-native work record — git-tracked, observed-fact
-files about what your agents actually did — and turns it into three things:
+Open Scaffold is for developers and teams using AI agents on work that must survive context loss, PR review, client handoff, or audit-sensitive delivery. It keeps a repo-native work record — git-tracked, observed-fact files about what your agents actually did — and turns it into three things:
 
 - **Record (ambient).** The record is extracted from observed facts —
   transcripts, receipts, test results, scores — around whatever workflow you
@@ -51,7 +50,7 @@ The front door is three commands:
 | `osc review` | Review recorded attempts: plateaus, failing criteria, question-the-requirement signals. |
 | `osc gate` | Authorize or block the next attempt from the analysis plus an optional independent judge. |
 
-Why cheap models? Because with the record they stop guessing. In pilot-grade,
+Why cheap models? Because the record gives them facts to read instead of a chat archaeology problem to guess through. In pilot-grade,
 preregistered reviewability trials, a mid-tier reviewer answering factual
 questions about finished work — graded against answer keys committed before it
 ran — reconstructed the work at 94% accuracy with the record vs 30% on the bare
@@ -60,8 +59,8 @@ cost. This is not a production-readiness claim or universal benchmark; it is
 bounded evidence that the repo record helps the next reader. And when a judge is
 too weak to be trusted, the gate fails closed: no parseable verdict means no
 authorization, and the record's own blocks override a permissive ruling. Small
-and locally-hosted models (haiku-class, DeepSeek, Qwen, Ollama/MLX) become viable
-reviewers, resumers, and bookkeepers inside those boundaries, so the frontier
+and locally-hosted models (haiku-class, DeepSeek, Qwen, Ollama/MLX) can be useful
+as bounded reviewers, resumers, and bookkeepers inside those boundaries, so the frontier
 model is spent only where frontier capability is needed.
 
 ## What's measured
@@ -221,7 +220,7 @@ not need a work record.
 
 ## Honest limits
 
-Open Scaffold is pre-1.0 (`v0.32.x`) and it does not make your model smarter —
+Open Scaffold's current package line is pre-1.0 (`v0.32.x`) and it does not make your model smarter —
 it makes the *loop around the model* disciplined: bounded slices, gated
 execution, compact resumes, receipts for everything. A bounded Codex
 cold-resume fixture and the older scaffold-vs-naked fixture ship in
@@ -235,15 +234,13 @@ what is stable, what is experimental, what is future — lives in one place:
 ## Key docs
 
 - [`docs/START_HERE.md`](docs/START_HERE.md) — the single entry point.
-- [`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md) — the record, analyze, and gate in detail.
-- [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) — the measured claim ledger with boundaries.
-- [`docs/MCP.md`](docs/MCP.md) — plugging the record into MCP-capable clients.
-- [`docs/STABILITY.md`](docs/STABILITY.md) — command maturity and honest limits, in one place.
+- [`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md) — review and gate over recorded attempts.
+- [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) — measured claims, raw pointers, and proof boundaries.
+- [`docs/MCP.md`](docs/MCP.md) — exposing the record to MCP-capable clients.
+- [`docs/STABILITY.md`](docs/STABILITY.md) — command maturity, version truth, and honest limits.
 - [`docs/RESUME_WALKTHROUGH.md`](docs/RESUME_WALKTHROUGH.md) — zero-context resume, narrated.
-- [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) — the proof fixture and its boundaries.
 - [`docs/GITHUB_WORKFLOW.md#structural-pr-review-with-open-scaffold`](docs/GITHUB_WORKFLOW.md#structural-pr-review-with-open-scaffold) — PRs that carry intent and evidence.
 - [`docs/EXAMPLES.md`](docs/EXAMPLES.md) — worked examples and demos.
-- [`docs/STABILITY.md`](docs/STABILITY.md) — the maturity contract and honest limits.
 - [`docs/FAQ.md`](docs/FAQ.md) — deeper questions.
 - [`docs/GLOSSARY.md`](docs/GLOSSARY.md) — the vocabulary.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,11 +4,11 @@ Open Scaffold is developed with Open Scaffold. This roadmap is both a product pl
 
 ## Product thesis
 
-Open Scaffold is a runtime-neutral, repo-native work record and repository protocol for AI-assisted work. It gives humans and agents a durable shared record for mission, roadmap, plans, amendments, evidence, handoffs, verification, GitHub traceability, and operator-room reporting.
+Open Scaffold is a runtime-neutral, repo-native work record and repository protocol for AI-assisted work. It gives developers and teams a durable shared record for mission, roadmap, plans, amendments, evidence, handoffs, review/gate decisions, GitHub traceability, and status-room reporting.
 
 The core promise:
 
-> Any capable agent or orchestrator can enter a repository, understand what matters, pick up bounded work, prove what changed, and hand the project back without relying on vanished chat context.
+> A fresh session, smaller model, teammate, or reviewer can enter a repository, understand what mattered, pick up bounded work, check claims against evidence, and hand the project back without relying on vanished chat context.
 
 ## System ontology
 
@@ -38,9 +38,13 @@ ROADMAP item
 
 Not every small task needs every link, but meaningful work should make the chain explicit.
 
+## Historical baseline milestones
+
+The early milestones below preserve the project-history shape that was once called v1. The current public package line is `v0.32.x` pre-1.0; these entries are proof of dogfood history, not a fresh npm/GitHub Release authorization.
+
 ## Milestone 0 — Product contract and dogfood baseline
 
-Status: v1 complete; product mission, roadmap, ontology, and self-dogfood baseline are established.
+Status: historical baseline complete; product mission, roadmap, ontology, and self-dogfood baseline are established.
 
 Goal: make the product identity and ontology precise enough that agents stop making wrong boundary assumptions.
 
@@ -61,13 +65,13 @@ Acceptance criteria:
 
 ## Milestone 1 — Core documentation hardening
 
-Status: v1 complete; README/root docs explain Open Scaffold as a runtime-neutral product rather than only a template.
+Status: historical baseline complete; README/root docs explain Open Scaffold as a runtime-neutral product rather than only a template.
 
 Goal: make Open Scaffold understandable as a product, not only as a template.
 
 Deliverables:
 
-- Rewrite README positioning around repo-native agent-orchestrated development.
+- Rewrite README positioning around repo-native AI-assisted work records.
 - Add concise diagrams or examples for the identity chain.
 - Update `docs/WORKFLOW.md` to separate generic phases from runtime/harness choices.
 - Update `docs/ADAPTERS.md` or replace it with an integrations/harnesses guide.
@@ -81,7 +85,7 @@ Acceptance criteria:
 
 ## Milestone 2 — Evolutionary closed-loop protocol
 
-Status: v1 complete in PR #5 via `docs/SLICE_CLOSE_PROTOCOL.md`; future CLI validation is an optional backlog follow-up, not required for the v1 milestone to count as done.
+Status: historical baseline complete in PR #5 via `docs/SLICE_CLOSE_PROTOCOL.md`; future CLI validation is an optional backlog follow-up, not required for the historical milestone to count as done.
 
 Goal: productize the “slice → feedback → correction → approval → next slice” learning loop.
 
@@ -98,17 +102,17 @@ Acceptance criteria:
 - Weak-positive / procedural approvals can be marked differently from strong product approval.
 - The next slice can inherit corrections without relying on chat memory.
 
-## Milestone 3 — Glass cockpit MVP
+## Milestone 3 — Historical status-room event protocol
 
-Status: v1 complete in PR #6 via the glass-cockpit event protocol (archived 2026-06-10; see git history); implementation examples are optional follow-up slices, not required for the protocol milestone to count as done.
+Status: historical baseline complete in PR #6 via the archived glass-cockpit/status-event protocol (archived 2026-06-10; see git history); implementation examples are optional follow-up slices, not required for the protocol milestone to count as done.
 
-Goal: make build-in-public / private control-room operation a first-class Open Scaffold capability.
+Goal: make build-in-public / private status-room operation a first-class Open Scaffold capability.
 
 Deliverables:
 
-- Define glass-cockpit event types: nudge, active session, blocker, question, answer, approval request, completion report, evidence receipt, PR link. First public shape: the glass-cockpit event protocol (archived 2026-06-10; see git history).
+- Define status-event types: nudge, active session, blocker, question, answer, approval request, completion report, evidence receipt, PR link. First public shape: the archived glass-cockpit/status-event protocol (archived 2026-06-10; see git history).
 - Define event/session transport separately from the cockpit: clawhip-style routers, webhooks, gateway adapters, and session hooks carry events but do not plan or execute.
-- Define public/team/private modes. First public shape: private, team, build-in-public, and stakeholder modes in the glass-cockpit event protocol (archived 2026-06-10; see git history).
+- Define public/team/private modes. First public shape: private, team, build-in-public, and stakeholder status modes in the archived protocol (archived 2026-06-10; see git history).
 - Provide Discord-first examples while keeping the protocol surface generic enough for Slack/Telegram/CLI/GitHub comments.
 - Specify that chat is a surface, not canonical truth.
 
@@ -121,7 +125,7 @@ Acceptance criteria:
 
 ## Milestone 4 — ROADMAP / GitHub / task bridge
 
-Status: v1 complete via PR #3, PR #4, and the Milestone 6 proof in PR #9: task/run identity, GitHub issue/PR templates, run binding options, runtime dispatch pattern, and public issue -> task/run -> PR -> release-note chain exist.
+Status: historical baseline complete via PR #3, PR #4, and the Milestone 6 proof in PR #9: task/run identity, GitHub issue/PR templates, run binding options, runtime dispatch pattern, and public issue -> task/run -> PR -> release-note chain exist.
 
 Goal: connect roadmap intent to live work without duplicating truth.
 
@@ -145,7 +149,7 @@ Acceptance criteria:
 
 ## Milestone 5 — Runtime harness bindings
 
-Status: v1 complete in PR #7 via `docs/RUNTIME_BINDING_CONTRACT.md`; executable OMC/OMX launchers and JSON-schema enforcement remain adapter/backlog work, not core spawning work.
+Status: historical baseline complete in PR #7 via `docs/RUNTIME_BINDING_CONTRACT.md`; executable OMC/OMX launchers and JSON-schema enforcement remain adapter/backlog work, not core spawning work.
 
 Goal: support specific harnesses without making them the core system.
 
@@ -165,7 +169,7 @@ Acceptance criteria:
 
 ## Milestone 6 — Self-dogfood release loop
 
-Status: v1 complete in PR #9 via GitHub issue #8, `.osc/plans/done/005-self-dogfood-release-loop.md`, run ID `20260512T135850Z-005-self-dogfood-release-loop-run`, Codex clean review, and `.osc/releases/2026-05-12-self-dogfood-release-loop.md`.
+Status: historical baseline complete in PR #9 via GitHub issue #8, `.osc/plans/done/005-self-dogfood-release-loop.md`, run ID `20260512T135850Z-005-self-dogfood-release-loop-run`, Codex clean review, and `.osc/releases/2026-05-12-self-dogfood-release-loop.md`.
 
 Goal: ship Open Scaffold improvements through Open Scaffold itself.
 
@@ -186,7 +190,7 @@ Acceptance criteria:
 
 ## V2 roadmap — harden the protocol into a usable product
 
-The v1 baseline proves the model. V2 should make it harder for agents to drift, easier for humans to adopt, and cleaner for runtime harnesses to bind without contaminating core.
+The historical baseline proved the model. V2 should make it harder for agents to drift, easier for humans to adopt, and cleaner for runtime harnesses to bind without contaminating core.
 
 ### Public roadmap visibility rule
 
@@ -226,7 +230,7 @@ Goal: make Open Scaffold adoptable by people who have never seen any owner-local
 Deliverables:
 
 - Solo developer example.
-- Team control-room example.
+- Team status-room example.
 - GitHub-only workflow example.
 - Runtime harness handoff example.
 
@@ -378,7 +382,7 @@ Goal: turn the `docs/wiki/` skeleton into a small, public-safe Open Scaffold bod
 Deliverables:
 
 - Seed 8-12 curated wiki pages across concepts, comparisons, and reusable query answers.
-- Prioritize durable project concepts: source-of-truth-first development, repo-native work records, agent resumability, evidence-first development, human-in-the-loop governance, glass cockpit, run packets, and scaffold tiers.
+- Prioritize durable project concepts: source-of-truth-first development, repo-native work records, agent resumability, evidence-first development, human-in-the-loop governance, status/approval surfaces, run packets, and scaffold tiers.
 - Clarify boundaries through comparison pages such as Open Scaffold versus agent memory, README-driven development, and traditional SDLC.
 - Add query pages that help humans and agents answer what Open Scaffold is for, what to read first, and why the project matters.
 - Update `docs/wiki/index.md` and `docs/wiki/log.md` so the wiki remains navigable and traceable.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -2,7 +2,7 @@
 
 Short examples for understanding Open Scaffold without reading every protocol page.
 
-For four worked operating modes — solo developer, team control-room, GitHub-only workflow, and runtime harness handoff — see [`examples/README.md`](examples/README.md). For the evolution-ledger wedge, see [`examples/evolution-loop-compare.md`](examples/evolution-loop-compare.md): two attempts, `osc evolve compare`, and a PR-ready frontier rationale. For a fixture you can run locally, see [`examples/evolution-ledger-demo/`](../examples/evolution-ledger-demo/) — `osc evolve check` and `osc evolve compare` against committed loop, attempts, frontier, and evaluation files.
+For four worked paths — solo developer, team status room, GitHub-only workflow, and runtime handoff — see [`examples/README.md`](examples/README.md). For the evolution-ledger wedge, see [`examples/evolution-loop-compare.md`](examples/evolution-loop-compare.md): two attempts, `osc evolve compare`, and a PR-ready frontier rationale. For a fixture you can run locally, see [`examples/evolution-ledger-demo/`](../examples/evolution-ledger-demo/) — `osc evolve check` and `osc evolve compare` against committed loop, attempts, frontier, and evaluation files.
 
 For the next reproducible proof layer, see [Lifecycle E2E Smoke Strategy](CI.md#lifecycle-e2e-smoke). It defines and links the local smoke test that proves a fresh downstream project can move through mission → plan → verification → evidence → close without Hermes, Discord, or private infrastructure.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,7 +14,7 @@ Questions that did not fit in the main README but are still worth answering.
 
 ### Can I run this for 5 hours straight and come back to a finished product?
 
-> Not by Open Scaffold itself. Open Scaffold is not a hands-off product factory. What you *can* do: write a plan, give it to an outside tool or runner, and come back to work that still traces back to your acceptance criteria. Examples include a private coordinator deployment such as Hermes/Claw, OMC with `/autopilot`/`/ralph` for Claude Code, or OMX with Codex team/retry/execution workflows. These are runtime lanes or private deployment examples, not Open Scaffold dependencies; see [`ADAPTERS.md#reference-labels-for-named-tools`](ADAPTERS.md#reference-labels-for-named-tools). The difference the scaffold makes is **recoverability** — because the plan is on disk, you can read what the agent did, compare against the ACs, and know exactly where to resume. Without it, a long run is hard to audit.
+> Not by Open Scaffold itself. Open Scaffold is not a hands-off product factory. What you *can* do: write a plan, hand that plan to an outside agent, runner, teammate, or coordinator, and come back to work that still traces back to your acceptance criteria. Those execution lanes are optional and external; Open Scaffold's job is the durable record, handoff, evidence, review, and gate. The difference the scaffold makes is **recoverability** — because the plan is on disk, you can read what the agent did, compare against the ACs, and know exactly where to resume. Without it, a long run is hard to audit.
 
 ### Does this reduce token usage / cost?
 

--- a/docs/OPEN_SCAFFOLD_SYSTEM.md
+++ b/docs/OPEN_SCAFFOLD_SYSTEM.md
@@ -4,7 +4,7 @@ Open Scaffold is not an agent runtime. It is a repo-native work record and repos
 
 ## One-sentence definition
 
-Open Scaffold is a runtime-neutral repository protocol for agent-orchestrated development: mission, roadmap, plans, amendments, evidence, handoffs, verification gates, and publication traces as durable files.
+Open Scaffold is a runtime-neutral, repo-native work record and repository protocol for AI-assisted work: mission, roadmap, plans, amendments, evidence, handoffs, review/gate decisions, verification, and publication traces as durable files.
 
 ## Reader path
 
@@ -121,9 +121,9 @@ Examples:
 - gateway adapters
 - tmux/session notification hooks
 
-Transport can post active-session updates, blockers, and completion events into a glass cockpit — an operator dashboard/control room. It should not become canonical task state or perform planning/execution itself.
+Transport can post active-session updates, blockers, and completion events into a status/approval surface such as an operator dashboard or team room. It should not become canonical task state or perform planning/execution itself.
 
-### 6. Operator surfaces / glass cockpits — human dashboards/control rooms
+### 6. Operator surfaces — human dashboards, chats, and status rooms
 
 Operator surfaces let humans and teams see, steer, approve, or unblock work.
 
@@ -136,14 +136,14 @@ Examples:
 - GitHub issue/PR comments
 - web dashboards
 
-The glass cockpit can run in several modes:
+A status/approval surface can run in several modes:
 
 - **Private cockpit:** solo dev / personal agent room.
 - **Team control room:** internal engineering room.
 - **Build-in-public room:** public or semi-public devlog channel.
 - **Stakeholder room:** curated client/product updates.
 
-Operator surfaces are **not canonical truth**. They should link back to roadmap items, task IDs, `run.json` work packages (run packets), evidence, issues, branches, and PRs. Their event vocabulary is the operator-event table in [`docs/HARNESS_ARCHITECTURE.md`](HARNESS_ARCHITECTURE.md).
+Operator surfaces are **not canonical truth**. They should link back to roadmap items, task IDs, `run.json` work packages (run packets), evidence, issues, branches, and PRs. The historical operator-event vocabulary lives in [`docs/HARNESS_ARCHITECTURE.md`](HARNESS_ARCHITECTURE.md).
 
 ### 7. GitHub/public versioning layer
 
@@ -175,7 +175,7 @@ OMX is a Codex execution/orchestration lane.
 OMX is not automatically the runtime engine for Hermes or OMC; it becomes one only when a coordinator dispatches a bounded package into an OMX/Codex session.
 Runtime-specific packages such as `packages/runtime-omx/` stay separate from core contracts, evidence, and approval boundaries.
 clawhip-style tooling is routing/status/event transport, not the planner or executor.
-Discord is a glass cockpit, not canonical state.
+Discord is a status/approval surface, not canonical state.
 A chat thread is a binding on a task/run, not the task/run itself.
 GitHub is public/versioned work truth.
 ```

--- a/docs/RUNTIME_BINDING_CONTRACT.md
+++ b/docs/RUNTIME_BINDING_CONTRACT.md
@@ -229,7 +229,7 @@ A binding should:
    - log path;
    - operator thread/comment ID;
    - PR number if opened.
-7. Emit glass-cockpit events — operator-dashboard/control-room messages — for status, blockers, questions, approval requests, completion, and evidence receipts when an operator surface is bound.
+7. Emit status/approval events — operator-dashboard or team-room messages — for status, blockers, questions, approval requests, completion, and evidence receipts when an operator surface is bound.
 8. Route human answers by `question_id -> run_id`.
 9. Promote final artifacts and evidence to `.osc/runs`, tracked evidence docs, PRs, issues, or release notes.
 10. Leave approval/merge/release to the configured gate.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -12,7 +12,7 @@ Everything Open Scaffold does not claim, in one place:
 - **Receipts prove handoff and execution facts, not correctness.** Verification against acceptance criteria is a separate, recorded step — and a human still owns the judgment call.
 - **The benchmark program is pilot-grade and partly self-run.** One worker model, n=1 cells, owner-built instrument (preregistration, hidden inputs, blind double-implementation, and kill rules as mitigations); replication with humans and larger n is open work. The older bounded `examples/proof/` fixture remains a separate, narrower surface.
 - **It is not a compliance certification, sandbox, or security guarantee.** It produces structural evidence a process can build on; it does not replace the process.
-- **Humans own merge, publish, release, and deployment.** Nothing in the harness self-approves.
+- **Humans own merge, publish, release, and deployment.** Nothing in Open Scaffold self-approves.
 - **Historical `v1.0.x` packages exist** as immutable publication history; the forward line is `v0.32.x` and the next 1.0 will be cut when the contract has earned it.
 
 ## Release status
@@ -43,8 +43,12 @@ These surfaces are intended to remain usable across the current pre-1.0 hardenin
 
 The stable day-two CLI surface is:
 
+- `osc first-run` as guided repo initialization for the minimum work record
+- `osc handoff` as the public read-only packet that lets a fresh session continue from repo truth
+- `osc resume` as the original/back-compat alias for `osc handoff`
+- `osc review` as the public recorded-attempt review command (`osc analyze` is the original synonym)
+- `osc gate` as the stop/continue gate over recorded attempts
 - `osc init`
-- `osc resume` as the read-only resume packet that lets a fresh session continue from repo truth
 - `osc status`
 - `osc plan new`
 - `osc plan validate`
@@ -54,7 +58,6 @@ The stable day-two CLI surface is:
 - `osc evidence new`
 - `osc evidence collect`
 - `osc verify`
-- `osc first-run` as guided repo initialization for the minimum work record
 - `osc pr check` as a PR-native structural check surface
 - `osc schemas list` and `osc schemas show` for package-visible schema discovery
 - `osc compare` as a read-only first-read demo for comparing two recorded attempts
@@ -70,7 +73,7 @@ The zero-dependency shell helpers remain a stable fallback floor:
 
 ### Verification expectations
 
-- `./verify.sh --quick`, `--standard`, and `--strict` remain the canonical repository compliance tiers.
+- `./verify.sh --quick`, `--standard`, and `--strict` remain the canonical structural verification tiers.
 - `npm test` and `npm run build` remain the package-level local gates for this repository.
 - Public PRs should cite the plan, evidence note, verification commands, review state, and owner gates.
 - `osc trace <plan-slug>` is a reconstruction aid; `osc verify --evidence-chain` remains the structural integrity check.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,8 +47,8 @@ npx open-scaffold@latest compare \
 |---|---|
 | Understand the mission and goals | [`MISSION.md`](../MISSION.md) |
 | Learn the review-and-gate loop | [`EVOLUTION_LOOP.md`](EVOLUTION_LOOP.md) |
-| See how the record layer is wired | [`HARNESS_ARCHITECTURE.md`](HARNESS_ARCHITECTURE.md) |
-| Pick or write a runtime adapter | [`ADAPTERS.md`](ADAPTERS.md) |
+| See the current workflow map | [`WORKFLOW.md`](WORKFLOW.md) |
+| Understand runtime/execution boundaries | [`TRUST_BOUNDARIES.md`](TRUST_BOUNDARIES.md) and [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) |
 | Check what is stable vs experimental | [`STABILITY.md`](STABILITY.md) |
 | Understand the version story | [`STABILITY.md#release-status`](STABILITY.md#release-status) |
 | Look up unfamiliar terms | [`GLOSSARY.md`](GLOSSARY.md) |

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -48,7 +48,7 @@ Unsafe local overrides such as full environment passthrough belong in package-sp
 
 ## Runtime spawning boundary
 
-Open Scaffold core does not silently spawn provider agents. It can create run packets, render handoff prompts, and invoke reviewed explicit adapters. Runtime harnesses such as Codex/OMX/Claude/OpenHands own their own authentication, process model, sandboxing, and provider logs.
+Open Scaffold core does not silently spawn provider agents. It creates run packets and handoff prompts; external coordinators, humans, or runtime-specific packages invoke adapters and own authentication, process model, sandboxing, and provider logs.
 
 A write-capable runtime lane must use an isolated non-main branch/worktree and must stop before commit/push/PR/merge/publish unless the owner grants that separate authority.
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,6 +1,6 @@
 # Workflow
 
-A phase-to-tool reference for agent-orchestrated development. This file is the operational reference; `README.md` is the landing page. When in doubt about which tool to reach for, start with the stable repo record: `MISSION.md` → plan → run packet or amendment → evidence → verification → close. Across every phase, the product front door is three commands: `osc handoff` (resume packet for the next session or model), `osc review` (review recorded attempts; `osc analyze` remains a synonym), and `osc gate` (authorize or block the next attempt).
+A phase-to-tool reference for AI-assisted work. This file is the operational reference; `README.md` is the landing page. When in doubt about which tool to reach for, start with the stable repo record: `MISSION.md` → plan → run packet or amendment → evidence → verification → close. Across every phase, the product front door is three commands: `osc handoff` (resume packet for the next session or model), `osc review` (review recorded attempts; `osc analyze` remains a synonym), and `osc gate` (authorize or block the next attempt).
 
 The stable core is the file protocol and lifecycle helpers. Lab surfaces such as evolution ledgers, cockpit webhooks, and runtime profiles are optional layers around that record; they do not replace the plan/evidence/verification/close chain. Historical helpers removed from the reduced maintained CLI, such as `osc work`, `osc dashboard`, `osc task`, `osc plan wizard`, `osc plan graph`, `osc metrics`, and broad `osc doctor --fix`, are migration references only unless a future plan restores them with fresh evidence.
 
@@ -144,7 +144,7 @@ There is no automatic router between tools. You, the human, decide based on the 
 | Stuck or uncertain | Second opinion | A different model's perspective breaks deadlocks |
 | Public/versioned change | GitHub PR loop | CI, Codex review, and human approval gate merges |
 
-> **Runtime split:** Open Scaffold is the runtime-neutral contract. Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, or custom scripts can act as orchestrators/agents. OMC is a Claude Code harness; OMX is a Codex harness. Status/approval channels such as Discord are operator surfaces — visible control rooms, not canonical state.
+> **Runtime split:** Open Scaffold is the runtime-neutral contract. Hermes, Claw/OpenClaw, Claude Code, Codex, Gemini, or custom scripts can act as orchestrators/agents. OMC is a Claude Code harness; OMX is a Codex harness. Status/approval channels such as Discord are operator surfaces — visible status rooms, not canonical state.
 
 ### Delegation decision tree
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,13 +1,13 @@
 # Examples
 
-Five worked example paths a fresh user or agent can read end-to-end. The first four are operating modes; the fifth shows the evolution-ledger comparison wedge directly. Each path links to existing protocol docs and shipped fixtures rather than inventing new machinery.
+Five worked example paths a fresh user or agent can read end-to-end. The first four are ways to use the repo record; the fifth shows the evolution-ledger comparison wedge directly. Each path links to existing protocol docs and shipped fixtures rather than inventing new machinery.
 
 The example paths:
 
 1. [Solo developer](#1-solo-developer) — one human, one repo, AI assist.
-2. [Team control-room](#2-team-control-room) — multiple humans/agents coordinating with the repo as truth.
+2. [Team status room](#2-team-status-room) — multiple humans/agents coordinating with the repo as truth.
 3. [GitHub-only workflow](#3-github-only-workflow) — issue → plan → PR → evidence with no chat coordinator.
-4. [Runtime harness handoff](#4-runtime-harness-handoff) — packaging work for an external runtime lane to execute.
+4. [External handoff packet](#4-external-handoff-packet) — packaging work for an external agent, runtime lane, or teammate to execute.
 5. [Evolution loop compare](evolution-loop-compare.md) — two attempts → `osc evolve compare` → frontier rationale.
    - [`examples/evolution-ledger-demo/`](../../examples/evolution-ledger-demo/) — runnable fixture: checked-in loop, attempts, evaluations, a promoted frontier, and committed expected compare output. Verified by the evolution CLI tests.
 
@@ -25,7 +25,7 @@ A single operator using AI assistance against one repo. Truth lives in `MISSION.
 
 Reading path:
 
-- [`README.md` Quickstart](../../README.md#quickstart) — initialize the scaffold, bootstrap a mission, write the first plan, run `./verify.sh`.
+- [`README.md` Start in 60 seconds](../../README.md#start-in-60-seconds) — run the guided first work-record command and follow the printed next steps.
 - [`docs/EXAMPLES.md` 60-second viewer demo](../EXAMPLES.md#60-second-viewer-demo) — mission → plan → verification → evidence in four shell commands.
 - [`downstream-walkthrough.md`](downstream-walkthrough.md) — the same loop on Tiny Notes, a small non-Open-Scaffold project with concrete commands, expected outputs, and a day-2 resume check that works without chat history.
 - [`examples/lifecycle-e2e-smoke/`](../../examples/lifecycle-e2e-smoke/README.md) — boring downstream fixture that proves the loop on a non-Open-Scaffold project. Run it with `npm run smoke:e2e`.
@@ -33,20 +33,18 @@ Reading path:
 Loop in shell:
 
 ```bash
-./bootstrap.sh                                    # define mission
-cp .osc/plans/handoff-template.md \
-   .osc/plans/active/my-first-task.md             # scoped plan
-# ... agent edits code against the plan ...
-./verify.sh --standard                            # methodology check
-# write .osc/releases/<date>-<slug>.md when done
-./close.sh my-first-task                          # move plan to done/
+npx open-scaffold@latest first-run               # mission + first plan + evidence skeleton
+# ... agent or human edits against the generated plan ...
+osc evidence new <slug>                           # record real verification output before close
+osc verify --evidence-chain                       # structural linkage check
+osc close <slug> --message "verified"            # move plan to done/
 ```
 
 What this mode does **not** require: a chat surface, a coordinator, a runtime harness, or any private deployment.
 
 ---
 
-## 2. Team control-room
+## 2. Team status room
 
 Multiple humans and/or agents coordinating around the same repo. A team room (Slack/Discord/Telegram/CLI dashboard) shows status and collects approvals; the repo still owns durable truth.
 
@@ -58,7 +56,7 @@ Reading path:
 How the loop differs from solo:
 
 - Each plan binds to a `task_id` so multiple runs and reviewers can attach to the same work.
-- Cockpit events (status, blocker, question, approval) point back at a plan, run, evidence path, or PR — never at a chat thread alone.
+- Status-room events (status, blocker, question, approval) point back at a plan, run, evidence path, or PR — never at a chat thread alone.
 - Approvals land as evidence/PR review, not as chat reactions.
 
 Coordinators that can sit in front of this loop (issue trackers, Kanban tools, custom bots, or private deployment examples) are external by design. Open Scaffold core does not bundle, require, or authenticate against any of them.
@@ -91,7 +89,7 @@ What this mode does **not** require: a chat/status channel (operator surface), a
 
 ---
 
-## 4. Runtime harness handoff
+## 4. External handoff packet
 
 When a runtime lane (Claude Code, Codex, OMC, OMX, a custom adapter, or a human terminal) should execute a plan, Open Scaffold core packages the work into `.osc/runs/<run_id>/run.json`. Core does not launch the lane — `spawning: false` is the boundary that keeps the protocol portable.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -35,7 +35,7 @@ Loop in shell:
 ```bash
 npx open-scaffold@latest first-run               # mission + first plan + evidence skeleton
 # ... agent or human edits against the generated plan ...
-osc evidence new <slug>                           # record real verification output before close
+osc evidence collect <slug>                       # append real verification output to the existing evidence note
 osc verify --evidence-chain                       # structural linkage check
 osc close <slug> --message "verified"            # move plan to done/
 ```

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -33,10 +33,14 @@ Reading path:
 Loop in shell:
 
 ```bash
-npx open-scaffold@latest first-run                         # mission + first plan + evidence skeleton
-# ... agent or human edits against the generated plan ...
-npx open-scaffold@latest evidence collect <slug>            # append real verification output to the existing evidence note
+npx open-scaffold@latest first-run --non-interactive \
+  --slug "<slug>" --mission "<mission>" --goal "<goal>"
+# ... complete the first bounded task ...
+npx open-scaffold@latest plan validate <slug> --strict
+# edit .osc/plans/active/<slug>.md: mark the acceptance criteria that actually passed
+# edit .osc/releases/<date>-<slug>.md: replace Pending with real command output
 npx open-scaffold@latest close <slug> --message "verified" # move plan to done/
+# if the evidence note still points at active/, update its Plan line to .osc/plans/done/<slug>.md
 npx open-scaffold@latest verify --evidence-chain --plan <slug> --strict
 ```
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -33,11 +33,11 @@ Reading path:
 Loop in shell:
 
 ```bash
-npx open-scaffold@latest first-run               # mission + first plan + evidence skeleton
+npx open-scaffold@latest first-run                         # mission + first plan + evidence skeleton
 # ... agent or human edits against the generated plan ...
-osc evidence collect <slug>                       # append real verification output to the existing evidence note
-osc verify --evidence-chain                       # structural linkage check
-osc close <slug> --message "verified"            # move plan to done/
+npx open-scaffold@latest evidence collect <slug>            # append real verification output to the existing evidence note
+npx open-scaffold@latest close <slug> --message "verified" # move plan to done/
+npx open-scaffold@latest verify --evidence-chain --plan <slug> --strict
 ```
 
 What this mode does **not** require: a chat surface, a coordinator, a runtime harness, or any private deployment.

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,13 @@
         <div class="links">
           <a href="../README.md">README</a>
           <span aria-hidden="true"> · </span>
+          <a href="START_HERE.md">Start here</a>
+          <span aria-hidden="true"> · </span>
+          <a href="PROOF_HARNESS.md">Proof</a>
+          <span aria-hidden="true"> · </span>
           <a href="STABILITY.md">Stability</a>
+          <span aria-hidden="true"> · </span>
+          <a href="FAQ.md">FAQ</a>
           <span aria-hidden="true"> · </span>
           <a href="CHANGELOG.md">Changelog</a>
           <span aria-hidden="true"> · </span>
@@ -122,7 +128,7 @@
         <div>
           <h1>AI work needs a record.</h1>
           <p class="lead">Open Scaffold records AI-assisted work in your repo: plans, run packets, evidence, handoffs, review gates, and close records that survive the session.</p>
-          <p>Kill the session mid-task. Any agent or operator can <strong>resume bounded work straight from the repo after total chat-context loss</strong> — no re-explaining. See the <a href="../examples/resume-demo/">resume demo fixture</a> and the <a href="RESUME_WALKTHROUGH.md">resume walkthrough</a>.</p>
+          <p>Kill the session mid-task. A fresh reader, compatible agent, or operator can <strong>resume bounded work straight from the repo after total chat-context loss</strong> — no archaeology through vanished chat. See the <a href="../examples/resume-demo/">resume demo fixture</a> and the <a href="RESUME_WALKTHROUGH.md">resume walkthrough</a>.</p>
         </div>
         <aside class="panel">
           <h2>First command</h2>
@@ -157,6 +163,7 @@
       <section class="panel">
         <h2>What you can rely on today</h2>
         <p>The work loop and its record are stable: <code>MISSION.md</code>, plan folders with acceptance criteria, amendments, no-spawn run packets, evidence notes, <code>osc handoff</code>, <code>osc review</code>, <code>osc gate</code>, and <code>osc verify</code>. Runtime launch stays outside Open Scaffold core.</p>
+        <p>Current package truth: the public line is still pre-1.0 and the evidence is pilot-grade. Treat Open Scaffold as a repo record and review layer, not as a hosted orchestrator, compliance program, or production-readiness certificate.</p>
         <p>One page holds the full maturity contract — stable, experimental, future, and the honest limits: <a href="STABILITY.md">the stability page</a>.</p>
       </section>
 
@@ -170,7 +177,7 @@
       </section>
 
       <footer class="muted">
-        <p><strong class="accent">Owner gates stay human.</strong> npm publication, GitHub Release latest movement, deployment, and launch announcements require explicit approval.</p>
+        <p><strong class="accent">Owner gates stay human.</strong> npm publication, GitHub Release latest movement, merge, deployment, and launch announcements require explicit approval. Start with <a href="START_HERE.md">Start here</a>.</p>
       </footer>
     </main>
   </body>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -744,11 +744,11 @@ function schemasCommand(args: string[]): void {
   else die('Usage: osc schemas list | osc schemas show <schema-id>');
 }
 
-function resumeCommand(args: string[]): void {
-  if (isHelpArg(args[0])) { console.log('Usage: osc resume [--json] [--plan <slug>] [--max-chars <n>]\n\nCompiles a compact, read-only resume packet from repo truth: mission digest, active plan with acceptance criteria, latest run state, repair hypotheses, accepted lessons, and the next bounded action. A fresh agent or session continues from this packet instead of chat history.'); return; }
-  validateOptions(args, ['--plan', '--max-chars'], ['--json'], 'resume');
+function resumeCommand(args: string[], commandName = 'resume'): void {
+  if (isHelpArg(args[0])) { const aliasLine = commandName === 'handoff' ? '\n\n`osc resume` is the original alias for the same read-only packet.' : '\n\n`osc handoff` is the product-named front door for the same read-only packet.'; console.log(`Usage: osc ${commandName} [--json] [--plan <slug>] [--max-chars <n>]\n\nCompiles a compact, read-only handoff/resume packet from repo truth: mission digest, active plan with acceptance criteria, latest run state, repair hypotheses, accepted lessons, and the next bounded action. A fresh agent or session continues from this packet instead of chat history.${aliasLine}`); return; }
+  validateOptions(args, ['--plan', '--max-chars'], ['--json'], commandName);
   const extra = positional(args, ['--plan', '--max-chars']);
-  if (extra.length) die(`Unknown argument for resume: ${extra[0]}`, 2);
+  if (extra.length) die(`Unknown argument for ${commandName}: ${extra[0]}`, 2);
   const maxCharsRaw = value(args, '--max-chars');
   let maxChars: number | undefined;
   if (maxCharsRaw !== undefined) {
@@ -1075,7 +1075,7 @@ async function main(): Promise<void> {
       case 'resume': resumeCommand(args); return;
       // Product-named front door: handoff/review/gate are stable aliases of
       // resume / evolve analyze / evolve checkpoint. analyze stays as a synonym.
-      case 'handoff': resumeCommand(args); return;
+      case 'handoff': resumeCommand(args, 'handoff'); return;
       case 'review': case 'analyze':
         if (args.some(isHelpArg)) { console.log(reviewAliasHelp(command)); return; }
         await evolveCommand(['analyze', ...args]); return;

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -116,6 +116,12 @@ const cases: HelpCase[] = [
     forbidden: 'Unknown option',
   },
   {
+    name: 'handoff alias',
+    args: ['handoff', '--help'],
+    expected: 'Usage: osc handoff [--json] [--plan <slug>] [--max-chars <n>]',
+    forbidden: 'Usage: osc resume',
+  },
+  {
     name: 'review alias',
     args: ['review', '--help'],
     expected: 'Usage: osc review <loop-dir> [--compact] [--format <terminal|markdown|json>] [--out <path>] [--plateau-threshold <n>]',
@@ -277,8 +283,8 @@ describe('plan lifecycle help flags', () => {
 
 describe('removed/repositioned command shims', () => {
 
-  it('routes retired harness and dispatch commands to the migration notice', () => {
-    for (const args of [['harness'], ['harness', '--help'], ['dispatch'], ['adapter'], ['ultrareview']]) {
+  it('routes retired harness, dispatch, and framework-cleanup commands to the migration notice', () => {
+    for (const args of [['harness'], ['harness', '--help'], ['dispatch'], ['adapter'], ['ultrareview'], ['work'], ['task'], ['metrics'], ['dashboard'], ['study'], ['ab']]) {
       const result = spawnSync(node, [...cliArgs, ...args], { cwd: repoRoot, encoding: 'utf8' });
 
       expect(result.status).toBe(2);

--- a/tests/cli-lifecycle-help.test.ts
+++ b/tests/cli-lifecycle-help.test.ts
@@ -282,16 +282,15 @@ describe('plan lifecycle help flags', () => {
 
 
 describe('removed/repositioned command shims', () => {
+  const retiredCommandCases: string[][] = [['harness'], ['harness', '--help'], ['dispatch'], ['adapter'], ['ultrareview'], ['work'], ['task'], ['metrics'], ['dashboard'], ['study'], ['ab']];
 
-  it('routes retired harness, dispatch, and framework-cleanup commands to the migration notice', () => {
-    for (const args of [['harness'], ['harness', '--help'], ['dispatch'], ['adapter'], ['ultrareview'], ['work'], ['task'], ['metrics'], ['dashboard'], ['study'], ['ab']]) {
-      const result = spawnSync(node, [...cliArgs, ...args], { cwd: repoRoot, encoding: 'utf8' });
+  it.each(retiredCommandCases.map((args) => [args]))('routes retired command %j to the migration notice', (args) => {
+    const result = spawnSync(node, [...cliArgs, ...args], { cwd: repoRoot, encoding: 'utf8' });
 
-      expect(result.status).toBe(2);
-      expect(result.stdout).toBe('');
-      expect(result.stderr).toContain('was removed/repositioned by the framework cleanup');
-      expect(result.stderr).toContain('docs/STABILITY.md#command-maturity');
-    }
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('was removed/repositioned by the framework cleanup');
+    expect(result.stderr).toContain('docs/STABILITY.md#command-maturity');
   });
 
   it('treats missing amend/close operands as errors, not help', () => {

--- a/tests/first-run-docs.test.ts
+++ b/tests/first-run-docs.test.ts
@@ -42,11 +42,15 @@ describe('first-run documentation truth', () => {
     const examples = read('docs/examples/README.md');
     const loop = examples.split('Loop in shell:')[1]?.split('```bash')[1]?.split('```')[0] ?? '';
 
-    expect(loop).toContain('npx open-scaffold@latest first-run');
-    expect(loop).toContain('npx open-scaffold@latest evidence collect <slug>');
+    expect(loop).toContain('npx open-scaffold@latest first-run --non-interactive');
+    expect(loop).toContain('npx open-scaffold@latest plan validate <slug> --strict');
+    expect(loop).toContain('edit .osc/plans/active/<slug>.md');
+    expect(loop).toContain('edit .osc/releases/<date>-<slug>.md');
+    expect(loop).toContain('update its Plan line to .osc/plans/done/<slug>.md');
     expect(loop).toContain('npx open-scaffold@latest close <slug> --message "verified"');
     expect(loop).toContain('npx open-scaffold@latest verify --evidence-chain --plan <slug> --strict');
     expect(loop).not.toMatch(/^osc /m);
+    expect(loop.indexOf('mark the acceptance criteria')).toBeLessThan(loop.indexOf('close <slug>'));
     expect(loop.indexOf('close <slug>')).toBeLessThan(loop.indexOf('verify --evidence-chain'));
   });
 

--- a/tests/first-run-docs.test.ts
+++ b/tests/first-run-docs.test.ts
@@ -24,6 +24,17 @@ describe('first-run documentation truth', () => {
     expect(minimum).toContain('node dist/cli.js init');
   });
 
+  it('keeps the LLM quickstart runnable without assuming a global osc binary', () => {
+    const quickstart = read('LLM_QUICKSTART.md');
+
+    expect(quickstart).toContain('npx open-scaffold@latest first-run');
+    expect(quickstart).toContain('npx open-scaffold@latest handoff');
+    expect(quickstart).not.toContain('\nosc handoff\n');
+    expect(quickstart).toContain('TARGET_REPO=/path/to/your/project');
+    expect(quickstart).toContain('cd "$TARGET_REPO"');
+    expect(quickstart).toContain('node "$OSC_SOURCE/dist/cli.js" first-run');
+  });
+
   it('documents lifecycle helper commands without removing shell fallbacks', () => {
     const readme = read('README.md');
     for (const command of ['osc plan new', 'osc evidence new', 'osc amend', 'osc close']) {

--- a/tests/first-run-docs.test.ts
+++ b/tests/first-run-docs.test.ts
@@ -35,6 +35,18 @@ describe('first-run documentation truth', () => {
     expect(quickstart).toContain('node "$OSC_SOURCE/dist/cli.js" first-run');
   });
 
+  it('keeps the solo example loop runnable from npx and checks the closed plan chain', () => {
+    const examples = read('docs/examples/README.md');
+    const loop = examples.split('Loop in shell:')[1]?.split('```bash')[1]?.split('```')[0] ?? '';
+
+    expect(loop).toContain('npx open-scaffold@latest first-run');
+    expect(loop).toContain('npx open-scaffold@latest evidence collect <slug>');
+    expect(loop).toContain('npx open-scaffold@latest close <slug> --message "verified"');
+    expect(loop).toContain('npx open-scaffold@latest verify --evidence-chain --plan <slug> --strict');
+    expect(loop).not.toMatch(/^osc /m);
+    expect(loop.indexOf('close <slug>')).toBeLessThan(loop.indexOf('verify --evidence-chain'));
+  });
+
   it('documents lifecycle helper commands without removing shell fallbacks', () => {
     const readme = read('README.md');
     for (const command of ['osc plan new', 'osc evidence new', 'osc amend', 'osc close']) {

--- a/tests/first-run-docs.test.ts
+++ b/tests/first-run-docs.test.ts
@@ -27,12 +27,15 @@ describe('first-run documentation truth', () => {
   it('keeps the LLM quickstart runnable without assuming a global osc binary', () => {
     const quickstart = read('LLM_QUICKSTART.md');
 
-    expect(quickstart).toContain('npx open-scaffold@latest first-run');
+    expect(quickstart).toContain('npx open-scaffold@latest first-run --non-interactive');
+    expect(quickstart).toContain('--slug "<slug>"');
+    expect(quickstart).toContain('--mission "<mission>"');
+    expect(quickstart).toContain('--goal "<goal>"');
     expect(quickstart).toContain('npx open-scaffold@latest handoff');
     expect(quickstart).not.toContain('\nosc handoff\n');
     expect(quickstart).toContain('TARGET_REPO=/path/to/your/project');
     expect(quickstart).toContain('cd "$TARGET_REPO"');
-    expect(quickstart).toContain('node "$OSC_SOURCE/dist/cli.js" first-run');
+    expect(quickstart).toContain('node "$OSC_SOURCE/dist/cli.js" first-run --non-interactive');
   });
 
   it('keeps the solo example loop runnable from npx and checks the closed plan chain', () => {

--- a/tests/first-run-docs.test.ts
+++ b/tests/first-run-docs.test.ts
@@ -11,7 +11,8 @@ function read(path: string): string {
 describe('first-run documentation truth', () => {
   it('advertises the published guided first-run as the default adoption path', () => {
     expect(read('README.md')).toContain('npx open-scaffold@latest first-run');
-    expect(read('docs/START_HERE.md')).toContain('npx open-scaffold init --tier min');
+    expect(read('docs/START_HERE.md')).toContain('npx open-scaffold@latest first-run');
+    expect(read('LLM_QUICKSTART.md')).toContain('npx open-scaffold@latest first-run');
   });
 
   it('keeps a source-checkout fallback path for users who do not want npx', () => {

--- a/tests/public-positioning.test.ts
+++ b/tests/public-positioning.test.ts
@@ -31,6 +31,50 @@ describe('public work-record positioning', () => {
     expect(firstScreen).not.toMatch(/agent OS|control plane|compliance-grade|operating system|tamper-proof/i);
   });
 
+  it('keeps first-touch identity on one product offering', () => {
+    const missionIntro = firstLines(read('MISSION.md'), 50);
+    const agentsIntro = firstLines(read('AGENTS.md'), 20);
+    const claudeIntro = firstLines(read('CLAUDE.md'), 20);
+    const startHereIntro = firstLines(read('docs/START_HERE.md'), 20);
+
+    for (const [path, text] of [
+      ['MISSION.md', missionIntro],
+      ['AGENTS.md', agentsIntro],
+      ['CLAUDE.md', claudeIntro],
+      ['docs/START_HERE.md', startHereIntro],
+    ] as const) {
+      expect(text, path).toMatch(/repo-native work[- ]record|repo record layer/i);
+      expect(text, path).not.toMatch(/repo-native operating system|agent-orchestrated development|harness is the product|a harness for AI-assisted work/i);
+    }
+
+    expect(agentsIntro).toContain('osc handoff');
+    expect(claudeIntro).toContain('osc handoff');
+    expect(agentsIntro).toContain('source checkout alias');
+    expect(claudeIntro).toContain('source checkout alias');
+  });
+
+  it('keeps README key docs deduplicated and linked to the right first-use surfaces', () => {
+    const readme = read('README.md');
+    const keyDocs = readme.split('## Key docs')[1]?.split('## Dogfooded')[0] ?? '';
+    const links = [...keyDocs.matchAll(/\(([^)]+)\)/g)].map((match) => match[1]);
+
+    expect(links).toContain('docs/START_HERE.md');
+    expect(links).toContain('docs/PROOF_HARNESS.md');
+    expect(links).toContain('docs/STABILITY.md');
+    expect(new Set(links).size).toBe(links.length);
+  });
+
+  it('keeps the docs landing page pointed at the public first-read path and maturity boundary', () => {
+    const index = read('docs/index.html');
+
+    expect(index).toContain('START_HERE.md');
+    expect(index).toContain('PROOF_HARNESS.md');
+    expect(index).toContain('FAQ.md');
+    expect(index).toContain('pre-1.0');
+    expect(index).toContain('not as a hosted orchestrator, compliance program, or production-readiness certificate');
+    expect(index).not.toContain('Any agent or operator can');
+  });
+
   it('documents auditability as evidence substrate, not a compliance program', () => {
     const auditability = read('docs/TRUST_BOUNDARIES.md');
 
@@ -108,6 +152,27 @@ describe('public work-record positioning', () => {
     }
   });
 
+  it('keeps first-touch public docs off broad authority and runtime-product claims', () => {
+    const firstTouchDocs = [
+      'README.md',
+      'MISSION.md',
+      'AGENTS.md',
+      'CLAUDE.md',
+      'LLM_QUICKSTART.md',
+      'docs/START_HERE.md',
+      'docs/STABILITY.md',
+      'docs/FAQ.md',
+      'docs/TRUST_BOUNDARIES.md',
+      'docs/index.html',
+    ];
+
+    for (const path of firstTouchDocs) {
+      const raw = read(path);
+      const text = path === 'MISSION.md' ? raw.split('## Changelog')[0] : raw;
+      expect(text, path).not.toMatch(/is a hosted orchestrator|is the control plane|acts as a control plane|certifies compliance|guarantees compliance|guarantees production readiness|is a production-readiness certificate|offers a production-readiness certificate|proves broad benchmark dominance|ships default runtime spawning|provides native autonomous agent spawning|supports native autonomous agent spawning/i);
+    }
+  });
+
   it('keeps the release evidence summary off software-only framing', () => {
     const evidence = read('.osc/releases/2026-05-27-108-public-work-record-positioning.md');
     const summary = evidence.split('## Traceability')[0];
@@ -182,7 +247,8 @@ describe('public work-record positioning', () => {
     const startHere = read('docs/START_HERE.md');
     const pkg = JSON.parse(read('package.json')) as { description: string; keywords: string[] };
 
-    expect(firstLines(readme, 100)).toContain('published, pilot-grade evidence and explicit proof boundaries');
+    expect(firstLines(readme, 100)).toContain('pilot-grade proof boundaries');
+    expect(firstLines(readme, 100)).toContain('AI-assisted work that needs evidence, recovery, and human gates');
     expect(readme).toContain('This is not a production-readiness claim');
     expect(faq).toContain('Not as a mature production platform.');
     expect(faq).toContain('pre-1.0');

--- a/tests/reduced-cli-docs.test.ts
+++ b/tests/reduced-cli-docs.test.ts
@@ -6,10 +6,19 @@ const repoRoot = resolve(import.meta.dirname, '..');
 
 const currentFacingDocs = [
   'README.md',
+  'MISSION.md',
+  'AGENTS.md',
+  'CLAUDE.md',
+  'LLM_QUICKSTART.md',
   'ROADMAP.md',
+  'docs/START_HERE.md',
   'docs/WORKFLOW.md',
   'docs/EVOLUTION_LOOP.md',
   'docs/STABILITY.md',
+  'docs/FAQ.md',
+  'docs/TRUST_BOUNDARIES.md',
+  'docs/EXAMPLES.md',
+  'docs/examples/README.md',
   'docs/index.html',
   'docs/OPEN_SCAFFOLD_SYSTEM.md',
   'docs/RESUME_WALKTHROUGH.md',
@@ -44,7 +53,7 @@ const removedCommandPatterns = [
 ];
 
 const migrationContext = /historical|repositioned|removed|retired|migration|future|backlog|previous|previously|earlier|no longer|not live|not a live|outside the reduced|reduced maintained CLI|not current/i;
-const fileLevelMigrationContext = /Status: historical\/repositioned|Historical\/repositioned|historical\/repositioned .*document|historical\/repositioned .*protocol/i;
+const fileLevelMigrationContext = /Status: historical\/repositioned|Historical\/repositioned|historical\/repositioned .*document|historical\/repositioned .*protocol|Historical entries below preserve the wording used at the time/i;
 
 describe('reduced CLI documentation coherence', () => {
   it('marks references to removed commands as historical, migration, or future context', () => {
@@ -52,7 +61,7 @@ describe('reduced CLI documentation coherence', () => {
 
     for (const path of currentFacingDocs) {
       const text = readFileSync(resolve(repoRoot, path), 'utf8');
-      const wholeFileIsMigrationContext = fileLevelMigrationContext.test(text.slice(0, 1000));
+      const wholeFileIsMigrationContext = fileLevelMigrationContext.test(text.slice(0, 5000));
       for (const pattern of removedCommandPatterns) {
         pattern.lastIndex = 0;
         for (const match of text.matchAll(pattern)) {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -250,7 +250,8 @@ This sample must not count as the real section.
     // public-readiness-hardening: added done plan and release note for bounded public readiness copy.
     // 172 release closeout: moved public-readiness package-sync plan to done after npm/GitHub Release publication proof.
     // 173 planning: added active Codex token-efficiency proof plan.
-    expect(hash(planIssueSnapshot)).toBe('bb76c5bf806d92780d0a5952b275eed892c8d931c2cedc9043aec2c0df92dbb4');
+    // v1-public-positioning-polish closeout: added done public-positioning polish plan.
+    expect(hash(planIssueSnapshot)).toBe('55dd29a6c867d789ee41042e20af0f8d720bdc15d394aa086a93a3012b08dcf7');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     // 170 review hardening: evidence note refreshed with PR URL, final test count, and Codex-reported total_tokens.
@@ -258,7 +259,8 @@ This sample must not count as the real section.
     // public-readiness-hardening: release note added with no new release warnings.
     // 172 release closeout: finalized v0.32.1 publication evidence note; release-warning set unchanged.
     // 173 planning plus proof provenance/rubric updates changed the live scaffold corpus hash.
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('69c2c3f35a7e509d9c3d23e4ee20b5ddb1d8c13f28dad7f242843b04c3d74f37');
+    // v1-public-positioning-polish closeout added local evidence note; release-warning set unchanged.
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('6e07f75f90220e2b484338bb75520b751202dae6b29a58d226e4ef603db46f24');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Aligns the first-touch public product story around one offering: a repo-native work record for AI-assisted work.
- Clarifies the target audience: developers and teams whose AI work must survive context loss, PR review, client/audit handoff, or repeated attempts.
- Keeps runtime/spawning, compliance certification, npm publication, GitHub Release movement, merge, deploy, and launch authority outside this PR.
- Adds regression guards for public positioning, command/version truth, retired-command boundaries, LLM quickstart command paths, example evidence collection/closed-plan verification, and live corpus state.

## Verification

- `npm run -s osc -- plan validate .osc/plans/done/v1-public-positioning-polish.md --strict` — `0 issues found`
- `npm test -- tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/section-parser.test.ts` — `5 passed`, `65 tests passed`
- `npm test -- tests/public-positioning.test.ts tests/reduced-cli-docs.test.ts tests/first-run-docs.test.ts tests/cli-lifecycle-help.test.ts tests/package-payload.test.ts tests/section-parser.test.ts` — `6 passed`, `69 tests passed`
- `npm run build` — passed
- `npm test -- --run` — `48 passed`, `556 tests passed`
- `./verify.sh --strict` — `10 pass`, `0 fail`, `0 warn`
- `git diff --check` — passed
- `npm run -s osc -- doctor --check secret-scan` — passed
- `npm pack --dry-run --json` — passed (`224` files)
- Retired-command smoke checks for `work dispatch adapter metrics dashboard task study ab harness` — each exited with the documented migration path

## Risk / gates

- Docs/positioning plus a small CLI help alias fix; no runtime/spawning behavior added.
- No npm publish, no GitHub Release movement, no merge, no website deploy, and no launch announcement.
- The current public package line remains `open-scaffold@0.32.1` / GitHub Latest `v0.32.1` until a separate owner-approved release train changes it.

## Traceability

- Plan: `.osc/plans/done/v1-public-positioning-polish.md`
- Evidence: `.osc/releases/2026-06-18-v1-public-positioning-polish.md`
