### PR TITLE
Add skill front door + reproduce kit; slim README to the contrarian result

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Open Scaffold keeps a repo-native work record — git-tracked, observed-fact fil
 
 The interesting result is not "the scaffold makes your agent smarter" — measured, it does not. A naked frontier model matched or beat every scaffolded arm on in-session task quality. That dead result is published at equal weight with the wins.
 
-What the record fixes is amnesia and confabulation. In preregistered trials, a mid-tier reviewer answering factual questions about finished work — graded against answer keys committed before it ran — hit **94% accuracy with the record vs 30% without, zero confident wrong-history answers, at half the review cost**. The record turns a cheap model into a trustworthy auditor. Boundaries in [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md).
+What the record fixes is amnesia and memory errors. In preregistered trials, a mid-tier reviewer model answering factual questions about finished work — graded against answer keys committed before it ran — hit **94% accuracy with the record vs 30% without, zero confident wrong-history answers, at half the review cost**. The record turns a cheap model into a trustworthy auditor. Boundaries in [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md).
 
 A bounded Codex cold-resume fixture: a 1,557-byte resume capsule vs 419,233 bytes of raw transcript, three replicates per arm, decision quality tied at 6/6 on a deterministic human-facing reader-usability rubric, **4.330033x fewer tokens** (median 137,327 → 31,715). One cold-resume decision, not a universal claim. This is not a production-readiness claim.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 **Your AI agent's work belongs in your repo, not its chat history.**
 
-Ambient work records, compact handoffs, and bounded review/gate checks from cheap and
-local models — for AI-assisted work that needs evidence, recovery, and human gates, with pilot-grade proof boundaries.
+Ambient work records, compact handoffs, and bounded review/gate checks from cheap and local models — for AI-assisted work that needs evidence, recovery, and human gates, with pilot-grade proof boundaries.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-black.svg)](LICENSE)
 [![npm](https://img.shields.io/npm/v/open-scaffold.svg)](https://www.npmjs.com/package/open-scaffold)
@@ -16,33 +15,15 @@ local models — for AI-assisted work that needs evidence, recovery, and human g
 
 ## The problem
 
-You pay frontier prices for everything — including the review, the status
-checks, the "where were we", the bookkeeping — because nothing cheaper can be
-trusted with them. Cheaper models guess; when a chat ends, the work's memory
-dies with it; the next session (or the reviewer) reconstructs history from a
-scrollback buffer, and what it can't reconstruct, it invents.
+You pay frontier prices for review, status checks, and "where were we" because nothing cheaper can be trusted. Cheaper models guess; when a chat ends, the work's memory dies with it; the next session reconstructs from a scrollback buffer and invents what it can't recover.
 
-## What Open Scaffold does
+## What it does
 
-Open Scaffold is for developers and teams using AI agents on work that must survive context loss, PR review, client handoff, or audit-sensitive delivery. It keeps a repo-native work record — git-tracked, observed-fact files about what your agents actually did — and turns it into three things:
+Open Scaffold keeps a repo-native work record — git-tracked, observed-fact files about what your agents did — and turns it into three things:
 
-- **Record (ambient).** The record is extracted from observed facts —
-  transcripts, receipts, test results, scores — around whatever workflow you
-  already run. It costs the working model nothing: no ceremony, no hand-written
-  bookkeeping. `osc capture --from claude-code|codex` reads a finished session
-  transcript into a work record (turns, tokens, tool census) with no worker
-  cooperation — see [`docs/CAPTURE.md`](docs/CAPTURE.md). Add a plan and evidence
-  files when you want claims checked against intent; feedback and lessons carry
-  into future attempts instead of being relearned.
-- **Handoff.** `osc handoff` compiles the record into a packet that lets the
-  next reader — a fresh session, a smaller model, another vendor's agent, or a
-  teammate — resume from the truth instead of re-deriving (or inventing) it.
-- **Review and gate.** Cheap models read the record and judge: `osc review`
-  reports plateaus, failing criteria, and requirements that deserve questioning;
-  `osc gate` turns that into a retry authorization — a stop authority that
-  lives outside the worker, with claims checked against evidence.
-
-The front door is three commands:
+- **Record (ambient).** Extracted from observed facts — transcripts, receipts, test results — costing the working model nothing. `osc capture --from claude-code|codex` reads a finished session into a record with no worker cooperation. Add a plan and evidence files to check claims against intent; feedback and lessons carry forward instead of being relearned.
+- **Handoff.** `osc handoff` compiles the record into a budgeted, secret-redacted packet so the next reader — a fresh session, a smaller model, another vendor's agent, or a teammate — resumes from truth instead of re-deriving or inventing it.
+- **Review and gate.** `osc review` reports plateaus, failing criteria, and requirements worth questioning; `osc gate` turns that into a retry authorization with stop authority outside the worker. Any file-reading model can be the judge. Fails closed: no parseable verdict means no authorization.
 
 | Command | Meaning |
 | --- | --- |
@@ -50,64 +31,23 @@ The front door is three commands:
 | `osc review` | Review recorded attempts: plateaus, failing criteria, question-the-requirement signals. |
 | `osc gate` | Authorize or block the next attempt from the analysis plus an optional independent judge. |
 
-Why cheap models? Because the record gives them facts to read instead of a chat archaeology problem to guess through. In pilot-grade,
-preregistered reviewability trials, a mid-tier reviewer answering factual
-questions about finished work — graded against answer keys committed before it
-ran — reconstructed the work at 94% accuracy with the record vs 30% on the bare
-workspace, with zero confident wrong-history answers and roughly half the review
-cost. This is not a production-readiness claim or universal benchmark; it is
-bounded evidence that the repo record helps the next reader. And when a judge is
-too weak to be trusted, the gate fails closed: no parseable verdict means no
-authorization, and the record's own blocks override a permissive ruling. Small
-and locally-hosted models (haiku-class, DeepSeek, Qwen, Ollama/MLX) can be useful
-as bounded reviewers, resumers, and bookkeepers inside those boundaries, so the frontier
-model is spent only where frontier capability is needed.
-
 ## What's measured
 
-Open Scaffold ran a preregistered benchmark program against itself in an
-independent repo (hidden inputs, pre-committed hashes, kill rules) and publishes
-the verdicts both ways:
+The interesting result is not "the scaffold makes your agent smarter" — measured, it does not. A naked frontier model matched or beat every scaffolded arm on in-session task quality. That dead result is published at equal weight with the wins.
 
-- **The work record's measured value is to the next reader, not the current
-  worker.** In with/without-record review trials over real finished work, a
-  fresh reviewer reconstructed what happened at **94% accuracy with the record
-  vs 30% without — with zero confabulated history — at half the review cost**
-  (pilot-grade n; boundaries and raw-data pointers in
-  [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md)).
-- **Bounded Codex cold-resume token efficiency:** a checked-in read-only Codex
-  fixture compares a naked prompt over 419,233 bytes of raw paused-session
-  artifacts with a 1,557-byte Open Scaffold resume capsule compiled from the
-  same facts. Three `codex exec`/`gpt-5.5` replicates per arm tied decision
-  quality at 6/6 on a deterministic human-facing reader-usability rubric, while
-  median reported total tokens fell from 137,327 to
-  31,715 - **4.330033x fewer tokens**. This is one cold-resume decision fixture,
-  not a universal cost or workload claim.
-- **What it does not do, measured:** it does not improve a strong model's
-  in-session task output — an explicit non-goal. Resume value scales with how
-  much recoverable state an interruption leaves behind. The dead claims stay
-  published alongside the live ones; that is the point.
+What the record fixes is amnesia and confabulation. In preregistered trials, a mid-tier reviewer answering factual questions about finished work — graded against answer keys committed before it ran — hit **94% accuracy with the record vs 30% without, zero confident wrong-history answers, at half the review cost**. The record turns a cheap model into a trustworthy auditor. Boundaries in [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md).
+
+A bounded Codex cold-resume fixture: a 1,557-byte resume capsule vs 419,233 bytes of raw transcript, three replicates per arm, decision quality tied at 6/6 on a deterministic human-facing reader-usability rubric, **4.330033x fewer tokens** (median 137,327 → 31,715). One cold-resume decision, not a universal claim. This is not a production-readiness claim.
+
+Audit every receipt, zero spend: [`REPRODUCE.md`](REPRODUCE.md).
 
 ## Start in 60 seconds
-
-In any repo, new or existing:
 
 ```bash
 npx open-scaffold@latest first-run
 ```
 
-Three guided questions (plan slug, mission, first goal) produce the minimum
-work record — `MISSION.md`, one active plan with acceptance criteria, an
-evidence skeleton — and print the exact commands to run next. That first record
-is structural: it does not certify the work, prove production readiness, or make
-a claim about model quality. Before closing the slice, replace the evidence
-skeleton with real command output and use `osc verify --evidence-chain` as a file
-linkage check; broader proof boundaries live in
-[`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) and
-[`docs/STABILITY.md`](docs/STABILITY.md).
-
-Work however you already work — your agent, your editor, your loop. The record
-accumulates as files; you close each slice with evidence:
+Three questions produce `MISSION.md`, an active plan with acceptance criteria, and an evidence skeleton. Work however you already work; the record accumulates as files:
 
 ```bash
 osc verify
@@ -115,137 +55,43 @@ osc evidence new first-slice
 osc close first-slice --message "verified first slice"
 ```
 
-Scope changed mid-slice? `osc amend first-slice --message "what changed"`
-records the change without rewriting the plan — plans are immutable, learnings
-are appended. More plans: `osc plan new <slug> --stage active`.
+Scope changed? `osc amend first-slice --message "what changed"` — plans are immutable, learnings appended. More plans: `osc plan new <slug> --stage active`. Fresh session: `osc handoff`.
 
-Back tomorrow in a brand-new session, or handing to a different model?
+Want the discipline without the CLI? [`SKILL.md`](SKILL.md) — the methodology works with plain files.
 
-```bash
-osc handoff
-```
-
-One read-only command compiles the working memory into a budgeted packet.
-
-Prefer a global install? `npm i -g open-scaffold` gives you `osc` everywhere.
-
-## Under the hood, it is just files
+## It is just files
 
 ```text
-MISSION.md                          why this repo exists
-.osc/plans/                         scoped work with acceptance criteria
-.osc/runs/<run_id>/run.json         handoff package for a worker or reviewer
-.osc/runs/<run_id>/status.json      live state, pending human gates
-.osc/runs/<run_id>/feedback.jsonl   feedback and repair hypotheses
-.osc/improvements/applied/          accepted lessons future runs inherit
-.osc/releases/                      evidence notes and release records
+MISSION.md                     why this repo exists
+.osc/plans/                    scoped work with acceptance criteria (active/backlog/done/blocked)
+.osc/runs/<run>/run.json       handoff package for a worker or reviewer
+.osc/releases/                 evidence notes and release records
 ```
 
-No daemon, no database, no SaaS, no hidden state. Everything is reviewable in a
-PR and survives any tool change.
+No daemon, no database, no SaaS — reviewable in a PR, survives any tool change.
 
-## Handoff after total context loss
-
-This is the core trick. Kill the session mid-task — close the laptop, lose the
-chat, switch agents or vendors. Then, in a fresh session:
-
-```bash
-osc handoff
-```
-
-One read-only command compiles the repo's working memory into a budgeted,
-secret-redacted packet: mission digest, the active plan with its acceptance
-criteria, the latest recorded state, repair hypotheses, lessons to inherit, and
-the exact next bounded action. The next reader gets the truth, not archaeology.
-In with/without trials, reviewers given the record reconstructed the work at
-94-96% accuracy versus 30-46% without it — and never invented history.
-
-Try it on the committed mid-flight fixture: [`examples/resume-demo/`](examples/resume-demo/)
-with the narrated path in [`docs/RESUME_WALKTHROUGH.md`](docs/RESUME_WALKTHROUGH.md).
-
-## Review and gate with cheap models
-
-Real AI work means repeated attempts — and someone deciding whether the next
-attempt is justified. That judgment should not belong to the worker (it grades
-its own homework), and it should not cost frontier prices. Record attempts,
-then ask the record:
-
-```bash
-osc evolve init .osc/plans/active/my-task.md --out .osc/evolution/my-task --strategy manual
-osc evolve record .osc/evolution/my-task --run <run.json> --evaluation <eval.json> --decision retry --rationale "..."
-osc review .osc/evolution/my-task --compact
-osc gate .osc/evolution/my-task --format json
-```
-
-`osc review` reports plateaus, zero-sensitivity failures, and requirements
-that deserve questioning instead of another retry. `osc gate` converts that —
-plus an optional independent judge ruling — into a retry authorization: a
-packet-level *redesign* blocks the retry even if everyone feels optimistic.
-Claims are checked against evidence (test results, scored criteria), so
-"complete" while the suite fails is caught mechanically. Any model that can
-read files can be the judge — including locally-hosted ones. See
-[`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md).
-
-## Simple mental model
+## Mental model
 
 - **You** own the goal, taste, risk, merge, and publish gates.
-- **Your agent or workflow** does the implementation work — Open Scaffold never
-  runs or disciplines it.
-- **Open Scaffold** keeps the record and serves the readers: what was asked,
-  what actually happened, what was claimed versus verified, what the next
-  session or the reviewer needs to know.
+- **Your agent** does the work — Open Scaffold never runs or disciplines it.
+- **Open Scaffold** keeps the record: what was asked, what happened, what was claimed versus verified, what the next session needs to know.
 
-## Vendor-neutral by design
-
-```text
-Work record      = git-tracked, observed-fact files: plans, receipts, evaluations, attempts
-Handoff packet   = compiled, budgeted, redacted working memory for the next reader
-Review + gate    = cheap-model judgment over the record, with stop authority outside the worker
-Reader           = a fresh session, a smaller model, another vendor's agent, or a human
-```
-
-Core stays portable: files first, versioned schemas, no provider lock-in. The
-[MCP server](docs/MCP.md) exposes the record, handoff packets, and gate
-checks to any MCP-capable client.
-
-## When it helps — and when to skip it
-
-Use it for multi-session AI work, PRs that need intent and evidence attached,
-client or audit-sensitive delivery, multi-agent handoffs, and repeated attempts
-where you need to know which one won and why.
-
-Skip it for one-off scripts, throwaway prototypes, and work nobody will ever
-need to review. If the task fits in one clean session and dies there, you do
-not need a work record.
+Use for multi-session AI work, PRs needing intent and evidence, audit-sensitive delivery. Skip for one-off scripts and prototypes that die in one session.
 
 ## Honest limits
 
-Open Scaffold's current package line is pre-1.0 (`v0.32.x`) and it does not make your model smarter —
-it makes the *loop around the model* disciplined: bounded slices, gated
-execution, compact resumes, receipts for everything. A bounded Codex
-cold-resume fixture and the older scaffold-vs-naked fixture ship in
-[`examples/proof/`](examples/proof/) and are honest about their current scope;
-the broader benchmark program now lives in the source-labeled claim ledger in
-[`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md), with raw receipts in the public
-[`harness-bench`](https://github.com/graphanov/harness-bench) results tree. The full maturity contract —
-what is stable, what is experimental, what is future — lives in one place:
-[`docs/STABILITY.md`](docs/STABILITY.md).
+Pre-1.0 (`v0.32.x`). Does not make your model smarter — it makes the loop around the model disciplined. Maturity contract: [`docs/STABILITY.md`](docs/STABILITY.md). Claim ledger: [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md). Raw receipts: [`harness-bench`](https://github.com/graphanov/harness-bench).
 
 ## Key docs
 
 - [`docs/START_HERE.md`](docs/START_HERE.md) — the single entry point.
-- [`docs/EVOLUTION_LOOP.md`](docs/EVOLUTION_LOOP.md) — review and gate over recorded attempts.
-- [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) — measured claims, raw pointers, and proof boundaries.
-- [`docs/MCP.md`](docs/MCP.md) — exposing the record to MCP-capable clients.
-- [`docs/STABILITY.md`](docs/STABILITY.md) — command maturity, version truth, and honest limits.
-- [`docs/RESUME_WALKTHROUGH.md`](docs/RESUME_WALKTHROUGH.md) — zero-context resume, narrated.
-- [`docs/GITHUB_WORKFLOW.md#structural-pr-review-with-open-scaffold`](docs/GITHUB_WORKFLOW.md#structural-pr-review-with-open-scaffold) — PRs that carry intent and evidence.
-- [`docs/EXAMPLES.md`](docs/EXAMPLES.md) — worked examples and demos.
+- [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) — measured claims, raw pointers, proof boundaries.
+- [`docs/STABILITY.md`](docs/STABILITY.md) — command maturity, version truth, honest limits.
+- [`REPRODUCE.md`](REPRODUCE.md) — audit every receipt yourself, zero spend.
+- [`SKILL.md`](SKILL.md) — the methodology as a portable agent skill.
 - [`docs/FAQ.md`](docs/FAQ.md) — deeper questions.
 - [`docs/GLOSSARY.md`](docs/GLOSSARY.md) — the vocabulary.
 
 ## Dogfooded
 
-Open Scaffold is built with Open Scaffold. This repo carries its own mission,
-plans, run records, evidence notes, decisions, and releases — inspect the
-method instead of taking it on faith.
+Open Scaffold is built with Open Scaffold. This repo carries its own mission, plans, run records, evidence notes, decisions, and releases — inspect the method instead of taking it on faith.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Pre-1.0 (`v0.32.x`). Does not make your model smarter — it makes the loop arou
 - [`docs/START_HERE.md`](docs/START_HERE.md) — the single entry point.
 - [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) — measured claims, raw pointers, proof boundaries.
 - [`docs/STABILITY.md`](docs/STABILITY.md) — command maturity, version truth, honest limits.
-- [`REPRODUCE.md`](REPRODUCE.md) — audit every receipt yourself, zero spend.
+- [`REPRODUCE.md`](REPRODUCE.md) — audit every receipt, zero spend.
 - [`SKILL.md`](SKILL.md) — the methodology as a portable agent skill.
 - [`docs/FAQ.md`](docs/FAQ.md) — deeper questions.
 - [`docs/GLOSSARY.md`](docs/GLOSSARY.md) — the vocabulary.

--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -1,0 +1,78 @@
+# Reproduce
+
+Every claim Open Scaffold makes is backed by committed receipts you can audit without spending a cent, or re-run yourself if you want to spend. Nothing here is a screenshot of vibes.
+
+## 1. Audit the headline token-efficiency result (zero spend, ~10 seconds)
+
+The claim: a 1.5 KB Open Scaffold resume capsule lets a model preserve decision quality while using 4.33× fewer tokens than a 419 KB raw paused-session transcript.
+
+The receipts are committed in this repo. Validate and compare them without calling any model:
+
+```bash
+git clone https://github.com/graphanov/open-scaffold
+cd open-scaffold
+
+# Validate the manifest against its committed receipts (no model, no network)
+npx open-scaffold@latest prove check examples/proof/codex-token-efficient-resume/manifest.json
+
+# Print the full comparison table from those same receipts
+npx open-scaffold@latest prove compare examples/proof/codex-token-efficient-resume/manifest.json --format markdown
+```
+
+You will see the exact numbers — 419,233 bytes vs 1,557 bytes, 137,327 vs 31,715 median tokens, 6/6 decision quality tied — printed from JSON files you can open and read yourself:
+
+```bash
+cat examples/proof/codex-token-efficient-resume/receipts/aggregate.json
+```
+
+The tool prints its own caveats inline, including the one that matters most: the quality score is a deterministic rubric over committed answers, not a blind human-reader study, on one cold-resume decision. It does not prove universal savings. We lead with the honest boundary because that is the price of being believed.
+
+## 2. Audit the reviewability result (zero spend, read-only)
+
+The claim: a mid-tier reviewer answering factual questions about finished work got 94% right with the work record, 30% without, and zero confident wrong answers with the record (eight without).
+
+The receipts live in the independent [harness-bench](https://github.com/graphanov/harness-bench) repo — deliberately separate from this one, so the framework is never grading its own homework:
+
+```bash
+git clone https://github.com/graphanov/harness-bench
+cd harness-bench
+
+# The preregistration: hypotheses, answer keys, kill rules — committed before any model ran
+cat PREREGISTRATION.md
+
+# The mechanical scorer validates against committed golden answers
+node scorer/scorer-v2.mjs --selftest
+
+# The raw per-run JSONL receipts (every token, every answer, every score)
+ls results/
+```
+
+You can read every receipt, re-grade against the committed keys, and check the kill rule yourself. The scorer is mechanical and deterministic — taste is not in the loop.
+
+## 3. The honest spend boundary
+
+Auditing (steps 1–2) costs nothing. **Re-running** the experiments costs money, because the worker and reviewer are real model calls:
+
+- Re-running the token-efficiency fixture requires Codex CLI access and paid `codex exec` / model calls (3 replicates per arm).
+- Re-running the reviewability trial requires a worker model and a reviewer model (paid calls).
+- The receipts above are the proof. Re-running is for someone who does not trust committed receipts and wants to see them regenerated live.
+
+If you re-run and get a different number, that is the single most useful thing you can do for this project. Open an issue with your receipts.
+
+## 4. The challenge
+
+The one thing no amount of self-authored benchmarks can prove is adoption. The credibility lever that actually matters is a stranger reproducing a result on their own repo.
+
+So: take the discipline (see [`SKILL.md`](SKILL.md)) into a real multi-session slice of your own work where context loss actually hurt. Run `osc handoff` after an interruption. Have a cheap model review the record with `osc review`. Publish your number — tokens saved, recovery time, or review accuracy — with your own receipts.
+
+If the record did not help, publish that too. The negative results are part of the product. We measured where the scaffold does not help (near-zero recoverable state, in-session task quality for a strong model) and published those at equal weight with the wins. Do the same.
+
+## What this does not prove
+
+- Not a production-readiness claim.
+- Not broad third-party adoption (yet).
+- Not universal superiority over naked agents.
+- Not that the scaffold makes your model smarter (measured: it does not).
+- Not compliance certification of any kind.
+
+It proves: the work record turns a cheap model into a trustworthy auditor of finished work, and a compact record preserves a resume decision at a fraction of the token cost. Those are the two claims. Everything else is honestly bounded.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: open-scaffold-discipline
+description: Keep a durable, checkable work record in your repo so AI-assisted work survives context loss, PR review, and handoff. Amend, don't edit. Verify before claiming done. One focus at a time. Any agent can follow this with plain markdown files; the open-scaffold CLI makes it mechanical and provable.
+---
+
+# Open Scaffold Discipline
+
+A work-record discipline for AI-assisted work. Your agent's work belongs in your repo, not its chat history. When a session ends, the work's memory should not die with it.
+
+This skill is the **methodology**. It works with plain files — no tool required. The [open-scaffold](https://github.com/graphanov/open-scaffold) CLI is the optional **proof engine** that makes the claims mechanical and reproducible (redaction, receipt aggregation, benchmark scoring). Use the discipline first; reach for the CLI when you need evidence, recovery, or cheap-model review.
+
+## When to use
+
+- Work outlives its first session.
+- Multiple sessions, agents, PRs, or reviewers need to reconstruct what happened and why.
+- You hand work to a fresh session, a smaller model, another vendor's agent, or a teammate.
+- The work is audit-sensitive: someone may later ask "what was attempted, what passed, what was claimed versus verified."
+
+Skip it when the work fits in one clean session and nobody else needs to reconstruct it: one-off scripts, disposable prototypes, an hour of automation you will never read again.
+
+## The five non-negotiables
+
+1. **Mission first.** Every repo has a `MISSION.md` — one paragraph on why this repo exists, plus a changelog of every scope pivot. If the mission is unset, stop and define it before any work. An agent without a mission optimizes the wrong thing.
+
+2. **Plans are immutable; you amend, never edit.** A plan is a committed record of what you decided *at the time*. When the world changes, you write an amendment that says what changed and why — you do not rewrite history. The plan file records intent; the amendment records learning. This is the single most important rule. If you break it, the record lies about what was known when.
+
+3. **Verify before claiming done.** A plan is not done because the agent says so. It is done when its acceptance criteria pass — mechanically, against real command output. "Complete" while the test suite fails is the most common AI-work lie. Run the verification. Read the output. The claim must match the evidence.
+
+4. **One focus at a time.** Keep at most 2–3 plans active. Finish or park before pulling new work from the backlog. An agent with ten open plans produces ten half-finished threads and zero shipped slices.
+
+5. **Chat is working context, not truth.** If a decision matters, it goes in a repo file — a plan, an amendment, an evidence note, a changelog entry. Chat scrolls away. Files survive. When in doubt, ask: "if this session ended right now, would the next reader know this?" If not, write it down.
+
+## The record (what lives in the repo)
+
+```
+MISSION.md                     why this repo exists + scope-pivot changelog
+.osc/plans/active/             work in flight (2–3 max)
+.osc/plans/backlog/            identified, not yet started
+.osc/plans/done/               completed and verified
+.osc/plans/blocked/            parked, waiting on external input
+.osc/plans/<slug>.md           one plan: context, goal, constraints, files, acceptance criteria, verification, open questions
+.osc/plans/<slug>-amendment-N.md   what changed and why (stays with parent)
+.osc/releases/<date>-<slug>.md     evidence note: what shipped, verification output, traceability
+```
+
+Folder IS the status. Move files between folders; never rename them. The plan number is a permanent ID.
+
+## The loop
+
+```
+read MISSION.md
+  → check active/ (continue in-flight work, do not start new)
+  → write a plan with testable acceptance criteria
+  → do the bounded work
+  → run verification against acceptance criteria
+  → if scope changed: amend (never edit the plan)
+  → evidence note with real command output
+  → close: move plan to done/ only after verify passes
+  → lessons from this slice inherit into the next plan
+```
+
+## How to write a plan a stranger can act on
+
+A plan has seven parts. If you cannot fill them, you are not ready to code.
+
+- **Context** — 1–3 sentences: why this plan exists now. What happened that made us write it.
+- **Goal** — one crisp sentence: the single observable change in the world when this is complete. Not a feature list.
+- **Constraints / out of scope** — what this plan will NOT do. Boundaries on stack, time, surface.
+- **Files to touch** — the paths and a one-line reason for each.
+- **Acceptance criteria** — testable bullets. Something a verifier checks mechanically or with a clear yes/no.
+- **Verification steps** — the exact commands and the pass criterion for each.
+- **Open questions** — unresolved decisions and assumptions that need validation.
+
+## With the CLI (the proof engine)
+
+The discipline above works with any editor. The CLI makes it mechanical and adds three things plain files cannot do:
+
+- **Ambient capture** — `osc capture --from claude-code|codex` reads a finished session transcript into a work record (turns, tokens, tool census) with no worker cooperation. The record is extracted from observed facts, not hand-written.
+- **Handoff** — `osc handoff` compiles the record into a budgeted, secret-redacted packet so the next reader resumes from truth instead of re-deriving or inventing it. Works after total context loss.
+- **Review and gate** — `osc review` reports plateaus, failing criteria, and requirements worth questioning; `osc gate` turns that into a retry authorization with stop authority that lives outside the worker. Any file-reading model can be the judge, including locally-hosted cheap models. Fails closed: no parseable verdict means no authorization.
+
+```bash
+npx open-scaffold@latest first-run          # guided: mission + first plan + evidence skeleton
+osc handoff                                  # compile resume packet for next session/model
+osc review <loop-dir>                        # cheap-model review of recorded attempts
+osc gate <loop-dir>                          # authorize or block the next attempt
+```
+
+## The honest boundary
+
+This discipline does not make your model smarter. It does not improve a strong model's in-session task output — that was measured and the naked model matched or beat every scaffolded arm. What it fixes is amnesia, confabulation, and unaccountability: the work has a durable, checkable memory, and a cheap model can audit it instead of you re-spending frontier tokens on review and re-derivation.
+
+With near-zero recoverable state, the record is pure overhead. It pays for itself when an interruption leaves recoverable state behind — which is most real work, not all of it. The discipline is opt-in, and opt-in process discipline is the thing humans most reliably abandon. Treat verification as a habit, not a ceremony. If the check fails, fix it before moving on — do not accumulate stale plans.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: open-scaffold-discipline
+name: oscd
 description: Keep a durable, checkable work record in your repo so AI-assisted work survives context loss, PR review, and handoff. Amend, don't edit. Verify before claiming done. One focus at a time. Any agent can follow this with plain markdown files; the open-scaffold CLI makes it mechanical and provable.
 ---
 


### PR DESCRIPTION
## What this does

Three public-surface artifacts aimed at the adoption bottleneck — getting a first-time visitor from "what is this" to "I can verify this claim myself" as fast as possible.

### `SKILL.md` (new) — the skill front door
The methodology distilled into a portable agent skill: the five non-negotiables (mission first; amend don't edit; verify before done; one focus at a time; chat is context not truth), the record layout, the loop, and the plan schema. Works with plain files — no CLI required. The CLI is positioned as the optional **proof engine** (ambient capture, handoff, review/gate) that makes the claims mechanical and reproducible.

This is the honest answer to "can't open-scaffold just be a skill.md?": the **methodology** is skill-shaped and now exists as one; the **proof engine** (deterministic redaction, receipt aggregation, benchmark scoring) is not, and cannot be — a skill cannot reproduce a number deterministically.

### `REPRODUCE.md` (new) — the credibility lever
Three paths for a stranger:
1. **Zero-spend audit** of the token-efficiency claim — `osc prove check` + `osc prove compare` on committed receipts (verified working from the published package).
2. **Zero-spend audit** of the 94/30 reviewability claim — via the separate `harness-bench` repo's committed JSONL receipts + mechanical scorer selftest.
3. **The honest spend boundary** for re-running, plus the challenge to reproduce on your own repo and publish your number (including negative results).

### `README.md` (rewritten, 12,850 → 6,144 bytes)
Leads with the contrarian result: measured, the scaffold does **not** make the agent smarter (naked matched or beat every scaffolded arm — published as a dead result); what the record fixes is amnesia and confabulation (94% vs 30% reviewability, zero confident wrong answers). Demotes the token-efficiency tautology (summary beats firehose) to a measured-results footnote. Adds links to `SKILL.md` and `REPRODUCE.md`. Cuts 190 lines. Every pinned `public-positioning.test.ts` assertion preserved.

## Verification

- `npx vitest run` — **556/556 pass**
- `./verify.sh --strict` — **10 pass, 0 fail, 0 warn**
- `README.md` — **6,144 bytes** (meets the `<=6144` AC)
- `osc prove check examples/proof/codex-token-efficient-resume/manifest.json` — **PASS** (audit path confirmed from built CLI)
- `npm run build` — clean
- No plan/release-note changes → no section-parser corpus re-pin needed
