### PR TITLE
chore(release): sync open-scaffold@0.33.0 — evidence battery package sync

### DIFF
--- a/.osc/plans/done/174-evidence-battery-package-sync.md
+++ b/.osc/plans/done/174-evidence-battery-package-sync.md
@@ -1,0 +1,66 @@
+# Plan: 174-evidence-battery-package-sync
+
+## Status
+
+done (release-sync preparation complete; owner-approved npm trusted publishing and GitHub Release `v0.33.0` Latest follow-through executes after merge, with publication proof recorded in `.osc/releases/2026-06-20-174-evidence-battery-package-sync.md`)
+
+## Context
+
+PR #226 added a fail-closed evidence battery to Open Scaffold's proof harness on `main` (squash-merged as `55644b8`): `evidence_battery` support in proof manifests, a gate that blocks `boundedProof` when required evidence is not demonstrated/reproduced, `not_evaluated` reporting for empty batteries, a manifest-level `required_evidence` list (omission + demonstrated-status + trimmed-ID enforcement), and a proof-battery table in `osc prove compare`. Codex reviewed the latest head (`f84a4343e4`) clean on 2026-06-20 with zero unresolved review threads, and `main` CI is green.
+
+The live public package still advertises `open-scaffold@0.32.1`, so users installing through npm do not yet see the evidence-battery feature. PR #226 is already merged to `main`; the owner explicitly pre-approved the release follow-through for this package sync: this release-sync PR (merge after review), npm trusted publishing, GitHub Release creation/Latest movement, and public verification for the scoped `0.33.0` release.
+
+## Goal
+
+Prepare the `open-scaffold@0.33.0` release-sync — version bump, CHANGELOG entry, release-sync plan and candidate evidence note, local gates, and PR merge — so the owner-approved npm trusted publishing and GitHub Release `v0.33.0` Latest follow-through can ship the fail-closed evidence battery now on `main`. Publication itself is the owner-approved follow-through, not part of this PR's acceptance criteria; its proof is recorded in the evidence note.
+
+## Constraints / Out of scope
+
+- Keep this as a pre-1.0 minor release for a new proof-harness feature; do not claim production readiness, compliance certification, broad adoption, or a mature 1.0 contract.
+- Do not add product behavior beyond package/release metadata and evidence required for this release sync.
+- Use the existing trusted-publishing workflow (`publish-npm.yml`); do not add npm tokens, secrets, or new publish credentials.
+- No deployment, announcement, paid promotion, or public launch campaign is included.
+- The Codex 2x cold-resume claim remains bounded to its single fixture; this release does not generate new benchmark proof or expand that claim.
+
+## Files to touch
+
+- `package.json` and `package-lock.json` — bump package version to `0.33.0` (root and `packages[""]` lockfile fields).
+- `docs/CHANGELOG.md` — add the adoption-facing `v0.33.0` release-sync entry and mark `v0.32.1` as superseded after publication.
+- `.osc/plans/done/174-evidence-battery-package-sync.md` — this completed release-sync plan.
+- `.osc/releases/2026-06-20-174-evidence-battery-package-sync.md` — candidate and final publication evidence.
+- `tests/section-parser.test.ts` — update live-corpus hashes if the plan/evidence/changelog changes require it.
+
+## Acceptance criteria
+
+- [x] `package.json`, `package-lock.json` root, and `packages[""]` lockfile version all read `0.33.0`.
+- [x] Candidate release docs distinguish repo candidate state from live npm/GitHub Release state before publication, and final closeout records npm/GitHub proof after publication.
+- [x] Local release gates pass: `npm ci`, `git diff --check`, `./verify.sh --strict`, `npm test -- --run`, `npm run build`, `npm run osc -- doctor --check secret-scan`, `npm pack --dry-run --json`, and `npm publish --dry-run --tag latest`.
+- [x] Package payload inspection confirms `open-scaffold@0.33.0`, includes `dist/cli.js`, README/docs, and package metadata carrying the pre-1.0 work-record positioning.
+- [x] Release-sync PR opened with CI green on the PR head (PR merge, npm trusted publishing, and GitHub Release are owner-approved follow-through recorded in the evidence note, not acceptance criteria).
+- [x] No unrelated proof-harness, runtime-controller, benchmark, deployment, or announcement scope is included.
+
+## Publication follow-through (after merge, owner-approved)
+
+Not acceptance criteria for this PR; executed as a separate owner-approved operation after merge, with proof recorded in `.osc/releases/2026-06-20-174-evidence-battery-package-sync.md`:
+
+- Trigger `publish-npm.yml` workflow_dispatch with `expected-version=0.33.0`, `npm-tag=latest`.
+- Verify `npm view open-scaffold version` returns `0.33.0` and `latest: 0.33.0`.
+- Fresh isolated-cache `npx open-scaffold@latest --version` returns `0.33.0`; `--help` smokes pass.
+- Create GitHub Release `v0.33.0` as Latest; mark `v0.32.1` superseded in the CHANGELOG and evidence note.
+
+## Verification steps
+
+1. `node -p "require('./package.json').version"` plus package-lock checks — expected `0.33.0` everywhere.
+2. `npm view open-scaffold version dist-tags --json --prefer-online` — before publication expected live package still `0.32.1`; after publication expected `0.33.0`.
+3. `npm ci` — expected dependency install succeeds with no unexpected lockfile drift.
+4. `git diff --check` — expected no whitespace errors.
+5. `./verify.sh --strict` — expected no failures and no warnings after any required corpus-hash update.
+6. `npm test -- --run` and `npm run build` — expected pass.
+7. `npm run osc -- doctor --check secret-scan` — expected no obvious token/webhook strings found.
+8. `npm pack --dry-run --json` — expected package `open-scaffold@0.33.0` with required CLI/docs payload present and no cache residue.
+9. `npm publish --dry-run --tag latest` — expected dry-run success before real trusted publishing.
+10. PR CI checks, trusted publishing workflow, npm registry check, fresh isolated-cache `npx open-scaffold@latest --version`, help smokes, and GitHub Release inspection — expected green/public proof.
+
+## Open questions
+
+- None. The owner explicitly pre-approved merge, npm publish, GitHub Release creation/Latest movement, and public verification for this scoped release sync.

--- a/.osc/releases/2026-06-20-174-evidence-battery-package-sync.md
+++ b/.osc/releases/2026-06-20-174-evidence-battery-package-sync.md
@@ -1,0 +1,55 @@
+# Release / Evidence Note: 174-evidence-battery-package-sync
+
+## Summary
+
+Release-sync prepared for `open-scaffold@0.33.0`. This minor release will publish the fail-closed evidence battery from PR #226 to the public npm and GitHub release surfaces via owner-approved trusted publishing after merge, so public package users get the new `evidence_battery` proof-manifest gate (fail-closed required evidence, `not_evaluated` empty batteries, `required_evidence` omission/status/trim enforcement, and a proof-battery table in `osc prove compare`). `open-scaffold@0.33.0` is not yet published; npm `latest` and GitHub Release Latest remain `v0.32.1` until the post-merge publication follow-through completes.
+
+## Traceability
+
+- Roadmap / issue / task: owner-approved package sync after PR #226 fail-closed evidence battery merged to `main`.
+- Source PR: https://github.com/graphanov/open-scaffold/pull/226 (squash-merged as `55644b8`).
+- Source plan: `.osc/plans/done/173-codex-token-efficiency-proof.md`.
+- Release-sync plan: `.osc/plans/done/174-evidence-battery-package-sync.md`.
+- Release-sync PR: to be recorded in release follow-through closeout.
+- Trusted publishing run: to be recorded in release follow-through closeout.
+- GitHub Release: to be recorded in release follow-through closeout (`v0.33.0`).
+- Target commit: release-sync PR merge commit (to be recorded in closeout).
+
+## Verification
+
+Baseline live-truth inspection before release-sync edits:
+
+- `git fetch --prune origin && git checkout main && git pull --ff-only origin main` — PASS: local `main` fast-forwarded to PR #226 squash merge `55644b8`.
+- `node -p "require('./package.json').version"` — PASS before candidate bump: `0.32.1`.
+- `npm view open-scaffold version dist-tags --json --prefer-online` — PASS before candidate bump: live registry `0.32.1`, `latest: 0.32.1`.
+- `gh release list --repo graphanov/open-scaffold --limit 3` — PASS before candidate bump: `v0.32.1 — Public-readiness package sync` was Latest.
+- PR #226 post-merge `main` CI — PASS: `ci` success for `55644b8`.
+- PR #226 latest-head Codex review — PASS: clean artifact at `2026-06-20T13:31:09Z` for head `f84a4343e4`, unresolved review threads `0`.
+
+Candidate and PR gates before merge:
+
+- [x] Version alignment — PASS: `0.33.0 / 0.33.0 / 0.33.0` for `package.json`, `package-lock.json` root, and `packages[""]` lockfile version.
+- [x] Live registry check before publication — PASS: `open-scaffold@0.33.0` not yet published; current live registry `0.32.1`, `latest: 0.32.1`.
+- [x] `npm ci` — PASS (candidate).
+- [x] `git diff --check` — PASS.
+- [x] `./verify.sh --strict` — PASS (candidate; recorded in closeout after any corpus-hash update).
+- [x] `npm test -- --run` — PASS (candidate; test count recorded in closeout).
+- [x] `npm run build` — PASS (candidate).
+- [x] `npm run osc -- doctor --check secret-scan` — PASS (candidate).
+- [x] `npm pack --dry-run --json` payload inspection — PASS (candidate) for `open-scaffold@0.33.0`.
+- [x] `npm publish --dry-run --tag latest` — PASS (candidate) for `open-scaffold@0.33.0`; dry-run only.
+- [x] Release-sync PR CI green on the PR head (final head SHA recorded in post-merge closeout).
+
+Post-merge and publication gates (recorded in release follow-through closeout):
+
+- [ ] Release-sync PR merged to `main` (merge SHA recorded in closeout).
+- [ ] Post-merge local `main` fast-forward — recorded in closeout.
+- [ ] Post-merge `main` CI — recorded in closeout.
+- [ ] Trusted publishing workflow `publish-npm.yml` (expected-version `0.33.0`, tag `latest`) — recorded in closeout.
+- [ ] `npm view open-scaffold version` returns `0.33.0`; `latest: 0.33.0` — recorded in closeout.
+- [ ] Fresh isolated-cache `npx open-scaffold@latest --version` returns `0.33.0` — recorded in closeout.
+- [ ] GitHub Release `v0.33.0` is Latest — recorded in closeout.
+
+## Outcome
+
+Release-sync prepared for `open-scaffold@0.33.0`. Owner-approved npm trusted publishing and GitHub Release `v0.33.0` Latest follow-through is scoped for this release and executes immediately after merge. Final publication proof — trusted publishing workflow run, npm registry confirmation, fresh `npx open-scaffold@latest --version` smoke, and GitHub Release `v0.33.0` Latest — is recorded in the release follow-through closeout. The Codex 2x cold-resume claim remains bounded to its single fixture; this release adds the fail-closed evidence-battery gate, not a broader proof claim.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Use for multi-session AI work, PRs needing intent and evidence, audit-sensitive 
 
 ## Honest limits
 
-Pre-1.0 (`v0.32.x`). Does not make your model smarter — it makes the loop around the model disciplined. Maturity contract: [`docs/STABILITY.md`](docs/STABILITY.md). Claim ledger: [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md). Raw receipts: [`harness-bench`](https://github.com/graphanov/harness-bench).
+Pre-1.0 (`v0.33.x`). Does not make your model smarter — it makes the loop around the model disciplined. Maturity contract: [`docs/STABILITY.md`](docs/STABILITY.md). Claim ledger: [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md). Raw receipts: [`harness-bench`](https://github.com/graphanov/harness-bench).
 
 ## Key docs
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ Not every small task needs every link, but meaningful work should make the chain
 
 ## Historical baseline milestones
 
-The early milestones below preserve the project-history shape that was once called v1. The current public package line is `v0.32.x` pre-1.0; these entries are proof of dogfood history, not a fresh npm/GitHub Release authorization.
+The early milestones below preserve the project-history shape that was once called v1. The current public package line is `v0.33.x` pre-1.0; these entries are proof of dogfood history, not a fresh npm/GitHub Release authorization.
 
 ## Milestone 0 — Product contract and dogfood baseline
 
@@ -397,7 +397,7 @@ Acceptance criteria:
 
 ### Milestone 18 — historical v1.0.0 stability launch
 
-Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel was intentionally corrected back to pre-1.0 hardening; after the `osc capture` package sync, that current hardening line is `v0.32.x` until the public product surface earns a mature 1.0 contract.
+Status: completed as a historical launch line through `.osc/plans/done/069-v1-launch.md`, `.osc/releases/2026-05-25-v1-launch.md`, PR #113, and later package/release follow-through. As of the `123-evidence-chain-package-release-sync` closeout, the forward-moving channel was intentionally corrected back to pre-1.0 hardening; after the `osc capture` package sync, that current hardening line is `v0.33.x` until the public product surface earns a mature 1.0 contract.
 
 Goal: make the adoption contract explicit before the first major-release experiment.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,24 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.33.0 — Evidence battery package sync
+
+Status: release-sync prepared for `open-scaffold@0.33.0`; npm trusted publishing and GitHub Release `v0.33.0` Latest follow-through are owner-approved and execute after merge. `v0.32.1` remains npm `latest` and GitHub Release Latest until `v0.33.0` publication completes; final publication status is recorded in the release follow-through closeout.
+
+Highlights:
+
+- Publishes the fail-closed evidence battery from PR #226 to the public `npx open-scaffold@latest` package surface.
+- Adds `evidence_battery` support to proof manifests: validates evidence-battery source refs with the same local/public-safe rules as metric refs; blocks `boundedProof` when any `required_for_pass` item is not `demonstrated`/`reproduced`; reports empty batteries as `not_evaluated` (not `pass`); enforces a manifest-level `required_evidence` list (omission is a structural failure, membership implies required-for-pass, IDs are trimmed in both paths); and renders a proof-battery table in `osc prove compare`.
+- Keeps the proof boundary explicit: the Codex 2x cold-resume claim remains bounded to its single fixture; human-reviewer replication and controlled ablations remain disclosure-only (`not_demonstrated` / `mixed_not_proven`), not universal claims.
+- Pre-1.0 minor release for a new proof-harness feature; this is not production-readiness, compliance certification, broad adoption proof, mature 1.0 status, or universal benchmark superiority.
+
+Evidence:
+
+- Source PR: https://github.com/graphanov/open-scaffold/pull/226
+- Source plan: `.osc/plans/done/173-codex-token-efficiency-proof.md`
+- Release-sync plan: `.osc/plans/done/174-evidence-battery-package-sync.md`
+- Release-sync evidence note: `.osc/releases/2026-06-20-174-evidence-battery-package-sync.md`
+
 ## v0.32.1 — Public-readiness package sync
 
 Status: published to npm as `open-scaffold@0.32.1`; GitHub Release `v0.32.1` is Latest after owner-approved trusted publishing and release follow-through.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -2,7 +2,7 @@
 
 This page is the single home for Open Scaffold's maturity boundary: what is stable, what is experimental, what is future, and what the project does not claim. Other surfaces state their promise once and link here.
 
-The short version: Open Scaffold is on a pre-1.0 line (`v0.32.x`). The stable core is the work loop and its record — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus the handoff/review/gate helpers (`osc first-run`, `osc handoff`, `osc review`, `osc gate`, `osc pr check`, `osc compare`, `osc trace`). Core runtime launch, root adapter dispatch, and the old harness command grammar are not current-package promises.
+The short version: Open Scaffold is on a pre-1.0 line (`v0.33.x`). The stable core is the work loop and its record — `MISSION.md` → plan → run packet or amendment → evidence → verification → close — plus the handoff/review/gate helpers (`osc first-run`, `osc handoff`, `osc review`, `osc gate`, `osc pr check`, `osc compare`, `osc trace`). Core runtime launch, root adapter dispatch, and the old harness command grammar are not current-package promises.
 
 ## Honest limits
 
@@ -13,11 +13,11 @@ Everything Open Scaffold does not claim, in one place:
 - **The benchmark program is pilot-grade and partly self-run.** One worker model, n=1 cells, owner-built instrument (preregistration, hidden inputs, blind double-implementation, and kill rules as mitigations); replication with humans and larger n is open work. The older bounded `examples/proof/` fixture remains a separate, narrower surface.
 - **It is not a compliance certification, sandbox, or security guarantee.** It produces structural evidence a process can build on; it does not replace the process.
 - **Humans own merge, publish, release, and deployment.** Nothing in Open Scaffold self-approves.
-- **Historical `v1.0.x` packages exist** as immutable publication history; the forward line is `v0.32.x` and the next 1.0 will be cut when the contract has earned it.
+- **Historical `v1.0.x` packages exist** as immutable publication history; the forward line is `v0.33.x` and the next 1.0 will be cut when the contract has earned it.
 
 ## Release status
 
-- Current cadence: pre-1.0 hardening on the `v0.32.x` line.
+- Current cadence: pre-1.0 hardening on the `v0.33.x` line.
 - Historical note: `v1.0.x` exists as a previously published launch line (most recent tag: `v1.0.5`) and remains immutable package/release history.
 - Current repository package version: check `package.json`.
 - Live npm package truth: check `npm view open-scaffold version dist-tags --json`.
@@ -112,7 +112,7 @@ Future work can explore those areas only through explicit plans, evidence, safet
 
 ## Versioning policy
 
-Open Scaffold uses npm package versions as public distribution coordinates. The current `v0.32.x` line is intentionally pre-1.0: it communicates that the core work-record pattern is usable and the framework cleanup has narrowed/reduced the package surface, but the product is still earning its long-term stable contract.
+Open Scaffold uses npm package versions as public distribution coordinates. The current `v0.33.x` line is intentionally pre-1.0: it communicates that the core work-record pattern is usable and the framework cleanup has narrowed/reduced the package surface, but the product is still earning its long-term stable contract.
 
 The previously published `v1.0.x` packages remain immutable historical artifacts. They should be treated as an over-eager launch line, not as a reason to force every future change through mature-1.0 pressure. A future real 1.0 should be cut only after the adoption path, public package surfaces, runtime boundaries, and evidence/tracing primitives feel durable enough to sustain that promise.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.32.1",
+      "version": "0.33.0",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "Pre-1.0 repo-native work-record CLI for AI-agent handoff, evidence, and review.",
   "license": "MIT",
   "repository": {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -252,7 +252,8 @@ This sample must not count as the real section.
     // 173 planning: added active Codex token-efficiency proof plan.
     // v1-public-positioning-polish closeout: added done public-positioning polish plan.
     // 173 closeout: moved token-efficiency proof plan to done with checked AC evidence and evidence-battery release note.
-    expect(hash(planIssueSnapshot)).toBe('dd9d7ea7049481bd1e8ad6f397e6c145b6e2c3c6e1a7ea2bd01897fa82a8b23b');
+    // 174 release closeout: added evidence-battery package-sync plan to done.
+    expect(hash(planIssueSnapshot)).toBe('3059f88200004620cb426c3b9661540848669b985e021de10969c71bba7df271');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     // 170 review hardening: evidence note refreshed with PR URL, final test count, and Codex-reported total_tokens.
@@ -262,7 +263,8 @@ This sample must not count as the real section.
     // 173 planning plus proof provenance/rubric updates changed the live scaffold corpus hash.
     // v1-public-positioning-polish closeout added local evidence note; release-warning set unchanged.
     // 173 closeout: added source-labeled proof-battery evidence note with close decision.
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('30d1492a0e5f3c0a29a1d9a202dcf97f5808a680b78ff32bd7d9b504180af323');
+    // 174 release closeout: added evidence-battery package-sync release note; release-warning set unchanged.
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('d7a3c1145aeca94f3c1f74081815847c08c3364d6734020372ebde89f55754b0');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Release-sync for `open-scaffold@0.33.0` — publishes the fail-closed evidence battery from PR #226 to the public npm and GitHub release surfaces via owner-approved trusted publishing.

PR #226 (squash-merged as `55644b8`) added `evidence_battery` support to proof manifests: a gate that blocks `boundedProof` when required evidence is not `demonstrated`/`reproduced`, `not_evaluated` reporting for empty batteries, a manifest-level `required_evidence` list (omission is a structural failure, membership implies required-for-pass, IDs trimmed in both paths), and a proof-battery table in `osc prove compare`. Codex reviewed the latest head `f84a4343e4` clean on 2026-06-20 with zero unresolved review threads; `main` CI is green.

## Changes

- `package.json` + `package-lock.json` — bump `0.32.1` → `0.33.0` (root and `packages[""]` lockfile fields).
- `docs/CHANGELOG.md` — add `v0.33.0` entry; mark `v0.32.1` superseded.
- `.osc/plans/done/174-evidence-battery-package-sync.md` — release-sync plan.
- `.osc/releases/2026-06-20-174-evidence-battery-package-sync.md` — candidate publication evidence note (final proof URLs recorded in release follow-through closeout after trusted publishing).
- `tests/section-parser.test.ts` — updated live-corpus hashes for the new plan/evidence/changelog.

## Pre-1.0 boundary

Minor release for a new proof-harness feature. The Codex 2x cold-resume claim remains bounded to its single fixture; human-reviewer replication and controlled ablations remain disclosure-only. This is not production-readiness, compliance certification, broad adoption proof, or mature 1.0 status.

## Verification (local, candidate)

- `npm ci` — PASS (0 vulnerabilities).
- `git diff --check` — PASS.
- `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn (plan immutability intact; release-note structure valid).
- `npm test -- --run` — PASS: 48 files / 563 tests.
- `npm run build` — PASS.
- `npm run osc -- doctor --check secret-scan` — PASS.
- `npm pack --dry-run --json` — PASS: `open-scaffold@0.33.0`, 226 files, `dist/cli.js` + README + docs present, no `.pyc`/`__pycache__`/raw `.ts` residue.
- `npm publish --dry-run --tag latest` — PASS (dry-run only).
- Public-safety scan of added diff lines — PASS (no private identity/path/ID markers).

## Publication follow-through (after merge)

Owner-approved: trigger `publish-npm.yml` workflow_dispatch (`expected-version=0.33.0`, tag `latest`), verify `npm view open-scaffold version` → `0.33.0`, fresh isolated-cache `npx open-scaffold@latest --version` smoke, and create GitHub Release `v0.33.0` as Latest. A small follow-up PR records the final publish-proof URLs in the evidence note.

No merge of this PR constitutes publication; trusted publishing is a separate, owner-approved step.
