### PR TITLE
chore(release): close out open-scaffold@0.33.0 — record publication proof

### DIFF
--- a/.osc/releases/2026-06-20-174-evidence-battery-package-sync.md
+++ b/.osc/releases/2026-06-20-174-evidence-battery-package-sync.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Release-sync prepared for `open-scaffold@0.33.0`. This minor release will publish the fail-closed evidence battery from PR #226 to the public npm and GitHub release surfaces via owner-approved trusted publishing after merge, so public package users get the new `evidence_battery` proof-manifest gate (fail-closed required evidence, `not_evaluated` empty batteries, `required_evidence` omission/status/trim enforcement, and a proof-battery table in `osc prove compare`). `open-scaffold@0.33.0` is not yet published; npm `latest` and GitHub Release Latest remain `v0.32.1` until the post-merge publication follow-through completes.
+`open-scaffold@0.33.0` is published to npm as `latest` (with build provenance), and GitHub Release `v0.33.0 — Evidence battery package sync` is published as Latest. This minor release publishes the fail-closed evidence battery from PR #226 to the public npm and GitHub release surfaces, so public package users get the new `evidence_battery` proof-manifest gate (fail-closed required evidence, `not_evaluated` empty batteries, `required_evidence` omission/status/trim enforcement, and a proof-battery table in `osc prove compare`). This closeout records the post-merge publication proof; the candidate release-sync state was carried by PR #228.
 
 ## Traceability
 
@@ -10,10 +10,11 @@ Release-sync prepared for `open-scaffold@0.33.0`. This minor release will publis
 - Source PR: https://github.com/graphanov/open-scaffold/pull/226 (squash-merged as `55644b8`).
 - Source plan: `.osc/plans/done/173-codex-token-efficiency-proof.md`.
 - Release-sync plan: `.osc/plans/done/174-evidence-battery-package-sync.md`.
-- Release-sync PR: to be recorded in release follow-through closeout.
-- Trusted publishing run: to be recorded in release follow-through closeout.
-- GitHub Release: to be recorded in release follow-through closeout (`v0.33.0`).
-- Target commit: release-sync PR merge commit (to be recorded in closeout).
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/228 (squash-merged as `d250e3a`); latest head `4f7ea49` Codex clean at `2026-06-20T15:18:39Z`, unresolved review threads `0`.
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/27875553205 (`Publish npm package`, `workflow_dispatch`, `expected-version=0.33.0`, tag `latest`).
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.33.0 (Latest).
+- npm: https://www.npmjs.com/package/open-scaffold/v/0.33.0 (`latest: 0.33.0`).
+- Target commit: `d250e3a1bebaa09c4105ce9fa11af1f206453447` (release-sync PR #228 merge on `main`).
 
 ## Verification
 
@@ -26,30 +27,31 @@ Baseline live-truth inspection before release-sync edits:
 - PR #226 post-merge `main` CI — PASS: `ci` success for `55644b8`.
 - PR #226 latest-head Codex review — PASS: clean artifact at `2026-06-20T13:31:09Z` for head `f84a4343e4`, unresolved review threads `0`.
 
-Candidate and PR gates before merge:
+Candidate and PR gates before merge (PR #228, head `4f7ea49`):
 
 - [x] Version alignment — PASS: `0.33.0 / 0.33.0 / 0.33.0` for `package.json`, `package-lock.json` root, and `packages[""]` lockfile version.
 - [x] Live registry check before publication — PASS: `open-scaffold@0.33.0` not yet published; current live registry `0.32.1`, `latest: 0.32.1`.
-- [x] `npm ci` — PASS (candidate).
+- [x] `npm ci` — PASS.
 - [x] `git diff --check` — PASS.
-- [x] `./verify.sh --strict` — PASS (candidate; recorded in closeout after any corpus-hash update).
-- [x] `npm test -- --run` — PASS (candidate; test count recorded in closeout).
-- [x] `npm run build` — PASS (candidate).
-- [x] `npm run osc -- doctor --check secret-scan` — PASS (candidate).
-- [x] `npm pack --dry-run --json` payload inspection — PASS (candidate) for `open-scaffold@0.33.0`.
-- [x] `npm publish --dry-run --tag latest` — PASS (candidate) for `open-scaffold@0.33.0`; dry-run only.
-- [x] Release-sync PR CI green on the PR head (final head SHA recorded in post-merge closeout).
+- [x] `./verify.sh --strict` — PASS: 10 pass / 0 fail / 0 warn.
+- [x] `npm test -- --run` — PASS: 48 files / 563 tests.
+- [x] `npm run build` — PASS.
+- [x] `npm run osc -- doctor --check secret-scan` — PASS.
+- [x] `npm pack --dry-run --json` payload inspection — PASS for `open-scaffold@0.33.0` (226 files; `dist/cli.js`, README, `docs/STABILITY.md`, `docs/CHANGELOG.md` present; no `.pyc`/`__pycache__`/raw `.ts` residue).
+- [x] `npm publish --dry-run --tag latest` — PASS for `open-scaffold@0.33.0`; dry-run only.
+- [x] Release-sync PR CI green on the PR head; latest-head Codex review PASS (no remaining actionable issues on `4f7ea49` at `2026-06-20T15:18:39Z`); unresolved review threads `0` after closeout.
 
-Post-merge and publication gates (recorded in release follow-through closeout):
+Post-merge and publication gates:
 
-- [ ] Release-sync PR merged to `main` (merge SHA recorded in closeout).
-- [ ] Post-merge local `main` fast-forward — recorded in closeout.
-- [ ] Post-merge `main` CI — recorded in closeout.
-- [ ] Trusted publishing workflow `publish-npm.yml` (expected-version `0.33.0`, tag `latest`) — recorded in closeout.
-- [ ] `npm view open-scaffold version` returns `0.33.0`; `latest: 0.33.0` — recorded in closeout.
-- [ ] Fresh isolated-cache `npx open-scaffold@latest --version` returns `0.33.0` — recorded in closeout.
-- [ ] GitHub Release `v0.33.0` is Latest — recorded in closeout.
+- [x] Release-sync PR #228 merged to `main` — PASS: squash-merged as `d250e3a1bebaa09c4105ce9fa11af1f206453447` at `2026-06-20T15:28:35Z`.
+- [x] Post-merge local `main` fast-forward — PASS: fast-forwarded to `d250e3a`.
+- [x] Post-merge `main` CI — PASS: `ci` success for `d250e3a` (run `27875541958`).
+- [x] Trusted publishing workflow `publish-npm.yml` (`expected-version=0.33.0`, tag `latest`) — PASS: run `27875553205` completed/success; all steps green (install, build, test, `verify.sh --strict`, version validation, `npm publish --provenance`).
+- [x] `npm view open-scaffold version` returns `0.33.0`; `latest: 0.33.0` — PASS.
+- [x] Fresh isolated-cache `npx open-scaffold@latest` — PASS: installs `open-scaffold@0.33.0` and `--help` renders `osc — Open Scaffold CLI`.
+- [x] GitHub Release `v0.33.0` is Latest — PASS: https://github.com/graphanov/open-scaffold/releases/tag/v0.33.0.
+- [x] Repo About (description, homepage, topics) — PASS: current, no change required for this release.
 
 ## Outcome
 
-Release-sync prepared for `open-scaffold@0.33.0`. Owner-approved npm trusted publishing and GitHub Release `v0.33.0` Latest follow-through is scoped for this release and executes immediately after merge. Final publication proof — trusted publishing workflow run, npm registry confirmation, fresh `npx open-scaffold@latest --version` smoke, and GitHub Release `v0.33.0` Latest — is recorded in the release follow-through closeout. The Codex 2x cold-resume claim remains bounded to its single fixture; this release adds the fail-closed evidence-battery gate, not a broader proof claim.
+`open-scaffold@0.33.0` is published to npm as `latest` with provenance, and GitHub Release `v0.33.0` is Latest, superseding `v0.32.1`. The fail-closed evidence-battery gate is now on the public package surface. The Codex 2x cold-resume claim remains bounded to its single fixture; this release adds the fail-closed evidence-battery gate, not a broader proof claim. Plan `174-evidence-battery-package-sync` remains in `.osc/plans/done/` with its acceptance criteria (release-sync preparation) met; publication was the owner-approved follow-through recorded in this evidence note.

--- a/MISSION.md
+++ b/MISSION.md
@@ -52,6 +52,7 @@ Historical entries below preserve the wording used at the time, including supers
 One-line dated entries for every scope pivot. Format: `YYYY-MM-DD: <one-line pivot description + link to amendment file if applicable>`. Append entries in chronological order. Never rewrite history here.
 
 <!-- append YYYY-MM-DD entries below this line -->
+- 2026-06-20: closed 174-evidence-battery-package-sync — Published open-scaffold@0.33.0 to npm latest and created GitHub Release v0.33.0 as Latest; shipped the fail-closed evidence battery from PR #226 to the public package surface.
 - 2026-06-18: closed v1-public-positioning-polish — polished v1 public positioning and release-readiness boundaries
 - 2026-06-18: closed 173-codex-token-efficiency-proof — closed proof-battery hardening with fail-closed evidence battery and source-labeled Codex 2x fixture boundaries
 - 2026-06-18: Owner expanded proof-battery hardening: add source-labeled evidence-battery metadata for more fixtures, human-reviewer replication status, controlled ablation status, and cold-resume packet contract without broadening the Codex 2x claim. — see .osc/plans/done/173-codex-token-efficiency-proof-amendment-1.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,25 +6,30 @@ For live package truth, check npm. For live release truth, check GitHub Releases
 
 ## v0.33.0 — Evidence battery package sync
 
-Status: release-sync prepared for `open-scaffold@0.33.0`; npm trusted publishing and GitHub Release `v0.33.0` Latest follow-through are owner-approved and execute after merge. `v0.32.1` remains npm `latest` and GitHub Release Latest until `v0.33.0` publication completes; final publication status is recorded in the release follow-through closeout.
+Status: published to npm as `open-scaffold@0.33.0`; GitHub Release `v0.33.0` is Latest after owner-approved trusted publishing and release follow-through, superseding `v0.32.1`.
 
 Highlights:
 
 - Publishes the fail-closed evidence battery from PR #226 to the public `npx open-scaffold@latest` package surface.
 - Adds `evidence_battery` support to proof manifests: validates evidence-battery source refs with the same local/public-safe rules as metric refs; blocks `boundedProof` when any `required_for_pass` item is not `demonstrated`/`reproduced`; reports empty batteries as `not_evaluated` (not `pass`); enforces a manifest-level `required_evidence` list (omission is a structural failure, membership implies required-for-pass, IDs are trimmed in both paths); and renders a proof-battery table in `osc prove compare`.
 - Keeps the proof boundary explicit: the Codex 2x cold-resume claim remains bounded to its single fixture; human-reviewer replication and controlled ablations remain disclosure-only (`not_demonstrated` / `mixed_not_proven`), not universal claims.
+- Forward-line references in `docs/STABILITY.md`, `README.md`, and `ROADMAP.md` updated to `v0.33.x`.
 - Pre-1.0 minor release for a new proof-harness feature; this is not production-readiness, compliance certification, broad adoption proof, mature 1.0 status, or universal benchmark superiority.
 
 Evidence:
 
 - Source PR: https://github.com/graphanov/open-scaffold/pull/226
 - Source plan: `.osc/plans/done/173-codex-token-efficiency-proof.md`
+- Release-sync PR: https://github.com/graphanov/open-scaffold/pull/228
 - Release-sync plan: `.osc/plans/done/174-evidence-battery-package-sync.md`
 - Release-sync evidence note: `.osc/releases/2026-06-20-174-evidence-battery-package-sync.md`
+- Trusted publishing run: https://github.com/graphanov/open-scaffold/actions/runs/27875553205
+- GitHub Release: https://github.com/graphanov/open-scaffold/releases/tag/v0.33.0
+- npm: https://www.npmjs.com/package/open-scaffold/v/0.33.0
 
 ## v0.32.1 — Public-readiness package sync
 
-Status: published to npm as `open-scaffold@0.32.1`; GitHub Release `v0.32.1` is Latest after owner-approved trusted publishing and release follow-through.
+Status: published to npm as `open-scaffold@0.32.1`; GitHub Release `v0.32.1` was Latest after owner-approved trusted publishing and release follow-through, then was superseded by `v0.33.0`.
 
 Highlights:
 


### PR DESCRIPTION
## Summary

Release closeout for `open-scaffold@0.33.0` — records the post-merge publication proof in repo truth now that 0.33.0 is published to npm (`latest`, with provenance) and GitHub Release `v0.33.0` is Latest. PR #228 carried the candidate release-sync state; this PR finalizes it.

## Changes

- `.osc/releases/2026-06-20-174-evidence-battery-package-sync.md` — finalize from candidate to published state: Summary now records `0.33.0` published; Traceability filled with the release-sync PR (#228, merge `d250e3a`), trusted publishing run (`27875553205`), GitHub Release, and npm URLs; all post-merge/publication gates checked with proof; Outcome records `v0.33.0` Latest superseding `v0.32.1`.
- `docs/CHANGELOG.md` — `v0.33.0` Status moved from candidate to published; publish-proof evidence lines (release-sync PR, trusted publishing run, GitHub Release, npm) added; `v0.32.1` marked superseded.
- `MISSION.md` — append the `2026-06-20: closed 174-evidence-battery-package-sync` closeout entry.

Plan `174-evidence-battery-package-sync` is left untouched in `.osc/plans/done/` (plan immutability); its acceptance criteria (release-sync preparation) are met, and publication was the owner-approved follow-through recorded in the evidence note.

## Verification

- `npm view open-scaffold version` → `0.33.0`; `latest: 0.33.0`.
- Fresh isolated-cache `npx open-scaffold@latest` installs `0.33.0` and `--help` renders.
- Trusted publishing run `27875553205` completed/success.
- GitHub Release `v0.33.0` is Latest.
- Local: `./verify.sh --strict` 10 pass / 0 fail / 0 warn; `npm test -- --run` 48 files / 563 tests pass; `git diff --check` clean; secret-scan PASS; public-safety scan of added diff lines clean.

No code, version, or package-surface changes in this PR — it is release-truth closeout only.
