### PR TITLE
docs: add MCP coding-agent quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Pre-1.0 (`v0.33.x`). Does not make your model smarter — it makes the loop arou
 ## Key docs
 
 - [`docs/START_HERE.md`](docs/START_HERE.md) — the single entry point.
+- [`docs/MCP.md`](docs/MCP.md) — connect MCP-capable coding agents to repo truth.
 - [`docs/PROOF_HARNESS.md`](docs/PROOF_HARNESS.md) — measured claims, raw pointers, proof boundaries.
 - [`docs/STABILITY.md`](docs/STABILITY.md) — command maturity, version truth, honest limits.
 - [`REPRODUCE.md`](REPRODUCE.md) — audit every receipt, zero spend.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -10,6 +10,97 @@ The server is local-first and optional:
 - write tools are visible but blocked unless the server starts with `--allow-write`;
 - no agent spawning, runtime launching, deployment, publication, or approval automation.
 
+## Solo coding-agent quickstart
+
+Use this path when you are already inside an MCP-capable coding agent such as
+Claude Code, Codex, Cursor, Continue, or another local MCP client and you want
+the agent to read Open Scaffold repo truth.
+
+Replace `/absolute/path/to/repo` with the repository root you want the agent to
+inspect. This config starts the packaged `osc-mcp` binary through `npx` and
+keeps the server read-only:
+
+```json
+{
+  "mcpServers": {
+    "open_scaffold": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "-p",
+        "open-scaffold@latest",
+        "osc-mcp",
+        "--repo",
+        "/absolute/path/to/repo"
+      ]
+    }
+  }
+}
+```
+
+If your client accepts a single command string instead of JSON command/args, use
+the same argv shape:
+
+```bash
+npx -y -p open-scaffold@latest osc-mcp --repo /absolute/path/to/repo
+```
+
+Client config wrappers differ, but the command and args above are the portable
+part:
+
+- Claude Code / Claude Desktop: put the `open_scaffold` server object in the
+  MCP config surface your client supports.
+- Codex CLI: use an underscore server name (`open_scaffold`) so tool names are
+  sanitized predictably.
+- Cursor: place the same `mcpServers.open_scaffold` object in the project or
+  user MCP config.
+- Continue: put the same command and args under its MCP server list.
+
+This is not a compatibility matrix. It is the local stdio command Open Scaffold
+ships; use each client's current MCP docs for the surrounding config file
+location and reload behavior.
+
+### Try these first
+
+Once connected, ask your agent to call these read tools before it reads source
+files:
+
+- `get_status` — mission state, plan counts, and local scaffold validation.
+- `get_handoff` — the current resume packet compiled from repo truth.
+- `list_plans` — active/backlog/done/blocked plan inventory.
+- `list_evidence`, then `get_evidence` — evidence inventory, then one evidence
+  note by path, file name, or slug. `get_evidence` needs an existing evidence
+  note to read.
+
+### Verify the connection
+
+These line-delimited JSON-RPC smoke checks exercise the same packaged command
+without needing a full client UI.
+
+Call `get_status`:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_status","arguments":{}}}' \
+  | npx -y -p open-scaffold@latest osc-mcp --repo /absolute/path/to/repo
+```
+
+Call `get_handoff`:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_handoff","arguments":{}}}' \
+  | npx -y -p open-scaffold@latest osc-mcp --repo /absolute/path/to/repo
+```
+
+Both responses should be JSON-RPC `result` envelopes with `structuredContent`.
+
+### Authority boundary
+
+By default MCP is read-only. Starting the server with `--allow-write` only
+enables scaffold-file helpers such as plan, amendment, close, and evidence
+file creation/mutation. It still has no authority to spawn runtimes, launch
+adapters, run shell commands, commit, push, open PRs, merge, publish, release,
+deploy, read secrets, or use credentials.
+
 ## Start the server
 
 From an Open Scaffold repository:
@@ -122,20 +213,22 @@ Expected result: JSON-RPC error code `-32000`.
 
 ## Client configuration examples
 
-Replace `/absolute/path/to/repo` with the Open Scaffold repository you want the client to inspect.
+Replace `/absolute/path/to/repo` with the Open Scaffold repository you want the
+client to inspect. These examples use the same packaged `osc-mcp` command from
+the solo quickstart.
 
-### Claude Desktop
+### Claude Code / Claude Desktop
 
 ```json
 {
   "mcpServers": {
-    "open-scaffold": {
+    "open_scaffold": {
       "command": "npx",
       "args": [
         "-y",
+        "-p",
         "open-scaffold@latest",
-        "mcp",
-        "serve",
+        "osc-mcp",
         "--repo",
         "/absolute/path/to/repo"
       ]
@@ -149,13 +242,13 @@ Replace `/absolute/path/to/repo` with the Open Scaffold repository you want the 
 ```json
 {
   "mcpServers": {
-    "open-scaffold": {
+    "open_scaffold": {
       "command": "npx",
       "args": [
         "-y",
+        "-p",
         "open-scaffold@latest",
-        "mcp",
-        "serve",
+        "osc-mcp",
         "--repo",
         "/absolute/path/to/repo"
       ]
@@ -171,13 +264,13 @@ Replace `/absolute/path/to/repo` with the Open Scaffold repository you want the 
   "experimental": {
     "modelContextProtocolServers": [
       {
-        "name": "open-scaffold",
+        "name": "open_scaffold",
         "command": "npx",
         "args": [
           "-y",
+          "-p",
           "open-scaffold@latest",
-          "mcp",
-          "serve",
+          "osc-mcp",
           "--repo",
           "/absolute/path/to/repo"
         ]
@@ -190,7 +283,7 @@ Replace `/absolute/path/to/repo` with the Open Scaffold repository you want the 
 ### Codex CLI
 
 ```bash
-codex mcp add open_scaffold -- node /absolute/path/to/open-scaffold/dist/cli.js mcp serve --repo /absolute/path/to/repo
+codex mcp add open_scaffold -- npx -y -p open-scaffold@latest osc-mcp --repo /absolute/path/to/repo
 ```
 
 Name the server with underscores (`open_scaffold`, not `open-scaffold`).
@@ -208,9 +301,9 @@ mcp_servers:
     command: npx
     args:
       - -y
+      - -p
       - open-scaffold@latest
-      - mcp
-      - serve
+      - osc-mcp
       - --repo
       - /absolute/path/to/repo
 ```
@@ -219,7 +312,7 @@ mcp_servers:
 
 - MCP exposes local scaffold state; it does not make MCP the source of truth.
 - Git-tracked Open Scaffold files, GitHub issues/PRs, evidence notes, and operator approvals remain the durable record.
-- `--allow-write` only enables scaffold file helpers. It still does not authorize merge, publication, release mutation, deployment, credential changes, or runtime spawning.
+- `--allow-write` only enables scaffold file helpers. It still does not authorize runtime spawning, shell execution, commits, pushes, PRs, merges, publication, release mutation, deployment, secret reads, or credential changes.
 
 ## Readiness posture
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,6 +47,7 @@ npx open-scaffold@latest compare \
 |---|---|
 | Understand the mission and goals | [`MISSION.md`](../MISSION.md) |
 | Learn the review-and-gate loop | [`EVOLUTION_LOOP.md`](EVOLUTION_LOOP.md) |
+| Connect an MCP-capable coding agent | [`MCP.md`](MCP.md) |
 | See the current workflow map | [`WORKFLOW.md`](WORKFLOW.md) |
 | Understand runtime/execution boundaries | [`TRUST_BOUNDARIES.md`](TRUST_BOUNDARIES.md) and [`RUNTIME_BINDING_CONTRACT.md`](RUNTIME_BINDING_CONTRACT.md) |
 | Check what is stable vs experimental | [`STABILITY.md`](STABILITY.md) |

--- a/tests/mcp-docs.test.ts
+++ b/tests/mcp-docs.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(process.cwd());
+
+function read(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf8');
+}
+
+describe('MCP quickstart documentation', () => {
+  it('front-loads the packaged osc-mcp path for solo coding-agent users', () => {
+    const docs = read('docs/MCP.md');
+
+    expect(docs.indexOf('## Solo coding-agent quickstart')).toBeLessThan(docs.indexOf('## Start the server'));
+    expect(docs).toContain('npx -y -p open-scaffold@latest osc-mcp --repo /absolute/path/to/repo');
+    expect(docs).toContain('"open_scaffold"');
+    expect(docs).toContain('"mcpServers"');
+    expect(docs).toContain('"osc-mcp"');
+  });
+
+  it('keeps common client adaptation guidance tied to one command shape', () => {
+    const docs = read('docs/MCP.md');
+
+    for (const client of ['Claude Code', 'Codex CLI', 'Cursor', 'Continue']) {
+      expect(docs, client).toContain(client);
+    }
+
+    expect(docs).toContain('Name the server with underscores (`open_scaffold`, not `open-scaffold`)');
+    expect(docs).toContain('This is not a compatibility matrix.');
+  });
+
+  it('names the first useful read calls and the evidence prerequisite', () => {
+    const docs = read('docs/MCP.md');
+
+    for (const toolName of ['get_status', 'get_handoff', 'list_plans', 'list_evidence', 'get_evidence']) {
+      expect(docs, toolName).toContain(`\`${toolName}\``);
+    }
+
+    expect(docs).toContain('`get_evidence` needs an existing evidence');
+  });
+
+  it('pins the read-only authority boundary in public docs', () => {
+    const docs = read('docs/MCP.md');
+
+    expect(docs).toContain('By default MCP is read-only.');
+    expect(docs).toContain('--allow-write');
+    expect(docs).toContain('scaffold-file helpers');
+    for (const boundary of ['spawn runtimes', 'run shell commands', 'commit', 'push', 'open PRs', 'merge', 'publish', 'release', 'deploy', 'read secrets', 'use credentials']) {
+      expect(docs, boundary).toContain(boundary);
+    }
+  });
+
+  it('links the MCP quickstart from public entry points', () => {
+    expect(read('README.md')).toContain('[`docs/MCP.md`](docs/MCP.md) — connect MCP-capable coding agents to repo truth.');
+    expect(read('docs/START_HERE.md')).toContain('| Connect an MCP-capable coding agent | [`MCP.md`](MCP.md) |');
+  });
+
+  it('keeps the packaged MCP binary documented against package truth', () => {
+    const packageJson = JSON.parse(read('package.json')) as { bin?: Record<string, string> };
+
+    expect(packageJson.bin?.['osc-mcp']).toBe('dist/mcp-cli.js');
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -519,6 +519,34 @@ describe('Open Scaffold MCP JSON-RPC server', () => {
     expect(lines[1].result.tools.map((tool: { name: string }) => tool.name)).toContain('list_plans');
   }, 20_000);
 
+  it('serves the documented first solo-agent calls over the osc-mcp stdio path', () => {
+    const root = scaffoldFixture();
+    const input = [
+      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}',
+      '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_status","arguments":{}}}',
+      '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_handoff","arguments":{}}}',
+      '',
+    ].join('\n');
+
+    const run = execFileSync(tsx, [mcpCli, '--repo', root], { cwd: repoRoot, input, encoding: 'utf8' });
+    const lines = run.trim().split(/\r?\n/).map((line) => JSON.parse(line)) as Array<{
+      id: number;
+      result: {
+        structuredContent?: unknown;
+      };
+    }>;
+
+    expect(lines[0]).toMatchObject({ id: 1, result: {} });
+    expect(lines[1].result.structuredContent).toMatchObject({
+      mission: { defined: true },
+      plan_counts: { active: 1, backlog: 1 },
+    });
+    expect(lines[2].result.structuredContent).toMatchObject({
+      summary: { schema: 'open-scaffold.resume.v1' },
+    });
+    expect((lines[2].result.structuredContent as { packet: string }).packet).toContain('001-sample');
+  }, 20_000);
+
   it('responds over stdio with MCP content-length frames', () => {
     const root = scaffoldFixture();
     const input = [


### PR DESCRIPTION
## Summary
- Adds a public quickstart for connecting MCP-capable coding agents to Open Scaffold repo truth.

## Scope
- Documents the packaged `osc-mcp`/`npx -p open-scaffold@latest` command shape.
- Names first useful read calls and adds JSON-RPC smoke-check guidance.
- Adds fixture-backed tests for the MCP quickstart docs and stdio path.

## Out of scope
- No merge, publish, release, workflow dispatch, runtime spawning, or credential behavior changes.

## Verification
- `git diff --check` → passed
- `npm test -- --run tests/mcp-server.test.ts tests/mcp-docs.test.ts` → 23 tests passed
- `npm run build` → passed
- `./verify.sh --strict && npm test -- --run` → 10 compliance checks passed; 49 test files / 570 tests passed

## Risk
- Docs-only product surface plus MCP smoke-test coverage; normal PR review risk remains.

## Linked issue
Closes #231

## Authority boundary
john-lomein did not merge, publish, release, dispatch workflows, change settings, force-push, rewrite history, or touch secrets.
