### PR TITLE
Add ambient capture setup helper for Codex and Claude Code

### DIFF
--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -73,8 +73,10 @@ with `--claude-settings <path>` and `--codex-config <path>`.
 `examples/hooks/ambient-hook.mjs` reads the hook JSON on stdin
 (`transcript_path`, `session_id`, `cwd`) and runs `osc capture --from claude-code`.
 `osc capture setup claude-code --write` installs the owner-local
-`.claude/settings.local.json` hook. If you need to register it manually, keep the file
-owner-local/gitignored and use the absolute command printed by the dry-run:
+`.claude/settings.local.json` hook and, for the default path, adds
+`.claude/settings.local.json` to the repository root `.gitignore` if needed. If you need
+to register it manually, keep the file owner-local/gitignored and use the absolute command
+printed by the dry-run:
 
 ```json
 { "hooks": { "SessionEnd": [ { "hooks": [ { "type": "command",

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -47,15 +47,38 @@ the record.
 
 ## Hook recipes
 
+Use the setup helper first. It prints a safe dry-run by default and does not dump
+unrelated local config values:
+
+```bash
+osc capture setup claude-code
+osc capture setup codex
+osc capture setup all
+```
+
+Add `--write` to install the proposed local config. Write mode is idempotent; it refuses
+to clobber incompatible existing Claude hooks or Codex top-level `notify` settings. For
+`setup all --write`, any blocker stops all writes so capture is not half-installed.
+
+The generated commands use the current Node executable plus the shipped hook path under
+`examples/hooks`. Because runtime configs store absolute hook paths, run setup from the
+installed package or checkout you intend to keep. If the package cache or checkout is
+deleted later, rerun setup from the durable location.
+
+Use `--json` for a machine-readable summary. Test or owner-local paths can be overridden
+with `--claude-settings <path>` and `--codex-config <path>`.
+
 ### Claude Code (SessionEnd)
 
 `examples/hooks/ambient-hook.mjs` reads the hook JSON on stdin
 (`transcript_path`, `session_id`, `cwd`) and runs `osc capture --from claude-code`.
-Register it owner-locally in `.claude/settings.local.json` (gitignored):
+`osc capture setup claude-code --write` installs the owner-local
+`.claude/settings.local.json` hook. If you need to register it manually, keep the file
+owner-local/gitignored and use the absolute command printed by the dry-run:
 
 ```json
 { "hooks": { "SessionEnd": [ { "hooks": [ { "type": "command",
-  "command": "node examples/hooks/ambient-hook.mjs" } ] } ] } }
+  "command": "/path/to/node /path/to/open-scaffold/examples/hooks/ambient-hook.mjs" } ] } ] } }
 ```
 
 The hook always exits 0 and can never block or fail a session.
@@ -66,7 +89,19 @@ The hook always exits 0 and can never block or fail a session.
 `notify` event `thread-id` on `agent-turn-complete` / session end. The notify program
 receives event JSON and runs `osc capture --from codex --hook-safe` on the matching
 `~/.codex/sessions/.../rollout-*<thread-id>*.jsonl`, so concurrent sessions cannot be
-cross-captured.
+cross-captured. `osc capture setup codex --write` inserts a top-level `notify` stanza in
+`${CODEX_HOME:-$HOME/.codex}/config.toml` before any tables when no top-level `notify`
+already exists.
+
+Manual fallback:
+
+```toml
+notify = ["/path/to/node", "/path/to/open-scaffold/examples/hooks/codex-notify.mjs"]
+```
+
+If you already have a different top-level `notify` value, the helper blocks instead of
+rewriting it. Merge that setup manually and keep table-local `notify` settings under
+profiles separate from the top-level ambient capture hook.
 
 ## Boundary
 

--- a/examples/hooks/codex-notify.md
+++ b/examples/hooks/codex-notify.md
@@ -21,11 +21,23 @@ rather than risking the wrong concurrent session.
 
 ## Registration
 
-In `~/.codex/config.toml` (owner-local):
+Prefer the setup helper. It dry-runs by default and prints only generated setup data,
+not unrelated local config values:
+
+```bash
+osc capture setup codex
+osc capture setup codex --write
+```
+
+Manual fallback in `~/.codex/config.toml` (owner-local):
 
 ```toml
-notify = ["node", "/absolute/path/to/open-scaffold/examples/hooks/codex-notify.mjs"]
+notify = ["/path/to/node", "/absolute/path/to/open-scaffold/examples/hooks/codex-notify.mjs"]
 ```
+
+The helper inserts the top-level `notify` before the first table and refuses to rewrite
+a different existing top-level `notify`. Absolute hook paths should point at an installed
+package or checkout you intend to keep.
 
 ## Notify program (`codex-notify.mjs`)
 

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -80,8 +80,8 @@ export function runCaptureSetup(target: CaptureSetupTarget, options: CaptureSetu
       for (let i = 0; i < writes.length; i += 1) {
         const write = writes[i];
         const snapshot = snapshots[i];
-        writeUtf8NoFollow(write.path, write.content, snapshot.label);
         written.push(snapshot);
+        writeUtf8NoFollow(write.path, write.content, snapshot.label);
       }
     } catch (error) {
       rollbackWrites(written, error);

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -281,6 +281,9 @@ function mergeCodexConfig(content: string, stanza: string): { content?: string; 
     if (notifyLine.trim() === stanza) return { content, changed: false };
     return { blocked: 'Codex config already has a different top-level notify setting; not rewriting it.' };
   }
+  if (preamble.firstTableLine && isTomlNotifyTableHeader(preamble.firstTableLine)) {
+    return { blocked: 'Codex config already has a top-level notify table; not rewriting it.' };
+  }
   if (preamble.firstTable === -1) {
     const prefix = content.length === 0 ? '' : content.endsWith('\n') ? content : `${content}\n`;
     return { content: `${prefix}${stanza}\n`, changed: true };
@@ -293,6 +296,7 @@ function mergeCodexConfig(content: string, stanza: string): { content?: string; 
 
 interface TomlPreamble {
   firstTable: number;
+  firstTableLine?: string;
   lines: string[];
 }
 
@@ -310,7 +314,7 @@ function tomlPreamble(content: string): TomlPreamble {
   const lines: string[] = [];
   for (const line of content.split(/(?<=\n)/)) {
     const body = line.replace(/\r?\n$/, '');
-    if (stringState === 'none' && arrayDepth === 0 && isTomlTableHeader(body)) return { firstTable: offset, lines };
+    if (stringState === 'none' && arrayDepth === 0 && isTomlTableHeader(body)) return { firstTable: offset, firstTableLine: body, lines };
     if (stringState === 'none' && arrayDepth === 0) lines.push(body);
     ({ stringState, arrayDepth } = scanTomlLineState(body, stringState, arrayDepth));
     offset += line.length;
@@ -320,6 +324,14 @@ function tomlPreamble(content: string): TomlPreamble {
 
 function isTomlTableHeader(line: string): boolean {
   return /^\s*(?:\[\s*[A-Za-z0-9_."'-][^\]]*?\s*\]|\[\[\s*[A-Za-z0-9_."'-][^\]]*?\s*\]\])\s*(?:#.*)?$/.test(line);
+}
+
+function isTomlNotifyTableHeader(line: string): boolean {
+  const header = line.replace(/\s*#.*$/, '').trim();
+  const inner = header.startsWith('[[')
+    ? header.replace(/^\[\[\s*/, '').replace(/\s*\]\]$/, '')
+    : header.replace(/^\[\s*/, '').replace(/\s*\]$/, '');
+  return /^(?:notify|"notify"|'notify')(?:\s*\.|$)/.test(inner.trim());
 }
 
 function scanTomlLineState(line: string, initialStringState: TomlStringState, initialArrayDepth: number): TomlLineState {

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -1,6 +1,6 @@
 import { constants, closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, writeSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, parse, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export const CAPTURE_SETUP_TARGETS = ['claude-code', 'codex', 'all'] as const;
@@ -186,6 +186,8 @@ function preflightConfig(configPath: string, hookPath: string, label: string): P
   }
   const symlinkMessage = finalSymlinkMessage(configPath, `${label} config`);
   if (symlinkMessage) return { status: 'blocked', changed: false, message: symlinkMessage };
+  const parentSymlinkMessage = parentPathMessage(configPath, `${label} config`);
+  if (parentSymlinkMessage) return { status: 'blocked', changed: false, message: parentSymlinkMessage };
   return null;
 }
 
@@ -221,35 +223,103 @@ function mergeClaudeSettings(settings: JsonObject, command: string): { settings?
 }
 
 function mergeCodexConfig(content: string, stanza: string): { content?: string; changed?: boolean; blocked?: string } {
-  const firstTable = firstTableStart(content);
-  const preamble = firstTable === -1 ? content : content.slice(0, firstTable);
-  const notifyLine = findTopLevelNotifyLine(preamble);
+  const preamble = tomlPreamble(content);
+  const notifyLine = findTopLevelNotifyLine(preamble.lines);
   if (notifyLine) {
     if (notifyLine.trim() === stanza) return { content, changed: false };
     return { blocked: 'Codex config already has a different top-level notify setting; not rewriting it.' };
   }
-  if (firstTable === -1) {
+  if (preamble.firstTable === -1) {
     const prefix = content.length === 0 ? '' : content.endsWith('\n') ? content : `${content}\n`;
     return { content: `${prefix}${stanza}\n`, changed: true };
   }
-  const before = content.slice(0, firstTable);
-  const after = content.slice(firstTable);
+  const before = content.slice(0, preamble.firstTable);
+  const after = content.slice(preamble.firstTable);
   const separator = before.length === 0 || before.endsWith('\n') ? '' : '\n';
   return { content: `${before}${separator}${stanza}\n${after}`, changed: true };
 }
 
-function firstTableStart(content: string): number {
-  let offset = 0;
-  for (const line of content.split(/(?<=\n)/)) {
-    const body = line.replace(/\r?\n$/, '');
-    if (/^\s*\[\[?[A-Za-z0-9_."'-][^\]]*\]\]?\s*(?:#.*)?$/.test(body)) return offset;
-    offset += line.length;
-  }
-  return -1;
+interface TomlPreamble {
+  firstTable: number;
+  lines: string[];
 }
 
-function findTopLevelNotifyLine(preamble: string): string | null {
-  for (const line of preamble.split(/\r?\n/)) {
+type TomlStringState = 'none' | 'multiline-basic' | 'multiline-literal';
+
+function tomlPreamble(content: string): TomlPreamble {
+  let offset = 0;
+  let stringState: TomlStringState = 'none';
+  const lines: string[] = [];
+  for (const line of content.split(/(?<=\n)/)) {
+    const body = line.replace(/\r?\n$/, '');
+    if (stringState === 'none' && isTomlTableHeader(body)) return { firstTable: offset, lines };
+    if (stringState === 'none') lines.push(body);
+    stringState = scanTomlStringState(body, stringState);
+    offset += line.length;
+  }
+  return { firstTable: -1, lines };
+}
+
+function isTomlTableHeader(line: string): boolean {
+  return /^\s*\[\[?[A-Za-z0-9_."'-][^\]]*\]\]?\s*(?:#.*)?$/.test(line);
+}
+
+function scanTomlStringState(line: string, initialState: TomlStringState): TomlStringState {
+  let state = initialState;
+  let i = 0;
+  while (i < line.length) {
+    if (state !== 'none') {
+      const marker = state === 'multiline-basic' ? '"""' : "'''";
+      const end = line.indexOf(marker, i);
+      if (end === -1) return state;
+      state = 'none';
+      i = end + marker.length;
+      continue;
+    }
+    if (line[i] === '#') return state;
+    if (line.startsWith('"""', i)) {
+      state = 'multiline-basic';
+      i += 3;
+      continue;
+    }
+    if (line.startsWith("'''", i)) {
+      state = 'multiline-literal';
+      i += 3;
+      continue;
+    }
+    if (line[i] === '"') {
+      i = skipBasicString(line, i + 1);
+      continue;
+    }
+    if (line[i] === "'") {
+      const end = line.indexOf("'", i + 1);
+      i = end === -1 ? line.length : end + 1;
+      continue;
+    }
+    i += 1;
+  }
+  return state;
+}
+
+function skipBasicString(line: string, start: number): number {
+  let escaped = false;
+  for (let i = start; i < line.length; i += 1) {
+    const char = line[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') return i + 1;
+  }
+  return line.length;
+}
+
+function findTopLevelNotifyLine(lines: string[]): string | null {
+  for (const line of lines) {
     if (/^\s*(?:#|$)/.test(line)) continue;
     if (/^\s*notify\s*=/.test(line)) return line.trim();
   }
@@ -266,8 +336,32 @@ function finalSymlinkMessage(path: string, label: string): string | null {
   return null;
 }
 
+function parentPathMessage(path: string, label: string): string | null {
+  let current = dirname(path);
+  const { root } = parse(current);
+  while (current !== root) {
+    try {
+      const stat = lstatSync(current);
+      if (stat.isSymbolicLink()) return `${label} parent directory must not be a symlink: ${current}`;
+      if (!stat.isDirectory()) return `${label} parent path is not a directory: ${current}`;
+      return null;
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'ENOENT') {
+        current = dirname(current);
+        continue;
+      }
+      return `Could not inspect ${label} parent path: ${errorMessage(error)}`;
+    }
+  }
+  return null;
+}
+
 function writeUtf8NoFollow(path: string, content: string, label: string): void {
+  const parentMessage = parentPathMessage(path, label);
+  if (parentMessage) throw new Error(parentMessage);
   mkdirSync(dirname(path), { recursive: true });
+  const postMkdirParentMessage = parentPathMessage(path, label);
+  if (postMkdirParentMessage) throw new Error(postMkdirParentMessage);
   const symlinkMessage = finalSymlinkMessage(path, label);
   if (symlinkMessage) throw new Error(symlinkMessage);
   const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW ?? 0);

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -1,4 +1,4 @@
-import { constants, closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, writeSync } from 'node:fs';
+import { constants, closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, rmSync, writeSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, parse, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -35,6 +35,13 @@ interface CaptureSetupPlan extends CaptureSetupResult {
   content?: string;
 }
 
+interface WriteSnapshot {
+  configPath: string;
+  label: string;
+  existed: boolean;
+  content?: string;
+}
+
 type JsonObject = Record<string, unknown>;
 
 export function isCaptureSetupTarget(value: string): value is CaptureSetupTarget {
@@ -57,8 +64,19 @@ export function runCaptureSetup(target: CaptureSetupTarget, options: CaptureSetu
     });
   }
   if (options.write) {
-    for (const plan of plans) {
-      if (plan.changed && plan.content !== undefined) writeUtf8NoFollow(plan.configPath, plan.content, `${plan.runtime} config`);
+    const changedPlans = plans.filter((plan) => plan.changed && plan.content !== undefined);
+    const snapshots = changedPlans.map((plan) => snapshotConfig(plan.configPath, `${plan.runtime} config`));
+    const written: WriteSnapshot[] = [];
+    try {
+      for (let i = 0; i < changedPlans.length; i += 1) {
+        const plan = changedPlans[i];
+        const snapshot = snapshots[i];
+        writeUtf8NoFollow(plan.configPath, plan.content ?? '', snapshot.label);
+        written.push(snapshot);
+      }
+    } catch (error) {
+      rollbackWrites(written, error);
+      throw error;
     }
     return plans.map((plan) => publicResult({
       ...plan,
@@ -354,6 +372,29 @@ function parentPathMessage(path: string, label: string): string | null {
     }
   }
   return null;
+}
+
+function snapshotConfig(configPath: string, label: string): WriteSnapshot {
+  if (!existsSync(configPath)) return { configPath, label, existed: false };
+  return { configPath, label, existed: true, content: readFileSync(configPath, 'utf8') };
+}
+
+function rollbackWrites(written: WriteSnapshot[], originalError: unknown): void {
+  let rollbackError: unknown;
+  for (const snapshot of [...written].reverse()) {
+    try {
+      if (snapshot.existed) {
+        writeUtf8NoFollow(snapshot.configPath, snapshot.content ?? '', snapshot.label);
+      } else {
+        rmSync(snapshot.configPath, { force: true });
+      }
+    } catch (error) {
+      rollbackError ??= error;
+    }
+  }
+  if (rollbackError) {
+    throw new Error(`${errorMessage(originalError)}; rollback failed: ${errorMessage(rollbackError)}`);
+  }
 }
 
 function writeUtf8NoFollow(path: string, content: string, label: string): void {

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -50,6 +50,7 @@ interface PlannedWrite {
 }
 
 type JsonObject = Record<string, unknown>;
+const CLAUDE_SETTINGS_GITIGNORE_ENTRY = '.claude/settings.local.json';
 
 export function isCaptureSetupTarget(value: string): value is CaptureSetupTarget {
   return (CAPTURE_SETUP_TARGETS as readonly string[]).includes(value);
@@ -417,7 +418,7 @@ function planClaudeGitignore(
   return {
     extraWrites: [{
       path: gitignorePath,
-      content: `${prefix}.claude/settings.local.json\n`,
+      content: `${prefix}${CLAUDE_SETTINGS_GITIGNORE_ENTRY}\n`,
       label: 'Git ignore file',
     }],
   };
@@ -431,15 +432,38 @@ function gitignoreCoversClaudeSettings(content: string): boolean {
     const negated = pattern.startsWith('!');
     if (negated) pattern = pattern.slice(1).trim();
     if (pattern.length === 0) continue;
-    const normalized = pattern.replace(/^\//, '');
-    const matches = normalized === '.claude'
-      || normalized === '.claude/'
-      || normalized === '.claude/*'
-      || normalized === '.claude/**'
-      || normalized === '.claude/settings.local.json';
-    if (matches) ignored = !negated;
+    if (gitignorePatternMatchesClaudeSettings(pattern)) ignored = !negated;
   }
   return ignored;
+}
+
+function gitignorePatternMatchesClaudeSettings(pattern: string): boolean {
+  const normalized = pattern.replace(/^\//, '');
+  if (normalized === '.claude') return true;
+  if (normalized.endsWith('/')) return CLAUDE_SETTINGS_GITIGNORE_ENTRY.startsWith(normalized);
+  return gitignorePatternRegex(normalized).test(CLAUDE_SETTINGS_GITIGNORE_ENTRY);
+}
+
+function gitignorePatternRegex(pattern: string): RegExp {
+  let source = '^';
+  for (let i = 0; i < pattern.length; i += 1) {
+    const char = pattern[i];
+    if (char === '*') {
+      if (pattern[i + 1] === '*') {
+        source += '.*';
+        i += 1;
+      } else {
+        source += '[^/]*';
+      }
+      continue;
+    }
+    if (char === '?') {
+      source += '[^/]';
+      continue;
+    }
+    source += char.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+  }
+  return new RegExp(`${source}$`);
 }
 
 function finalSymlinkMessage(path: string, label: string): string | null {

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -450,10 +450,11 @@ function gitignoreCoversClaudeSettings(content: string): boolean {
 }
 
 function gitignorePatternMatchesClaudeSettings(pattern: string): boolean {
-  const normalized = pattern.replace(/^\//, '');
+  const rootAnchored = pattern.startsWith('/');
+  const normalized = rootAnchored ? pattern.slice(1) : pattern;
   if (normalized === '.claude') return true;
   if (normalized.endsWith('/')) return CLAUDE_SETTINGS_GITIGNORE_ENTRY.startsWith(normalized);
-  const target = normalized.includes('/')
+  const target = rootAnchored || normalized.includes('/')
     ? CLAUDE_SETTINGS_GITIGNORE_ENTRY
     : CLAUDE_SETTINGS_GITIGNORE_ENTRY.split('/').at(-1) ?? CLAUDE_SETTINGS_GITIGNORE_ENTRY;
   return gitignorePatternRegex(normalized).test(target);

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -261,7 +261,7 @@ function tomlPreamble(content: string): TomlPreamble {
 }
 
 function isTomlTableHeader(line: string): boolean {
-  return /^\s*\[\[?[A-Za-z0-9_."'-][^\]]*\]\]?\s*(?:#.*)?$/.test(line);
+  return /^\s*(?:\[\s*[A-Za-z0-9_."'-][^\]]*?\s*\]|\[\[\s*[A-Za-z0-9_."'-][^\]]*?\s*\]\])\s*(?:#.*)?$/.test(line);
 }
 
 function scanTomlStringState(line: string, initialState: TomlStringState): TomlStringState {

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -355,23 +355,28 @@ function finalSymlinkMessage(path: string, label: string): string | null {
 }
 
 function parentPathMessage(path: string, label: string): string | null {
-  let current = dirname(path);
-  const { root } = parse(current);
-  while (current !== root) {
+  const parent = dirname(path);
+  const { root } = parse(parent);
+  let current = root;
+  for (const part of parent.slice(root.length).split(/[\\/]+/).filter(Boolean)) {
+    current = join(current, part);
     try {
       const stat = lstatSync(current);
-      if (stat.isSymbolicLink()) return `${label} parent directory must not be a symlink: ${current}`;
-      if (!stat.isDirectory()) return `${label} parent path is not a directory: ${current}`;
-      return null;
-    } catch (error) {
-      if ((error as { code?: string })?.code === 'ENOENT') {
-        current = dirname(current);
-        continue;
+      if (stat.isSymbolicLink()) {
+        if (isAllowedSystemSymlink(current)) continue;
+        return `${label} parent directory must not be a symlink: ${current}`;
       }
+      if (!stat.isDirectory()) return `${label} parent path is not a directory: ${current}`;
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'ENOENT') return null;
       return `Could not inspect ${label} parent path: ${errorMessage(error)}`;
     }
   }
   return null;
+}
+
+function isAllowedSystemSymlink(path: string): boolean {
+  return process.platform === 'darwin' && (path === '/var' || path === '/tmp');
 }
 
 function snapshotConfig(configPath: string, label: string): WriteSnapshot {

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -297,15 +297,21 @@ interface TomlPreamble {
 
 type TomlStringState = 'none' | 'multiline-basic' | 'multiline-literal';
 
+interface TomlLineState {
+  stringState: TomlStringState;
+  arrayDepth: number;
+}
+
 function tomlPreamble(content: string): TomlPreamble {
   let offset = 0;
   let stringState: TomlStringState = 'none';
+  let arrayDepth = 0;
   const lines: string[] = [];
   for (const line of content.split(/(?<=\n)/)) {
     const body = line.replace(/\r?\n$/, '');
-    if (stringState === 'none' && isTomlTableHeader(body)) return { firstTable: offset, lines };
-    if (stringState === 'none') lines.push(body);
-    stringState = scanTomlStringState(body, stringState);
+    if (stringState === 'none' && arrayDepth === 0 && isTomlTableHeader(body)) return { firstTable: offset, lines };
+    if (stringState === 'none' && arrayDepth === 0) lines.push(body);
+    ({ stringState, arrayDepth } = scanTomlLineState(body, stringState, arrayDepth));
     offset += line.length;
   }
   return { firstTable: -1, lines };
@@ -315,19 +321,20 @@ function isTomlTableHeader(line: string): boolean {
   return /^\s*(?:\[\s*[A-Za-z0-9_."'-][^\]]*?\s*\]|\[\[\s*[A-Za-z0-9_."'-][^\]]*?\s*\]\])\s*(?:#.*)?$/.test(line);
 }
 
-function scanTomlStringState(line: string, initialState: TomlStringState): TomlStringState {
-  let state = initialState;
+function scanTomlLineState(line: string, initialStringState: TomlStringState, initialArrayDepth: number): TomlLineState {
+  let state = initialStringState;
+  let arrayDepth = initialArrayDepth;
   let i = 0;
   while (i < line.length) {
     if (state !== 'none') {
       const marker = state === 'multiline-basic' ? '"""' : "'''";
       const end = line.indexOf(marker, i);
-      if (end === -1) return state;
+      if (end === -1) return { stringState: state, arrayDepth };
       state = 'none';
       i = end + marker.length;
       continue;
     }
-    if (line[i] === '#') return state;
+    if (line[i] === '#') return { stringState: state, arrayDepth };
     if (line.startsWith('"""', i)) {
       state = 'multiline-basic';
       i += 3;
@@ -347,9 +354,19 @@ function scanTomlStringState(line: string, initialState: TomlStringState): TomlS
       i = end === -1 ? line.length : end + 1;
       continue;
     }
+    if (line[i] === '[') {
+      arrayDepth += 1;
+      i += 1;
+      continue;
+    }
+    if (line[i] === ']') {
+      arrayDepth = Math.max(0, arrayDepth - 1);
+      i += 1;
+      continue;
+    }
     i += 1;
   }
-  return state;
+  return { stringState: state, arrayDepth };
 }
 
 function skipBasicString(line: string, start: number): number {

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -1,0 +1,313 @@
+import { constants, closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, writeSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const CAPTURE_SETUP_TARGETS = ['claude-code', 'codex', 'all'] as const;
+export type CaptureSetupTarget = typeof CAPTURE_SETUP_TARGETS[number];
+export type CaptureSetupRuntime = Exclude<CaptureSetupTarget, 'all'>;
+export type CaptureSetupStatus = 'would-install' | 'installed' | 'blocked';
+
+export interface CaptureSetupOptions {
+  cwd?: string;
+  repoRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  write?: boolean;
+  claudeSettingsPath?: string;
+  codexConfigPath?: string;
+  nodePath?: string;
+  claudeHookPath?: string;
+  codexHookPath?: string;
+}
+
+export interface CaptureSetupResult {
+  runtime: CaptureSetupRuntime;
+  status: CaptureSetupStatus;
+  configPath: string;
+  hookPath: string;
+  command?: string;
+  stanza?: string;
+  changed: boolean;
+  message: string;
+}
+
+interface CaptureSetupPlan extends CaptureSetupResult {
+  content?: string;
+}
+
+type JsonObject = Record<string, unknown>;
+
+export function isCaptureSetupTarget(value: string): value is CaptureSetupTarget {
+  return (CAPTURE_SETUP_TARGETS as readonly string[]).includes(value);
+}
+
+export function runCaptureSetup(target: CaptureSetupTarget, options: CaptureSetupOptions = {}): CaptureSetupResult[] {
+  const plans = expandTarget(target).map((runtime) => planRuntime(runtime, options));
+  const blocked = plans.some((plan) => plan.status === 'blocked');
+  if (options.write && blocked) {
+    return plans.map((plan) => {
+      if (plan.status === 'blocked' || plan.status === 'installed') return publicResult(plan);
+      return publicResult({
+        ...plan,
+        status: 'blocked',
+        changed: false,
+        message: `Not writing ${plan.runtime} setup because another requested target is blocked.`,
+        content: undefined,
+      });
+    });
+  }
+  if (options.write) {
+    for (const plan of plans) {
+      if (plan.changed && plan.content !== undefined) writeUtf8NoFollow(plan.configPath, plan.content, `${plan.runtime} config`);
+    }
+    return plans.map((plan) => publicResult({
+      ...plan,
+      status: 'installed',
+      message: plan.changed ? `Installed ${plan.runtime} ambient capture setup.` : plan.message,
+      content: undefined,
+    }));
+  }
+  return plans.map(publicResult);
+}
+
+export function renderCaptureSetupText(results: CaptureSetupResult[], mode: 'dry-run' | 'write'): string {
+  const lines = [`capture setup ${mode}:`];
+  for (const result of results) {
+    lines.push(`- ${result.runtime}: ${result.status}`);
+    lines.push(`  config: ${result.configPath}`);
+    lines.push(`  hook: ${result.hookPath}`);
+    if (result.command) lines.push(`  command: ${result.command}`);
+    if (result.stanza) lines.push(`  stanza: ${result.stanza}`);
+    lines.push(`  changed: ${String(result.changed)}`);
+    lines.push(`  message: ${result.message}`);
+  }
+  return lines.join('\n');
+}
+
+function publicResult(plan: CaptureSetupPlan): CaptureSetupResult {
+  const { content: _content, ...result } = plan;
+  return result;
+}
+
+function expandTarget(target: CaptureSetupTarget): CaptureSetupRuntime[] {
+  return target === 'all' ? ['claude-code', 'codex'] : [target];
+}
+
+function planRuntime(runtime: CaptureSetupRuntime, options: CaptureSetupOptions): CaptureSetupPlan {
+  return runtime === 'claude-code' ? planClaude(options) : planCodex(options);
+}
+
+function planClaude(options: CaptureSetupOptions): CaptureSetupPlan {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const configPath = resolvePath(options.claudeSettingsPath ?? join(options.repoRoot ?? cwd, '.claude', 'settings.local.json'), cwd);
+  const hookPath = resolvePath(options.claudeHookPath ?? shippedHookPath('ambient-hook.mjs'), cwd);
+  const command = `${shellQuote(options.nodePath ?? process.execPath)} ${shellQuote(hookPath)}`;
+  const base = basePlan('claude-code', configPath, hookPath, { command });
+  const preflight = preflightConfig(configPath, hookPath, 'Claude Code');
+  if (preflight) return { ...base, ...preflight };
+  let settings: JsonObject = {};
+  if (existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as unknown;
+      if (!isJsonObject(parsed)) return blocked(base, 'Claude Code settings must be a JSON object.');
+      settings = parsed;
+    } catch (error) {
+      return blocked(base, `Could not parse Claude Code settings JSON: ${errorMessage(error)}`);
+    }
+  }
+  const planned = mergeClaudeSettings(settings, command);
+  if (planned.blocked) return blocked(base, planned.blocked);
+  if (!planned.changed) return { ...base, status: 'installed', changed: false, message: 'Claude Code SessionEnd ambient capture hook is already installed.' };
+  return {
+    ...base,
+    status: 'would-install',
+    changed: true,
+    content: `${JSON.stringify(planned.settings, null, 2)}\n`,
+    message: 'Would install Claude Code SessionEnd ambient capture hook.',
+  };
+}
+
+function planCodex(options: CaptureSetupOptions): CaptureSetupPlan {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const configPath = resolvePath(options.codexConfigPath ?? defaultCodexConfigPath(options.env ?? process.env), cwd);
+  const hookPath = resolvePath(options.codexHookPath ?? shippedHookPath('codex-notify.mjs'), cwd);
+  const stanza = `notify = [${tomlString(options.nodePath ?? process.execPath)}, ${tomlString(hookPath)}]`;
+  const base = basePlan('codex', configPath, hookPath, { stanza });
+  const preflight = preflightConfig(configPath, hookPath, 'Codex');
+  if (preflight) return { ...base, ...preflight };
+  let content = '';
+  if (existsSync(configPath)) {
+    try {
+      content = readFileSync(configPath, 'utf8');
+    } catch (error) {
+      return blocked(base, `Could not read Codex config: ${errorMessage(error)}`);
+    }
+  }
+  const planned = mergeCodexConfig(content, stanza);
+  if (planned.blocked) return blocked(base, planned.blocked);
+  if (!planned.changed) return { ...base, status: 'installed', changed: false, message: 'Codex notify ambient capture hook is already installed.' };
+  return {
+    ...base,
+    status: 'would-install',
+    changed: true,
+    content: planned.content,
+    message: 'Would install Codex notify ambient capture hook.',
+  };
+}
+
+function basePlan(
+  runtime: CaptureSetupRuntime,
+  configPath: string,
+  hookPath: string,
+  generated: Pick<CaptureSetupResult, 'command'> | Pick<CaptureSetupResult, 'stanza'>,
+): CaptureSetupPlan {
+  return {
+    runtime,
+    status: 'blocked',
+    configPath,
+    hookPath,
+    changed: false,
+    message: '',
+    ...generated,
+  };
+}
+
+function blocked(base: CaptureSetupPlan, message: string): CaptureSetupPlan {
+  return { ...base, status: 'blocked', changed: false, message };
+}
+
+function preflightConfig(configPath: string, hookPath: string, label: string): Pick<CaptureSetupPlan, 'status' | 'changed' | 'message'> | null {
+  if (!existsSync(hookPath)) {
+    return {
+      status: 'blocked',
+      changed: false,
+      message: `${label} hook target not found: ${hookPath}. Run setup from an installed open-scaffold package or a checkout that includes examples/hooks.`,
+    };
+  }
+  const symlinkMessage = finalSymlinkMessage(configPath, `${label} config`);
+  if (symlinkMessage) return { status: 'blocked', changed: false, message: symlinkMessage };
+  return null;
+}
+
+function mergeClaudeSettings(settings: JsonObject, command: string): { settings?: JsonObject; changed?: boolean; blocked?: string } {
+  const hooksValue = settings.hooks;
+  if (hooksValue !== undefined && !isJsonObject(hooksValue)) {
+    return { blocked: 'Claude Code settings hooks must be an object; not rewriting incompatible settings.' };
+  }
+  const hooks = hooksValue === undefined ? {} : hooksValue;
+  const sessionEndValue = hooks.SessionEnd;
+  if (sessionEndValue !== undefined && !Array.isArray(sessionEndValue)) {
+    return { blocked: 'Claude Code hooks.SessionEnd must be an array; not rewriting incompatible settings.' };
+  }
+  const sessionEnd = sessionEndValue === undefined ? [] : [...sessionEndValue];
+  for (const entry of sessionEnd) {
+    if (!isJsonObject(entry)) return { blocked: 'Claude Code hooks.SessionEnd entries must be objects; not rewriting incompatible settings.' };
+    const commandHooks = entry.hooks;
+    if (!Array.isArray(commandHooks)) {
+      return { blocked: 'Claude Code SessionEnd entry hooks must be arrays; not rewriting incompatible settings.' };
+    }
+    for (const hook of commandHooks) {
+      if (!isJsonObject(hook)) return { blocked: 'Claude Code SessionEnd command hooks must be objects; not rewriting incompatible settings.' };
+      if (hook.command !== undefined && typeof hook.command !== 'string') {
+        return { blocked: 'Claude Code SessionEnd command hook command values must be strings; not rewriting incompatible settings.' };
+      }
+    }
+    if (commandHooks.some((hook) => isJsonObject(hook) && hook.command === command)) {
+      return { settings, changed: false };
+    }
+  }
+  const nextHooks: JsonObject = { ...hooks, SessionEnd: [...sessionEnd, { hooks: [{ type: 'command', command }] }] };
+  return { settings: { ...settings, hooks: nextHooks }, changed: true };
+}
+
+function mergeCodexConfig(content: string, stanza: string): { content?: string; changed?: boolean; blocked?: string } {
+  const firstTable = firstTableStart(content);
+  const preamble = firstTable === -1 ? content : content.slice(0, firstTable);
+  const notifyLine = findTopLevelNotifyLine(preamble);
+  if (notifyLine) {
+    if (notifyLine.trim() === stanza) return { content, changed: false };
+    return { blocked: 'Codex config already has a different top-level notify setting; not rewriting it.' };
+  }
+  if (firstTable === -1) {
+    const prefix = content.length === 0 ? '' : content.endsWith('\n') ? content : `${content}\n`;
+    return { content: `${prefix}${stanza}\n`, changed: true };
+  }
+  const before = content.slice(0, firstTable);
+  const after = content.slice(firstTable);
+  const separator = before.length === 0 || before.endsWith('\n') ? '' : '\n';
+  return { content: `${before}${separator}${stanza}\n${after}`, changed: true };
+}
+
+function firstTableStart(content: string): number {
+  let offset = 0;
+  for (const line of content.split(/(?<=\n)/)) {
+    const body = line.replace(/\r?\n$/, '');
+    if (/^\s*\[\[?[A-Za-z0-9_."'-][^\]]*\]\]?\s*(?:#.*)?$/.test(body)) return offset;
+    offset += line.length;
+  }
+  return -1;
+}
+
+function findTopLevelNotifyLine(preamble: string): string | null {
+  for (const line of preamble.split(/\r?\n/)) {
+    if (/^\s*(?:#|$)/.test(line)) continue;
+    if (/^\s*notify\s*=/.test(line)) return line.trim();
+  }
+  return null;
+}
+
+function finalSymlinkMessage(path: string, label: string): string | null {
+  try {
+    if (lstatSync(path).isSymbolicLink()) return `${label} must not be a symlink: ${path}`;
+  } catch (error) {
+    if ((error as { code?: string })?.code === 'ENOENT') return null;
+    return `Could not inspect ${label}: ${errorMessage(error)}`;
+  }
+  return null;
+}
+
+function writeUtf8NoFollow(path: string, content: string, label: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const symlinkMessage = finalSymlinkMessage(path, label);
+  if (symlinkMessage) throw new Error(symlinkMessage);
+  const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW ?? 0);
+  let handle: number | null = null;
+  try {
+    handle = openSync(path, flags, 0o666);
+    writeSync(handle, content, undefined, 'utf8');
+  } catch (error) {
+    if ((error as { code?: string })?.code === 'ELOOP') throw new Error(`${label} must not be a symlink: ${path}`);
+    throw error;
+  } finally {
+    if (handle !== null) closeSync(handle);
+  }
+}
+
+function shippedHookPath(filename: 'ambient-hook.mjs' | 'codex-notify.mjs'): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..', 'examples', 'hooks', filename);
+}
+
+function defaultCodexConfigPath(env: NodeJS.ProcessEnv): string {
+  const root = env.CODEX_HOME || (env.HOME ? join(env.HOME, '.codex') : join(homedir(), '.codex'));
+  return join(root, 'config.toml');
+}
+
+function resolvePath(path: string, cwd: string): string {
+  return isAbsolute(path) ? resolve(path) : resolve(cwd, path);
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -402,7 +402,7 @@ function skipBasicString(line: string, start: number): number {
 function findTopLevelNotifyLine(lines: string[]): string | null {
   for (const line of lines) {
     if (/^\s*(?:#|$)/.test(line)) continue;
-    if (/^\s*(?:notify|"notify"|'notify')\s*=/.test(line)) return line.trim();
+    if (/^\s*(?:notify|"notify"|'notify')\s*(?:=|\.)/.test(line)) return line.trim();
   }
   return null;
 }

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -33,6 +33,7 @@ export interface CaptureSetupResult {
 
 interface CaptureSetupPlan extends CaptureSetupResult {
   content?: string;
+  extraWrites?: PlannedWrite[];
 }
 
 interface WriteSnapshot {
@@ -40,6 +41,12 @@ interface WriteSnapshot {
   label: string;
   existed: boolean;
   content?: string;
+}
+
+interface PlannedWrite {
+  path: string;
+  content: string;
+  label: string;
 }
 
 type JsonObject = Record<string, unknown>;
@@ -64,14 +71,14 @@ export function runCaptureSetup(target: CaptureSetupTarget, options: CaptureSetu
     });
   }
   if (options.write) {
-    const changedPlans = plans.filter((plan) => plan.changed && plan.content !== undefined);
-    const snapshots = changedPlans.map((plan) => snapshotConfig(plan.configPath, `${plan.runtime} config`));
+    const writes = plans.flatMap(plannedWrites);
+    const snapshots = writes.map((write) => snapshotConfig(write.path, write.label));
     const written: WriteSnapshot[] = [];
     try {
-      for (let i = 0; i < changedPlans.length; i += 1) {
-        const plan = changedPlans[i];
+      for (let i = 0; i < writes.length; i += 1) {
+        const write = writes[i];
         const snapshot = snapshots[i];
-        writeUtf8NoFollow(plan.configPath, plan.content ?? '', snapshot.label);
+        writeUtf8NoFollow(write.path, write.content, snapshot.label);
         written.push(snapshot);
       }
     } catch (error) {
@@ -103,8 +110,17 @@ export function renderCaptureSetupText(results: CaptureSetupResult[], mode: 'dry
 }
 
 function publicResult(plan: CaptureSetupPlan): CaptureSetupResult {
-  const { content: _content, ...result } = plan;
+  const { content: _content, extraWrites: _extraWrites, ...result } = plan;
   return result;
+}
+
+function plannedWrites(plan: CaptureSetupPlan): PlannedWrite[] {
+  const writes: PlannedWrite[] = [];
+  writes.push(...(plan.extraWrites ?? []));
+  if (plan.changed && plan.content !== undefined) {
+    writes.push({ path: plan.configPath, content: plan.content, label: `${plan.runtime} config` });
+  }
+  return writes;
 }
 
 function expandTarget(target: CaptureSetupTarget): CaptureSetupRuntime[] {
@@ -117,12 +133,15 @@ function planRuntime(runtime: CaptureSetupRuntime, options: CaptureSetupOptions)
 
 function planClaude(options: CaptureSetupOptions): CaptureSetupPlan {
   const cwd = resolve(options.cwd ?? process.cwd());
-  const configPath = resolvePath(options.claudeSettingsPath ?? join(options.repoRoot ?? cwd, '.claude', 'settings.local.json'), cwd);
+  const repoRoot = resolvePath(options.repoRoot ?? cwd, cwd);
+  const configPath = resolvePath(options.claudeSettingsPath ?? join(repoRoot, '.claude', 'settings.local.json'), cwd);
   const hookPath = resolvePath(options.claudeHookPath ?? shippedHookPath('ambient-hook.mjs'), cwd);
   const command = `${shellQuote(options.nodePath ?? process.execPath)} ${shellQuote(hookPath)}`;
   const base = basePlan('claude-code', configPath, hookPath, { command });
   const preflight = preflightConfig(configPath, hookPath, 'Claude Code');
   if (preflight) return { ...base, ...preflight };
+  const gitignorePlan = planClaudeGitignore(configPath, repoRoot);
+  if (gitignorePlan.blocked) return blocked(base, gitignorePlan.blocked);
   let settings: JsonObject = {};
   if (existsSync(configPath)) {
     try {
@@ -135,13 +154,27 @@ function planClaude(options: CaptureSetupOptions): CaptureSetupPlan {
   }
   const planned = mergeClaudeSettings(settings, command);
   if (planned.blocked) return blocked(base, planned.blocked);
-  if (!planned.changed) return { ...base, status: 'installed', changed: false, message: 'Claude Code SessionEnd ambient capture hook is already installed.' };
+  if (!planned.changed) {
+    const hasGitignoreWrite = gitignorePlan.extraWrites.length > 0;
+    return {
+      ...base,
+      status: hasGitignoreWrite ? 'would-install' : 'installed',
+      changed: hasGitignoreWrite,
+      extraWrites: gitignorePlan.extraWrites,
+      message: hasGitignoreWrite
+        ? 'Would add .claude/settings.local.json to .gitignore; Claude Code SessionEnd ambient capture hook is already installed.'
+        : 'Claude Code SessionEnd ambient capture hook is already installed.',
+    };
+  }
   return {
     ...base,
     status: 'would-install',
     changed: true,
     content: `${JSON.stringify(planned.settings, null, 2)}\n`,
-    message: 'Would install Claude Code SessionEnd ambient capture hook.',
+    extraWrites: gitignorePlan.extraWrites,
+    message: gitignorePlan.extraWrites.length > 0
+      ? 'Would install Claude Code SessionEnd ambient capture hook and add .claude/settings.local.json to .gitignore.'
+      : 'Would install Claude Code SessionEnd ambient capture hook.',
   };
 }
 
@@ -339,9 +372,51 @@ function skipBasicString(line: string, start: number): number {
 function findTopLevelNotifyLine(lines: string[]): string | null {
   for (const line of lines) {
     if (/^\s*(?:#|$)/.test(line)) continue;
-    if (/^\s*notify\s*=/.test(line)) return line.trim();
+    if (/^\s*(?:notify|"notify"|'notify')\s*=/.test(line)) return line.trim();
   }
   return null;
+}
+
+function planClaudeGitignore(
+  configPath: string,
+  repoRoot: string,
+): { extraWrites: PlannedWrite[]; blocked?: string } {
+  if (configPath !== join(repoRoot, '.claude', 'settings.local.json')) return { extraWrites: [] };
+  const gitignorePath = join(repoRoot, '.gitignore');
+  const symlinkMessage = finalSymlinkMessage(gitignorePath, 'Git ignore file');
+  if (symlinkMessage) return { extraWrites: [], blocked: symlinkMessage };
+  const parentSymlinkMessage = parentPathMessage(gitignorePath, 'Git ignore file');
+  if (parentSymlinkMessage) return { extraWrites: [], blocked: parentSymlinkMessage };
+  let content = '';
+  if (existsSync(gitignorePath)) {
+    try {
+      content = readFileSync(gitignorePath, 'utf8');
+    } catch (error) {
+      return { extraWrites: [], blocked: `Could not read Git ignore file: ${errorMessage(error)}` };
+    }
+  }
+  if (gitignoreCoversClaudeSettings(content)) return { extraWrites: [] };
+  const prefix = content.length === 0 ? '' : content.endsWith('\n') ? content : `${content}\n`;
+  return {
+    extraWrites: [{
+      path: gitignorePath,
+      content: `${prefix}.claude/settings.local.json\n`,
+      label: 'Git ignore file',
+    }],
+  };
+}
+
+function gitignoreCoversClaudeSettings(content: string): boolean {
+  return content.split(/\r?\n/).some((line) => {
+    const pattern = line.trim();
+    if (pattern.length === 0 || pattern.startsWith('#') || pattern.startsWith('!')) return false;
+    const normalized = pattern.replace(/^\//, '');
+    return normalized === '.claude'
+      || normalized === '.claude/'
+      || normalized === '.claude/*'
+      || normalized === '.claude/**'
+      || normalized === '.claude/settings.local.json';
+  });
 }
 
 function finalSymlinkMessage(path: string, label: string): string | null {

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -16,6 +16,7 @@ export interface CaptureSetupOptions {
   claudeSettingsPath?: string;
   codexConfigPath?: string;
   nodePath?: string;
+  platform?: NodeJS.Platform;
   claudeHookPath?: string;
   codexHookPath?: string;
 }
@@ -137,7 +138,7 @@ function planClaude(options: CaptureSetupOptions): CaptureSetupPlan {
   const repoRoot = resolvePath(options.repoRoot ?? cwd, cwd);
   const configPath = resolvePath(options.claudeSettingsPath ?? join(repoRoot, '.claude', 'settings.local.json'), cwd);
   const hookPath = resolvePath(options.claudeHookPath ?? shippedHookPath('ambient-hook.mjs'), cwd);
-  const command = `${shellQuote(options.nodePath ?? process.execPath)} ${shellQuote(hookPath)}`;
+  const command = [options.nodePath ?? process.execPath, hookPath].map((path) => shellQuote(path, options.platform ?? process.platform)).join(' ');
   const base = basePlan('claude-code', configPath, hookPath, { command });
   const preflight = preflightConfig(configPath, hookPath, 'Claude Code');
   if (preflight) return { ...base, ...preflight };
@@ -276,13 +277,11 @@ function mergeClaudeSettings(settings: JsonObject, command: string): { settings?
 
 function mergeCodexConfig(content: string, stanza: string): { content?: string; changed?: boolean; blocked?: string } {
   const preamble = tomlPreamble(content);
+  if (preamble.hasNotifyTable) return { blocked: 'Codex config already has a top-level notify table; not rewriting it.' };
   const notifyLine = findTopLevelNotifyLine(preamble.lines);
   if (notifyLine) {
     if (notifyLine.trim() === stanza) return { content, changed: false };
     return { blocked: 'Codex config already has a different top-level notify setting; not rewriting it.' };
-  }
-  if (preamble.firstTableLine && isTomlNotifyTableHeader(preamble.firstTableLine)) {
-    return { blocked: 'Codex config already has a top-level notify table; not rewriting it.' };
   }
   if (preamble.firstTable === -1) {
     const prefix = content.length === 0 ? '' : content.endsWith('\n') ? content : `${content}\n`;
@@ -294,11 +293,7 @@ function mergeCodexConfig(content: string, stanza: string): { content?: string; 
   return { content: `${before}${separator}${stanza}\n${after}`, changed: true };
 }
 
-interface TomlPreamble {
-  firstTable: number;
-  firstTableLine?: string;
-  lines: string[];
-}
+interface TomlPreamble { firstTable: number; hasNotifyTable: boolean; lines: string[] }
 
 type TomlStringState = 'none' | 'multiline-basic' | 'multiline-literal';
 
@@ -308,18 +303,22 @@ interface TomlLineState {
 }
 
 function tomlPreamble(content: string): TomlPreamble {
-  let offset = 0;
-  let stringState: TomlStringState = 'none';
-  let arrayDepth = 0;
+  let offset = 0, arrayDepth = 0, firstTable = -1;
+  let stringState: TomlStringState = 'none', hasNotifyTable = false;
   const lines: string[] = [];
   for (const line of content.split(/(?<=\n)/)) {
     const body = line.replace(/\r?\n$/, '');
-    if (stringState === 'none' && arrayDepth === 0 && isTomlTableHeader(body)) return { firstTable: offset, firstTableLine: body, lines };
-    if (stringState === 'none' && arrayDepth === 0) lines.push(body);
+    if (stringState === 'none' && arrayDepth === 0 && isTomlTableHeader(body)) {
+      if (firstTable === -1) firstTable = offset;
+      hasNotifyTable ||= isTomlNotifyTableHeader(body);
+      offset += line.length;
+      continue;
+    }
+    if (firstTable === -1 && stringState === 'none' && arrayDepth === 0) lines.push(body);
     ({ stringState, arrayDepth } = scanTomlLineState(body, stringState, arrayDepth));
     offset += line.length;
   }
-  return { firstTable: -1, lines };
+  return { firstTable, hasNotifyTable, lines };
 }
 
 function isTomlTableHeader(line: string): boolean {
@@ -578,7 +577,8 @@ function isJsonObject(value: unknown): value is JsonObject {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function shellQuote(value: string): string {
+function shellQuote(value: string, platform: NodeJS.Platform): string {
+  if (platform === 'win32') return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/g, '$1$1')}"`;
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -407,16 +407,22 @@ function planClaudeGitignore(
 }
 
 function gitignoreCoversClaudeSettings(content: string): boolean {
-  return content.split(/\r?\n/).some((line) => {
-    const pattern = line.trim();
-    if (pattern.length === 0 || pattern.startsWith('#') || pattern.startsWith('!')) return false;
+  let ignored = false;
+  for (const line of content.split(/\r?\n/)) {
+    let pattern = line.trim();
+    if (pattern.length === 0 || pattern.startsWith('#')) continue;
+    const negated = pattern.startsWith('!');
+    if (negated) pattern = pattern.slice(1).trim();
+    if (pattern.length === 0) continue;
     const normalized = pattern.replace(/^\//, '');
-    return normalized === '.claude'
+    const matches = normalized === '.claude'
       || normalized === '.claude/'
       || normalized === '.claude/*'
       || normalized === '.claude/**'
       || normalized === '.claude/settings.local.json';
-  });
+    if (matches) ignored = !negated;
+  }
+  return ignored;
 }
 
 function finalSymlinkMessage(path: string, label: string): string | null {

--- a/src/capture-setup.ts
+++ b/src/capture-setup.ts
@@ -441,7 +441,10 @@ function gitignorePatternMatchesClaudeSettings(pattern: string): boolean {
   const normalized = pattern.replace(/^\//, '');
   if (normalized === '.claude') return true;
   if (normalized.endsWith('/')) return CLAUDE_SETTINGS_GITIGNORE_ENTRY.startsWith(normalized);
-  return gitignorePatternRegex(normalized).test(CLAUDE_SETTINGS_GITIGNORE_ENTRY);
+  const target = normalized.includes('/')
+    ? CLAUDE_SETTINGS_GITIGNORE_ENTRY
+    : CLAUDE_SETTINGS_GITIGNORE_ENTRY.split('/').at(-1) ?? CLAUDE_SETTINGS_GITIGNORE_ENTRY;
+  return gitignorePatternRegex(normalized).test(target);
 }
 
 function gitignorePatternRegex(pattern: string): RegExp {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { measureEvolutionAnalysisEfficiency, renderEvolutionEfficiencyReport } f
 import { analyzeFeedback, recordFeedback } from './feedback.js';
 import { askInteractiveFirstRun, formatFirstRunResult, runFirstRun } from './first-run.js';
 import { runBenchSuite, runHandoffLab } from './bench.js';
+import { CAPTURE_SETUP_TARGETS, isCaptureSetupTarget, renderCaptureSetupText, runCaptureSetup, type CaptureSetupTarget } from './capture-setup.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
 import { runMcpCommand } from './mcp-server.js';
 import { scanPublicFilesForSecrets } from './redaction.js';
@@ -58,6 +59,7 @@ Handoff (compile the work record into a resume packet):
 
 Record (extract an ambient work record from a finished session transcript):
   osc capture --from <claude-code|codex|jsonl-generic> --transcript <path> [--out <path>] [--detect]
+  osc capture setup <claude-code|codex|all> [--write] [--json]
 
 Review and gate (judgment over recorded attempts):
   osc review <loop-dir> [--compact] [--format <terminal|markdown|json>]        front door
@@ -106,6 +108,7 @@ Stable core protocol:
   osc evidence new <slug>
   osc evidence collect <slug> [--ci] [--dry-run] [--verbose]
   osc capture --from <claude-code|codex|jsonl-generic> --transcript <path> [--out <path>] [--detect] [--session-id <id>] [--repo <root>] [--hook-safe]
+  osc capture setup <claude-code|codex|all> [--write] [--dry-run] [--json]
   osc close <plan-slug> [--message <text>]
   osc trace <plan-slug> [--json] [--include-unverified]
   osc verify [--evidence-chain [--plan <slug>] [--json] [--strict] [--online-github]]
@@ -960,19 +963,82 @@ function benchCommand(args: string[]): void {
 function captureHelp(): string {
   return [
     `Usage: osc capture --from <${CAPTURE_FORMATS.join('|')}> --transcript <path> [--out <path>] [--detect] [--session-id <id>] [--repo <root>] [--json] [--hook-safe]`,
+    `       osc capture setup <${CAPTURE_SETUP_TARGETS.join('|')}> [--write] [--dry-run] [--json] [--claude-settings <path>] [--codex-config <path>]`,
     '',
     'Extract an osc.ambient-work-record.v1 record from a finished agent-session transcript:',
     'assistant turns, token usage, tool-call census, files touched, session span, and a',
     'redacted final-message digest. Read-only on the transcript; writes one record file.',
+    '',
+    'Setup ambient capture hooks without recording private config values:',
+    '  setup claude-code   plan/install .claude/settings.local.json SessionEnd hook',
+    '  setup codex         plan/install ${CODEX_HOME:-$HOME/.codex}/config.toml notify hook',
+    '  setup all           plan/install both runtimes; --write is all-or-nothing',
     '',
     '  --from <format>     transcript format: claude-code | codex | jsonl-generic',
     '  --transcript <path> path to the session JSONL to read',
     '  --detect            sniff the format from the first parseable lines (exit 2 on ambiguity)',
     '  --out <path>        record output path (default: .osc/state/ambient/<session-id>.json in an .osc repo)',
     '  --hook-safe         never exit non-zero on bad/missing input (for SessionEnd-style hook wrappers)',
+    '  --write             install setup changes; default setup mode is dry-run',
     '',
     'capture observes facts; it does not approve work, certify correctness, or spawn a runtime.',
   ].join('\n');
+}
+
+function validateCaptureSetupOptions(args: string[]): string | null {
+  const valueFlags = new Set(['--claude-settings', '--codex-config']);
+  const booleanFlags = new Set(['--write', '--dry-run', '--json']);
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) return `Unexpected argument for capture setup: ${arg}`;
+    const [flag, inlineValue] = arg.split('=', 2);
+    if (valueFlags.has(flag)) {
+      if (arg.includes('=')) {
+        if (!inlineValue) return `Missing value for ${flag}`;
+      } else {
+        const next = args[i + 1];
+        if (!next || next.startsWith('--')) return `Missing value for ${flag}`;
+        i += 1;
+      }
+      continue;
+    }
+    if (booleanFlags.has(flag) && !arg.includes('=')) continue;
+    return `Unknown option for capture setup: ${flag}`;
+  }
+  if (has(args, '--write') && has(args, '--dry-run')) return 'Use either --write or --dry-run, not both.';
+  return null;
+}
+
+function captureSetupCommand(args: string[]): void {
+  if (isHelpArg(args[0])) { console.log(captureHelp()); return; }
+  const targetRaw = args[0] ?? die(captureHelp(), 2);
+  if (!isCaptureSetupTarget(targetRaw)) {
+    die(`Invalid capture setup target: ${targetRaw}. Expected one of: ${CAPTURE_SETUP_TARGETS.join(', ')}`, 2);
+  }
+  const optionArgs = args.slice(1);
+  const optionError = validateCaptureSetupOptions(optionArgs);
+  if (optionError) die(optionError, 2);
+  const write = has(optionArgs, '--write');
+  const repoRoot = findScaffoldRoot(process.cwd()) ?? process.cwd();
+  const options = {
+    write,
+    repoRoot,
+    claudeSettingsPath: value(optionArgs, '--claude-settings'),
+    codexConfigPath: value(optionArgs, '--codex-config'),
+  };
+  try {
+    const results = runCaptureSetup(targetRaw as CaptureSetupTarget, options);
+    const mode = write ? 'write' : 'dry-run';
+    const blocked = results.some((result) => result.status === 'blocked');
+    if (has(optionArgs, '--json')) {
+      console.log(JSON.stringify({ mode, results }, null, 2));
+    } else {
+      console.log(renderCaptureSetupText(results, mode));
+    }
+    if (blocked) process.exitCode = 2;
+  } catch (error) {
+    die(error instanceof Error ? error.message : String(error), 2);
+  }
 }
 
 function validateCaptureOptions(args: string[]): string | null {
@@ -1006,6 +1072,7 @@ function validateCaptureOptions(args: string[]): string | null {
 // All errors are caught here; nothing bubbles to main()'s catch (which would exit 1).
 function captureCommand(args: string[]): void {
   if (isHelpArg(args[0])) { console.log(captureHelp()); return; }
+  if (args[0] === 'setup') { captureSetupCommand(args.slice(1)); return; }
   const hookSafe = has(args, '--hook-safe');
   const fail = (message: string): void => {
     if (hookSafe) return; // hook wrapper path: record nothing, never break the session

--- a/tests/capture-setup-rollback.test.ts
+++ b/tests/capture-setup-rollback.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const claudeHook = resolve(repoRoot, 'examples/hooks/ambient-hook.mjs');
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'osc-capture-setup-rollback-'));
+}
+
+afterEach(() => {
+  vi.doUnmock('node:fs');
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe('capture setup rollback', () => {
+  it('restores the current config when a write fails after truncation', async () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    const original = '{"hooks":{}}\n';
+    mkdirSync(dirname(settings), { recursive: true });
+    writeFileSync(settings, original);
+
+    let writeCalls = 0;
+    vi.resetModules();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const fs = await importOriginal<typeof import('node:fs')>();
+      return {
+        ...fs,
+        writeSync: vi.fn((...args: Parameters<typeof fs.writeSync>) => {
+          writeCalls += 1;
+          if (writeCalls === 1) {
+            const error = new Error('simulated write failure after truncation') as NodeJS.ErrnoException;
+            error.code = 'ENOSPC';
+            throw error;
+          }
+          return fs.writeSync(...args);
+        }),
+      };
+    });
+
+    const { runCaptureSetup } = await import('../src/capture-setup.js');
+
+    expect(() => runCaptureSetup('claude-code', {
+      write: true,
+      claudeSettingsPath: settings,
+      claudeHookPath: claudeHook,
+    })).toThrow('simulated write failure after truncation');
+
+    expect(writeCalls).toBe(2);
+    expect(readFileSync(settings, 'utf8')).toBe(original);
+  });
+});

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -54,6 +54,22 @@ describe('capture setup planning', () => {
     expect(parsed.hooks.SessionEnd[0].hooks[0].command).toContain(claudeHook);
   });
 
+  it('writes default Claude Code settings with a gitignore guard', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    const gitignore = join(dir, '.gitignore');
+
+    const [first] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+    const [second] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+
+    expect(first.status).toBe('installed');
+    expect(first.changed).toBe(true);
+    expect(second.status).toBe('installed');
+    expect(second.changed).toBe(false);
+    expect(read(settings)).toContain('ambient-hook.mjs');
+    expect(read(gitignore)).toBe('.claude/settings.local.json\n');
+  });
+
   it('blocks malformed Claude Code settings and preserves the file', () => {
     const dir = tempDir();
     const settings = join(dir, '.claude/settings.local.json');
@@ -229,6 +245,25 @@ describe('capture setup planning', () => {
     expect(multi.status).toBe('blocked');
     expect(read(singleConfig)).toBe('notify = ["custom"]\n[profiles.foo]\nmodel = "x"\n');
     expect(read(multiConfig)).toBe('notify = [\n  "custom"\n]\n[profiles.foo]\nmodel = "x"\n');
+  });
+
+  it('blocks quoted top-level Codex notify values', () => {
+    const basicDir = tempDir();
+    const basicConfig = join(basicDir, 'config.toml');
+    const basic = '"notify" = ["custom"]\n[profiles.foo]\nmodel = "x"\n';
+    const literalDir = tempDir();
+    const literalConfig = join(literalDir, 'config.toml');
+    const literal = "'notify' = [\"custom\"]\n[profiles.foo]\nmodel = \"x\"\n";
+    writeFileSync(basicConfig, basic);
+    writeFileSync(literalConfig, literal);
+
+    const [basicResult] = runCaptureSetup('codex', { write: true, codexConfigPath: basicConfig, codexHookPath: codexHook });
+    const [literalResult] = runCaptureSetup('codex', { write: true, codexConfigPath: literalConfig, codexHookPath: codexHook });
+
+    expect(basicResult.status).toBe('blocked');
+    expect(literalResult.status).toBe('blocked');
+    expect(read(basicConfig)).toBe(basic);
+    expect(read(literalConfig)).toBe(literal);
   });
 
   it('rejects a Codex config symlink before reading or writing it', () => {

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -112,6 +112,20 @@ describe('capture setup planning', () => {
     expect(read(gitignore)).toBe('.claude/*\n!*.json\n.claude/settings.local.json\n');
   });
 
+  it('does not trust unrelated root-anchored gitignore basename patterns for Claude settings', () => {
+    const dir = tempDir();
+    const gitignore = join(dir, '.gitignore');
+    writeFileSync(gitignore, '/settings.local.json\n');
+
+    const [first] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+    const [second] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+
+    expect(first.status).toBe('installed');
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(read(gitignore)).toBe('/settings.local.json\n.claude/settings.local.json\n');
+  });
+
   it('blocks malformed Claude Code settings and preserves the file', () => {
     const dir = tempDir();
     const settings = join(dir, '.claude/settings.local.json');

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { renderCaptureSetupText, runCaptureSetup } from '../src/capture-setup.js';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const claudeHook = resolve(repoRoot, 'examples/hooks/ambient-hook.mjs');
+const codexHook = resolve(repoRoot, 'examples/hooks/codex-notify.mjs');
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'osc-capture-setup-'));
+}
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+describe('capture setup planning', () => {
+  it('plans a Claude Code settings install without writing by default', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    const [result] = runCaptureSetup('claude-code', { claudeSettingsPath: settings, claudeHookPath: claudeHook });
+
+    expect(result.status).toBe('would-install');
+    expect(result.changed).toBe(true);
+    expect(result.command).toContain(claudeHook);
+    expect(existsSync(settings)).toBe(false);
+  });
+
+  it('writes Claude Code settings idempotently and preserves unrelated settings/hooks', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    mkdirSync(join(dir, '.claude'), { recursive: true });
+    writeFileSync(settings, JSON.stringify({
+      theme: 'dark',
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: 'command', command: 'echo keep' }] }],
+      },
+    }, null, 2));
+
+    const [first] = runCaptureSetup('claude-code', { write: true, claudeSettingsPath: settings, claudeHookPath: claudeHook });
+    const afterFirst = read(settings);
+    const [second] = runCaptureSetup('claude-code', { write: true, claudeSettingsPath: settings, claudeHookPath: claudeHook });
+
+    expect(first.status).toBe('installed');
+    expect(first.changed).toBe(true);
+    expect(second.status).toBe('installed');
+    expect(second.changed).toBe(false);
+    expect(read(settings)).toBe(afterFirst);
+    const parsed = JSON.parse(afterFirst);
+    expect(parsed.theme).toBe('dark');
+    expect(parsed.hooks.PreToolUse[0].hooks[0].command).toBe('echo keep');
+    expect(parsed.hooks.SessionEnd[0].hooks[0].command).toContain(claudeHook);
+  });
+
+  it('blocks malformed Claude Code settings and preserves the file', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    mkdirSync(join(dir, '.claude'), { recursive: true });
+    writeFileSync(settings, '{not json');
+
+    const [result] = runCaptureSetup('claude-code', { write: true, claudeSettingsPath: settings, claudeHookPath: claudeHook });
+
+    expect(result.status).toBe('blocked');
+    expect(result.message).toContain('Could not parse');
+    expect(read(settings)).toBe('{not json');
+  });
+
+  it('blocks incompatible Claude Code SessionEnd hook shapes and preserves the file', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    mkdirSync(join(dir, '.claude'), { recursive: true });
+    const original = JSON.stringify({ hooks: { SessionEnd: [{ hooks: ['bad-hook'] }] } }, null, 2);
+    writeFileSync(settings, original);
+
+    const [result] = runCaptureSetup('claude-code', { write: true, claudeSettingsPath: settings, claudeHookPath: claudeHook });
+
+    expect(result.status).toBe('blocked');
+    expect(result.message).toContain('command hooks must be objects');
+    expect(read(settings)).toBe(original);
+  });
+
+  it('quotes Claude Code command paths with spaces and remains idempotent', () => {
+    const dir = tempDir();
+    const hookDir = join(dir, 'hook path');
+    const hook = join(hookDir, 'ambient hook.mjs');
+    const settings = join(dir, '.claude/settings.local.json');
+    const nodePath = join(dir, 'node path', 'node');
+    mkdirSync(hookDir, { recursive: true });
+    writeFileSync(hook, '');
+
+    const [first] = runCaptureSetup('claude-code', {
+      write: true,
+      claudeSettingsPath: settings,
+      claudeHookPath: hook,
+      nodePath,
+    });
+    const [second] = runCaptureSetup('claude-code', {
+      write: true,
+      claudeSettingsPath: settings,
+      claudeHookPath: hook,
+      nodePath,
+    });
+
+    expect(first.command).toBe(`'${nodePath}' '${hook}'`);
+    expect(second.changed).toBe(false);
+    expect(read(settings)).toContain(`'${nodePath}' '${hook}'`);
+  });
+
+  it('rejects a Claude Code settings symlink before reading or writing it', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    const secret = join(dir, 'secret.json');
+    mkdirSync(join(dir, '.claude'), { recursive: true });
+    writeFileSync(secret, '{"private":"SENTINEL_SECRET"}');
+    symlinkSync(secret, settings);
+
+    const dryRun = runCaptureSetup('claude-code', { claudeSettingsPath: settings, claudeHookPath: claudeHook });
+    const text = renderCaptureSetupText(dryRun, 'dry-run');
+    const write = runCaptureSetup('claude-code', { write: true, claudeSettingsPath: settings, claudeHookPath: claudeHook });
+
+    expect(dryRun[0].status).toBe('blocked');
+    expect(write[0].status).toBe('blocked');
+    expect(text).not.toContain('SENTINEL_SECRET');
+    expect(JSON.stringify(dryRun)).not.toContain('SENTINEL_SECRET');
+    expect(read(secret)).toBe('{"private":"SENTINEL_SECRET"}');
+  });
+
+  it('plans a Codex notify install without writing by default', () => {
+    const dir = tempDir();
+    const config = join(dir, 'config.toml');
+    const [result] = runCaptureSetup('codex', { codexConfigPath: config, codexHookPath: codexHook });
+
+    expect(result.status).toBe('would-install');
+    expect(result.stanza).toContain(codexHook);
+    expect(existsSync(config)).toBe(false);
+  });
+
+  it('writes Codex notify idempotently while preserving comments and tables', () => {
+    const dir = tempDir();
+    const config = join(dir, 'config.toml');
+    writeFileSync(config, '# keep comment\nmodel = "gpt-test"\n[profiles.foo]\nmodel = "other"\n');
+
+    const [first] = runCaptureSetup('codex', { write: true, codexConfigPath: config, codexHookPath: codexHook });
+    const afterFirst = read(config);
+    const [second] = runCaptureSetup('codex', { write: true, codexConfigPath: config, codexHookPath: codexHook });
+
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(read(config)).toBe(afterFirst);
+    expect(afterFirst).toMatch(/^# keep comment\nmodel = "gpt-test"\nnotify = \[/);
+    expect(afterFirst.indexOf('notify = [')).toBeLessThan(afterFirst.indexOf('[profiles.foo]'));
+    expect(afterFirst).toContain('[profiles.foo]\nmodel = "other"');
+  });
+
+  it('does not treat table-local Codex notify as a top-level conflict', () => {
+    const dir = tempDir();
+    const config = join(dir, 'config.toml');
+    writeFileSync(config, '[profiles.foo]\nnotify = ["custom"]\n');
+
+    const [result] = runCaptureSetup('codex', { write: true, codexConfigPath: config, codexHookPath: codexHook });
+
+    expect(result.status).toBe('installed');
+    expect(result.changed).toBe(true);
+    expect(read(config).startsWith('notify = [')).toBe(true);
+    expect(read(config)).toContain('[profiles.foo]\nnotify = ["custom"]');
+  });
+
+  it('blocks different single-line and multiline top-level Codex notify values', () => {
+    const singleDir = tempDir();
+    const singleConfig = join(singleDir, 'config.toml');
+    writeFileSync(singleConfig, 'notify = ["custom"]\n[profiles.foo]\nmodel = "x"\n');
+    const multiDir = tempDir();
+    const multiConfig = join(multiDir, 'config.toml');
+    writeFileSync(multiConfig, 'notify = [\n  "custom"\n]\n[profiles.foo]\nmodel = "x"\n');
+
+    const [single] = runCaptureSetup('codex', { write: true, codexConfigPath: singleConfig, codexHookPath: codexHook });
+    const [multi] = runCaptureSetup('codex', { write: true, codexConfigPath: multiConfig, codexHookPath: codexHook });
+
+    expect(single.status).toBe('blocked');
+    expect(multi.status).toBe('blocked');
+    expect(read(singleConfig)).toBe('notify = ["custom"]\n[profiles.foo]\nmodel = "x"\n');
+    expect(read(multiConfig)).toBe('notify = [\n  "custom"\n]\n[profiles.foo]\nmodel = "x"\n');
+  });
+
+  it('rejects a Codex config symlink before reading or writing it', () => {
+    const dir = tempDir();
+    const config = join(dir, 'config.toml');
+    const secret = join(dir, 'secret.toml');
+    writeFileSync(secret, 'token = "SENTINEL_SECRET"\n');
+    symlinkSync(secret, config);
+
+    const dryRun = runCaptureSetup('codex', { codexConfigPath: config, codexHookPath: codexHook });
+    const text = renderCaptureSetupText(dryRun, 'dry-run');
+    const write = runCaptureSetup('codex', { write: true, codexConfigPath: config, codexHookPath: codexHook });
+
+    expect(dryRun[0].status).toBe('blocked');
+    expect(write[0].status).toBe('blocked');
+    expect(text).not.toContain('SENTINEL_SECRET');
+    expect(JSON.stringify(dryRun)).not.toContain('SENTINEL_SECRET');
+    expect(read(secret)).toBe('token = "SENTINEL_SECRET"\n');
+  });
+
+  it('does not leak unrelated existing config values in dry-run text or JSON', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    const config = join(dir, 'config.toml');
+    mkdirSync(join(dir, '.claude'), { recursive: true });
+    writeFileSync(settings, JSON.stringify({ privateValue: 'SENTINEL_SECRET' }));
+    writeFileSync(config, 'model = "SENTINEL_SECRET"\n');
+
+    const claude = runCaptureSetup('claude-code', { claudeSettingsPath: settings, claudeHookPath: claudeHook });
+    const codex = runCaptureSetup('codex', { codexConfigPath: config, codexHookPath: codexHook });
+
+    expect(renderCaptureSetupText(claude, 'dry-run')).not.toContain('SENTINEL_SECRET');
+    expect(renderCaptureSetupText(codex, 'dry-run')).not.toContain('SENTINEL_SECRET');
+    expect(JSON.stringify(claude)).not.toContain('SENTINEL_SECRET');
+    expect(JSON.stringify(codex)).not.toContain('SENTINEL_SECRET');
+  });
+
+  it('blocks setup all writes without partial changes when any target is blocked', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    const config = join(dir, 'config.toml');
+    writeFileSync(config, 'notify = ["custom"]\n');
+
+    const results = runCaptureSetup('all', {
+      write: true,
+      claudeSettingsPath: settings,
+      codexConfigPath: config,
+      claudeHookPath: claudeHook,
+      codexHookPath: codexHook,
+    });
+
+    expect(results.some((result) => result.status === 'blocked')).toBe(true);
+    expect(existsSync(settings)).toBe(false);
+    expect(read(config)).toBe('notify = ["custom"]\n');
+  });
+
+  it('blocks missing hook targets with an actionable message', () => {
+    const dir = tempDir();
+    const config = join(dir, 'config.toml');
+    const [result] = runCaptureSetup('codex', { codexConfigPath: config, codexHookPath: join(dir, 'missing.mjs') });
+
+    expect(result.status).toBe('blocked');
+    expect(result.message).toContain('hook target not found');
+    expect(result.message).toContain('examples/hooks');
+  });
+});

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -180,6 +180,28 @@ describe('capture setup planning', () => {
     expect(read(settings)).toContain(`'${nodePath}' '${hook}'`);
   });
 
+  it('quotes Claude Code command paths for Windows shells', () => {
+    const dir = tempDir();
+    const hookDir = join(dir, 'hook path');
+    const hook = join(hookDir, 'ambient hook.mjs');
+    const settings = join(dir, '.claude/settings.local.json');
+    const nodePath = 'C:\\Program Files\\nodejs\\node.exe';
+    mkdirSync(hookDir, { recursive: true });
+    writeFileSync(hook, '');
+
+    const [result] = runCaptureSetup('claude-code', {
+      write: true,
+      claudeSettingsPath: settings,
+      claudeHookPath: hook,
+      nodePath,
+      platform: 'win32',
+    });
+
+    const parsed = JSON.parse(read(settings));
+    expect(result.command).toBe(`"${nodePath}" "${hook}"`);
+    expect(parsed.hooks.SessionEnd[0].hooks[0].command).toBe(`"${nodePath}" "${hook}"`);
+  });
+
   it('rejects a Claude Code settings symlink before reading or writing it', () => {
     const dir = tempDir();
     const settings = join(dir, '.claude/settings.local.json');
@@ -362,6 +384,27 @@ describe('capture setup planning', () => {
     const arrayDir = tempDir();
     const arrayConfig = join(arrayDir, 'config.toml');
     const arrayTable = '[[notify]]\ncommand = "custom"\n';
+    writeFileSync(tableConfig, table);
+    writeFileSync(arrayConfig, arrayTable);
+
+    const [tableResult] = runCaptureSetup('codex', { write: true, codexConfigPath: tableConfig, codexHookPath: codexHook });
+    const [arrayResult] = runCaptureSetup('codex', { write: true, codexConfigPath: arrayConfig, codexHookPath: codexHook });
+
+    expect(tableResult.status).toBe('blocked');
+    expect(arrayResult.status).toBe('blocked');
+    expect(tableResult.message).toContain('notify table');
+    expect(arrayResult.message).toContain('notify table');
+    expect(read(tableConfig)).toBe(table);
+    expect(read(arrayConfig)).toBe(arrayTable);
+  });
+
+  it('blocks top-level Codex notify tables after other tables', () => {
+    const tableDir = tempDir();
+    const tableConfig = join(tableDir, 'config.toml');
+    const table = '[profiles.foo]\nmodel = "x"\n[notify]\ncommand = "custom"\n';
+    const arrayDir = tempDir();
+    const arrayConfig = join(arrayDir, 'config.toml');
+    const arrayTable = '[profiles.foo]\nmodel = "x"\n[[notify]]\ncommand = "custom"\n';
     writeFileSync(tableConfig, table);
     writeFileSync(arrayConfig, arrayTable);
 

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -84,6 +84,20 @@ describe('capture setup planning', () => {
     expect(read(gitignore)).toBe('.claude/*\n!.claude/settings.local.json\n.claude/settings.local.json\n');
   });
 
+  it('respects later gitignore glob negations for Claude settings', () => {
+    const dir = tempDir();
+    const gitignore = join(dir, '.gitignore');
+    writeFileSync(gitignore, '.claude/*\n!.claude/*.json\n');
+
+    const [first] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+    const [second] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+
+    expect(first.status).toBe('installed');
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(read(gitignore)).toBe('.claude/*\n!.claude/*.json\n.claude/settings.local.json\n');
+  });
+
   it('blocks malformed Claude Code settings and preserves the file', () => {
     const dir = tempDir();
     const settings = join(dir, '.claude/settings.local.json');

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -322,6 +322,25 @@ describe('capture setup planning', () => {
     expect(read(literalConfig)).toBe(literal);
   });
 
+  it('blocks top-level dotted Codex notify keys', () => {
+    const bareDir = tempDir();
+    const bareConfig = join(bareDir, 'config.toml');
+    const bare = 'notify.command = "custom"\n[profiles.foo]\nmodel = "x"\n';
+    const quotedDir = tempDir();
+    const quotedConfig = join(quotedDir, 'config.toml');
+    const quoted = '"notify".command = "custom"\n[profiles.foo]\nmodel = "x"\n';
+    writeFileSync(bareConfig, bare);
+    writeFileSync(quotedConfig, quoted);
+
+    const [bareResult] = runCaptureSetup('codex', { write: true, codexConfigPath: bareConfig, codexHookPath: codexHook });
+    const [quotedResult] = runCaptureSetup('codex', { write: true, codexConfigPath: quotedConfig, codexHookPath: codexHook });
+
+    expect(bareResult.status).toBe('blocked');
+    expect(quotedResult.status).toBe('blocked');
+    expect(read(bareConfig)).toBe(bare);
+    expect(read(quotedConfig)).toBe(quoted);
+  });
+
   it('blocks top-level Codex notify tables', () => {
     const tableDir = tempDir();
     const tableConfig = join(tableDir, 'config.toml');

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -244,6 +244,20 @@ describe('capture setup planning', () => {
     expect(generatedNotify).toBeLessThan(after.indexOf('[profiles.real]'));
   });
 
+  it('inserts Codex notify after top-level arrays without treating array rows as tables', () => {
+    const dir = tempDir();
+    const config = join(dir, 'config.toml');
+    writeFileSync(config, 'sandbox = [\n  ["read", "write"]\n]\n[profiles.real]\nmodel = "x"\n');
+
+    const [result] = runCaptureSetup('codex', { write: true, codexConfigPath: config, codexHookPath: codexHook });
+    const after = read(config);
+
+    expect(result.status).toBe('installed');
+    expect(result.changed).toBe(true);
+    expect(after).toContain('sandbox = [\n  ["read", "write"]\n]\nnotify = [');
+    expect(after.indexOf('notify = [')).toBeLessThan(after.indexOf('[profiles.real]'));
+  });
+
   it('blocks different single-line and multiline top-level Codex notify values', () => {
     const singleDir = tempDir();
     const singleConfig = join(singleDir, 'config.toml');

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -173,14 +173,14 @@ describe('capture setup planning', () => {
   it('does not treat table-local Codex notify as a top-level conflict', () => {
     const dir = tempDir();
     const config = join(dir, 'config.toml');
-    writeFileSync(config, '[profiles.foo]\nnotify = ["custom"]\n');
+    writeFileSync(config, '[ profiles.foo ]\nnotify = ["custom"]\n');
 
     const [result] = runCaptureSetup('codex', { write: true, codexConfigPath: config, codexHookPath: codexHook });
 
     expect(result.status).toBe('installed');
     expect(result.changed).toBe(true);
     expect(read(config).startsWith('notify = [')).toBe(true);
-    expect(read(config)).toContain('[profiles.foo]\nnotify = ["custom"]');
+    expect(read(config)).toContain('[ profiles.foo ]\nnotify = ["custom"]');
   });
 
   it('inserts Codex notify before the first real table while ignoring multiline string content', () => {

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { renderCaptureSetupText, runCaptureSetup } from '../src/capture-setup.js';
@@ -268,6 +268,28 @@ describe('capture setup planning', () => {
     expect(results.some((result) => result.status === 'blocked')).toBe(true);
     expect(existsSync(settings)).toBe(false);
     expect(read(config)).toBe('notify = ["custom"]\n');
+  });
+
+  it('rolls back setup all when a later config write fails', () => {
+    const dir = tempDir();
+    const settings = join(dir, '.claude/settings.local.json');
+    const locked = join(dir, 'locked');
+    const config = join(locked, 'codex', 'config.toml');
+    mkdirSync(locked);
+    chmodSync(locked, 0o555);
+
+    try {
+      expect(() => runCaptureSetup('all', {
+        write: true,
+        claudeSettingsPath: settings,
+        codexConfigPath: config,
+        claudeHookPath: claudeHook,
+        codexHookPath: codexHook,
+      })).toThrow();
+      expect(existsSync(settings)).toBe(false);
+    } finally {
+      chmodSync(locked, 0o755);
+    }
   });
 
   it('blocks missing hook targets with an actionable message', () => {

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { renderCaptureSetupText, runCaptureSetup } from '../src/capture-setup.js';
@@ -143,6 +143,21 @@ describe('capture setup planning', () => {
     expect(existsSync(join(external, 'settings.local.json'))).toBe(false);
   });
 
+  it('rejects a symlinked ancestor even when the immediate settings directory exists', () => {
+    const dir = tempDir();
+    const external = tempDir();
+    const link = join(dir, 'link');
+    mkdirSync(join(external, 'sub'));
+    symlinkSync(external, link, 'dir');
+    const settings = join(link, 'sub', 'settings.local.json');
+
+    const [result] = runCaptureSetup('claude-code', { write: true, claudeSettingsPath: settings, claudeHookPath: claudeHook });
+
+    expect(result.status).toBe('blocked');
+    expect(result.message).toContain('parent directory must not be a symlink');
+    expect(existsSync(join(external, 'sub', 'settings.local.json'))).toBe(false);
+  });
+
   it('plans a Codex notify install without writing by default', () => {
     const dir = tempDir();
     const config = join(dir, 'config.toml');
@@ -270,26 +285,21 @@ describe('capture setup planning', () => {
     expect(read(config)).toBe('notify = ["custom"]\n');
   });
 
-  it('rolls back setup all when a later config write fails', () => {
+  it('does not write earlier setup when a later config path is invalid', () => {
     const dir = tempDir();
     const settings = join(dir, '.claude/settings.local.json');
-    const locked = join(dir, 'locked');
-    const config = join(locked, 'codex', 'config.toml');
-    mkdirSync(locked);
-    chmodSync(locked, 0o555);
+    const config = join(dir, `${'x'.repeat(300)}.toml`);
 
-    try {
-      expect(() => runCaptureSetup('all', {
-        write: true,
-        claudeSettingsPath: settings,
-        codexConfigPath: config,
-        claudeHookPath: claudeHook,
-        codexHookPath: codexHook,
-      })).toThrow();
-      expect(existsSync(settings)).toBe(false);
-    } finally {
-      chmodSync(locked, 0o755);
-    }
+    const results = runCaptureSetup('all', {
+      write: true,
+      claudeSettingsPath: settings,
+      codexConfigPath: config,
+      claudeHookPath: claudeHook,
+      codexHookPath: codexHook,
+    });
+
+    expect(results.some((result) => result.status === 'blocked')).toBe(true);
+    expect(existsSync(settings)).toBe(false);
   });
 
   it('blocks missing hook targets with an actionable message', () => {

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -70,6 +70,20 @@ describe('capture setup planning', () => {
     expect(read(gitignore)).toBe('.claude/settings.local.json\n');
   });
 
+  it('respects later gitignore negations before trusting a Claude settings ignore', () => {
+    const dir = tempDir();
+    const gitignore = join(dir, '.gitignore');
+    writeFileSync(gitignore, '.claude/*\n!.claude/settings.local.json\n');
+
+    const [first] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+    const [second] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+
+    expect(first.status).toBe('installed');
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(read(gitignore)).toBe('.claude/*\n!.claude/settings.local.json\n.claude/settings.local.json\n');
+  });
+
   it('blocks malformed Claude Code settings and preserves the file', () => {
     const dir = tempDir();
     const settings = join(dir, '.claude/settings.local.json');

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -322,6 +322,27 @@ describe('capture setup planning', () => {
     expect(read(literalConfig)).toBe(literal);
   });
 
+  it('blocks top-level Codex notify tables', () => {
+    const tableDir = tempDir();
+    const tableConfig = join(tableDir, 'config.toml');
+    const table = '[notify]\ncommand = "custom"\n';
+    const arrayDir = tempDir();
+    const arrayConfig = join(arrayDir, 'config.toml');
+    const arrayTable = '[[notify]]\ncommand = "custom"\n';
+    writeFileSync(tableConfig, table);
+    writeFileSync(arrayConfig, arrayTable);
+
+    const [tableResult] = runCaptureSetup('codex', { write: true, codexConfigPath: tableConfig, codexHookPath: codexHook });
+    const [arrayResult] = runCaptureSetup('codex', { write: true, codexConfigPath: arrayConfig, codexHookPath: codexHook });
+
+    expect(tableResult.status).toBe('blocked');
+    expect(arrayResult.status).toBe('blocked');
+    expect(tableResult.message).toContain('notify table');
+    expect(arrayResult.message).toContain('notify table');
+    expect(read(tableConfig)).toBe(table);
+    expect(read(arrayConfig)).toBe(arrayTable);
+  });
+
   it('rejects a Codex config symlink before reading or writing it', () => {
     const dir = tempDir();
     const config = join(dir, 'config.toml');

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -98,6 +98,20 @@ describe('capture setup planning', () => {
     expect(read(gitignore)).toBe('.claude/*\n!.claude/*.json\n.claude/settings.local.json\n');
   });
 
+  it('respects later gitignore basename negations for Claude settings', () => {
+    const dir = tempDir();
+    const gitignore = join(dir, '.gitignore');
+    writeFileSync(gitignore, '.claude/*\n!*.json\n');
+
+    const [first] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+    const [second] = runCaptureSetup('claude-code', { write: true, repoRoot: dir, claudeHookPath: claudeHook });
+
+    expect(first.status).toBe('installed');
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(read(gitignore)).toBe('.claude/*\n!*.json\n.claude/settings.local.json\n');
+  });
+
   it('blocks malformed Claude Code settings and preserves the file', () => {
     const dir = tempDir();
     const settings = join(dir, '.claude/settings.local.json');

--- a/tests/capture-setup.test.ts
+++ b/tests/capture-setup.test.ts
@@ -127,6 +127,22 @@ describe('capture setup planning', () => {
     expect(read(secret)).toBe('{"private":"SENTINEL_SECRET"}');
   });
 
+  it('rejects a symlinked Claude Code settings directory before writing outside the repo', () => {
+    const dir = tempDir();
+    const external = tempDir();
+    const settingsDir = join(dir, '.claude');
+    const settings = join(settingsDir, 'settings.local.json');
+    symlinkSync(external, settingsDir, 'dir');
+
+    const [dryRun] = runCaptureSetup('claude-code', { claudeSettingsPath: settings, claudeHookPath: claudeHook });
+    const [write] = runCaptureSetup('claude-code', { write: true, claudeSettingsPath: settings, claudeHookPath: claudeHook });
+
+    expect(dryRun.status).toBe('blocked');
+    expect(write.status).toBe('blocked');
+    expect(write.message).toContain('parent directory must not be a symlink');
+    expect(existsSync(join(external, 'settings.local.json'))).toBe(false);
+  });
+
   it('plans a Codex notify install without writing by default', () => {
     const dir = tempDir();
     const config = join(dir, 'config.toml');
@@ -165,6 +181,22 @@ describe('capture setup planning', () => {
     expect(result.changed).toBe(true);
     expect(read(config).startsWith('notify = [')).toBe(true);
     expect(read(config)).toContain('[profiles.foo]\nnotify = ["custom"]');
+  });
+
+  it('inserts Codex notify before the first real table while ignoring multiline string content', () => {
+    const dir = tempDir();
+    const config = join(dir, 'config.toml');
+    writeFileSync(config, 'developer_instructions = """\nnotify = ["not-top-level"]\n[profiles.fake]\n"""\n[profiles.real]\nmodel = "x"\n');
+
+    const [result] = runCaptureSetup('codex', { write: true, codexConfigPath: config, codexHookPath: codexHook });
+    const after = read(config);
+    const generatedNotify = after.indexOf('notify = [', after.indexOf('"""\n', after.indexOf('[profiles.fake]')));
+
+    expect(result.status).toBe('installed');
+    expect(result.changed).toBe(true);
+    expect(after).toContain('developer_instructions = """\nnotify = ["not-top-level"]\n[profiles.fake]\n"""\n');
+    expect(after.indexOf('notify = ["not-top-level"]')).toBeLessThan(generatedNotify);
+    expect(generatedNotify).toBeLessThan(after.indexOf('[profiles.real]'));
   });
 
   it('blocks different single-line and multiline top-level Codex notify values', () => {

--- a/tests/cli-capture.test.ts
+++ b/tests/cli-capture.test.ts
@@ -181,4 +181,86 @@ describe('osc capture CLI surface', () => {
     expect(result.stdout).toContain('Usage: osc capture --from');
     expect(result.stderr).toBe('');
   });
+
+  it('dry-runs Claude Code capture setup from the CLI without writing', () => {
+    const repo = tempRepo();
+    const settings = join(repo, '.claude/settings.local.json');
+    const result = run(['capture', 'setup', 'claude-code', '--claude-settings', settings], repo);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('claude-code: would-install');
+    expect(result.stdout).toContain('ambient-hook.mjs');
+    expect(existsSync(settings)).toBe(false);
+  });
+
+  it('dry-runs Codex capture setup from the CLI without writing', () => {
+    const repo = tempRepo();
+    const config = join(repo, 'codex-config.toml');
+    const result = run(['capture', 'setup', 'codex', '--codex-config', config], repo);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('codex: would-install');
+    expect(result.stdout).toContain('codex-notify.mjs');
+    expect(existsSync(config)).toBe(false);
+  });
+
+  it('dry-runs all capture setup targets from the CLI', () => {
+    const repo = tempRepo();
+    const result = run([
+      'capture',
+      'setup',
+      'all',
+      '--claude-settings',
+      join(repo, '.claude/settings.local.json'),
+      '--codex-config',
+      join(repo, 'codex-config.toml'),
+    ], repo);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('claude-code: would-install');
+    expect(result.stdout).toContain('codex: would-install');
+  });
+
+  it('prints safe JSON for capture setup', () => {
+    const repo = tempRepo();
+    const config = join(repo, 'codex-config.toml');
+    writeFileSync(config, 'model = "SENTINEL_SECRET"\n');
+    const result = run(['capture', 'setup', 'codex', '--codex-config', config, '--json'], repo);
+
+    expect(result.status).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.mode).toBe('dry-run');
+    expect(payload.results[0].runtime).toBe('codex');
+    expect(result.stdout).not.toContain('SENTINEL_SECRET');
+  });
+
+  it('writes capture setup config from the CLI', () => {
+    const repo = tempRepo();
+    const settings = join(repo, '.claude/settings.local.json');
+    const config = join(repo, 'codex-config.toml');
+    const result = run([
+      'capture',
+      'setup',
+      'all',
+      '--write',
+      '--claude-settings',
+      settings,
+      '--codex-config',
+      config,
+    ], repo);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(settings, 'utf8')).toContain('ambient-hook.mjs');
+    expect(readFileSync(config, 'utf8')).toContain('codex-notify.mjs');
+  });
+
+  it('rejects conflicting capture setup modes', () => {
+    const repo = tempRepo();
+    const result = run(['capture', 'setup', 'codex', '--write', '--dry-run', '--codex-config', join(repo, 'codex-config.toml')], repo);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Use either --write or --dry-run');
+  });
 });

--- a/tests/cli-capture.test.ts
+++ b/tests/cli-capture.test.ts
@@ -256,6 +256,15 @@ describe('osc capture CLI surface', () => {
     expect(readFileSync(config, 'utf8')).toContain('codex-notify.mjs');
   });
 
+  it('writes default Claude Code setup with a gitignore guard from the CLI', () => {
+    const repo = tempRepo();
+    const result = run(['capture', 'setup', 'claude-code', '--write'], repo);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(repo, '.claude/settings.local.json'), 'utf8')).toContain('ambient-hook.mjs');
+    expect(readFileSync(join(repo, '.gitignore'), 'utf8')).toContain('.claude/settings.local.json');
+  });
+
   it('rejects conflicting capture setup modes', () => {
     const repo = tempRepo();
     const result = run(['capture', 'setup', 'codex', '--write', '--dry-run', '--codex-config', join(repo, 'codex-config.toml')], repo);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -35,7 +35,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
-const cleanupTargetLoc = 15_714;
+// 233 Codex review fix: default Claude gitignore guard and quoted Codex notify conflict detection (+75 LOC).
+const cleanupTargetLoc = 15_789;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -78,7 +79,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_714);
+    expect(cleanupTargetLoc).toBe(15_789);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -34,8 +34,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: empty evidence battery reports not_evaluated (nullable pass) instead of overstated pass (+1 LOC).
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
-// 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+515 LOC, +1 file).
-const cleanupTargetLoc = 15_709;
+// 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
+const cleanupTargetLoc = 15_714;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -78,7 +78,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_709);
+    expect(cleanupTargetLoc).toBe(15_714);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -34,8 +34,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: empty evidence battery reports not_evaluated (nullable pass) instead of overstated pass (+1 LOC).
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
-// 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML safety (+474 LOC, +1 file).
-const cleanupTargetLoc = 15_668;
+// 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+515 LOC, +1 file).
+const cleanupTargetLoc = 15_709;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -78,7 +78,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_668);
+    expect(cleanupTargetLoc).toBe(15_709);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -35,8 +35,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
-// 233 Codex review fix: default Claude gitignore guard, TOML array-row handling, later-negation handling, and quoted Codex notify conflict detection (+98 LOC).
-const cleanupTargetLoc = 15_812;
+// 233 Codex review fix: default Claude gitignore guard, glob/negation handling, TOML array-row handling, and quoted Codex notify conflict detection (+122 LOC).
+const cleanupTargetLoc = 15_836;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -79,7 +79,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_812);
+    expect(cleanupTargetLoc).toBe(15_836);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -35,8 +35,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
-// 233 Codex review fix: default Claude gitignore guard, glob/negation handling, TOML array-row handling, and quoted Codex notify conflict detection (+122 LOC).
-const cleanupTargetLoc = 15_836;
+// 233 Codex review fix: default Claude gitignore guard, glob/basename negation handling, TOML array-row handling, and quoted Codex notify conflict detection (+125 LOC).
+const cleanupTargetLoc = 15_839;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -79,7 +79,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_836);
+    expect(cleanupTargetLoc).toBe(15_839);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -35,8 +35,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
-// 233 Codex review fix: default Claude gitignore guard and quoted Codex notify conflict detection (+75 LOC).
-const cleanupTargetLoc = 15_789;
+// 233 Codex review fix: default Claude gitignore guard, later-negation handling, and quoted Codex notify conflict detection (+81 LOC).
+const cleanupTargetLoc = 15_795;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -79,7 +79,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_789);
+    expect(cleanupTargetLoc).toBe(15_795);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -35,8 +35,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
-// 233 Codex review fix: default Claude gitignore guard, glob/basename negation handling, TOML array-row handling, and quoted Codex notify conflict detection (+125 LOC).
-const cleanupTargetLoc = 15_839;
+// 233 Codex review fix: default Claude gitignore guard, glob/basename negation handling, TOML notify-table/array-row handling, and quoted Codex notify conflict detection (+137 LOC).
+const cleanupTargetLoc = 15_851;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -79,7 +79,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_839);
+    expect(cleanupTargetLoc).toBe(15_851);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -34,8 +34,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: empty evidence battery reports not_evaluated (nullable pass) instead of overstated pass (+1 LOC).
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
-// 233: ambient capture setup helper for Claude Code/Codex config planning and idempotent writes (+380 LOC, +1 file).
-const cleanupTargetLoc = 15_574;
+// 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML safety (+474 LOC, +1 file).
+const cleanupTargetLoc = 15_668;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -78,7 +78,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_574);
+    expect(cleanupTargetLoc).toBe(15_668);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -35,8 +35,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
-// 233 Codex review fix: default Claude gitignore guard, glob/basename negation handling, TOML notify-table/array-row handling, and quoted Codex notify conflict detection (+137 LOC).
-const cleanupTargetLoc = 15_851;
+// 233 Codex review fix: default Claude gitignore guard, root/glob/basename negation handling, TOML notify-table/array-row handling, and quoted Codex notify conflict detection (+138 LOC).
+const cleanupTargetLoc = 15_852;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -79,7 +79,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_851);
+    expect(cleanupTargetLoc).toBe(15_852);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -35,8 +35,8 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
-// 233 Codex review fix: default Claude gitignore guard, later-negation handling, and quoted Codex notify conflict detection (+81 LOC).
-const cleanupTargetLoc = 15_795;
+// 233 Codex review fix: default Claude gitignore guard, TOML array-row handling, later-negation handling, and quoted Codex notify conflict detection (+98 LOC).
+const cleanupTargetLoc = 15_812;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -79,7 +79,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_795);
+    expect(cleanupTargetLoc).toBe(15_812);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -34,8 +34,9 @@ const cleanupBaselineLoc = 20_890;
 // 173 Codex review fix: empty evidence battery reports not_evaluated (nullable pass) instead of overstated pass (+1 LOC).
 // 173 Codex review fix: required_evidence manifest list rejects omitted required rows (+10 LOC).
 // 173 Codex review fix: render required_evidence rows as required in the proof-battery table (+1 LOC).
-const cleanupTargetLoc = 15_194;
-const cleanupTargetFiles = 40;
+// 233: ambient capture setup helper for Claude Code/Codex config planning and idempotent writes (+380 LOC, +1 file).
+const cleanupTargetLoc = 15_574;
+const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
   path: string;
@@ -77,7 +78,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(15_194);
+    expect(cleanupTargetLoc).toBe(15_574);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/package-payload.test.ts
+++ b/tests/package-payload.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -206,6 +206,44 @@ describe('npm package payload', () => {
         cwd: packageDir,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
+
+      const codexSetupOutput = execFileSync('node', [
+        join(packageDir, 'dist/cli.js'),
+        'capture',
+        'setup',
+        'codex',
+        '--dry-run',
+        '--json',
+        '--codex-config',
+        join(target, 'codex-config.toml'),
+      ], {
+        cwd: packageDir,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const codexSetup = JSON.parse(codexSetupOutput);
+      const packagedCodexHook = realpathSync.native(join(packageDir, 'examples/hooks/codex-notify.mjs'));
+      expect(codexSetup.results[0].hookPath).toBe(packagedCodexHook);
+      expect(codexSetup.results[0].stanza).toContain(packagedCodexHook);
+
+      const claudeSetupOutput = execFileSync('node', [
+        join(packageDir, 'dist/cli.js'),
+        'capture',
+        'setup',
+        'claude-code',
+        '--dry-run',
+        '--json',
+        '--claude-settings',
+        join(target, '.claude/settings.local.json'),
+      ], {
+        cwd: packageDir,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const claudeSetup = JSON.parse(claudeSetupOutput);
+      const packagedClaudeHook = realpathSync.native(join(packageDir, 'examples/hooks/ambient-hook.mjs'));
+      expect(claudeSetup.results[0].hookPath).toBe(packagedClaudeHook);
+      expect(claudeSetup.results[0].command).toContain(packagedClaudeHook);
 
       const ignore = readFileSync(join(target, '.osc/.gitignore'), 'utf8');
       expect(ignore).toContain('tasks.db*');


### PR DESCRIPTION
## Summary
- Adds a local ambient capture setup helper for Claude Code and Codex.

## Scope
- Implements osc capture setup for claude-code, codex, and all; dry-run/JSON output; idempotent write mode; docs and package-payload coverage.

## Out of scope
- Merge, publish, release, workflow dispatch, and owner-local secret/config mutation.

## Verification
- git diff --check; npm run build; ./verify.sh --strict && npm test -- --run -> passed locally (50 test files, 590 tests).

## Risk
- Low-to-medium: touches local runtime config generation; guarded by dry-run default, no-follow writes, symlink checks, and fixture tests.

## Linked issue
Closes #233

## Authority boundary
Maintainer recovery of interrupted scoped issue work only; no merge/publish/release authority used.
