### PR TITLE
Improve first-run conflict recovery guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ Audit every receipt, zero spend: [`REPRODUCE.md`](REPRODUCE.md).
 ## Start in 60 seconds
 
 ```bash
+mkdir -p ./my-project
+cd ./my-project
 npx open-scaffold@latest first-run
 ```
 
-Three questions produce `MISSION.md`, an active plan with acceptance criteria, and an evidence skeleton. Work however you already work; the record accumulates as files:
+Run `first-run` inside the project folder where Open Scaffold should write `AGENTS.md`, `MISSION.md`, and `.osc/`. Three questions produce `MISSION.md`, an active plan with acceptance criteria, and an evidence skeleton. Work however you already work; the record accumulates as files:
 
 ```bash
 osc verify

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -394,6 +394,7 @@ function initCommand(args: string[]): void {
 
 async function firstRunCommand(args: string[]): Promise<void> {
   if (isHelpArg(args[0])) { console.log('Usage: osc first-run [--non-interactive --slug <slug> --mission <text> --goal <text>]'); return; }
+  validateOptions(args, ['--slug', '--mission', '--goal'], ['--non-interactive'], 'first-run');
   const options = has(args, '--non-interactive')
     ? { slug: requireValue(args, '--slug'), mission: requireValue(args, '--mission'), goal: requireValue(args, '--goal') }
     : await askInteractiveFirstRun();

--- a/src/first-run.ts
+++ b/src/first-run.ts
@@ -3,7 +3,7 @@ import { join, relative } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { findScaffoldRoot } from './scaffold.js';
-import { initializeScaffold } from './init.js';
+import { initializeScaffold, ScaffoldConflictError } from './init.js';
 import { validatePlanFile } from './plan-validate.js';
 
 export interface FirstRunOptions {
@@ -31,10 +31,36 @@ function isSafeSlug(value: string): boolean {
 function requireOrCreateRoot(start: string): string {
   const existing = findScaffoldRoot(start);
   if (existing) return existing;
-  initializeScaffold({ tier: 'min', target: start, fromExisting: true });
+  try {
+    initializeScaffold({ tier: 'min', target: start, fromExisting: true });
+  } catch (error) {
+    if (error instanceof ScaffoldConflictError) {
+      throw new Error(formatFirstRunConflictMessage(error));
+    }
+    throw error;
+  }
   const created = findScaffoldRoot(start);
   if (!created) throw new Error(`No Open Scaffold root found from ${start}. Run \`osc init\` first.`);
   return created;
+}
+
+function formatFirstRunConflictMessage(error: ScaffoldConflictError): string {
+  return [
+    'Open Scaffold first-run stopped before writing files.',
+    '',
+    'first-run creates starter guidance and .osc work-record files in the current target directory.',
+    `Target directory: ${error.target}`,
+    'Conflicting files:',
+    ...error.conflicts.map((file) => `- ${file}`),
+    '',
+    'For a new project, create and enter a fresh folder, then run first-run there:',
+    'mkdir -p ./my-project',
+    'cd ./my-project',
+    'npx open-scaffold@latest first-run',
+    '',
+    'For an existing project, preserve, move, or rename the listed conflicting files first, then initialize brownfield scaffolding:',
+    `npx open-scaffold@latest init --from-existing --tier min --target ${error.target}`,
+  ].join('\n');
 }
 
 function missionIsUnset(text: string): boolean {

--- a/src/first-run.ts
+++ b/src/first-run.ts
@@ -63,7 +63,7 @@ function formatFirstRunConflictMessage(error: ScaffoldConflictError): string {
     'npx open-scaffold@latest first-run',
     '',
     'For an existing project, preserve, move, or rename the listed conflicting files first, then initialize brownfield scaffolding:',
-    `npx open-scaffold@latest init --from-existing --tier min --target ${shellQuote(error.target)}`,
+    `npx open-scaffold@latest init --from-existing --tier min --target ${shellQuote(error.target)}\n\nAfter brownfield scaffolding is initialized, rerun first-run in that target to create the mission, active plan, and evidence skeleton:\ncd ${shellQuote(error.target)}\nnpx open-scaffold@latest first-run`,
   ].join('\n');
 }
 

--- a/src/first-run.ts
+++ b/src/first-run.ts
@@ -44,6 +44,10 @@ function requireOrCreateRoot(start: string): string {
   return created;
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function formatFirstRunConflictMessage(error: ScaffoldConflictError): string {
   return [
     'Open Scaffold first-run stopped before writing files.',
@@ -59,7 +63,7 @@ function formatFirstRunConflictMessage(error: ScaffoldConflictError): string {
     'npx open-scaffold@latest first-run',
     '',
     'For an existing project, preserve, move, or rename the listed conflicting files first, then initialize brownfield scaffolding:',
-    `npx open-scaffold@latest init --from-existing --tier min --target ${error.target}`,
+    `npx open-scaffold@latest init --from-existing --tier min --target ${shellQuote(error.target)}`,
   ].join('\n');
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -85,6 +85,21 @@ export interface InitializeScaffoldResult {
   summary: string;
 }
 
+export class ScaffoldConflictError extends Error {
+  readonly target: string;
+  readonly conflicts: string[];
+  readonly fromExisting: boolean;
+
+  constructor(target: string, conflicts: readonly string[], fromExisting: boolean) {
+    const noun = fromExisting ? 'existing scaffold files' : 'existing files';
+    super(`Refusing to overwrite ${noun}: ${conflicts.join(', ')}. Re-run with --force only if you intend to replace them.`);
+    this.name = 'ScaffoldConflictError';
+    this.target = target;
+    this.conflicts = [...conflicts];
+    this.fromExisting = fromExisting;
+  }
+}
+
 function packageRoot(): string {
   return resolve(dirname(fileURLToPath(import.meta.url)), '..');
 }
@@ -729,8 +744,7 @@ export function initializeScaffold(options: InitializeScaffoldOptions): Initiali
   const existing = scaffoldConflicts(target, files, fromExisting);
 
   if (existing.length > 0 && !options.force) {
-    const noun = fromExisting ? 'existing scaffold files' : 'existing files';
-    throw new Error(`Refusing to overwrite ${noun}: ${existing.join(', ')}. Re-run with --force only if you intend to replace them.`);
+    throw new ScaffoldConflictError(target, existing, fromExisting);
   }
 
   for (const file of files) {

--- a/tests/blueprint-mega.test.ts
+++ b/tests/blueprint-mega.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -110,6 +110,44 @@ describe('blueprint first-run and PR check surfaces', () => {
       expect(existsSync(join(root, '.osc/plans/active/first-work-record.md'))).toBe(true);
       const validation = runOsc(root, ['plan', 'validate', 'first-work-record', '--strict']);
       expect(validation.status, validation.stdout + validation.stderr).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('explains first-run scaffold file conflicts with safe recovery commands', () => {
+    const root = mkdtempSync(join(tmpdir(), 'osc-first-run-conflict-'));
+    try {
+      writeFileSync(join(root, 'AGENTS.md'), '# Existing agent guidance\n');
+      const target = realpathSync(root);
+
+      const result = runOsc(root, ['first-run', '--non-interactive', '--slug', 'first-work-record', '--mission', 'Build a tiny service safely.', '--goal', 'Add the first reviewed change.']);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Open Scaffold first-run stopped before writing files.');
+      expect(result.stderr).toContain('starter guidance and .osc work-record files');
+      expect(result.stderr).toContain(`Target directory: ${target}`);
+      expect(result.stderr).toContain('AGENTS.md');
+      expect(result.stderr).toContain('mkdir -p ./my-project');
+      expect(result.stderr).toContain('cd ./my-project');
+      expect(result.stderr).toContain('npx open-scaffold@latest first-run');
+      expect(result.stderr).toContain('preserve, move, or rename the listed conflicting files first');
+      expect(result.stderr).toContain(`npx open-scaffold@latest init --from-existing --tier min --target ${target}`);
+      expect(result.stderr).not.toContain('--force');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unsupported first-run force usage before prompting', () => {
+    const root = mkdtempSync(join(tmpdir(), 'osc-first-run-force-'));
+    try {
+      const result = runOsc(root, ['first-run', '--force']);
+
+      expect(result.status).toBe(2);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Unknown option for first-run: --force');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/blueprint-mega.test.ts
+++ b/tests/blueprint-mega.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -137,7 +137,15 @@ describe('blueprint first-run and PR check surfaces', () => {
       expect(result.stderr).toContain('npx open-scaffold@latest first-run');
       expect(result.stderr).toContain('preserve, move, or rename the listed conflicting files first');
       expect(result.stderr).toContain(`npx open-scaffold@latest init --from-existing --tier min --target ${quotedTarget}`);
+      expect(result.stderr).toContain(`After brownfield scaffolding is initialized, rerun first-run in that target to create the mission, active plan, and evidence skeleton:\ncd ${quotedTarget}`);
       expect(result.stderr).not.toContain('--force');
+
+      renameSync(join(root, 'AGENTS.md'), join(root, 'AGENTS.existing.md'));
+      const init = runOsc(root, ['init', '--from-existing', '--tier', 'min', '--target', root]);
+      expect(init.status, init.stderr).toBe(0);
+      const rerun = runOsc(root, ['first-run', '--non-interactive', '--slug', 'first-work-record', '--mission', 'Build a tiny service safely.', '--goal', 'Add the first reviewed change.']);
+      expect(rerun.status, rerun.stderr).toBe(0);
+      expect([existsSync(join(root, '.osc/plans/active/first-work-record.md')), readdirSync(join(root, '.osc/releases')).some((file: string) => file.endsWith('-first-work-record.md'))]).toEqual([true, true]);
     } finally {
       rmSync(parent, { recursive: true, force: true });
     }

--- a/tests/blueprint-mega.test.ts
+++ b/tests/blueprint-mega.test.ts
@@ -116,10 +116,13 @@ describe('blueprint first-run and PR check surfaces', () => {
   });
 
   it('explains first-run scaffold file conflicts with safe recovery commands', () => {
-    const root = mkdtempSync(join(tmpdir(), 'osc-first-run-conflict-'));
+    const parent = mkdtempSync(join(tmpdir(), 'osc-first-run-conflict-'));
+    const root = join(parent, "project's path with spaces");
     try {
+      mkdirSync(root);
       writeFileSync(join(root, 'AGENTS.md'), '# Existing agent guidance\n');
       const target = realpathSync(root);
+      const quotedTarget = `'${target.replace(/'/g, `'\\''`)}'`;
 
       const result = runOsc(root, ['first-run', '--non-interactive', '--slug', 'first-work-record', '--mission', 'Build a tiny service safely.', '--goal', 'Add the first reviewed change.']);
 
@@ -133,10 +136,10 @@ describe('blueprint first-run and PR check surfaces', () => {
       expect(result.stderr).toContain('cd ./my-project');
       expect(result.stderr).toContain('npx open-scaffold@latest first-run');
       expect(result.stderr).toContain('preserve, move, or rename the listed conflicting files first');
-      expect(result.stderr).toContain(`npx open-scaffold@latest init --from-existing --tier min --target ${target}`);
+      expect(result.stderr).toContain(`npx open-scaffold@latest init --from-existing --tier min --target ${quotedTarget}`);
       expect(result.stderr).not.toContain('--force');
     } finally {
-      rmSync(root, { recursive: true, force: true });
+      rmSync(parent, { recursive: true, force: true });
     }
   });
 

--- a/tests/first-run-docs.test.ts
+++ b/tests/first-run-docs.test.ts
@@ -15,6 +15,17 @@ describe('first-run documentation truth', () => {
     expect(read('LLM_QUICKSTART.md')).toContain('npx open-scaffold@latest first-run');
   });
 
+  it('tells first-time users to run first-run from the target project folder', () => {
+    const readme = read('README.md');
+
+    expect(readme).toContain('mkdir -p ./my-project');
+    expect(readme).toContain('cd ./my-project');
+    expect(readme).toContain('inside the project folder');
+    expect(readme).toContain('AGENTS.md');
+    expect(readme).toContain('MISSION.md');
+    expect(readme).toContain('.osc/');
+  });
+
   it('keeps a source-checkout fallback path for users who do not want npx', () => {
     const minimum = read('docs/START_HERE.md');
 

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -38,8 +38,8 @@ const cleanupBaselineLoc = 20_890;
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
 // 233 Codex review fix: default Claude gitignore guard, root/glob/basename negation handling, TOML notify-table/array-row handling, and quoted Codex notify conflict detection (+138 LOC).
 // 235: ambient capture handoff/resume consumption adds normalized untrusted-record summaries, CLI/MCP selection, and budget-aware rendering (+320 LOC).
-// 241: first-run conflict metadata and beginner-safe recovery guidance (+41 LOC).
-const cleanupTargetLoc = 16_531;
+// 241: first-run conflict metadata and beginner-safe recovery guidance (+45 LOC).
+const cleanupTargetLoc = 16_535;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -82,7 +82,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(16_531);
+    expect(cleanupTargetLoc).toBe(16_535);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -38,7 +38,8 @@ const cleanupBaselineLoc = 20_890;
 // 233: ambient capture setup helper for Claude Code/Codex config planning, idempotent writes, and symlink/TOML/setup-all safety (+520 LOC, +1 file).
 // 233 Codex review fix: default Claude gitignore guard, root/glob/basename negation handling, TOML notify-table/array-row handling, and quoted Codex notify conflict detection (+138 LOC).
 // 235: ambient capture handoff/resume consumption adds normalized untrusted-record summaries, CLI/MCP selection, and budget-aware rendering (+320 LOC).
-const cleanupTargetLoc = 16_490;
+// 241: first-run conflict metadata and beginner-safe recovery guidance (+41 LOC).
+const cleanupTargetLoc = 16_531;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -81,7 +82,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(16_490);
+    expect(cleanupTargetLoc).toBe(16_531);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);


### PR DESCRIPTION
## Summary
- Improves first-run conflict handling so new users get a safe recovery path when they run guided setup in a directory that already has scaffold files.

## Scope
- Adds structured conflict metadata, first-run-specific recovery guidance, unsupported overwrite-option rejection, README onboarding wording, and targeted tests.

## Out of scope
- No merge, publish, release, workflow dispatch, tag, settings change, secret change, or overwrite behavior expansion.

## Verification
- git diff --check -> passed; npm test -- --run tests/blueprint-mega.test.ts tests/first-run-docs.test.ts tests/framework-cleanup-metric.test.ts -> 19 passed; npm run build -> passed; ./verify.sh --strict -> 10 pass, 0 fail; npm test -- --run -> 628 passed.

## Risk
- Low; scoped to first-run/init conflict messaging, README guidance, and tests.

## Linked issue
Closes #241

## Authority boundary
john-lomein did not merge, publish, release, dispatch workflows, change settings, force-push, rewrite history, or touch secrets.
