### PR TITLE
Polish first-run onboarding preview

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ import { evidenceChainExitCode, formatEvidenceChainReport, verifyEvidenceChain }
 import { EVOLUTION_DECISIONS, EVOLUTION_STRATEGIES, analyzeEvolutionLoop, buildEvolutionJudgmentCheckpoint, compareEvolutionLoop, recordEvolutionAttempt, renderEvolutionAnalysis, renderEvolutionComparison, renderEvolutionJudgmentCheckpoint, validateEvolutionLoopDir, writeEvolutionLoop, type EvolutionAnalysisFormat, type EvolutionCompareFormat, type EvolutionDecision, type EvolutionJudgeAction, type EvolutionStrategy } from './evolution.js';
 import { measureEvolutionAnalysisEfficiency, renderEvolutionEfficiencyReport } from './evolution-efficiency.js';
 import { analyzeFeedback, recordFeedback } from './feedback.js';
-import { askInteractiveFirstRun, formatFirstRunResult, runFirstRun } from './first-run.js';
+import { askInteractiveFirstRun, formatFirstRunIntro, formatFirstRunPrewrite, formatFirstRunResult, previewFirstRun, previewFirstRunTarget, resolveFirstRunRenderMode, runFirstRun, type FirstRunTargetPreview } from './first-run.js';
 import { runBenchSuite, runHandoffLab } from './bench.js';
 import { CAPTURE_SETUP_TARGETS, isCaptureSetupTarget, renderCaptureSetupText, runCaptureSetup, type CaptureSetupTarget } from './capture-setup.js';
 import { initializeScaffold, scaffoldTiers, type ScaffoldTier } from './init.js';
@@ -395,10 +395,19 @@ function initCommand(args: string[]): void {
 async function firstRunCommand(args: string[]): Promise<void> {
   if (isHelpArg(args[0])) { console.log('Usage: osc first-run [--non-interactive --slug <slug> --mission <text> --goal <text>]'); return; }
   validateOptions(args, ['--slug', '--mission', '--goal'], ['--non-interactive'], 'first-run');
-  const options = has(args, '--non-interactive')
-    ? { slug: requireValue(args, '--slug'), mission: requireValue(args, '--mission'), goal: requireValue(args, '--goal') }
-    : await askInteractiveFirstRun();
-  process.stdout.write(formatFirstRunResult(runFirstRun(options, process.cwd())));
+  const nonInteractive = has(args, '--non-interactive');
+  const mode = resolveFirstRunRenderMode({ nonInteractive });
+  let targetPreview: FirstRunTargetPreview | undefined;
+  const options = nonInteractive
+    ? { slug: requireValue(args, '--slug'), mission: requireValue(args, '--mission'), goal: requireValue(args, '--goal'), nonInteractive: true }
+    : await (async () => {
+      targetPreview = previewFirstRunTarget(process.cwd());
+      process.stdout.write(formatFirstRunIntro(mode));
+      return askInteractiveFirstRun(targetPreview, mode);
+    })();
+  const preview = previewFirstRun(options, process.cwd(), targetPreview);
+  process.stdout.write(formatFirstRunPrewrite(preview, mode));
+  process.stdout.write(formatFirstRunResult(runFirstRun(options, process.cwd()), mode));
 }
 
 function statusCommand(args: string[]): void {

--- a/src/first-run.ts
+++ b/src/first-run.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { createInterface } from 'node:readline/promises';
-import { stdin as input, stdout as output } from 'node:process';
+import { env, stdin as input, stdout as output } from 'node:process';
 import { findScaffoldRoot } from './scaffold.js';
-import { initializeScaffold, ScaffoldConflictError } from './init.js';
+import { initializeScaffold, previewScaffoldInitialization, ScaffoldConflictError, type ExistingProjectDetection, type ScaffoldInitializationPreview } from './init.js';
 import { validatePlanFile } from './plan-validate.js';
 
 export interface FirstRunOptions {
@@ -22,6 +22,28 @@ export interface FirstRunResult {
   evidencePath: string;
   validationIssueCount: number;
   nextCommands: string[];
+}
+
+export interface FirstRunRenderMode {
+  style: 'polished' | 'plain';
+}
+
+export interface FirstRunTargetPreview {
+  root: string;
+  target: string;
+  scaffoldPresent: boolean;
+  willInitializeScaffold: boolean;
+  scaffoldFiles: string[];
+  project?: ExistingProjectDetection;
+}
+
+export interface FirstRunPreview extends FirstRunTargetPreview {
+  slug: string;
+  missionPath: string;
+  missionAction: 'write' | 'replace-unset' | 'preserve';
+  planPath: string;
+  evidencePath: string;
+  nextVerificationCommands: string[];
 }
 
 function isSafeSlug(value: string): boolean {
@@ -48,14 +70,22 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function formatFirstRunConflictMessage(error: ScaffoldConflictError): string {
+function formatProjectDetection(project?: ExistingProjectDetection): string {
+  if (!project) return 'No existing project marker detected.';
+  if (!project.marker && project.label === 'existing project') return 'No existing project marker detected; treating this as a new or generic local project.';
+  return `Detected existing ${project.label}${project.marker ? ` via ${project.marker}` : ''}${project.packageManager ? ` (${project.packageManager})` : ''}.`;
+}
+
+function formatFirstRunConflictMessage(error: Pick<ScaffoldConflictError, 'target' | 'conflicts'>): string {
   return [
     'Open Scaffold first-run stopped before writing files.',
     '',
-    'first-run creates starter guidance and .osc work-record files in the current target directory.',
+    'first-run creates starter guidance and .osc work-record files in the current target directory, but it will not overwrite existing scaffold-owned files.',
     `Target directory: ${error.target}`,
     'Conflicting files:',
     ...error.conflicts.map((file) => `- ${file}`),
+    '',
+    'No mission, active plan, or evidence skeleton was created.',
     '',
     'For a new project, create and enter a fresh folder, then run first-run there:',
     'mkdir -p ./my-project',
@@ -65,6 +95,12 @@ function formatFirstRunConflictMessage(error: ScaffoldConflictError): string {
     'For an existing project, preserve, move, or rename the listed conflicting files first, then initialize brownfield scaffolding:',
     `npx open-scaffold@latest init --from-existing --tier min --target ${shellQuote(error.target)}\n\nAfter brownfield scaffolding is initialized, rerun first-run in that target to create the mission, active plan, and evidence skeleton:\ncd ${shellQuote(error.target)}\nnpx open-scaffold@latest first-run`,
   ].join('\n');
+}
+
+function assertNoInitConflicts(preview: ScaffoldInitializationPreview): void {
+  if (preview.conflicts.length > 0) {
+    throw new Error(formatFirstRunConflictMessage({ target: preview.target, conflicts: preview.conflicts }));
+  }
 }
 
 function missionIsUnset(text: string): boolean {
@@ -96,6 +132,12 @@ function writeMissionIfNeeded(root: string, mission: string): string {
     '',
   ].join('\n'));
   return path;
+}
+
+function missionAction(root: string): FirstRunPreview['missionAction'] {
+  const path = join(root, 'MISSION.md');
+  if (!existsSync(path)) return 'write';
+  return missionIsUnset(readFileSync(path, 'utf8')) ? 'replace-unset' : 'preserve';
 }
 
 function planMarkdown(slug: string, goal: string, evidencePath: string): string {
@@ -211,7 +253,131 @@ export function runFirstRun(options: FirstRunOptions, start = process.cwd()): Fi
   };
 }
 
-export async function askInteractiveFirstRun(): Promise<FirstRunOptions> {
+export function resolveFirstRunRenderMode(options: { nonInteractive?: boolean; env?: NodeJS.ProcessEnv; inputIsTTY?: boolean; outputIsTTY?: boolean } = {}): FirstRunRenderMode {
+  const environment = options.env ?? env;
+  const interactiveTerminal = options.inputIsTTY ?? Boolean(input.isTTY);
+  const outputTerminal = options.outputIsTTY ?? Boolean(output.isTTY);
+  const simplified = options.nonInteractive || environment.CI || Object.prototype.hasOwnProperty.call(environment, 'NO_COLOR') || !interactiveTerminal || !outputTerminal;
+  return { style: simplified ? 'plain' : 'polished' };
+}
+
+export function previewFirstRunTarget(start = process.cwd()): FirstRunTargetPreview {
+  const existing = findScaffoldRoot(start);
+  if (existing) {
+    return {
+      root: existing,
+      target: existing,
+      scaffoldPresent: true,
+      willInitializeScaffold: false,
+      scaffoldFiles: [],
+    };
+  }
+
+  const preview = previewScaffoldInitialization({ tier: 'min', target: start, fromExisting: true });
+  assertNoInitConflicts(preview);
+  return {
+    root: preview.target,
+    target: preview.target,
+    scaffoldPresent: false,
+    willInitializeScaffold: true,
+    scaffoldFiles: preview.filesToCreate,
+    project: preview.project,
+  };
+}
+
+export function previewFirstRun(options: FirstRunOptions, start = process.cwd(), targetPreview = previewFirstRunTarget(start)): FirstRunPreview {
+  const slug = options.slug.trim();
+  if (!isSafeSlug(slug)) throw new Error(`Unsafe first-run slug: ${options.slug}`);
+  const date = new Date().toISOString().slice(0, 10);
+  const planPath = join(targetPreview.root, '.osc', 'plans', 'active', `${slug}.md`);
+  const evidencePath = join(targetPreview.root, '.osc', 'releases', `${date}-${slug}.md`);
+  return {
+    ...targetPreview,
+    slug,
+    missionPath: relative(targetPreview.root, join(targetPreview.root, 'MISSION.md')).replace(/\\/g, '/'),
+    missionAction: missionAction(targetPreview.root),
+    planPath: relative(targetPreview.root, planPath).replace(/\\/g, '/'),
+    evidencePath: relative(targetPreview.root, evidencePath).replace(/\\/g, '/'),
+    nextVerificationCommands: [
+      `osc plan validate ${slug} --strict`,
+      `osc trace ${slug}`,
+      `osc verify --evidence-chain --plan ${slug} --strict`,
+    ],
+  };
+}
+
+export function formatFirstRunIntro(mode = resolveFirstRunRenderMode()): string {
+  if (mode.style === 'polished') {
+    return [
+      'Open Scaffold',
+      'First-run onboarding',
+      '',
+      '[1/4] Inspect the target directory',
+      '[2/4] Show the local files that will be written',
+      '[3/4] Create mission, plan, and evidence skeletons',
+      '[4/4] Print verification commands',
+      '',
+      'Boundary: this setup is local and structural. It will not run agents, tests, deployment, publish, or provider APIs.',
+      '',
+    ].join('\n');
+  }
+  return [
+    'Open Scaffold first-run',
+    'Local structural setup only. No agents, tests, deployment, publish, or provider APIs will run.',
+    '',
+  ].join('\n');
+}
+
+function missionActionText(action: FirstRunPreview['missionAction']): string {
+  if (action === 'preserve') return 'preserve existing defined mission';
+  if (action === 'replace-unset') return 'replace unset scaffold mission';
+  return 'write project mission';
+}
+
+export function formatFirstRunPrewrite(preview: FirstRunPreview, mode = resolveFirstRunRenderMode()): string {
+  const lines = mode.style === 'polished'
+    ? ['[2/4] Planned local writes', '']
+    : ['Open Scaffold first-run preview', ''];
+
+  lines.push(`Target: ${preview.target}`);
+  if (preview.scaffoldPresent) {
+    lines.push('Open Scaffold root: already present; first-run will not rewrite scaffold guidance.');
+  } else {
+    lines.push('Open Scaffold root: will initialize the minimum local scaffold here.');
+    lines.push(formatProjectDetection(preview.project));
+    lines.push('Existing non-scaffold project files are preserved.');
+  }
+
+  lines.push(
+    '',
+    'Before writing, first-run plans these local files:',
+  );
+
+  if (preview.willInitializeScaffold) {
+    lines.push(
+      '- AGENTS.md and CLAUDE.md: local agent guidance',
+      '- .osc/: work-record directories, templates, rules, and release-note area',
+    );
+  } else {
+    lines.push('- Existing AGENTS.md / CLAUDE.md / .osc/ scaffold files: preserved');
+  }
+
+  lines.push(
+    `- ${preview.missionPath}: ${missionActionText(preview.missionAction)}`,
+    `- ${preview.planPath}: active plan for ${preview.slug}`,
+    `- ${preview.evidencePath}: structural evidence skeleton`,
+    '',
+    'Next verification commands after setup:',
+    ...preview.nextVerificationCommands.map((command) => `- ${command}`),
+    '',
+    'Proof boundary: planned writes do not mean agents ran, tests passed, deployment happened, or production readiness was proven.',
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+export async function askInteractiveFirstRun(targetPreview?: FirstRunTargetPreview, mode = resolveFirstRunRenderMode()): Promise<FirstRunOptions> {
   if (!input.isTTY) {
     const lines = readFileSync(0, 'utf8').split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
     const [slug = 'first-work-record', mission = '', goal = 'Complete one reviewed local change.'] = lines;
@@ -219,6 +385,15 @@ export async function askInteractiveFirstRun(): Promise<FirstRunOptions> {
   }
   const rl = createInterface({ input, output });
   try {
+    if (targetPreview) {
+      output.write([
+        mode.style === 'polished' ? '[1/4] Target context' : 'Target context:',
+        `Target: ${targetPreview.target}`,
+        targetPreview.scaffoldPresent ? 'Open Scaffold root already exists.' : formatProjectDetection(targetPreview.project),
+        targetPreview.scaffoldPresent ? 'first-run will preserve existing scaffold files.' : 'Existing non-scaffold project files will be preserved.',
+        '',
+      ].join('\n'));
+    }
     const slug = (await rl.question('Plan slug [first-work-record]: ')).trim() || 'first-work-record';
     const mission = (await rl.question('Mission: ')).trim();
     const goal = (await rl.question('First work goal: ')).trim() || 'Complete one reviewed local change.';
@@ -228,9 +403,9 @@ export async function askInteractiveFirstRun(): Promise<FirstRunOptions> {
   }
 }
 
-export function formatFirstRunResult(result: FirstRunResult): string {
+export function formatFirstRunResult(result: FirstRunResult, mode = resolveFirstRunRenderMode()): string {
   return [
-    'Open Scaffold first-run complete',
+    mode.style === 'polished' ? '[4/4] Open Scaffold first-run complete' : 'Open Scaffold first-run complete',
     `Mission: ${result.missionPath}`,
     `Plan: ${result.planPath}`,
     `Evidence skeleton: ${result.evidencePath}`,

--- a/src/init.ts
+++ b/src/init.ts
@@ -72,7 +72,7 @@ export interface InitializeScaffoldOptions {
   fromExisting?: boolean;
 }
 
-interface ExistingProjectDetection {
+export interface ExistingProjectDetection {
   label: string;
   marker: string | null;
   packageManager?: string;
@@ -83,6 +83,16 @@ export interface InitializeScaffoldResult {
   target: string;
   filesCreated: string[];
   summary: string;
+}
+
+export interface ScaffoldInitializationPreview {
+  tier: ScaffoldTier;
+  target: string;
+  fromExisting: boolean;
+  filesToCreate: string[];
+  conflicts: string[];
+  protectedExistingProjectFiles: string[];
+  project?: ExistingProjectDetection;
 }
 
 export class ScaffoldConflictError extends Error {
@@ -211,6 +221,12 @@ function scaffoldConflicts(target: string, files: readonly string[], fromExistin
   }
   if (oscExists) conflicts.push('.osc');
   return conflicts;
+}
+
+function protectedBrownfieldFiles(target: string, fromExisting: boolean, force?: boolean): string[] {
+  return fromExisting && force
+    ? ['verify.sh', 'close.sh', 'bootstrap.sh'].filter((file) => existsSync(join(target, file)))
+    : [];
 }
 
 function downstreamReadmeTemplate(): string {
@@ -719,49 +735,39 @@ function rejectSymlinkedDestination(target: string, destination: string): void {
 }
 
 export function initializeScaffold(options: InitializeScaffoldOptions): InitializeScaffoldResult {
-  ensureKnownTier(options.tier);
-  if (options.fromExisting && options.tier !== 'min') {
-    throw new Error('Brownfield init currently supports --tier min only. Use greenfield init for standard/max docs, or add advanced docs manually after preserving existing project files.');
+  const preview = previewScaffoldInitialization(options);
+  const { tier, target, fromExisting, project } = preview;
+
+  if (preview.protectedExistingProjectFiles.length > 0) {
+    throw new Error(`Refusing to overwrite existing project files in brownfield mode: ${preview.protectedExistingProjectFiles.join(', ')}. Rename or move them before re-running with --force.`);
   }
-  const target = normalizeKnownSystemAlias(options.target);
-  const fromExisting = Boolean(options.fromExisting);
-  const protectedExistingProjectFiles = fromExisting && options.force
-    ? ['verify.sh', 'close.sh', 'bootstrap.sh'].filter((file) => existsSync(join(target, file)))
-    : [];
-  if (protectedExistingProjectFiles.length > 0) {
-    throw new Error(`Refusing to overwrite existing project files in brownfield mode: ${protectedExistingProjectFiles.join(', ')}. Rename or move them before re-running with --force.`);
-  }
-  const project = fromExisting ? detectExistingProject(target) : undefined;
-  const files = filesForInitialization(options.tier, fromExisting);
 
   rejectSymlinkedExistingPath(target);
   mkdirSync(target, { recursive: true });
 
-  for (const file of files) {
+  for (const file of preview.filesToCreate) {
     rejectSymlinkedDestination(target, join(target, file));
   }
 
-  const existing = scaffoldConflicts(target, files, fromExisting);
-
-  if (existing.length > 0 && !options.force) {
-    throw new ScaffoldConflictError(target, existing, fromExisting);
+  if (preview.conflicts.length > 0 && !options.force) {
+    throw new ScaffoldConflictError(target, preview.conflicts, fromExisting);
   }
 
-  for (const file of files) {
+  for (const file of preview.filesToCreate) {
     const destination = join(target, file);
     mkdirSync(dirname(destination), { recursive: true });
 
-    const generatedTemplate = downstreamTemplateFor(file, options.tier);
+    const generatedTemplate = downstreamTemplateFor(file, tier);
     const source = sourcePathFor(file);
     if (generatedTemplate !== null) {
       writeFileSync(destination, generatedTemplate);
     } else if (source === null) {
       writeFileSync(destination, file === 'MISSION.md' ? missionTemplate(project) : '');
-    } else if (file === '.osc/RULES.md' && options.tier === 'min') {
+    } else if (file === '.osc/RULES.md' && tier === 'min') {
       writeFileSync(destination, minRulesTemplate());
-    } else if (file === '.osc/plans/README.md' && options.tier === 'min') {
+    } else if (file === '.osc/plans/README.md' && tier === 'min') {
       writeFileSync(destination, minPlansReadmeTemplate());
-    } else if (file === '.osc/plans/handoff-template.md' && options.tier === 'min') {
+    } else if (file === '.osc/plans/handoff-template.md' && tier === 'min') {
       writeFileSync(destination, minHandoffTemplate());
     } else {
       assertTemplateExists(file, source);
@@ -772,10 +778,32 @@ export function initializeScaffold(options: InitializeScaffoldOptions): Initiali
   }
 
   return {
+    tier,
+    target,
+    filesCreated: preview.filesToCreate,
+    summary: formatSummary(tier, target, preview.filesToCreate, project),
+  };
+}
+
+export function previewScaffoldInitialization(options: InitializeScaffoldOptions): ScaffoldInitializationPreview {
+  ensureKnownTier(options.tier);
+  if (options.fromExisting && options.tier !== 'min') {
+    throw new Error('Brownfield init currently supports --tier min only. Use greenfield init for standard/max docs, or add advanced docs manually after preserving existing project files.');
+  }
+  const target = normalizeKnownSystemAlias(options.target);
+  const fromExisting = Boolean(options.fromExisting);
+  const project = fromExisting ? detectExistingProject(target) : undefined;
+  const files = filesForInitialization(options.tier, fromExisting);
+  const conflicts = scaffoldConflicts(target, files, fromExisting);
+
+  return {
     tier: options.tier,
     target,
-    filesCreated: files,
-    summary: formatSummary(options.tier, target, files, project),
+    fromExisting,
+    filesToCreate: files,
+    conflicts,
+    protectedExistingProjectFiles: protectedBrownfieldFiles(target, fromExisting, options.force),
+    project,
   };
 }
 

--- a/tests/blueprint-mega.test.ts
+++ b/tests/blueprint-mega.test.ts
@@ -79,6 +79,10 @@ describe('blueprint first-run and PR check surfaces', () => {
     try {
       const result = runOsc(root, ['first-run', '--non-interactive', '--slug', 'first-work-record', '--mission', 'Build a tiny service safely.', '--goal', 'Add the first reviewed change.']);
       expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('Open Scaffold first-run preview');
+      expect(result.stdout).toContain('Before writing, first-run plans these local files:');
+      expect(result.stdout).toContain('.osc/plans/active/first-work-record.md');
+      expect(result.stdout).toContain('Proof boundary: planned writes do not mean agents ran, tests passed, deployment happened, or production readiness was proven.');
       expect(result.stdout).toContain('Open Scaffold first-run complete');
       expect(result.stdout).toContain('osc trace first-work-record');
       expect(result.stdout).toContain('osc verify --evidence-chain --plan first-work-record --strict');
@@ -100,12 +104,41 @@ describe('blueprint first-run and PR check surfaces', () => {
     }
   });
 
+  it('onboards an empty folder with a clear planned-writes preview', () => {
+    const root = mkdtempSync(join(tmpdir(), 'osc-first-run-empty-'));
+    try {
+      const result = runOsc(root, ['first-run', '--non-interactive', '--slug', 'first-work-record', '--mission', 'Build a tiny service safely.', '--goal', 'Add the first reviewed change.']);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('Open Scaffold root: will initialize the minimum local scaffold here.');
+      expect(result.stdout).toContain('No existing project marker detected; treating this as a new or generic local project.');
+      expect(result.stdout).toContain('AGENTS.md and CLAUDE.md: local agent guidance');
+      expect(result.stdout).toContain('.osc/: work-record directories, templates, rules, and release-note area');
+      expect(result.stdout).toContain('.osc/plans/active/first-work-record.md');
+      expect(result.stdout).toContain('Open Scaffold first-run complete');
+      expect(existsSync(join(root, 'AGENTS.md'))).toBe(true);
+      expect(existsSync(join(root, 'CLAUDE.md'))).toBe(true);
+      expect(existsSync(join(root, 'MISSION.md'))).toBe(true);
+      expect(existsSync(join(root, '.osc/plans/active/first-work-record.md'))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('creates one valid first work-record path in an existing non-scaffold repo', () => {
     const root = mkdtempSync(join(tmpdir(), 'osc-first-run-existing-'));
     try {
       writeFileSync(join(root, 'package.json'), '{"scripts":{"test":"node --version"}}\n');
+      mkdirSync(join(root, 'src'));
+      writeFileSync(join(root, 'src/index.js'), 'console.log("keep me")\n');
       const result = runOsc(root, ['first-run', '--non-interactive', '--slug', 'first-work-record', '--mission', 'Build a tiny service safely.', '--goal', 'Add the first reviewed change.']);
       expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('Open Scaffold root: will initialize the minimum local scaffold here.');
+      expect(result.stdout).toContain('Detected existing Node.js project via package.json.');
+      expect(result.stdout).toContain('Existing non-scaffold project files are preserved.');
+      expect(result.stdout).toContain('AGENTS.md and CLAUDE.md: local agent guidance');
+      expect(readFileSync(join(root, 'package.json'), 'utf8')).toBe('{"scripts":{"test":"node --version"}}\n');
+      expect(readFileSync(join(root, 'src/index.js'), 'utf8')).toBe('console.log("keep me")\n');
       expect(existsSync(join(root, '.osc/RULES.md'))).toBe(true);
       expect(existsSync(join(root, '.osc/plans/active/first-work-record.md'))).toBe(true);
       const validation = runOsc(root, ['plan', 'validate', 'first-work-record', '--strict']);
@@ -132,6 +165,7 @@ describe('blueprint first-run and PR check surfaces', () => {
       expect(result.stderr).toContain('starter guidance and .osc work-record files');
       expect(result.stderr).toContain(`Target directory: ${target}`);
       expect(result.stderr).toContain('AGENTS.md');
+      expect(result.stderr).toContain('No mission, active plan, or evidence skeleton was created.');
       expect(result.stderr).toContain('mkdir -p ./my-project');
       expect(result.stderr).toContain('cd ./my-project');
       expect(result.stderr).toContain('npx open-scaffold@latest first-run');
@@ -139,6 +173,9 @@ describe('blueprint first-run and PR check surfaces', () => {
       expect(result.stderr).toContain(`npx open-scaffold@latest init --from-existing --tier min --target ${quotedTarget}`);
       expect(result.stderr).toContain(`After brownfield scaffolding is initialized, rerun first-run in that target to create the mission, active plan, and evidence skeleton:\ncd ${quotedTarget}`);
       expect(result.stderr).not.toContain('--force');
+      expect(existsSync(join(root, 'MISSION.md'))).toBe(false);
+      expect(existsSync(join(root, '.osc/plans/active/first-work-record.md'))).toBe(false);
+      expect(existsSync(join(root, '.osc/releases'))).toBe(false);
 
       renameSync(join(root, 'AGENTS.md'), join(root, 'AGENTS.existing.md'));
       const init = runOsc(root, ['init', '--from-existing', '--tier', 'min', '--target', root]);
@@ -174,10 +211,27 @@ describe('blueprint first-run and PR check surfaces', () => {
         env: { ...process.env },
       });
       expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('Open Scaffold first-run preview');
       expect(result.stdout).toContain('Open Scaffold first-run complete');
       expect(existsSync(join(root, '.osc/plans/active/interactive-work.md'))).toBe(true);
       const validation = runOsc(root, ['plan', 'validate', 'interactive-work', '--strict']);
       expect(validation.status, validation.stdout + validation.stderr).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps CI and NO_COLOR first-run output plain and deterministic', () => {
+    const root = mkdtempSync(join(tmpdir(), 'osc-first-run-ci-'));
+    try {
+      const result = runOsc(root, ['first-run', '--non-interactive', '--slug', 'first-work-record', '--mission', 'Build safely.', '--goal', 'Create the first reviewed slice.'], { CI: '1', NO_COLOR: '1' });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('Open Scaffold first-run preview');
+      expect(result.stdout).not.toContain('First-run onboarding');
+      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain('[1/4]');
+      expect(result.stdout).toContain('Open Scaffold first-run complete');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/framework-cleanup-metric.test.ts
+++ b/tests/framework-cleanup-metric.test.ts
@@ -39,7 +39,8 @@ const cleanupBaselineLoc = 20_890;
 // 233 Codex review fix: default Claude gitignore guard, root/glob/basename negation handling, TOML notify-table/array-row handling, and quoted Codex notify conflict detection (+138 LOC).
 // 235: ambient capture handoff/resume consumption adds normalized untrusted-record summaries, CLI/MCP selection, and budget-aware rendering (+320 LOC).
 // 241: first-run conflict metadata and beginner-safe recovery guidance (+45 LOC).
-const cleanupTargetLoc = 16_535;
+// 244: first-run onboarding preview, brownfield context rendering, and output-mode tests (+212 LOC).
+const cleanupTargetLoc = 16_747;
 const cleanupTargetFiles = 41;
 
 interface MaintainedSourceFile {
@@ -82,7 +83,7 @@ describe('framework cleanup maintained-source metric', () => {
     expect(files.map((file) => file.path)).toContain('src/cli.ts');
     expect(files.map((file) => file.path)).toContain('packages/runtime-omx/src/index.ts');
     expect(files.every((file) => maintainedRoots.some((root) => file.path === root || file.path.startsWith(`${root}/`)))).toBe(true);
-    expect(cleanupTargetLoc).toBe(16_535);
+    expect(cleanupTargetLoc).toBe(16_747);
     expect(totalLoc).toBeLessThanOrEqual(cleanupTargetLoc);
     expect(totalLoc).toBeLessThanOrEqual(cleanupBaselineLoc);
     expect(files.length).toBeLessThanOrEqual(cleanupTargetFiles);

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { initializeScaffold, tierFiles } from '../src/init.js';
+import { initializeScaffold, previewScaffoldInitialization, tierFiles } from '../src/init.js';
 
 function tempTarget() {
   return mkdtempSync(join(tmpdir(), 'osc-init-'));
@@ -170,6 +170,24 @@ describe('tiered scaffold initialization', () => {
     expect(readFileSync(join(target, 'MISSION.md'), 'utf8')).toContain('<!-- mission:unset -->');
     expect(readFileSync(join(target, 'package.json'), 'utf8')).toBe(packageJson);
     expect(readFileSync(join(target, 'src/index.js'), 'utf8')).toBe(source);
+  });
+
+  it('previews brownfield scaffold context and conflicts without writing files', () => {
+    const target = tempTarget();
+    writeFileSync(join(target, 'package.json'), '{"name":"preview-node"}\n');
+    writeFileSync(join(target, 'AGENTS.md'), '# Existing guidance\n');
+
+    const preview = previewScaffoldInitialization({ tier: 'min', target, fromExisting: true });
+
+    expect(preview.target).toBe(target);
+    expect(preview.fromExisting).toBe(true);
+    expect(preview.project?.label).toBe('Node.js project');
+    expect(preview.project?.marker).toBe('package.json');
+    expect(preview.filesToCreate).toContain('AGENTS.md');
+    expect(preview.filesToCreate).toContain('CLAUDE.md');
+    expect(preview.conflicts).toEqual(['AGENTS.md']);
+    expect(existsSync(join(target, 'MISSION.md'))).toBe(false);
+    expect(existsSync(join(target, '.osc'))).toBe(false);
   });
 
   it('refuses brownfield scaffold conflicts without force and lists scaffold-owned conflicts', () => {


### PR DESCRIPTION
## Summary
- Polishes first-run onboarding with a planned-writes preview before local scaffold files are created.

## Scope
- Adds target/context preview rendering, safe brownfield initialization preview support, terminal/CI output mode selection, and tests for greenfield, brownfield, conflict, and CI/NO_COLOR paths.

## Out of scope
- No merge, publish, release, workflow dispatch, secrets, branch protection, or runtime spawning.

## Verification
- `./verify.sh --quick --quiet` -> passed; `git diff --check` -> passed; `npm run build` -> passed; `./verify.sh --strict && npm test -- --run` -> passed (631 tests).

## Risk
- Moderate: user-facing CLI text changes; automation path remains non-interactive and covered by tests.

## Linked issue
Closes #244

## Authority boundary
Review-ready PR only. No merge, publish, release, force-push, workflow dispatch, settings, or secret authority used.