### PR TITLE
Fix macOS brownfield preview target test

### DIFF
--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -179,7 +179,7 @@ describe('tiered scaffold initialization', () => {
 
     const preview = previewScaffoldInitialization({ tier: 'min', target, fromExisting: true });
 
-    expect(preview.target).toBe(target);
+    expect(preview.target).toBe(realpathSync(target));
     expect(preview.fromExisting).toBe(true);
     expect(preview.project?.label).toBe('Node.js project');
     expect(preview.project?.marker).toBe('package.json');

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -173,13 +173,13 @@ describe('tiered scaffold initialization', () => {
   });
 
   it('previews brownfield scaffold context and conflicts without writing files', () => {
-    const target = tempTarget();
+    const target = realpathSync(tempTarget());
     writeFileSync(join(target, 'package.json'), '{"name":"preview-node"}\n');
     writeFileSync(join(target, 'AGENTS.md'), '# Existing guidance\n');
 
     const preview = previewScaffoldInitialization({ tier: 'min', target, fromExisting: true });
 
-    expect(preview.target).toBe(realpathSync(target));
+    expect(preview.target).toBe(target);
     expect(preview.fromExisting).toBe(true);
     expect(preview.project?.label).toBe('Node.js project');
     expect(preview.project?.marker).toBe('package.json');


### PR DESCRIPTION
## Summary
- Fixes the macOS-specific brownfield preview target expectation so local configured verification matches the canonical /tmp alias behavior.

## Scope
- Updates one init test assertion to compare the preview target with the real path returned by the scaffold preview helper.

## Out of scope
- No production code change, merge, publish, release, workflow dispatch, settings, or secrets.

## Verification
- git diff --check -> passed; npm test -- --run tests/init.test.ts -> 18 passed; npm run build -> passed; ./verify.sh --strict && npm test -- --run -> 631 passed.

## Risk
- Low: test-only correction for macOS /tmp canonicalization already exercised by the init suite.

## Linked issue
Follow-up to #245; no issue closed.

## Authority boundary
Review-ready PR only. No merge, publish, release, force-push, workflow dispatch, settings, or secret authority used.
