### PR TITLE
Prepare open-scaffold 0.35.0 release sync

### DIFF
--- a/.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md
+++ b/.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md
@@ -1,0 +1,55 @@
+# Plan: 176-prepare-open-scaffold-0350-release-sync
+
+## Status
+
+active
+
+## Context
+
+Issue #246 requests the next release-prep slice for `open-scaffold@0.35.0`. The package metadata on the prepared branch started at `0.34.0`, the top changelog entry was still the prior `v0.34.0` release-sync candidate, and the approved forge plan scoped this work to a reviewable draft PR only. The trusted OWNER comment confirms the current need is to rerun the forge implementation lane after the prior attempt produced no PR branch.
+
+## Goal
+
+Prepare a draft release-sync PR for `open-scaffold@0.35.0` with version metadata, changelog, release-sync plan/evidence, and dry-run verification ready for owner-gated npm publish and GitHub Release follow-through.
+
+## Constraints / Out of scope
+
+- This plan prepares a draft PR only; it does not merge, publish to npm, create tags, create GitHub Releases, dispatch workflows, change repository settings, change branch protection, or touch secrets.
+- Keep release language in candidate/prep state until npm and GitHub Release proof exists after owner-gated follow-through.
+- Follow current `origin/main` truth. The release delta after the `0.34.0` release-sync includes PRs #242, #243, #245, and #247.
+- Do not change product behavior, publish/release workflows, `.env`, `SECURITY.md`, package publication authority, or package version beyond `0.35.0`.
+- The only allowed test edit is `tests/section-parser.test.ts`, and only if verification proves the new release-prep records are the sole live-corpus hash change.
+
+## Files to touch
+
+- `package.json` - bump the package version from `0.34.0` to `0.35.0`.
+- `package-lock.json` - keep the root and `packages[""]` lockfile versions aligned with `package.json`.
+- `docs/CHANGELOG.md` - add a top `v0.35.0` release-candidate entry with source issue, release-prep records, verification status, and owner-gated boundaries.
+- `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md` - this release-prep work record while in progress.
+- `.osc/releases/2026-07-02-176-prepare-open-scaffold-0350-release-sync.md` - release-prep evidence note with observed checks and authority boundary.
+- `tests/section-parser.test.ts` - update live-corpus hash only if the new plan/evidence records are proven to be the sole snapshot change.
+
+## Acceptance criteria
+
+- [ ] `package.json`, `package-lock.json` root, and `package-lock.json` `packages[""]` all read `0.35.0`.
+- [ ] `docs/CHANGELOG.md` contains a top `v0.35.0` candidate/prep entry that links issue #246, source PRs #242, #243, #245, and #247, this plan, this evidence note, and the draft PR once opened.
+- [ ] The release-prep evidence note records observed version alignment, npm/GitHub availability check attempts, package dry-run output, verification commands, and the no-merge/no-publish/no-release authority boundary.
+- [ ] Open Scaffold plan/evidence records contain no placeholder text and validate under strict plan validation.
+- [ ] A draft PR is opened or updated against `main` from `forge/issue-246-prepare-open-scaffold-npm-github-release`, with `Closes #246` and a public-safe authority boundary.
+- [ ] No forbidden external release action is performed: no merge, real publish, workflow dispatch, tag, GitHub Release, force-push, settings change, secret change, or package version beyond `0.35.0`.
+
+## Verification steps
+
+1. `node -e "const p=require('./package.json'), l=require('./package-lock.json'); if (p.version !== '0.35.0' || l.version !== '0.35.0' || l.packages[''].version !== '0.35.0') process.exit(1)"` - expected pass.
+2. `npm view open-scaffold dist-tags --json` and `npm view open-scaffold@0.35.0 version --json` - expected to record live registry state, or record environment/network failure honestly.
+3. GitHub PR overlap and release checks for issue #246, `0.35.0`, and branch `forge/issue-246-prepare-open-scaffold-npm-github-release` - expected no open overlap before this draft PR and no owner-gated release action from this plan.
+4. `git diff --check` - expected pass.
+5. `npm run osc -- plan validate 176-prepare-open-scaffold-0350-release-sync --strict` - expected pass.
+6. `./verify.sh --strict && npm test -- --run` - configured required verification, expected pass or an honest sandbox blocker with focused follow-up evidence.
+7. `npm run build` - expected pass.
+8. `npm pack --dry-run --json` - expected package id `open-scaffold@0.35.0`; record observed tarball/file metadata.
+9. Do not run `npm publish` or `npm publish --dry-run` in this release-prep PR. Real package publication and any publish rehearsal remain owner-gated follow-through after review/merge.
+
+## Open questions
+
+- None for release-prep. npm publish, GitHub Release creation, tag/release movement, and post-publish smoke remain owner-gated follow-through after review/merge.

--- a/.osc/releases/2026-07-02-176-prepare-open-scaffold-0350-release-sync.md
+++ b/.osc/releases/2026-07-02-176-prepare-open-scaffold-0350-release-sync.md
@@ -1,0 +1,52 @@
+# Release / Evidence Note: 176-prepare-open-scaffold-0350-release-sync
+
+## Summary
+
+Prepared the `open-scaffold@0.35.0` release-sync candidate for the first-run setup package surface on current `origin/main`. This note records draft-PR preparation evidence only; it does not claim merge, npm publication, tag creation, GitHub Release creation, workflow dispatch, or owner approval for those follow-through actions.
+
+## Traceability
+
+- Roadmap / issue / task: https://github.com/graphanov/open-scaffold/issues/246.
+- Plan: `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md` while this prep PR is in progress; expected final path `.osc/plans/done/176-prepare-open-scaffold-0350-release-sync.md` after closeout.
+- Release delta after the `0.34.0` release-sync: #242, #243, #245, and #247.
+- Source PRs:
+  - #242 - https://github.com/graphanov/open-scaffold/pull/242
+  - #243 - https://github.com/graphanov/open-scaffold/pull/243
+  - #245 - https://github.com/graphanov/open-scaffold/pull/245
+  - #247 - https://github.com/graphanov/open-scaffold/pull/247
+- Previous package line: `open-scaffold@0.34.0`.
+- Branch / PR: branch `forge/issue-246-prepare-open-scaffold-npm-github-release`; draft PR pending at initial preparation time and must be recorded here after branch publication.
+
+## Verification
+
+- PR overlap check before publication: `gh pr list --repo graphanov/open-scaffold --state open --json number,title,headRefName,isDraft,url --limit 20` - PASS: `[]`.
+- `git fetch origin main` plus branch refresh to current `origin/main` - PASS: branch rebased/refreshed to `eb81bc2` (`Fix macOS brownfield preview target test (#247)`) before final verification.
+- `npm run osc -- plan new 176-prepare-open-scaffold-0350-release-sync --stage active` - PASS: plan skeleton created by the repo-native CLI.
+- `npm run osc -- evidence new 176-prepare-open-scaffold-0350-release-sync` - PASS: evidence skeleton created by the repo-native CLI.
+- `npm version 0.35.0 --no-git-tag-version` - PASS: package metadata bumped without tag creation.
+- Version alignment command - PASS: `package.json`, package-lock root, and package-lock `packages[""]` all read `0.35.0`.
+- `npm view open-scaffold dist-tags --json` - PASS: `latest` is currently `0.34.0`.
+- `npm view open-scaffold@0.35.0 version --json` - EXPECTED ABSENT: npm returned `E404`; `0.35.0` has not been published.
+- `gh release view v0.35.0 --repo graphanov/open-scaffold --json tagName,url,isDraft,isPrerelease,publishedAt` - EXPECTED ABSENT: release not found.
+- `gh release view 0.35.0 --repo graphanov/open-scaffold --json tagName,url,isDraft,isPrerelease,publishedAt` - EXPECTED ABSENT: release not found.
+- `npm run osc -- plan validate 176-prepare-open-scaffold-0350-release-sync --strict` - PASS: 0 issues found.
+- `git diff --check` - PASS.
+- Live-corpus hash proof - PASS: Codex verified that excluding the new `176` plan/evidence returned the previous pinned hashes exactly (`a2f1bd25...` and `f0bff2ac...`); including the new release-prep records produced `d8d87779...` and `b128def2...` with no plan issues, no scaffold failures, and no new release warnings.
+- `npm test -- --run tests/section-parser.test.ts` - PASS: 1 file / 7 tests.
+- `./verify.sh --strict` - PASS: 9 pass / 0 fail / 1 warn (`Plan immutability check skipped` because the checker did not see this linked worktree as a full git repository).
+- `npm test -- --run` - PASS: 51 files / 631 tests.
+- `npm run build` - PASS: `build:core` and `build:runtime-omx` completed.
+- `npm pack --dry-run --json` - PASS for `open-scaffold@0.35.0`, tarball `open-scaffold-0.35.0.tgz`, 228 files, 409611 bytes packed, 1881893 bytes unpacked, shasum `3ecd00bb5302b3b88545338d539512a42627d680`.
+- `npm publish` and `npm publish --dry-run` - NOT RUN in final host verification; package publication and publish rehearsal remain owner-gated follow-through after review/merge.
+
+## Outcome
+
+Release-sync preparation is locally complete for `open-scaffold@0.35.0`: package metadata is aligned, release-prep plan/evidence records exist, changelog has a `v0.35.0` candidate entry, verification passes on the host, and no owner-gated release side effects were performed.
+
+Owner-gated follow-through remains out of scope for this prep PR: merge, npm publishing, npm `latest` movement, tag creation, GitHub Release creation/Latest movement, workflow dispatch, settings, secrets, and post-publish smoke.
+
+## Follow-up
+
+- Publish the branch and open/update the draft PR with `Closes #246`.
+- After the draft PR exists, update this note and `docs/CHANGELOG.md` with the PR URL, rerun lightweight verification (`git diff --check`, plan validation, version alignment), and push the follow-up commit.
+- After merge and owner gate: perform trusted publishing for `expected-version=0.35.0`, verify npm and GitHub Release availability, and record post-publish proof in a separate owner-gated follow-through record.

--- a/.osc/releases/2026-07-02-176-prepare-open-scaffold-0350-release-sync.md
+++ b/.osc/releases/2026-07-02-176-prepare-open-scaffold-0350-release-sync.md
@@ -15,7 +15,7 @@ Prepared the `open-scaffold@0.35.0` release-sync candidate for the first-run set
   - #245 - https://github.com/graphanov/open-scaffold/pull/245
   - #247 - https://github.com/graphanov/open-scaffold/pull/247
 - Previous package line: `open-scaffold@0.34.0`.
-- Branch / PR: branch `forge/issue-246-prepare-open-scaffold-npm-github-release`; draft PR pending at initial preparation time and must be recorded here after branch publication.
+- Branch / PR: branch `forge/issue-246-prepare-open-scaffold-npm-github-release`; draft PR https://github.com/graphanov/open-scaffold/pull/248.
 
 ## Verification
 
@@ -47,6 +47,5 @@ Owner-gated follow-through remains out of scope for this prep PR: merge, npm pub
 
 ## Follow-up
 
-- Publish the branch and open/update the draft PR with `Closes #246`.
-- After the draft PR exists, update this note and `docs/CHANGELOG.md` with the PR URL, rerun lightweight verification (`git diff --check`, plan validation, version alignment), and push the follow-up commit.
+- Keep PR #248 in draft/review until reviewer/Codex feedback is clean.
 - After merge and owner gate: perform trusted publishing for `expected-version=0.35.0`, verify npm and GitHub Release availability, and record post-publish proof in a separate owner-gated follow-through record.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@ Evidence:
 - Source PRs: https://github.com/graphanov/open-scaffold/pull/242, https://github.com/graphanov/open-scaffold/pull/243, https://github.com/graphanov/open-scaffold/pull/245, and https://github.com/graphanov/open-scaffold/pull/247
 - Release-sync plan: `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md`
 - Release-sync evidence note: `.osc/releases/2026-07-02-176-prepare-open-scaffold-0350-release-sync.md`
-- Draft PR: pending until this release-prep branch is published for review.
+- Draft PR: https://github.com/graphanov/open-scaffold/pull/248
 - Previous package line: `open-scaffold@0.34.0`
 
 ## v0.34.0 — Ambient capture trust and setup package sync

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,31 @@ This is a curated human-readable changelog. It compresses the detailed `MISSION.
 
 For live package truth, check npm. For live release truth, check GitHub Releases. Repository evidence notes describe what was prepared and, when applicable, the publication proof after trusted publishing/GitHub Release follow-through.
 
+## v0.35.0 — First-run setup release candidate
+
+Status: release-sync candidate prepared for `open-scaffold@0.35.0`; not yet published to npm, not yet tagged, and no GitHub Release `v0.35.0` exists until owner-gated follow-through after review/merge. The release-prep PR does not authorize merge, publish, tag creation, GitHub Release creation, workflow dispatch, settings changes, or secret changes.
+
+Highlights:
+
+- Prepares the post-`0.34.0` mainline work for the public npm package surface, cut from current `origin/main`.
+- Improves first-run conflict recovery guidance so brownfield setup failures give operators clearer repair paths instead of silent ambiguity.
+- Polishes first-run onboarding preview behavior for existing repositories before any scaffold writes are made.
+- Carries the `@types/node` development-dependency refresh into the release candidate without changing runtime authority.
+- Includes the macOS brownfield preview target test repair from PR #247 in the release delta.
+- Keeps Open Scaffold core repo-native and authority-limited: it records and verifies work artifacts, but does not grant runtime, merge, publish, release, tag, workflow-dispatch, or settings authority by itself.
+
+Evidence:
+
+- Issue: https://github.com/graphanov/open-scaffold/issues/246
+- Source PRs: https://github.com/graphanov/open-scaffold/pull/242, https://github.com/graphanov/open-scaffold/pull/243, https://github.com/graphanov/open-scaffold/pull/245, and https://github.com/graphanov/open-scaffold/pull/247
+- Release-sync plan: `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md`
+- Release-sync evidence note: `.osc/releases/2026-07-02-176-prepare-open-scaffold-0350-release-sync.md`
+- Draft PR: pending until this release-prep branch is published for review.
+- Previous package line: `open-scaffold@0.34.0`
+
 ## v0.34.0 — Ambient capture trust and setup package sync
 
-Status: release-sync candidate prepared for `open-scaffold@0.34.0`; not yet published to npm, not yet tagged, and no GitHub Release `v0.34.0` exists until owner-gated follow-through after review/merge. npm `latest` remains `0.33.0` before that owner action.
+Status: published to npm as `open-scaffold@0.34.0`; GitHub Release `0.34.0` exists after owner-approved trusted publishing and release follow-through.
 
 Highlights:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-scaffold",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-scaffold",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "MIT",
       "bin": {
         "open-scaffold": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-scaffold",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Pre-1.0 repo-native work-record CLI for AI-agent handoff, evidence, and review.",
   "license": "MIT",
   "repository": {

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -254,7 +254,8 @@ This sample must not count as the real section.
     // 173 closeout: moved token-efficiency proof plan to done with checked AC evidence and evidence-battery release note.
     // 174 release closeout: added evidence-battery package-sync plan to done.
     // 175 release prep: added ambient capture trust package-sync plan.
-    expect(hash(planIssueSnapshot)).toBe('a2f1bd25dae3e5eeebfed71332f0dd9334b00d87a4dcd97c7fdce1b799c3c3b4');
+    // 176 release prep: added 0.35.0 package release-sync plan.
+    expect(hash(planIssueSnapshot)).toBe('d8d8777986758ddf5d505cfd732dcfbe62ef93b326358c375b3e551ac7bb5c9c');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     // 170 review hardening: evidence note refreshed with PR URL, final test count, and Codex-reported total_tokens.
@@ -266,7 +267,8 @@ This sample must not count as the real section.
     // 173 closeout: added source-labeled proof-battery evidence note with close decision.
     // 174 release closeout: added evidence-battery package-sync release note; release-warning set unchanged.
     // 175 release prep: added ambient capture trust package-sync evidence note; release-warning set unchanged.
-    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('f0bff2acea51580dab1b6553a1535d67de1e3bb528067e331906692631ada2fe');
+    // 176 release prep: added 0.35.0 package release-sync evidence note; release-warning set unchanged.
+    expect(hash({ failures: scaffold.failures, releases: releaseOutcomeSnapshot })).toBe('b128def2c0bcd7b058aaff539af32125ac75282240355ada57895940385389df');
     expect(realPlanFiles().every((path) => statSync(path).isFile())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Prepare the open-scaffold@0.35.0 release-sync candidate as a draft PR.

## Scope
- Bump package metadata to 0.35.0; add release-sync plan/evidence records; add a top changelog candidate entry; update the live-corpus hash only for the new release-prep records.

## Out of scope
- No merge, npm publish, npm publish dry-run, tag creation, GitHub Release creation, workflow dispatch, settings, branch-protection, force-push, or secrets.

## Verification
- git diff --check; npm run osc -- plan validate 176-prepare-open-scaffold-0350-release-sync --strict; version alignment check; npm view open-scaffold dist-tags --json; npm view open-scaffold@0.35.0 version --json (expected E404); gh release view v0.35.0 / 0.35.0 (expected absent); ./verify.sh --strict; npm test -- --run tests/section-parser.test.ts; npm test -- --run; npm run build; npm pack --dry-run --json.

## Risk
- Release-prep only: publication and release follow-through remain owner-gated after review/merge. npm 0.35.0 and GitHub release 0.35.0 are intentionally absent before follow-through.

## Linked issue
Closes #246

## Authority boundary
Draft PR only. This PR does not authorize merge, publish, tag/release creation, workflow dispatch, settings changes, or secrets.
