### PR TITLE
docs(osc): add portfolio follow-up (active-open-questions-d2a918602b)

### DIFF
--- a/.osc/plans/backlog/177-active-open-questions-d2a918602b.md
+++ b/.osc/plans/backlog/177-active-open-questions-d2a918602b.md
@@ -10,7 +10,7 @@ backlog
 
 john-lomein's `.osc` portfolio steward detected a `active_open_questions` gap.
 
-Active plan `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md` still has unresolved open questions that can block roadmap/backlog alignment.
+Active plan `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md` was flagged for active open-question follow-up, but its recorded open-question entry states that release-prep has no unresolved open question beyond owner-gated publish/release follow-through. This backlog item should therefore verify whether the steward finding is a false positive or whether a different roadmap/backlog clarification is needed.
 
 Source evidence:
 

--- a/.osc/plans/backlog/177-active-open-questions-d2a918602b.md
+++ b/.osc/plans/backlog/177-active-open-questions-d2a918602b.md
@@ -1,6 +1,6 @@
 # Plan: .osc portfolio gap active-open-questions-d2a918602b
 
-<!-- john-lomein-osc-gap: active-open-questions-d2a918602b -->
+<!-- osc-portfolio-gap: active-open-questions-d2a918602b -->
 
 ## Status
 
@@ -8,7 +8,7 @@ backlog
 
 ## Context
 
-john-lomein's `.osc` portfolio steward detected a `active_open_questions` gap.
+The `.osc` portfolio steward detected an `active_open_questions` gap.
 
 Active plan `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md` was flagged for active open-question follow-up, but its recorded open-question entry states that release-prep has no unresolved open question beyond owner-gated publish/release follow-through. This backlog item should therefore verify whether the steward finding is a false positive or whether a different roadmap/backlog clarification is needed.
 

--- a/.osc/plans/backlog/177-active-open-questions-d2a918602b.md
+++ b/.osc/plans/backlog/177-active-open-questions-d2a918602b.md
@@ -1,0 +1,55 @@
+# Plan: .osc portfolio gap active-open-questions-d2a918602b
+
+<!-- john-lomein-osc-gap: active-open-questions-d2a918602b -->
+
+## Status
+
+backlog
+
+## Context
+
+john-lomein's `.osc` portfolio steward detected a `active_open_questions` gap.
+
+Active plan `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md` still has unresolved open questions that can block roadmap/backlog alignment.
+
+Source evidence:
+
+- Active plan: `.osc/plans/active/176-prepare-open-scaffold-0350-release-sync.md`
+- Open question: None for release-prep. npm publish, GitHub Release creation, tag/release movement, and post-publish smoke remain owner-gated follow-through after review/merge.
+
+GitHub intake: #250
+
+## Goal
+
+Resolve the detected roadmap/backlog/active-plan gap with a small, source-grounded follow-up that keeps the public roadmap and `.osc` work record coherent.
+
+## Constraints / Out of scope
+
+- Do not merge, publish, release, dispatch workflows, change repository settings, or touch secrets from this plan alone.
+- Keep public wording owner-neutral and avoid local/private machine context.
+- Do not overclaim proof, compliance, or runtime authority.
+- If the gap is a false positive, close this plan with evidence rather than forcing implementation.
+
+## Files to touch
+
+- `ROADMAP.md` or relevant docs only if the gap requires wording/priority clarification.
+- `.osc/plans/active/*` or `.osc/plans/backlog/*` only through normal plan/amendment flow.
+- Source/test files only if a later accepted issue narrows implementation scope.
+
+## Acceptance criteria
+
+- [ ] The gap is confirmed against current `ROADMAP.md` and `.osc/plans` source truth.
+- [ ] The chosen outcome is one of: create/update a real follow-up plan, mark the older backlog entry superseded/done with evidence, amend the active plan, or reject the steward finding as a false positive.
+- [ ] Any public issue/PR comments use compact Status / Evidence / Next wording.
+- [ ] Verification commands appropriate to touched files pass before closeout.
+
+## Verification steps
+
+1. Re-run the portfolio steward dry-run and confirm this gap no longer appears, or document why it remains intentionally open.
+2. Run the repository's configured verification for any touched code/docs.
+3. Run `git diff --check`.
+
+## Open questions
+
+- Should this gap become implementation work, roadmap clarification, backlog cleanup, or a rejected false-positive record?
+- If implementation is needed, which existing active/backlog plan should own it?

--- a/tests/section-parser.test.ts
+++ b/tests/section-parser.test.ts
@@ -255,7 +255,8 @@ This sample must not count as the real section.
     // 174 release closeout: added evidence-battery package-sync plan to done.
     // 175 release prep: added ambient capture trust package-sync plan.
     // 176 release prep: added 0.35.0 package release-sync plan.
-    expect(hash(planIssueSnapshot)).toBe('d8d8777986758ddf5d505cfd732dcfbe62ef93b326358c375b3e551ac7bb5c9c');
+    // 177 portfolio follow-up: added active-open-questions-d2a918602b backlog gap plan.
+    expect(hash(planIssueSnapshot)).toBe('afcb78cffa78ceaf03a5a8bb0577bbbdae2c7f9c31bb2e606450c49a061731ee');
     expect(scaffold.failures).toEqual([]);
     // 168: evidence note 2026-06-12-168-dollar-verb-retirement.md added to .osc/releases.
     // 170 review hardening: evidence note refreshed with PR URL, final test count, and Codex-reported total_tokens.


### PR DESCRIPTION
<!-- john-lomein-osc-gap: active-open-questions-d2a918602b -->

## Summary

Adds `.osc` portfolio follow-up plan `.osc/plans/backlog/177-active-open-questions-d2a918602b.md` for gap `active-open-questions-d2a918602b`.

## Scope

- Adds one `.osc` backlog plan file.
- Links the steward-created intake issue with `Closes #250`.

## Verification

- Not run by portfolio steward; maintainer/owner review should run repo verification before merge.

## Risk

Low repository mutation, but public roadmap/planning semantics require owner review.

## Linked issue

Closes #250

## Authority boundary

Draft PR only. This does not authorize merge, release, publish, workflow dispatch, force-push, settings changes, or secrets access.