### PR TITLE
docs(osc): add portfolio follow-up (folded-backlog-d4f3d3dbc7)

### DIFF
--- a/.osc/plans/backlog/177-folded-backlog-d4f3d3dbc7.md
+++ b/.osc/plans/backlog/177-folded-backlog-d4f3d3dbc7.md
@@ -1,0 +1,58 @@
+# Plan: .osc portfolio gap folded-backlog-d4f3d3dbc7
+
+<!-- john-lomein-osc-gap: folded-backlog-d4f3d3dbc7 -->
+
+## Status
+
+backlog
+
+## Context
+
+john-lomein's `.osc` portfolio steward detected a `folded_backlog_unreconciled` gap.
+
+A live plan says it folds older backlog intent, but those older backlog files still remain independently active in `.osc/plans/backlog`.
+
+Source evidence:
+
+- Aggregator: `.osc/plans/backlog/164-distribution-launch.md`
+- Still-backlog folded plan: `.osc/plans/backlog/110-attempt-diff-demo-readme.md`
+- Still-backlog folded plan: `.osc/plans/backlog/111-anatomy-of-a-slice-public-proof.md`
+- Still-backlog folded plan: `.osc/plans/backlog/115-downstream-example-proof.md`
+- Still-backlog folded plan: `.osc/plans/backlog/116-launch-readiness-distribution-pack.md`
+
+GitHub intake: #258
+
+## Goal
+
+Resolve the detected roadmap/backlog/active-plan gap with a small, source-grounded follow-up that keeps the public roadmap and `.osc` work record coherent.
+
+## Constraints / Out of scope
+
+- Do not merge, publish, release, dispatch workflows, change repository settings, or touch secrets from this plan alone.
+- Keep public wording owner-neutral and avoid local/private machine context.
+- Do not overclaim proof, compliance, or runtime authority.
+- If the gap is a false positive, close this plan with evidence rather than forcing implementation.
+
+## Files to touch
+
+- `ROADMAP.md` or relevant docs only if the gap requires wording/priority clarification.
+- `.osc/plans/active/*` or `.osc/plans/backlog/*` only through normal plan/amendment flow.
+- Source/test files only if a later accepted issue narrows implementation scope.
+
+## Acceptance criteria
+
+- [ ] The gap is confirmed against current `ROADMAP.md` and `.osc/plans` source truth.
+- [ ] The chosen outcome is one of: create/update a real follow-up plan, mark the older backlog entry superseded/done with evidence, amend the active plan, or reject the steward finding as a false positive.
+- [ ] Any public issue/PR comments use compact Status / Evidence / Next wording.
+- [ ] Verification commands appropriate to touched files pass before closeout.
+
+## Verification steps
+
+1. Re-run the portfolio steward dry-run and confirm this gap no longer appears, or document why it remains intentionally open.
+2. Run the repository's configured verification for any touched code/docs.
+3. Run `git diff --check`.
+
+## Open questions
+
+- Should this gap become implementation work, roadmap clarification, backlog cleanup, or a rejected false-positive record?
+- If implementation is needed, which existing active/backlog plan should own it?


### PR DESCRIPTION
<!-- john-lomein-osc-gap: folded-backlog-d4f3d3dbc7 -->

## Summary

Adds `.osc` portfolio follow-up plan `.osc/plans/backlog/177-folded-backlog-d4f3d3dbc7.md` for gap `folded-backlog-d4f3d3dbc7`.

## Scope

- Adds one `.osc` backlog plan file.
- Links the steward-created intake issue with `Closes #258`.

## Verification

- Not run by portfolio steward; maintainer/owner review should run repo verification before merge.

## Risk

Low repository mutation, but public roadmap/planning semantics require owner review.

## Linked issue

Closes #258

## Authority boundary

Draft PR only. This does not authorize merge, release, publish, workflow dispatch, force-push, settings changes, or secrets access.