### PR TITLE
docs(osc): add portfolio follow-up (roadmap-parking-lot-63214833db)

### DIFF
--- a/.osc/plans/backlog/178-roadmap-parking-lot-63214833db.md
+++ b/.osc/plans/backlog/178-roadmap-parking-lot-63214833db.md
@@ -1,0 +1,55 @@
+# Plan: .osc portfolio gap roadmap-parking-lot-63214833db
+
+<!-- john-lomein-osc-gap: roadmap-parking-lot-63214833db -->
+
+## Status
+
+backlog
+
+## Context
+
+john-lomein's `.osc` portfolio steward detected a `roadmap_parking_lot_unplanned` gap.
+
+A ROADMAP parking-lot item has no obvious active/backlog plan representation.
+
+Source evidence:
+
+- ROADMAP.md parking lot item:
+- Templates for stakeholder/client-facing cockpit modes.
+
+GitHub intake: #260
+
+## Goal
+
+Resolve the detected roadmap/backlog/active-plan gap with a small, source-grounded follow-up that keeps the public roadmap and `.osc` work record coherent.
+
+## Constraints / Out of scope
+
+- Do not merge, publish, release, dispatch workflows, change repository settings, or touch secrets from this plan alone.
+- Keep public wording owner-neutral and avoid local/private machine context.
+- Do not overclaim proof, compliance, or runtime authority.
+- If the gap is a false positive, close this plan with evidence rather than forcing implementation.
+
+## Files to touch
+
+- `ROADMAP.md` or relevant docs only if the gap requires wording/priority clarification.
+- `.osc/plans/active/*` or `.osc/plans/backlog/*` only through normal plan/amendment flow.
+- Source/test files only if a later accepted issue narrows implementation scope.
+
+## Acceptance criteria
+
+- [ ] The gap is confirmed against current `ROADMAP.md` and `.osc/plans` source truth.
+- [ ] The chosen outcome is one of: create/update a real follow-up plan, mark the older backlog entry superseded/done with evidence, amend the active plan, or reject the steward finding as a false positive.
+- [ ] Any public issue/PR comments use compact Status / Evidence / Next wording.
+- [ ] Verification commands appropriate to touched files pass before closeout.
+
+## Verification steps
+
+1. Re-run the portfolio steward dry-run and confirm this gap no longer appears, or document why it remains intentionally open.
+2. Run the repository's configured verification for any touched code/docs.
+3. Run `git diff --check`.
+
+## Open questions
+
+- Should this gap become implementation work, roadmap clarification, backlog cleanup, or a rejected false-positive record?
+- If implementation is needed, which existing active/backlog plan should own it?


### PR DESCRIPTION
<!-- john-lomein-osc-gap: roadmap-parking-lot-63214833db -->

## Summary

Adds `.osc` portfolio follow-up plan `.osc/plans/backlog/178-roadmap-parking-lot-63214833db.md` for gap `roadmap-parking-lot-63214833db`.

## Scope

- Adds one `.osc` backlog plan file.
- Links the steward-created intake issue with `Closes #260`.

## Verification

- Not run by portfolio steward; maintainer/owner review should run repo verification before merge.

## Risk

Low repository mutation, but public roadmap/planning semantics require owner review.

## Linked issue

Closes #260

## Authority boundary

Draft PR only. This does not authorize merge, release, publish, workflow dispatch, force-push, settings changes, or secrets access.